### PR TITLE
[SYSTEMML-2523] Update SystemML to Support Spark 2.3.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ to find out how to help make SystemML even better!
 
 To download SystemML, visit the [downloads](http://systemml.apache.org/download) page.
 
-This version of SystemML supports: Java 8+, Scala 2.11+, Python 2.7/3.5+, Hadoop 2.6+, and Spark 2.1+.
+This version of SystemML supports: Java 8+, Scala 2.11+, Python 2.7/3.5+, Hadoop 2.6+, and Spark 2.3+.
 
 ## Running SystemML
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 		<hadoop.version>2.7.7</hadoop.version>
 		<antlr.version>4.7</antlr.version>
 		<spark.version>2.3.0</spark.version>
-		<scala.version>2.12.4</scala.version>
-		<scala.binary.version>2.12</scala.binary.version>
+		<scala.version>2.11.8</scala.version>
+		<scala.binary.version>2.11</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
 		<enableGPU>false</enableGPU>

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,10 @@
 
 	<properties>
 		<hadoop.version>2.7.7</hadoop.version>
-		<antlr.version>4.5.3</antlr.version>
-		<spark.version>2.1.0</spark.version>
-		<scala.version>2.11.8</scala.version>
-		<scala.binary.version>2.11</scala.binary.version>
+		<antlr.version>4.7</antlr.version>
+		<spark.version>2.3.0</spark.version>
+		<scala.version>2.12.4</scala.version>
+		<scala.binary.version>2.12</scala.binary.version>
 		<scala.test.version>2.2.6</scala.test.version>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
 		<enableGPU>false</enableGPU>

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/SparkPSWorker.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/SparkPSWorker.java
@@ -88,7 +88,7 @@ public class SparkPSWorker extends LocalPSWorker implements VoidFunction<Tuple2<
 		call(); // Launch the worker
 	}
 
-	private void configureWorker(Tuple2<Integer, Tuple2<MatrixBlock, MatrixBlock>> input) throws IOException {
+	private void configureWorker(Tuple2<Integer, Tuple2<MatrixBlock, MatrixBlock>> input) throws IOException, InterruptedException {
 		_workerID = input._1;
 
 		// Initialize codegen class cache (before program parsing)

--- a/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/rpc/PSRpcFactory.java
+++ b/src/main/java/org/apache/sysml/runtime/controlprogram/paramserv/rpc/PSRpcFactory.java
@@ -50,7 +50,7 @@ public class PSRpcFactory {
 		return context.createServer(host, 0, Collections.emptyList());	// bind rpc to an ephemeral port
 	}
 
-	public static SparkPSProxy createSparkPSProxy(SparkConf conf, int port, LongAccumulator aRPC) throws IOException {
+	public static SparkPSProxy createSparkPSProxy(SparkConf conf, int port, LongAccumulator aRPC) throws IOException, InterruptedException {
 		long rpcTimeout = conf.contains("spark.rpc.askTimeout") ?
 			conf.getTimeAsMs("spark.rpc.askTimeout") :
 			conf.getTimeAsMs("spark.network.timeout", "120s");


### PR DESCRIPTION
Spark 2.3 (released on February 28, 2018) has updated the Antlr version from 4.3 to 4.7, which throws a warning every time we invoke SystemML.

@bertholdreinwald @romeokienzler @mboehm7 @prithvirajsen @nakul02 @j143  Let's use this PR for discussion and raising potential concerns.