### PR TITLE
[SYSTEMML-2528] Change String.equals to Objects.equals to avoid NullPointerException

### DIFF
--- a/src/main/java/org/apache/sysml/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysml/parser/DMLTranslator.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -606,8 +607,8 @@ public class DMLTranslator
 				
 				String execType = ((ExternalFunctionStatement) fstmt)
 						.getOtherParams().get(ExternalFunctionStatement.EXEC_TYPE);
-				boolean isCP = (execType.equals(ExternalFunctionStatement.IN_MEMORY)) ? true : false;
-				
+				boolean isCP = (Objects.equals(execType,ExternalFunctionStatement.IN_MEMORY)) ? true : false;
+			
 				StringBuilder buff = new StringBuilder();
 				buff.append(config.getTextValue(DMLConfig.SCRATCH_SPACE));
 				buff.append(Lop.FILE_SEPARATOR);

--- a/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
@@ -213,7 +213,7 @@ public class GPUInstructionParser  extends InstructionParser
 				
 			case ArithmeticBinary:
 				String opcode = InstructionUtils.getOpCode(str);
-				if( opcode.equals("+*") || opcode.equals("-*")  )
+				if( Objects.equals(opcode,"+*") || Objects.equals(opcode,"-*")  )
 					return MatrixMatrixAxpyGPUInstruction.parseInstruction(str);
 				else
 					return ArithmeticBinaryGPUInstruction.parseInstruction(str);

--- a/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
+++ b/src/main/java/org/apache/sysml/runtime/instructions/GPUInstructionParser.java
@@ -19,6 +19,7 @@
 package org.apache.sysml.runtime.instructions;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.apache.sysml.lops.RightIndex;
 import org.apache.sysml.runtime.DMLRuntimeException;


### PR DESCRIPTION
Hello,
The String "execType" and "opcode" in the two files may have potential risk of 
NullPointerException since they are immediately used after initialization. One recommended API is Objects.equals(String,String) which can avoid this exception.