### PR TITLE
[SYSTEMDS-2558][SYSTEMDS-2554][SYSTEMDS-2561] Fed frame recode transform (encode) support

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -76,6 +76,10 @@ public class FederatedData {
 		_varID = varID;
 	}
 	
+	public long getVarID() {
+		return _varID;
+	}
+	
 	public String getFilepath() {
 		return _filepath;
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
@@ -34,7 +34,9 @@ public class FederatedRequest implements Serializable {
 		READ_VAR, // create variable for local data, read on first access
 		PUT_VAR,  // receive data from main and store to local variable
 		GET_VAR,  // return local variable to main
-		EXEC_INST // execute arbitrary instruction over
+		EXEC_INST, // execute arbitrary instruction over
+		FRAME_ENCODE, // TODO replace with user defined functions
+		ENCODE_META
 	}
 	
 	private RequestType _method;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
@@ -36,7 +36,7 @@ public class FederatedRequest implements Serializable {
 		GET_VAR,  // return local variable to main
 		EXEC_INST, // execute arbitrary instruction over
 		FRAME_ENCODE, // TODO replace with user defined functions
-		ENCODE_META
+		CREATE_ENCODER
 	}
 	
 	private RequestType _method;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -19,9 +19,10 @@
 
 package org.apache.sysds.runtime.controlprogram.federated;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.util.Arrays;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -59,10 +60,9 @@ import org.apache.sysds.runtime.transform.encode.EncoderFactory;
 import org.apache.sysds.utils.JSONHelper;
 import org.apache.wink.json4j.JSONObject;
 
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
 
 public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 	protected static Logger log = Logger.getLogger(FederatedWorkerHandler.class);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 
@@ -162,7 +163,7 @@ public class FederationMap
 	 * @param forEachFunction function to execute for each pair
 	 */
 	public void forEachParallel(BiFunction<FederatedRange, FederatedData, Void> forEachFunction) {
-		CommonThreadPool pool = new CommonThreadPool(CommonThreadPool.get(_fedMap.size()));
+		ExecutorService pool = CommonThreadPool.get(_fedMap.size());
 
 		ArrayList<MappingTask> mappingTasks = new ArrayList<>();
 		for(Map.Entry<FederatedRange, FederatedData> fedMap : _fedMap.entrySet())
@@ -181,7 +182,7 @@ public class FederationMap
 	 * @return the new <code>FederationMap</code>
 	 */
 	public FederationMap mapParallel(long newVarID, BiFunction<FederatedRange, FederatedData, Void> mappingFunction) {
-		CommonThreadPool pool = new CommonThreadPool(CommonThreadPool.get(_fedMap.size()));
+		ExecutorService pool = CommonThreadPool.get(_fedMap.size());
 
 		FederationMap fedMapCopy = copyWithNewID(_ID);
 		ArrayList<MappingTask> mappingTasks = new ArrayList<>();

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/CPOperand.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/CPOperand.java
@@ -93,6 +93,10 @@ public class CPOperand
 	public boolean isMatrix() {
 		return _dataType.isMatrix();
 	}
+	
+	public boolean isFrame() {
+		return _dataType.isFrame();
+	}
 
 	public boolean isTensor() {
 		return _dataType.isTensor();

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
@@ -27,11 +27,12 @@ import org.apache.sysds.runtime.privacy.PrivacyPropagator;
 public abstract class FEDInstruction extends Instruction {
 	
 	public enum FEDType {
-		Init,
 		AggregateBinary,
 		AggregateUnary,
 		Append,
-		Binary
+		Binary,
+		Init,
+		MultiReturnParameterizedBuiltin
 	}
 	
 	protected final FEDType _fedType;

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.instructions.fed;
 
+import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
@@ -62,6 +63,17 @@ public class FEDInstructionUtils {
 				MatrixObject mo = ec.getMatrixObject(instruction.input2);
 				if(mo.isFederated())
 					return BinaryFEDInstruction.parseInstruction(inst.getInstructionString());
+			}
+		}
+		else if (inst instanceof MultiReturnParameterizedBuiltinCPInstruction) {
+			MultiReturnParameterizedBuiltinCPInstruction instruction = (MultiReturnParameterizedBuiltinCPInstruction) inst;
+			String opcode = instruction.getOpcode();
+			if(opcode.equals("transformencode") && instruction.input1.isFrame()) {
+				CacheableData<?> fo = ec.getCacheableData(instruction.input1);
+				if(fo.isFederated()) {
+					return MultiReturnParameterizedBuiltinFEDInstruction
+						.parseInstruction(instruction.getInstructionString());
+				}
 			}
 		}
 		return inst;

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.instructions.fed;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.matrix.data.FrameBlock;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+import org.apache.sysds.runtime.transform.encode.EncoderRecode;
+
+public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFEDInstruction {
+	protected final ArrayList<CPOperand> _outputs;
+
+	private MultiReturnParameterizedBuiltinFEDInstruction(Operator op, CPOperand input1, CPOperand input2,
+		ArrayList<CPOperand> outputs, String opcode, String istr) {
+		super(FEDType.MultiReturnParameterizedBuiltin, op, input1, input2, outputs.get(0), opcode, istr);
+		_outputs = outputs;
+	}
+
+	public CPOperand getOutput(int i) {
+		return _outputs.get(i);
+	}
+
+	public static MultiReturnParameterizedBuiltinFEDInstruction parseInstruction(String str) {
+		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
+		ArrayList<CPOperand> outputs = new ArrayList<>();
+		String opcode = parts[0];
+
+		if(opcode.equalsIgnoreCase("transformencode")) {
+			// one input and two outputs
+			CPOperand in1 = new CPOperand(parts[1]);
+			CPOperand in2 = new CPOperand(parts[2]);
+			outputs.add(new CPOperand(parts[3], Types.ValueType.FP64, Types.DataType.MATRIX));
+			outputs.add(new CPOperand(parts[4], Types.ValueType.STRING, Types.DataType.FRAME));
+			return new MultiReturnParameterizedBuiltinFEDInstruction(null, in1, in2, outputs, opcode, str);
+		}
+		else {
+			throw new DMLRuntimeException("Invalid opcode in MultiReturnBuiltin instruction: " + opcode);
+		}
+
+	}
+
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		// obtain and pin input frame
+		FrameObject fin = ec.getFrameObject(input1.getName());
+		String spec = ec.getScalarInput(input2).getStringValue();
+
+		Map<FederatedRange, FederatedData> fedMapping = fin.getFedMapping();
+
+		// first we use the spec to construct a meta frame which will provide us with info about the encodings
+		List<Pair<FederatedRange, Future<FederatedResponse>>> metaFutures = new ArrayList<>();
+		for(Map.Entry<FederatedRange, FederatedData> entry : fedMapping.entrySet()) {
+			Future<FederatedResponse> response = entry.getValue().executeFederatedOperation(new FederatedRequest(
+				FederatedRequest.FedMethod.ENCODE_META, spec, entry.getKey().getBeginDimsInt()[1] + 1), true);
+			metaFutures.add(new ImmutablePair<>(entry.getKey(), response));
+		}
+
+		// TODO support encodings other than recode
+		// the combined mappings for the frame columns (because we only support recode)
+		Map<String, Long>[] combinedRecodeMaps = new HashMap[(int) fin.getNumColumns()];
+		try {
+			for(Pair<FederatedRange, Future<FederatedResponse>> pair : metaFutures) {
+				FederatedRange range = pair.getKey();
+				FederatedResponse federatedResponse = pair.getValue().get();
+				if(federatedResponse.isSuccessful()) {
+					FrameBlock fb = (FrameBlock) federatedResponse.getData()[0];
+					combineRecodeMaps(combinedRecodeMaps, fb, range.getBeginDimsInt()[1]);
+				}
+			}
+		}
+		catch(InterruptedException | ExecutionException e) {
+			throw new DMLRuntimeException("Federated meta frame creation failed: " + e.getMessage());
+		}
+
+		// construct a single meta frameblock out of the multiple HashMaps with the recodings
+		FrameBlock meta = frameBlockFromRecodeMaps(combinedRecodeMaps);
+
+		// actually encode the frame block and construct an encoded matrix block at worker
+		List<Pair<Map.Entry<FederatedRange, FederatedData>, Future<FederatedResponse>>> encodedFutures = new ArrayList<>();
+		for(Map.Entry<FederatedRange, FederatedData> entry : fedMapping.entrySet()) {
+			FederatedRange fedRange = entry.getKey();
+			int columnStart = (int) fedRange.getBeginDims()[1];
+			int columnEnd = (int) fedRange.getEndDims()[1];
+			
+			// Slice out relevant meta part
+			// range is inclusive
+			FrameBlock slicedMeta = meta.slice(0, meta.getNumRows() - 1, columnStart, columnEnd - 1, null);
+			
+			Future<FederatedResponse> response = entry.getValue().executeFederatedOperation(new FederatedRequest(
+				FederatedRequest.FedMethod.FRAME_ENCODE, slicedMeta, spec, columnStart + 1), true);
+			encodedFutures.add(new ImmutablePair<>(entry, response));
+		}
+		
+		// construct a federated matrix with the encoded data
+		MatrixObject transformedMat = ec.getMatrixObject(getOutput(0));
+		transformedMat.getDataCharacteristics().set(fin.getDataCharacteristics());
+		Map<FederatedRange, FederatedData> transformedFedMapping = new HashMap<>();
+		try {
+			for(Pair<Map.Entry<FederatedRange, FederatedData>, Future<FederatedResponse>> data : encodedFutures) {
+				FederatedResponse federatedResponse = data.getValue().get();
+				if(federatedResponse.isSuccessful()) {
+					FederatedRange federatedRange = data.getKey().getKey();
+					FederatedData federatedData = data.getKey().getValue();
+					long varId = (long) federatedResponse.getData()[0];
+					
+					transformedFedMapping.put(federatedRange, new FederatedData(federatedData, varId));
+				}
+			}
+		}
+		catch(InterruptedException | ExecutionException e) {
+			throw new DMLRuntimeException("Federated transform apply failed: " + e.getMessage());
+		}
+		// set the federated mapping for the matrix
+		transformedMat.setFedMapping(transformedFedMapping);
+
+		// release input and outputs
+		ec.setFrameOutput(getOutput(1).getName(), meta);
+	}
+
+	private FrameBlock frameBlockFromRecodeMaps(Map<String, Long>[] combinedRecodeMaps) {
+		int rows = 0;
+		for(Map<String, Long> map : combinedRecodeMaps) {
+			if(map != null) {
+				rows = Integer.max(rows, map.size());
+			}
+		}
+		FrameBlock fb = new FrameBlock(combinedRecodeMaps.length, Types.ValueType.STRING);
+		fb.ensureAllocatedColumns(rows);
+
+		// find maximum number of elements needed for a column
+		int c = -1;
+		for(Map<String, Long> map : combinedRecodeMaps) {
+			c++;
+			if(map == null) {
+				continue;
+			}
+			int r = 0;
+			for(Map.Entry<String, Long> entry : map.entrySet()) {
+				fb.set(r++, c, EncoderRecode.constructRecodeMapEntry(entry.getKey(), entry.getValue()));
+			}
+		}
+		return fb;
+	}
+
+	private void combineRecodeMaps(Map<String, Long>[] combinedRecodeMaps, FrameBlock frameBlock, int startColumn) {
+		for(int c = 0; c < frameBlock.getNumColumns(); c++) {
+			HashMap<String, Long> recodeMap = frameBlock.getRecodeMap(c);
+			int columnCombined = startColumn + c;
+
+			if(recodeMap.isEmpty()) {
+				// no values present so no values needed in combinedRecodeMaps
+				continue;
+			}
+			else if(combinedRecodeMaps[columnCombined] == null) {
+				// the combined map was not yet needed for this column and therefore is not allocated yet
+				// we can just copy the map of the current frameblock
+				combinedRecodeMaps[columnCombined] = new HashMap<>(recodeMap);
+				continue;
+			}
+
+			// check if any keys are not yet in the combined mapping
+			Map<String, Long> combinedColumnRecodeMap = combinedRecodeMaps[columnCombined];
+			boolean keysMissing = !combinedColumnRecodeMap.keySet().containsAll(recodeMap.keySet());
+
+			if(keysMissing) {
+				// add new recode values
+				Set<String> allKeys = new HashSet<>(combinedColumnRecodeMap.keySet());
+				allKeys.addAll(recodeMap.keySet());
+
+				combinedColumnRecodeMap.clear();
+				long mapping = 1;
+				for(String key : allKeys)
+					combinedColumnRecodeMap.put(key, mapping++);
+			}
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -143,6 +143,10 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 					
 					transformedFedMapping.put(federatedRange, new FederatedData(federatedData, varId));
 				}
+				else {
+					throw new DMLRuntimeException(
+						"Federated request was not successful: " + federatedResponse.getErrorMessage());
+				}
 			}
 		}
 		catch(InterruptedException | ExecutionException e) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -20,8 +20,8 @@
 package org.apache.sysds.runtime.instructions.fed;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -85,12 +85,9 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 
 		Map<FederatedRange, FederatedData> fedMapping = fin.getFedMapping();
 
-		// add the encoder types we support in a federated environment
-		List<Encoder> encoderList = new ArrayList<>();
-		encoderList.add(new EncoderRecode());
-		encoderList.add(new EncoderPassThrough());
 		// the encoder in which the complete encoding information will be aggregated
-		EncoderComposite globalEncoder = new EncoderComposite(encoderList);
+		EncoderComposite globalEncoder = new EncoderComposite(
+			Arrays.asList(new EncoderRecode(), new EncoderPassThrough()));
 		// first create encoders at the federated workers, then collect them and aggregate them to a single large
 		// encoder
 		CommonThreadPool pool = new CommonThreadPool(CommonThreadPool.get(fedMapping.size()));

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
@@ -657,6 +657,9 @@ public class FrameBlock implements CacheBlock, Externalizable
 
 	///////
 	// serialization / deserialization (implementation of writable and externalizable)
+	// FIXME for FrameBlock fix write and readFields, it does not work if the Arrays are not yet
+	// allocated (after fixing remove hack in FederatedWorkerHandler.createFrameEncodeMeta(FederatedRequest) call to
+	// FrameBlock.ensureAllocatedColumns())
 	
 	@Override
 	public void write(DataOutput out) throws IOException {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
@@ -22,8 +22,11 @@ package org.apache.sysds.runtime.transform.encode;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.wink.json4j.JSONArray;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -121,6 +124,51 @@ public abstract class Encoder implements Serializable
 	 * @return output matrix block
 	 */
 	public abstract MatrixBlock apply(FrameBlock in, MatrixBlock out);
+
+	/**
+	 * Returns a new Encoder that only handles a sub range of columns.
+	 * 
+	 * @param colStart the start index of the sub-range (1-based, inclusive)
+	 * @param colEnd   the end index of the sub-range (1-based, exclusive)
+	 * @return an encoder of the same type, just for the sub-range
+	 */
+	public Encoder subRangeEncoder(int colStart, int colEnd) {
+		throw new DMLRuntimeException(
+			this.getClass().getName() + " does not support the creation of a sub-range encoder");
+	}
+
+	/**
+	 * Merges the column information, like how many columns the frame needs and which columns this encoder operates on.
+	 * 
+	 * @param other the other encoder of the same type
+	 * @param col   column at which the second encoder will be merged in (1-based)
+	 */
+	protected void mergeColumnInfo(Encoder other, int col) {
+		// update number of columns
+		if(col - 1 + other.getNumCols() > _colList.length)
+			_clen = col - 1 + other.getNumCols();
+
+		// update the new columns that this encoder operates on
+		Set<Integer> colListAgg = new HashSet<>();
+		for(int i : _colList)
+			colListAgg.add(i);
+		for(int i : other._colList)
+			colListAgg.add(col - 1 + i);
+		_colList = colListAgg.stream().mapToInt(i -> i).toArray();
+	}
+
+	/**
+	 * Merges another encoder, of a compatible type, in after a certain position. Resizes as necessary.
+	 * <code>Encoders</code> are compatible with themselves and <code>EncoderComposite</code> is compatible with every
+	 * other <code>Encoder</code>.
+	 * 
+	 * @param other the encoder that should be merged in
+	 * @param col   the position where it should be placed (1-based)
+	 */
+	public void mergeAt(Encoder other, int col) {
+		throw new DMLRuntimeException(
+			this.getClass().getName() + " does not support merging with " + other.getClass().getName());
+	}
 
 	/**
 	 * Construct a frame block out of the transform meta data.

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -41,6 +41,11 @@ public class EncoderFactory
 	public static Encoder createEncoder(String spec, String[] colnames, int clen, FrameBlock meta) {
 		return createEncoder(spec, colnames, UtilFunctions.nCopies(clen, ValueType.STRING), meta);
 	}
+	
+	public static Encoder createEncoder(String spec, String[] colnames, int clen, FrameBlock meta, int minCol,
+		int maxCol) {
+		return createEncoder(spec, colnames, UtilFunctions.nCopies(clen, ValueType.STRING), meta, minCol, maxCol);
+	}
 
 	public static Encoder createEncoder(String spec, String[] colnames, ValueType[] schema, int clen, FrameBlock meta) {
 		ValueType[] lschema = (schema==null) ? UtilFunctions.nCopies(clen, ValueType.STRING) : schema;
@@ -48,6 +53,12 @@ public class EncoderFactory
 	}
 	
 	public static Encoder createEncoder(String spec, String[] colnames, ValueType[] schema, FrameBlock meta) {
+		return createEncoder(spec, colnames, schema, meta, -1, -1);
+	}
+	
+	@SuppressWarnings("unchecked")
+	public static Encoder createEncoder(String spec, String[] colnames, ValueType[] schema, FrameBlock meta, int minCol,
+		int maxCol) {
 		Encoder encoder = null;
 		int clen = schema.length;
 		
@@ -55,23 +66,23 @@ public class EncoderFactory
 			//parse transform specification
 			JSONObject jSpec = new JSONObject(spec);
 			List<Encoder> lencoders = new ArrayList<>();
-		
+			
 			//prepare basic id lists (recode, feature hash, dummycode, pass-through)
 			List<Integer> rcIDs = Arrays.asList(ArrayUtils.toObject(
-				TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.RECODE.toString())));
+					TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.RECODE.toString(), minCol, maxCol)));
 			List<Integer>haIDs = Arrays.asList(ArrayUtils.toObject(
-				TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.HASH.toString())));
+					TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.HASH.toString(), minCol, maxCol)));
 			List<Integer> dcIDs = Arrays.asList(ArrayUtils.toObject(
-				TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.DUMMYCODE.toString())));
+					TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.DUMMYCODE.toString(), minCol, maxCol)));
 			List<Integer> binIDs = TfMetaUtils.parseBinningColIDs(jSpec, colnames);
 			//note: any dummycode column requires recode as preparation, unless it follows binning
 			rcIDs = except(unionDistinct(rcIDs, except(dcIDs, binIDs)), haIDs);
 			List<Integer> ptIDs = except(except(UtilFunctions.getSeqList(1, clen, 1),
 				unionDistinct(rcIDs,haIDs)), binIDs);
 			List<Integer> oIDs = Arrays.asList(ArrayUtils.toObject(
-				TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.OMIT.toString())));
+					TfMetaUtils.parseJsonIDList(jSpec, colnames, TfMethod.OMIT.toString(), minCol, maxCol)));
 			List<Integer> mvIDs = Arrays.asList(ArrayUtils.toObject(
-				TfMetaUtils.parseJsonObjectIDList(jSpec, colnames, TfMethod.IMPUTE.toString())));
+					TfMetaUtils.parseJsonObjectIDList(jSpec, colnames, TfMethod.IMPUTE.toString())));
 			
 			//create individual encoders
 			if( !rcIDs.isEmpty() ) {
@@ -86,7 +97,7 @@ public class EncoderFactory
 			}
 			if( !ptIDs.isEmpty() )
 				lencoders.add(new EncoderPassThrough(
-					ArrayUtils.toPrimitive(ptIDs.toArray(new Integer[0])), clen));
+						ArrayUtils.toPrimitive(ptIDs.toArray(new Integer[0])), clen));
 			if( !binIDs.isEmpty() )
 				lencoders.add(new EncoderBin(jSpec, colnames, schema.length));
 			if( !dcIDs.isEmpty() )
@@ -105,8 +116,8 @@ public class EncoderFactory
 			//initialize meta data w/ robustness for superset of cols
 			if( meta != null ) {
 				String[] colnames2 = meta.getColumnNames();
-				if( !TfMetaUtils.isIDSpec(jSpec) && colnames!=null && colnames2!=null 
-					&& !ArrayUtils.isEquals(colnames, colnames2) ) 
+				if( !TfMetaUtils.isIDSpec(jSpec) && colnames!=null && colnames2!=null
+						&& !ArrayUtils.isEquals(colnames, colnames2) )
 				{
 					HashMap<String, Integer> colPos = getColumnPositions(colnames2);
 					//create temporary meta frame block w/ shallow column copy
@@ -115,7 +126,7 @@ public class EncoderFactory
 					for( int i=0; i<colnames.length; i++ ) {
 						if( !colPos.containsKey(colnames[i]) ) {
 							throw new DMLRuntimeException("Column name not found in meta data: "
-								+colnames[i]+" (meta: "+Arrays.toString(colnames2)+")");
+									+colnames[i]+" (meta: "+Arrays.toString(colnames2)+")");
 						}
 						int pos = colPos.get(colnames[i]);
 						meta2.setColumn(i, meta.getColumn(pos));

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderRecode.java
@@ -19,9 +19,12 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.wink.json4j.JSONException;
@@ -45,6 +48,14 @@ public class EncoderRecode extends Encoder
 	{
 		super(null, clen);
 		_colList = TfMetaUtils.parseJsonIDList(parsedSpec, colnames, TfMethod.RECODE.toString());
+	}
+	
+	private EncoderRecode(int[] colList, int clen) {
+		super(colList, clen);
+	}
+	
+	public EncoderRecode() {
+		this(new int[0], 0);
 	}
 	
 	public HashMap<Integer, HashMap<String,Long>> getCPRecodeMaps() { 
@@ -145,6 +156,62 @@ public class EncoderRecode extends Encoder
 		}
 		
 		return out;
+	}
+
+	@Override
+	public Encoder subRangeEncoder(int colStart, int colEnd) {
+		if (colStart - 1 >= _clen)
+			return null;
+		
+		List<Integer> cols = new ArrayList<>();
+		HashMap<Integer, HashMap<String, Long>> rcdMaps = new HashMap<>();
+		for (int col : _colList) {
+			if (col >= colStart && col < colEnd) {
+				// add the correct column, removed columns before start
+				// colStart - 1 because colStart is 1-based
+				int corrColumn = col - (colStart - 1);
+				cols.add(corrColumn);
+				// copy rcdMap for column
+				rcdMaps.put(corrColumn, new HashMap<>(_rcdMaps.get(col)));
+			}
+		}
+		if (cols.isEmpty())
+			// empty encoder -> sub range encoder does not exist
+			return null;
+		
+		int[] colList = cols.stream().mapToInt(i -> i).toArray();
+		EncoderRecode subRangeEncoder = new EncoderRecode(colList, colEnd - colStart);
+		subRangeEncoder._rcdMaps = rcdMaps;
+		return subRangeEncoder;
+	}
+
+	@Override
+	public void mergeAt(Encoder other, int col) {
+		if(other instanceof EncoderRecode) {
+			mergeColumnInfo(other, col);
+			
+			// merge together overlapping columns or add new columns
+			EncoderRecode otherRec = (EncoderRecode) other;
+			for (int otherColID : other._colList) {
+				int colID = otherColID + col - 1;
+				//allocate column map if necessary
+				if( !_rcdMaps.containsKey(colID) )
+					_rcdMaps.put(colID, new HashMap<>());
+				
+				HashMap<String, Long> otherMap = otherRec._rcdMaps.get(otherColID);
+				if(otherMap != null) {
+					// for each column, add all non present recode values
+					for(Map.Entry<String, Long> entry : otherMap.entrySet()) {
+						if (lookupRCDMap(colID, entry.getKey()) == -1) {
+							// key does not yet exist
+							putCode(_rcdMaps.get(colID), entry.getKey());
+						}
+					}
+				}
+			}
+			return;
+		}
+		super.mergeAt(other, col);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/meta/TfMetaUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/meta/TfMetaUtils.java
@@ -83,7 +83,7 @@ public class TfMetaUtils
 	 *
 	 * @param spec transform specification as json string
 	 * @param colnames column names
-	 * @param group ?
+	 * @param group attribute name in json class
 	 * @return list of column ids
 	 * @throws JSONException if JSONException occurs
 	 */
@@ -94,11 +94,11 @@ public class TfMetaUtils
 	}
 	
 	/**
-	 * TODO consolidate external and internal json spec definitions
-	 * 
 	 * @param spec transform specification as json string
 	 * @param colnames column names
-	 * @param group ?
+	 * @param group attribute name in json class
+	 * @param minCol start of columns to ignore (1-based, inclusive, if -1 not used)
+	 * @param maxCol end of columns to ignore (1-based, exclusive, if -1 not used)
 	 * @return list of column ids
 	 * @throws JSONException if JSONException occurs
 	 */

--- a/src/main/java/org/apache/sysds/runtime/transform/meta/TfMetaUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/meta/TfMetaUtils.java
@@ -25,18 +25,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.wink.json4j.JSONArray;
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
 import org.apache.sysds.api.jmlc.Connection;
-import org.apache.sysds.lops.Lop;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.lops.Lop;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
@@ -47,6 +45,9 @@ import org.apache.sysds.runtime.transform.decode.DecoderRecode;
 import org.apache.sysds.runtime.util.CollectionUtils;
 import org.apache.sysds.runtime.util.HDFSTool;
 import org.apache.sysds.runtime.util.UtilFunctions;
+import org.apache.wink.json4j.JSONArray;
+import org.apache.wink.json4j.JSONException;
+import org.apache.wink.json4j.JSONObject;
 
 public class TfMetaUtils 
 {

--- a/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
@@ -129,7 +129,7 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 		rtplatform = Types.ExecMode.SINGLE_NODE;
 		// Run reference dml script with normal matrix
 		fullDMLScriptName = HOME + testFile + "Reference.dml";
-		programArgs = new String[] {"-args", input("A"), expected("B")};
+		programArgs = new String[] {"-args", input(inputIdentifier), expected("B")};
 		runTest(true, false, null, -1);
 
 		// reference file should not be written to hdfs

--- a/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
@@ -128,7 +128,7 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 		// we need the reference file to not be written to hdfs, so we get the correct format
 		rtplatform = Types.ExecMode.SINGLE_NODE;
 		// Run reference dml script with normal matrix
-		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+		fullDMLScriptName = HOME + testFile + "Reference.dml";
 		programArgs = new String[] {"-args", input("A"), expected("B")};
 		runTest(true, false, null, -1);
 

--- a/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/FederatedConstructionTest.java
@@ -91,7 +91,7 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 	/*
 	 * like other federated functionality, SPARK execution mode is not yet working (waiting for better integration of
 	 * federated instruction building, like propagating information that object is federated)
-	 * 
+	 *
 	 * @Test public void federatedFrameConstructionSP() throws IOException {
 	 * federatedFrameConstruction(Types.ExecMode.SPARK); }
 	 */
@@ -128,8 +128,8 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 		// we need the reference file to not be written to hdfs, so we get the correct format
 		rtplatform = Types.ExecMode.SINGLE_NODE;
 		// Run reference dml script with normal matrix
-		fullDMLScriptName = HOME + testFile + "Reference.dml";
-		programArgs = new String[] {"-args", input(inputIdentifier), expected("B")};
+		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+		programArgs = new String[] {"-args", input("A"), expected("B")};
 		runTest(true, false, null, -1);
 
 		// reference file should not be written to hdfs

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
@@ -87,7 +87,7 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 		ExecMode platformOld = rtplatform;
 		rtplatform = ExecMode.SINGLE_NODE;
 
-		Thread t1 = null, t2 = null;
+		Thread t1 = null, t2 = null, t3 = null, t4 = null;
 		try {
 			getAndLoadTestConfiguration(TEST_NAME1);
 
@@ -95,6 +95,10 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 			t1 = startLocalFedWorker(port1);
 			int port2 = getRandomAvailablePort();
 			t2 = startLocalFedWorker(port2);
+			int port3 = getRandomAvailablePort();
+			t3 = startLocalFedWorker(port3);
+			int port4 = getRandomAvailablePort();
+			t4 = startLocalFedWorker(port4);
 
 			// schema
 			Types.ValueType[] schema = new Types.ValueType[cols / 2];
@@ -120,9 +124,9 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 
 			programArgs = new String[] {"-nvargs",
 				"in_AU=" + TestUtils.federatedAddress("localhost", port1, input("AU")),
-				"in_AL=" + TestUtils.federatedAddress("localhost", port1, input("AL")),
-				"in_BU=" + TestUtils.federatedAddress("localhost", port1, input("BU")),
-				"in_BL=" + TestUtils.federatedAddress("localhost", port1, input("BL")), "rows=" + rows, "cols=" + cols,
+				"in_AL=" + TestUtils.federatedAddress("localhost", port2, input("AL")),
+				"in_BU=" + TestUtils.federatedAddress("localhost", port3, input("BU")),
+				"in_BL=" + TestUtils.federatedAddress("localhost", port4, input("BL")), "rows=" + rows, "cols=" + cols,
 				"spec_file=" + SCRIPT_DIR + TEST_DIR + SPEC, "out=" + output("FO"), "format=" + format.toString()};
 
 			// run test
@@ -147,6 +151,8 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 		finally {
 			TestUtils.shutdownThread(t1);
 			TestUtils.shutdownThread(t2);
+			TestUtils.shutdownThread(t3);
+			TestUtils.shutdownThread(t4);
 			rtplatform = platformOld;
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.transform;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.runtime.io.FrameReader;
+import org.apache.sysds.runtime.io.FrameReaderFactory;
+import org.apache.sysds.runtime.matrix.data.FrameBlock;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
+	private static final String TEST_NAME1 = "TransformFederatedEncodeDecode";
+	private static final String TEST_DIR = "functions/transform/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + TransformFederatedEncodeDecodeTest.class.getSimpleName()
+		+ "/";
+
+	private static final String SPEC = "TransformEncodeDecodeSpec.json";
+
+	private static final int rows = 1234;
+	private static final int cols = 2;
+	private static final double sparsity1 = 0.9;
+	private static final double sparsity2 = 0.1;
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"FO"}));
+	}
+
+	@Test
+	public void runTestCSVDenseCP() {
+		runTransformEncodeDecodeTest(false, Types.FileFormat.CSV);
+	}
+
+	@Test
+	public void runTestCSVSparseCP() {
+		runTransformEncodeDecodeTest(true, Types.FileFormat.CSV);
+	}
+
+	@Test
+	public void runTestTextcellDenseCP() {
+		runTransformEncodeDecodeTest(false, Types.FileFormat.TEXT);
+	}
+
+	@Test
+	public void runTestTextcellSparseCP() {
+		runTransformEncodeDecodeTest(true, Types.FileFormat.TEXT);
+	}
+
+	@Test
+	public void runTestBinaryDenseCP() {
+		runTransformEncodeDecodeTest(false, Types.FileFormat.BINARY);
+	}
+
+	@Test
+	public void runTestBinarySparseCP() {
+		runTransformEncodeDecodeTest(true, Types.FileFormat.BINARY);
+	}
+
+	private void runTransformEncodeDecodeTest(boolean sparse, Types.FileFormat format) {
+		ExecMode platformOld = rtplatform;
+		rtplatform = ExecMode.SINGLE_NODE;
+
+		Thread t1 = null, t2 = null;
+		try {
+			getAndLoadTestConfiguration(TEST_NAME1);
+
+			int port1 = getRandomAvailablePort();
+			t1 = startLocalFedWorker(port1);
+			int port2 = getRandomAvailablePort();
+			t2 = startLocalFedWorker(port2);
+
+			// schema
+			Types.ValueType[] schema = new Types.ValueType[cols / 2];
+			Arrays.fill(schema, Types.ValueType.FP64);
+			// generate and write input data
+			// A is the data that will be aggregated and not recoded
+			double[][] A = TestUtils.round(getRandomMatrix(rows, cols / 2, 1, 15, sparse ? sparsity2 : sparsity1, 7));
+			writeInputFrameWithMTD("A", A, false, schema, format);
+
+			// B will be recoded and will be the column that will be grouped by
+			Arrays.fill(schema, Types.ValueType.STRING);
+			// we set sparsity to 1.0 to ensure all the string labels exist
+			double[][] B = TestUtils.round(getRandomMatrix(rows, cols / 2, 1, 15, 1.0, 8));
+			writeInputFrameWithMTD("B", B, false, schema, format);
+
+			fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME1 + ".dml";
+
+			programArgs = new String[] {"-explain", "-args", TestUtils.federatedAddress("localhost", port1, input("A")),
+				TestUtils.federatedAddress("localhost", port1, input("B")), Integer.toString(rows),
+				Integer.toString(cols / 2), Integer.toString(cols), SCRIPT_DIR + TEST_DIR + SPEC, output("FO"),
+				format.toString()};
+
+			// run test
+			runTest(true, false, null, -1);
+
+			// compare matrices (values recoded to identical codes)
+			FrameReader reader = FrameReaderFactory.createFrameReader(format);
+			FrameBlock FO = reader.readFrameFromHDFS(output("FO"), 15, 2);
+			HashMap<String, Long> cFA = getCounts(A, B);
+			Iterator<String[]> iterFO = FO.getStringRowIterator();
+			while(iterFO.hasNext()) {
+				String[] row = iterFO.next();
+				Double expected = (double) cFA.get(row[1]);
+				Double val = (row[0] != null) ? Double.parseDouble(row[0]) : 0;
+				Assert.assertEquals("Output aggregates don't match: " + expected + " vs " + val, expected, val);
+			}
+		}
+		catch(Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+		finally {
+			TestUtils.shutdownThread(t1);
+			TestUtils.shutdownThread(t2);
+			rtplatform = platformOld;
+		}
+	}
+
+	private static HashMap<String, Long> getCounts(double[][] countFrame, double[][] groupFrame) {
+		HashMap<String, Long> ret = new HashMap<>();
+		for(int i = 0; i < countFrame.length; i++) {
+			String key = "Str" + groupFrame[i][0];
+			Long tmp = ret.get(key);
+			ret.put(key, (tmp != null) ? tmp + 1 : 1);
+		}
+		return ret;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
@@ -102,20 +102,28 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 			// generate and write input data
 			// A is the data that will be aggregated and not recoded
 			double[][] A = TestUtils.round(getRandomMatrix(rows, cols / 2, 1, 15, sparse ? sparsity2 : sparsity1, 7));
-			writeInputFrameWithMTD("A", A, false, schema, format);
+			double[][] AUpper = Arrays.copyOf(A, rows / 2);
+			double[][] ALower = Arrays.copyOfRange(A, rows / 2, rows);
+			writeInputFrameWithMTD("AU", AUpper, false, schema, format);
+			writeInputFrameWithMTD("AL", ALower, false, schema, format);
 
 			// B will be recoded and will be the column that will be grouped by
 			Arrays.fill(schema, Types.ValueType.STRING);
 			// we set sparsity to 1.0 to ensure all the string labels exist
 			double[][] B = TestUtils.round(getRandomMatrix(rows, cols / 2, 1, 15, 1.0, 8));
-			writeInputFrameWithMTD("B", B, false, schema, format);
+			double[][] BUpper = Arrays.copyOf(B, rows / 2);
+			double[][] BLower = Arrays.copyOfRange(B, rows / 2, rows);
+			writeInputFrameWithMTD("BU", BUpper, false, schema, format);
+			writeInputFrameWithMTD("BL", BLower, false, schema, format);
 
 			fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME1 + ".dml";
 
-			programArgs = new String[] {"-args", TestUtils.federatedAddress("localhost", port1, input("A")),
-				TestUtils.federatedAddress("localhost", port1, input("B")), Integer.toString(rows),
-				Integer.toString(cols / 2), Integer.toString(cols), SCRIPT_DIR + TEST_DIR + SPEC, output("FO"),
-				format.toString()};
+			programArgs = new String[] {"-nvargs",
+				"in_AU=" + TestUtils.federatedAddress("localhost", port1, input("AU")),
+				"in_AL=" + TestUtils.federatedAddress("localhost", port1, input("AL")),
+				"in_BU=" + TestUtils.federatedAddress("localhost", port1, input("BU")),
+				"in_BL=" + TestUtils.federatedAddress("localhost", port1, input("BL")), "rows=" + rows, "cols=" + cols,
+				"spec_file=" + SCRIPT_DIR + TEST_DIR + SPEC, "out=" + output("FO"), "format=" + format.toString()};
 
 			// run test
 			runTest(true, false, null, -1);

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFederatedEncodeDecodeTest.java
@@ -112,7 +112,7 @@ public class TransformFederatedEncodeDecodeTest extends AutomatedTestBase {
 
 			fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME1 + ".dml";
 
-			programArgs = new String[] {"-explain", "-args", TestUtils.federatedAddress("localhost", port1, input("A")),
+			programArgs = new String[] {"-args", TestUtils.federatedAddress("localhost", port1, input("A")),
 				TestUtils.federatedAddress("localhost", port1, input("B")), Integer.toString(rows),
 				Integer.toString(cols / 2), Integer.toString(cols), SCRIPT_DIR + TEST_DIR + SPEC, output("FO"),
 				format.toString()};

--- a/src/test/scripts/functions/transform/TransformFederatedEncodeDecode.dml
+++ b/src/test/scripts/functions/transform/TransformFederatedEncodeDecode.dml
@@ -19,8 +19,12 @@
 #
 #-------------------------------------------------------------
 
-F1 = federated(type="frame", addresses=list($1, $2), ranges=list(list(0,0), list($3, $4), list(0,$4), list($3,$5)));
-jspec = read($6, data_type="scalar", value_type="string");
+F1 = federated(type="frame", addresses=list($in_AU, $in_AL, $in_BU, $in_BL), ranges=
+  list(list(0,0), list($rows / 2, $cols / 2), # AUpper range
+    list($rows / 2, 0), list($rows, $cols / 2), # ALower range
+    list(0, $cols / 2), list($rows / 2, $cols), # BUpper range
+    list($rows / 2, $cols / 2), list($rows, $cols))); # BLower range
+jspec = read($spec_file, data_type="scalar", value_type="string");
 
 [X, M] = transformencode(target=F1, spec=jspec);
 
@@ -29,5 +33,5 @@ Ag = cbind(A, seq(1,nrow(A)));
 
 F2 = transformdecode(target=Ag, spec=jspec, meta=M);
 
-write(F2, $7, format=$8);
+write(F2, $out, format=$format);
 

--- a/src/test/scripts/functions/transform/TransformFederatedEncodeDecode.dml
+++ b/src/test/scripts/functions/transform/TransformFederatedEncodeDecode.dml
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+F1 = federated(type="frame", addresses=list($1, $2), ranges=list(list(0,0), list($3, $4), list(0,$4), list($3,$5)));
+jspec = read($6, data_type="scalar", value_type="string");
+
+[X, M] = transformencode(target=F1, spec=jspec);
+
+A = aggregate(target=X[,1], groups=X[,2], fn="count");
+Ag = cbind(A, seq(1,nrow(A)));
+
+F2 = transformdecode(target=Ag, spec=jspec, meta=M);
+
+write(F2, $7, format=$8);
+


### PR DESCRIPTION
This adds functionality for a federated recode transform. The resulting matrix will also be federated. 
Currently none of the other transform modes are supported and will result in failure (note: WIP). The decode works, but it is not a federated operation, instead the federated matrices are just sent back to the master and a local decode is executed.
This is again is quite a large PR so an early look (@Baunsgaard ?) would be appreciated while I continue to adapt things to support other encodings.
Federated decode will be done in a separate PR.

I already added the initial privacy features, but @sebwrede you might want to take a closer look since the current recode implementation leaks all the distinct values of columns to the master which could be reason for another level of privacy.