### PR TITLE
Check for extra values in test matrix comparison.

### DIFF
--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -217,10 +217,13 @@ public class TestUtils
 
 				readValuesFromFileStreamAndPut(outIn, actualValues);
 			}
-			
+
+			Set<CellIndex> allKeys = new HashSet<>();
+			allKeys.addAll(expectedValues.keySet());
+			allKeys.addAll(actualValues.keySet());
 
 			int countErrors = 0;
-			for (CellIndex index : expectedValues.keySet()) {
+			for (CellIndex index : allKeys) {
 				Double expectedValue = expectedValues.get(index);
 				Double actualValue = actualValues.get(index);
 				if (expectedValue == null)
@@ -346,8 +349,11 @@ public class TestUtils
 
 		readActualAndExpectedFile(null, expectedFile, actualDir, expectedValues, actualValues);
 
+		Set<CellIndex> allKeys = new HashSet<>();
+		allKeys.addAll(expectedValues.keySet());
+		allKeys.addAll(actualValues.keySet());
 		int countErrors = 0;
-		for(CellIndex index : expectedValues.keySet()) {
+		for(CellIndex index : allKeys) {
 			Double expectedValue = (Double) expectedValues.get(index);
 			Double actualValue = (Double) actualValues.get(index);
 			if(expectedValue == null)
@@ -383,8 +389,11 @@ public class TestUtils
 
 		readActualAndExpectedFile(schema, expectedFile, actualDir, expectedValues, actualValues);
 
+		Set<CellIndex> allKeys = new HashSet<>();
+		allKeys.addAll(expectedValues.keySet());
+		allKeys.addAll(actualValues.keySet());
 		int countErrors = 0;
-		for(CellIndex index : expectedValues.keySet()) {
+		for(CellIndex index : allKeys) {
 			Object expectedValue = expectedValues.get(index);
 			Object actualValue = actualValues.get(index);
 
@@ -1107,9 +1116,12 @@ public class TestUtils
 				FSDataInputStream fsout = fs.open(file.getPath());
 				readValuesFromFileStream(fsout, actualValues);
 			}
+			Set<CellIndex> allKeys = new HashSet<>();
+			allKeys.addAll(expectedValues.keySet());
+			allKeys.addAll(actualValues.keySet());
 
 			int countErrors = 0;
-			for (CellIndex index : expectedValues.keySet()) {
+			for (CellIndex index : allKeys) {
 				Double expectedValue = expectedValues.get(index);
 				Double actualValue = actualValues.get(index);
 				if (expectedValue == null)


### PR DESCRIPTION
In the case of expected matrices with zero values, TestUtils was not
correctly checking whether the actual test output matrix does have
values in these places.