### PR TITLE
TODO: forloop read

### DIFF
--- a/src/test/java/org/apache/sysds/test/functions/io/ForLoopRead.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/ForLoopRead.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.io;
+
+import org.junit.Test;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+
+public class ForLoopRead extends AutomatedTestBase 
+{
+	private final static String TEST_DIR = "functions/io/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ForLoopRead.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "forLoopRead";
+	
+	@Override
+	public void setUp() {
+		// positive tests
+		addTestConfiguration(TEST_NAME,
+			new TestConfiguration(TEST_CLASS_DIR, "forLoopRead", new String[] { }));
+		
+	}
+
+	@Test
+	public void testSimple() {
+		TestConfiguration config = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
+		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME + ".dml";
+		programArgs = new String[] {};
+
+		// output = runTest(true, false, null, -1).toString();
+
+		String out = runTest(true, false, null, -1).toString();
+		System.out.println(out);
+	}
+
+}

--- a/src/test/scripts/functions/io/forLoopRead.dml
+++ b/src/test/scripts/functions/io/forLoopRead.dml
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,15 +19,9 @@
 #
 #-------------------------------------------------------------
 
-log4j.rootLogger=ERROR,console
-
-log4j.logger.org.apache.sysds.test=INFO
-log4j.logger.org.apache.sysds.test.AutomatedTestBase=ERROR
-log4j.logger.org.apache.sysds=WARN
-log4j.logger.org.apache.spark=OFF
-log4j.logger.org.apache.hadoop=OFF
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+d = matrix(0, rows =1, cols = 1)
+for(x in 1:3){
+    v = read("src/test/scripts/functions/io/in/" + x + ".csv", rows=1, cols=1, format="csv" )
+    d = cbind(d,v)
+}
+print(toString(d));


### PR DESCRIPTION
This PR showcase a current limitation of the system where if one construct the sting path to read the system is unable to read the given file. It is not an issue if the path is created outside a for loop but in connection with the for loop the reading fails.

The PR does not contain a fix for the given problem.

