### PR TITLE
[SYSTEMDS-2616] Detect schema parallel

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
@@ -36,10 +36,10 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction
 		// get input frames
 		FrameBlock inBlock1 = ec.getFrameInput(input1.getName());
 		FrameBlock inBlock2 = ec.getFrameInput(input2.getName());
-		
+
 		if(getOpcode().equals("dropInvalidType")) {
 			// Perform computation using input frames, and produce the result frame
-			FrameBlock retBlock = inBlock1.dropInvalid(inBlock2);
+			FrameBlock retBlock = inBlock1.dropInvalidType(inBlock2);
 			// Attach result frame with FrameBlock associated with output_name
 			ec.setFrameOutput(output.getName(), retBlock);
 		}
@@ -50,7 +50,7 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction
 			// Attach result frame with FrameBlock associated with output_name
 			ec.setFrameOutput(output.getName(), outBlock);
 		}
-		
+
 		// Release the memory occupied by input frames
 		ec.releaseFrameInput(input1.getName());
 		ec.releaseFrameInput(input2.getName());

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
@@ -36,7 +36,7 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction
 		// get input frames
 		FrameBlock inBlock1 = ec.getFrameInput(input1.getName());
 		FrameBlock inBlock2 = ec.getFrameInput(input2.getName());
-
+		
 		if(getOpcode().equals("dropInvalidType")) {
 			// Perform computation using input frames, and produce the result frame
 			FrameBlock retBlock = inBlock1.dropInvalidType(inBlock2);
@@ -50,7 +50,7 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction
 			// Attach result frame with FrameBlock associated with output_name
 			ec.setFrameOutput(output.getName(), outBlock);
 		}
-
+		
 		// Release the memory occupied by input frames
 		ec.releaseFrameInput(input1.getName());
 		ec.releaseFrameInput(input2.getName());

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/BinaryFrameFrameSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/BinaryFrameFrameSPInstruction.java
@@ -95,7 +95,7 @@ public class BinaryFrameFrameSPInstruction extends BinarySPInstruction {
 
 		@Override
 		public FrameBlock call(FrameBlock arg0) throws Exception {
-			return arg0.dropInvalid(schema_frame);
+			return arg0.dropInvalidType(schema_frame);
 		}
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
@@ -68,45 +68,59 @@ public class FrameDropInvalidTypeTest extends AutomatedTestBase
 
 	@Test
 	public void testDoubleinStringCP() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 1, LopProperties.ExecType.CP);
+		// This test now verifies floating points are okay in string columns
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 1, LopProperties.ExecType.CP, true);
 	}
 
 	@Test
 	public void testDoubleinStringSpark() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 1, LopProperties.ExecType.SPARK);
+		// This test now verifies floating points are okay in string columns
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 1, LopProperties.ExecType.SPARK, true);
 	}
 
 	@Test
 	public void testStringInDouble() {
+		// This test now verifies strings are removed in float columns
 		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 2, LopProperties.ExecType.CP);
 	}
 
 	@Test
 	public void testStringInDoubleSpark() {
+		// This test now verifies strings are removed in float columns
 		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 3, 2, LopProperties.ExecType.SPARK);
 	}
 
 	@Test
 	public void testDoubleInFloat() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 3, LopProperties.ExecType.CP);
+		// This test now verifies that changing from FP64 to FP32 is okay.
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 3, LopProperties.ExecType.CP,true);
 	}
 
 	@Test
 	public void testDoubleInFloatSpark() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 3, LopProperties.ExecType.SPARK);
+		// This test now verifies that changing from FP64 to FP32 is okay.
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 3, LopProperties.ExecType.SPARK, true);
 	}
 
 	@Test
 	public void testLongInInt() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 4, LopProperties.ExecType.CP);
+		// This test now verifies that changing from INT32 to INT64 is okay.
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 4, LopProperties.ExecType.CP, true);
 	}
 
 	@Test
 	public void testLongInIntSpark() {
-		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 4, LopProperties.ExecType.SPARK);
+		// This test now verifies that changing from INT32 to INT64 is okay.
+		runIsCorrectTest(schemaStrings, rows, schemaStrings.length, 5, 4, LopProperties.ExecType.SPARK, true);
 	}
+
 	private void runIsCorrectTest(ValueType[] schema, int rows, int cols,
-		int badValues, int test, LopProperties.ExecType et)
+								  int badValues, int test, LopProperties.ExecType et){
+		runIsCorrectTest(schema, rows, cols, badValues, test, et, false);
+	}
+
+	private void runIsCorrectTest(ValueType[] schema, int rows, int cols,
+		int badValues, int test, LopProperties.ExecType et, boolean ignore)
 	{
 		Types.ExecMode platformOld = setExecMode(et);
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
@@ -182,7 +196,7 @@ public class FrameDropInvalidTypeTest extends AutomatedTestBase
 
 			int nullNum = Math.toIntExact(data.stream().filter(s -> s == null).count());
 			//verify output schema
-			Assert.assertEquals("Wrong result: " + nullNum + ".", badValues, nullNum);
+			Assert.assertEquals("Wrong result: " + nullNum + ".", ignore ? 0 : badValues, nullNum);
 		}
 		catch (Exception ex) {
 			throw new RuntimeException(ex);


### PR DESCRIPTION
Change in detect schema for frame blocks,

- Parallel operation across columns
- Reduced minimum number of rows to sample
- moved type detection to type method to simplify logic in sampling
- Removed resampling if null field found, if all samples are null the UNKNOWN datatype is assigned.