### PR TITLE
[MINOR] Fix POM for jacoco skipping

### DIFF
--- a/.github/workflows/componentTests.yml
+++ b/.github/workflows/componentTests.yml
@@ -48,14 +48,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
-    - name: Maven clean compile & test-compile
-      run: mvn clean compile test-compile
-
     - name: Component Tests
       run: |
         log="/tmp/sysdstest.log"
         echo "Starting Tests"
-        mvn surefire:test -DskipTests=false -Dtest=org.apache.sysds.test.component.*.** 2>&1 > $log
+        mvn test -D maven.test.skip=false -Dtest=org.apache.sysds.test.component.*.** 2>&1 > $log
         grep_args="SUCCESS"
         grepvals="$( tail -n 100 $log | grep $grep_args)"
         if [[ $grepvals == *"SUCCESS"* ]]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,20 +24,11 @@
 
 cd /github/workspace
 
-build="$(mvn -T 2 clean compile test-compile | grep 'BUILD')"
-
-if [[ $build == *"SUCCESS"* ]]; then
-  echo "Successfull build"
-else
-  echo "failed building"
-  exit 1
-fi
-
 log="/tmp/sysdstest.log"
 
 echo "Starting Tests"
 
-mvn surefire:test -DskipTests=false -Dtest=$1 2>&1 > $log
+mvn test -D maven.test.skip=false -Dtest=$1 2>&1 > $log
 
 grep_args="SUCCESS"
 grepvals="$( tail -n 100 $log | grep $grep_args)"

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
 		<jcuda.scope>provided</jcuda.scope>
 		<jcuda.version>10.2.0</jcuda.version>
 		<!-->Testing settings<!-->
-		<skipTests>true</skipTests>
+		<maven.test.skip>true</maven.test.skip>
+		<jacoco.skip>true</jacoco.skip>
 		<argLine>-Xms4g -Xmx4g -Xmn400m</argLine>
 	</properties>
 
@@ -256,7 +257,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M4</version><!--$NO-MVN-MAN-VER$ -->
 				<configuration>
-					<skipTests>${skipTests}</skipTests>
+					<skipTests>${maven.test.skip}</skipTests>
 					<parallel>classes</parallel>
 					<!-- <useUnlimitedThreads>true</useUnlimitedThreads> -->
 					<threadCount>12</threadCount>


### PR DESCRIPTION
This commit changes the Pom file to not execute any of the test steps
while building the project per default.

to enable tests use the flag '-D maven.test.skip=false'.
to enable code coverage use also the flag '-D jacoco..skip=false'

As a nice bonus, the time to package the project is reduced by ~50%