### PR TITLE
[MINOR] Usability Stack trace

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -33,6 +33,7 @@ import java.util.Scanner;
 
 import org.apache.commons.cli.AlreadySelectedException;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -148,16 +149,43 @@ public class DMLScript
 	}
 
 	/**
+	 * Main entry point for systemDS dml script execution
 	 *
 	 * @param args command-line arguments
-	 * @throws IOException if an IOException occurs in the hadoop GenericOptionsParser
 	 */
 	public static void main(String[] args)
-		throws IOException, ParseException, DMLScriptException
 	{
-		Configuration conf = new Configuration(ConfigurationManager.getCachedJobConf());
-		String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
-		DMLScript.executeScript(conf, otherArgs);
+		try{
+			Configuration conf = new Configuration(ConfigurationManager.getCachedJobConf());
+			String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
+			DMLScript.executeScript(conf, otherArgs);
+		} catch(Exception e){
+			for(String s: args){
+				if(s.trim().contains("-debug")){
+					e.printStackTrace();
+				}
+			}
+			final String ANSI_RED = "\u001B[31m";
+			final String ANSI_RESET = "\u001B[0m";
+			StringBuilder sb = new StringBuilder();
+			sb.append(ANSI_RED);
+			sb.append("An Error Occured : ");
+			sb.append("\n" );
+			sb.append(StringUtils.leftPad(e.getClass().getSimpleName(),25));
+			sb.append(" -- ");
+			sb.append(e.getMessage());
+			Throwable s =  e.getCause();
+			while(s != null){
+				sb.append("\n" );
+				sb.append(StringUtils.leftPad(s.getClass().getSimpleName(),25));
+				sb.append(" -- ");
+				sb.append(s.getMessage());
+				s = s.getCause();
+			}
+			sb.append(ANSI_RESET);
+			System.out.println(sb.toString());
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
This PR change the output for a user to not print the stack trace in case of an exception or stop has been called.

example script:

```R
x = 0
for(i in 1:10){
    if(i > 4){
        stop("I is to high")
    }
    x = x + i
}
print(x)
```

Before terminal:

```bash
Me:../secret$ ./run.sh 
Using existing SystemDS at ../../../systemds
SystemDS Statistics:
Total execution time:           0.003 sec.

Exception in thread "main" org.apache.sysds.runtime.DMLScriptException: I is to high
        at org.apache.sysds.runtime.instructions.cp.UnaryScalarCPInstruction.processInstruction(UnaryScalarCPInstruction.java:59)
        at org.apache.sysds.runtime.controlprogram.ProgramBlock.executeSingleInstruction(ProgramBlock.java:247)
        at org.apache.sysds.runtime.controlprogram.ProgramBlock.executeInstructions(ProgramBlock.java:204)
        at org.apache.sysds.runtime.controlprogram.BasicProgramBlock.execute(BasicProgramBlock.java:125)
        at org.apache.sysds.runtime.controlprogram.IfProgramBlock.execute(IfProgramBlock.java:106)
        at org.apache.sysds.runtime.controlprogram.ForProgramBlock.execute(ForProgramBlock.java:141)
        at org.apache.sysds.runtime.controlprogram.Program.execute(Program.java:149)
        at org.apache.sysds.api.ScriptExecutorUtils.executeRuntimeProgram(ScriptExecutorUtils.java:87)
        at org.apache.sysds.api.DMLScript.execute(DMLScript.java:395)
        at org.apache.sysds.api.DMLScript.executeScript(DMLScript.java:244)
        at org.apache.sysds.api.DMLScript.main(DMLScript.java:160)
```

now terminal:
```bash
Me:../secret$ ./run.sh 
Using existing SystemDS at ../../../systemds
SystemDS Statistics:
Total execution time:           0.003 sec.

An Error Occured : DMLScriptException
        I is to high
```

Also if the terminal supports colours, it will print in red:
![image](https://user-images.githubusercontent.com/9947148/90122874-45723b80-dd5e-11ea-8aa3-c6eb99c2eb74.png)



