### PR TITLE
[SYSTEMDS-2617] Add columnNames builtin to get Frame col names

### DIFF
--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -84,6 +84,7 @@ public enum Builtins {
 	CONFUSIONMATRIX("confusionMatrix", true),
 	COR("cor", true),
 	DETECTSCHEMA("detectSchema", false),
+	COLUMN_NAMES("columnNames", false),
 	DIAG("diag", false),
 	DISCOVER_FD("discoverFD", true),
 	DROP_INVALID_TYPE("dropInvalidType", false),

--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -195,7 +195,7 @@ public class Types
 		ABS, ACOS, ASIN, ASSERT, ATAN, CAST_AS_SCALAR, CAST_AS_MATRIX,
 		CAST_AS_FRAME, CAST_AS_DOUBLE, CAST_AS_INT, CAST_AS_BOOLEAN,
 		CEIL, CHOLESKY, COS, COSH, CUMMAX, CUMMIN, CUMPROD, CUMSUM,
-		CUMSUMPROD, DETECTSCHEMA, EIGEN, EXISTS, EXP, FLOOR, INVERSE,
+		CUMSUMPROD, DETECTSCHEMA, COLUMN_NAMES, EIGEN, EXISTS, EXP, FLOOR, INVERSE,
 		IQM, ISNA, ISNAN, ISINF, LENGTH, LINEAGE, LOG, NCOL, NOT, NROW,
 		MEDIAN, PRINT, ROUND, SIN, SINH, SIGN, SOFTMAX, SQRT, STOP, SVD,
 		TAN, TANH, TYPEOF,
@@ -232,6 +232,7 @@ public class Types
 				case CUMSUM:          return "ucumk+";
 				case CUMSUMPROD:      return "ucumk+*";
 				case DETECTSCHEMA:    return "detectSchema";
+				case COLUMN_NAMES:    return "columnNames";
 				case MULT2:           return "*2";
 				case NOT:             return "!";
 				case POW2:            return "^2";

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -539,7 +539,7 @@ public class UnaryOp extends MultiThreadedHop
 			setDim1(input.getDim1());
 			setDim2(1);
 		}
-		else if(_op == OpOp1.TYPEOF || _op == OpOp1.DETECTSCHEMA) {
+		else if(_op == OpOp1.TYPEOF || _op == OpOp1.DETECTSCHEMA || _op == OpOp1.COLUMN_NAMES) {
 			setDim1(1);
 			setDim2(input.getDim2());
 		}

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -716,6 +716,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			break;
 		case TYPEOF:
 		case DETECTSCHEMA:
+		case COLUMN_NAMES:
 			checkNumParameters(1);
 			checkMatrixFrameParam(getFirstExpr());
 			output.setDataType(DataType.FRAME);

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -2656,6 +2656,7 @@ public class DMLTranslator
 		case CHOLESKY:
 		case TYPEOF:
 		case DETECTSCHEMA:
+		case COLUMN_NAMES:
 			currBuiltinOp = new UnaryOp(target.getName(), target.getDataType(), target.getValueType(),
 				OpOp1.valueOf(source.getOpCode().name()), expr);
 			break;

--- a/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
@@ -190,6 +190,7 @@ public class CPInstructionParser extends InstructionParser
 		String2CPInstructionType.put( "sigmoid", CPType.Unary);
 		String2CPInstructionType.put( "typeOf", CPType.Unary);
 		String2CPInstructionType.put( "detectSchema", CPType.Unary);
+		String2CPInstructionType.put( "columnNames", CPType.Unary);
 		String2CPInstructionType.put( "isna", CPType.Unary);
 		String2CPInstructionType.put( "isnan", CPType.Unary);
 		String2CPInstructionType.put( "isinf", CPType.Unary);

--- a/src/main/java/org/apache/sysds/runtime/instructions/SPInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/SPInstructionParser.java
@@ -250,6 +250,7 @@ public class SPInstructionParser extends InstructionParser
 		String2SPInstructionType.put( "sprop", SPType.Unary);
 		String2SPInstructionType.put( "sigmoid", SPType.Unary);
 		String2SPInstructionType.put( "detectSchema", SPType.Unary);
+		String2SPInstructionType.put( "columnNames", SPType.Unary);
 		String2SPInstructionType.put( "isna", SPType.Unary);
 		String2SPInstructionType.put( "isnan", SPType.Unary);
 		String2SPInstructionType.put( "isinf", SPType.Unary);

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryFrameCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryFrameCPInstruction.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.instructions.cp;
 
 import org.apache.sysds.lops.Lop;
+import org.apache.sysds.runtime.DMLScriptException;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -37,12 +38,19 @@ public class UnaryFrameCPInstruction extends UnaryCPInstruction {
 			ec.releaseFrameInput(input1.getName());
 			ec.setFrameOutput(output.getName(), retBlock);
 		}
-		else if(getOpcode().equals("detectSchema"))
-		{
+		else if(getOpcode().equals("detectSchema")) {
 			FrameBlock inBlock = ec.getFrameInput(input1.getName());
 			FrameBlock retBlock = inBlock.detectSchemaFromRow(Lop.SAMPLE_FRACTION);
 			ec.releaseFrameInput(input1.getName());
 			ec.setFrameOutput(output.getName(), retBlock);
 		}
+		else if(getOpcode().equals("columnNames")) {
+			FrameBlock inBlock = ec.getFrameInput(input1.getName());
+			FrameBlock retBlock = inBlock.getColumnNamesFrameBlock();
+			ec.releaseFrameInput(input1.getName());
+			ec.setFrameOutput(output.getName(), retBlock);
+		}
+		else
+			throw new DMLScriptException("Opcode '" + getOpcode() + "' is not a valid UnaryFrameCPInstruction");
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/UnaryFrameSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/UnaryFrameSPInstruction.java
@@ -23,7 +23,9 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFunction;
 import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.OpOp1;
 import org.apache.sysds.lops.Lop;
+import org.apache.sysds.runtime.DMLScriptException;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
@@ -37,7 +39,7 @@ public class UnaryFrameSPInstruction extends UnarySPInstruction {
 		super(SPInstruction.SPType.Unary, op, in, out, opcode, instr);
 	}
 
-	public static UnaryFrameSPInstruction parseInstruction (String str ) {
+	public static UnaryFrameSPInstruction parseInstruction(String str) {
 		CPOperand in = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
 		CPOperand out = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
 		String opcode = parseUnaryInstruction(str, in, out);
@@ -46,18 +48,36 @@ public class UnaryFrameSPInstruction extends UnarySPInstruction {
 
 	@Override
 	public void processInstruction(ExecutionContext ec) {
-		SparkExecutionContext sec = (SparkExecutionContext)ec;
-		//get input
-		JavaPairRDD<Long, FrameBlock> in = sec.getFrameBinaryBlockRDDHandleForVariable(input1.getName() );
-		JavaPairRDD<Long,FrameBlock> out = in.mapToPair(new DetectSchemaUsingRows());
+		SparkExecutionContext sec = (SparkExecutionContext) ec;
+		if(getOpcode().equals(OpOp1.DETECTSCHEMA.toString()))
+			detectSchema(sec);
+		else if(getOpcode().equals(OpOp1.COLUMN_NAMES.toString()))
+			columnNames(sec);
+		else
+			throw new DMLScriptException("Opcode '" + getOpcode() + "' is not a valid UnaryFrameSPInstruction");
+	}
+
+	private void columnNames(SparkExecutionContext sec) {
+		// get input
+		JavaPairRDD<Long, FrameBlock> in = sec.getFrameBinaryBlockRDDHandleForVariable(input1.getName());
+		// get the first row block (frames are only blocked rowwise) and get its column names
+		FrameBlock outFrame = in.lookup(1L).get(0).getColumnNamesFrameBlock();
+		sec.setFrameOutput(output.getName(), outFrame);
+	}
+
+	public void detectSchema(SparkExecutionContext sec) {
+		// get input
+		JavaPairRDD<Long, FrameBlock> in = sec.getFrameBinaryBlockRDDHandleForVariable(input1.getName());
+		JavaPairRDD<Long, FrameBlock> out = in.mapToPair(new DetectSchemaUsingRows());
 		FrameBlock outFrame = out.values().reduce(new MergeFrame());
 		sec.setFrameOutput(output.getName(), outFrame);
 	}
 
 	private static class DetectSchemaUsingRows implements PairFunction<Tuple2<Long, FrameBlock>, Long, FrameBlock> {
 		private static final long serialVersionUID = 5850400295183766400L;
+
 		@Override
-		public Tuple2<Long,FrameBlock> call(Tuple2<Long, FrameBlock> arg0) throws Exception {
+		public Tuple2<Long, FrameBlock> call(Tuple2<Long, FrameBlock> arg0) throws Exception {
 			FrameBlock resultBlock = new FrameBlock(arg0._2.detectSchemaFromRow(Lop.SAMPLE_FRACTION));
 			return new Tuple2<>(1L, resultBlock);
 		}
@@ -65,6 +85,7 @@ public class UnaryFrameSPInstruction extends UnarySPInstruction {
 
 	private static class MergeFrame implements Function2<FrameBlock, FrameBlock, FrameBlock> {
 		private static final long serialVersionUID = 942744896521069893L;
+
 		@Override
 		public FrameBlock call(FrameBlock arg0, FrameBlock arg1) throws Exception {
 			return new FrameBlock(FrameBlock.mergeSchema(arg0, arg1));

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
@@ -202,6 +202,12 @@ public class FrameBlock implements CacheBlock, Externalizable
 			_colnames = createColNames(getNumColumns());
 		return _colnames[c];
 	}
+	
+	public FrameBlock getColumnNamesFrameBlock() {
+		FrameBlock fb = new FrameBlock(getNumColumns(), ValueType.STRING);
+		fb.appendRow(getColumnNames());
+		return fb;
+	}
 
 	public void setColumnNames(String[] colnames) {
 		_colnames = colnames;

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameColumnNamesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameColumnNamesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.frame;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.lops.LopProperties.ExecType;
+import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
+import org.apache.sysds.runtime.io.FrameWriter;
+import org.apache.sysds.runtime.io.FrameWriterFactory;
+import org.apache.sysds.runtime.matrix.data.FrameBlock;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+@RunWith(value = Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
+public class FrameColumnNamesTest extends AutomatedTestBase {
+	private final static String TEST_NAME = "ColumnNames";
+	private final static String TEST_DIR = "functions/frame/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + FrameColumnNamesTest.class.getSimpleName() + "/";
+
+	private final static int _rows = 10000;
+	@Parameterized.Parameter()
+	public String[] _columnNames;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {{new String[] {"A", "B", "C"}}, {new String[] {"1", "2", "3"}},
+			{new String[] {"Hello", "hello", "Hello", "hi", "u", "w", "u"}},});
+	}
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"B"}));
+	}
+
+	@Test
+	public void testDetectSchemaDoubleCP() {
+		runGetColNamesTest(_columnNames, ExecType.CP);
+	}
+
+	@Test
+	public void testDetectSchemaDoubleSpark() {
+		runGetColNamesTest(_columnNames, ExecType.SPARK);
+	}
+
+	private void runGetColNamesTest(String[] columnNames, ExecType et) {
+		Types.ExecMode platformOld = setExecMode(et);
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		try {
+			getAndLoadTestConfiguration(TEST_NAME);
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-args", input("A"), String.valueOf(_rows),
+				Integer.toString(columnNames.length), output("B")};
+
+			Types.ValueType[] schema = (Types.ValueType[]) Collections.nCopies(columnNames.length, Types.ValueType.FP64)
+				.toArray(new Types.ValueType[0]);
+			FrameBlock frame1 = new FrameBlock(schema);
+			frame1.setColumnNames(columnNames);
+			FrameWriter writer = FrameWriterFactory.createFrameWriter(FileFormat.CSV,
+				new FileFormatPropertiesCSV(true, ",", false));
+
+			double[][] A = getRandomMatrix(_rows, schema.length, Double.MIN_VALUE, Double.MAX_VALUE, 0.7, 14123);
+			TestUtils.initFrameData(frame1, A, schema, _rows);
+			writer.writeFrameToHDFS(frame1, input("A"), _rows, schema.length);
+
+			runTest(true, false, null, -1);
+			FrameBlock frame2 = readDMLFrameFromHDFS("B", FileFormat.BINARY);
+
+			// verify output schema
+			for(int i = 0; i < schema.length; i++) {
+				Assert
+					.assertEquals("Wrong result: " + columnNames[i] + ".", columnNames[i], frame2.get(0, i).toString());
+			}
+		}
+		catch(Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			rtplatform = platformOld;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/frame/ColumnNames.dml
+++ b/src/test/scripts/functions/frame/ColumnNames.dml
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = read($1, rows=$2, cols=$3, data_type="frame", format="csv", header=TRUE);
+R = columnNames(X);
+write(R, $4, format="binary");


### PR DESCRIPTION
This PR adds a new function `columnNames()` which takes a `Frame` and returns a `Frame` containing the names of the columns.
I did not yet add any documentation since I am not aware of the current process. Should documentation be added in the initial PR? Should a new PR be made just for documentation of this function? Is documentation added in bulk?
I also detected that the functions `typeOf` and `detectSchema`, which belong to the same "category" (instruction type) as this function are defined in `src/main/java/org/apache/sysds/runtime/functionobjects/Builtin.java`, but I believe those definitions are not used. Am I overlooking something and this function should be added there?