### PR TITLE
[SYSTEMDS-2600,2626] Fix federated backend request interference

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
@@ -1177,6 +1177,7 @@ public class ParForProgramBlock extends ForProgramBlock
 			
 			//deep copy execution context (including prepare parfor update-in-place)
 			ExecutionContext cpEc = ProgramConverter.createDeepCopyExecutionContext(ec);
+			cpEc.setTID(pwID);
 
 			// If GPU mode is enabled, gets a GPUContext from the pool of GPUContexts
 			// and sets it in the ExecutionContext of the parfor

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -629,6 +629,10 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		}
 	}
 	
+	public void clearData() {
+		clearData(-1);
+	}
+	
 	/**
 	 * Sets the cache block reference to <code>null</code>, abandons the old block.
 	 * Makes the "envelope" empty.  Run it to finalize the object (otherwise the
@@ -637,8 +641,10 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 	 * In-Status:  EMPTY, EVICTABLE, EVICTED;
 	 * Out-Status: EMPTY.
 	 * 
+	 * @param tid thread ID
+	 * 
 	 */
-	public synchronized void clearData() 
+	public synchronized void clearData(long tid) 
 	{
 		// check if cleanup enabled and possible 
 		if( !isCleanupEnabled() ) 
@@ -669,7 +675,7 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		
 		//clear federated matrix
 		if( _fedMapping != null )
-			_fedMapping.cleanup(_fedMapping.getID());
+			_fedMapping.cleanup(tid, _fedMapping.getID());
 		
 		// change object state EMPTY
 		setDirty(false);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -70,6 +70,7 @@ public class ExecutionContext {
 	
 	//symbol table
 	protected LocalVariableMap _variables;
+	protected long _tid = -1;
 	protected boolean _autoCreateVars;
 	
 	//lineage map, cache, prepared dedup blocks
@@ -130,6 +131,14 @@ public class ExecutionContext {
 	
 	public void setAutoCreateVars(boolean flag) {
 		_autoCreateVars = flag;
+	}
+	
+	public void setTID(long tid) {
+		_tid = tid;
+	}
+	
+	public long getTID() {
+		return _tid;
 	}
 
 	/**
@@ -750,7 +759,7 @@ public class ExecutionContext {
 		try {
 			//compute ref count only if matrix cleanup actually necessary
 			if ( mo.isCleanupEnabled() && !getVariables().hasReferences(mo) )  {
-				mo.clearData(); //clean cached data
+				mo.clearData(getTID()); //clean cached data
 				if( fileExists ) {
 					HDFSTool.deleteFileIfExistOnHDFS(mo.getFileName());
 					HDFSTool.deleteFileIfExistOnHDFS(mo.getFileName()+".mtd");

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1350,7 +1350,7 @@ public class SparkExecutionContext extends ExecutionContext
 			//compute ref count only if matrix cleanup actually necessary
 			if( !getVariables().hasReferences(mo) ) {
 				//clean cached data
-				mo.clearData();
+				mo.clearData(getTID());
 
 				//clean hdfs data if no pending rdd operations on it
 				if( mo.isHDFSFileExists() && mo.getFileName()!=null ) {

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/ExecutionContextMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/ExecutionContextMap.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContextFactory;
+
+public class ExecutionContextMap {
+	private final ExecutionContext _main;
+	private final Map<Long, ExecutionContext> _parEc;
+	
+	public ExecutionContextMap() {
+		_main = createExecutionContext();
+		_parEc = new ConcurrentHashMap<>();
+	}
+	
+	public ExecutionContext get(long tid) {
+		//return main execution context
+		if( tid <= 0 )
+			return _main;
+		
+		//atomic probe, create if necessary, and return
+		return _parEc.computeIfAbsent(tid,
+			k -> deriveExecutionContext(_main));
+	}
+	
+	private static ExecutionContext createExecutionContext() {
+		ExecutionContext ec = ExecutionContextFactory.createContext();
+		ec.setAutoCreateVars(true); //w/o createvar inst
+		return ec;
+	}
+	
+	private static ExecutionContext deriveExecutionContext(ExecutionContext ec) {
+		//derive execution context from main to make shared variables available
+		//but allow normal instruction processing and removal if necessary
+		ExecutionContext ec2 = ExecutionContextFactory
+			.createContext(ec.getVariables(), ec.getProgram());
+		ec2.setAutoCreateVars(true); //w/o createvar inst
+		return ec2;
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
@@ -41,6 +41,7 @@ public class FederatedRequest implements Serializable {
 	
 	private RequestType _method;
 	private long _id;
+	private long _tid;
 	private List<Object> _data;
 	private boolean _checkPrivacy;
 	
@@ -71,6 +72,14 @@ public class FederatedRequest implements Serializable {
 	
 	public long getID() {
 		return _id;
+	}
+	
+	public long getTID() {
+		return _tid;
+	}
+	
+	public void setTID(long tid) {
+		_tid = tid;
 	}
 	
 	public Object getParam(int i) {
@@ -112,7 +121,9 @@ public class FederatedRequest implements Serializable {
 		StringBuilder sb = new StringBuilder("FederatedRequest[");
 		sb.append(_method); sb.append(";");
 		sb.append(_id); sb.append(";");
-		sb.append(Arrays.toString(_data.toArray())); sb.append("]");
+		sb.append("t"); sb.append(_tid); sb.append(";");
+		if( _method != RequestType.PUT_VAR )
+			sb.append(Arrays.toString(_data.toArray())); sb.append("]");
 		return sb.toString();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -32,21 +32,15 @@ import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
 import org.apache.log4j.Logger;
 import org.apache.sysds.conf.DMLConfig;
-import org.apache.sysds.runtime.controlprogram.BasicProgramBlock;
-import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
-import org.apache.sysds.runtime.controlprogram.context.ExecutionContextFactory;
 
 public class FederatedWorker {
 	protected static Logger log = Logger.getLogger(FederatedWorker.class);
 
 	private int _port;
-	private final ExecutionContext _ec;
-	private final BasicProgramBlock _pb;
+	private final ExecutionContextMap _ecm;
 	
 	public FederatedWorker(int port) {
-		_ec = ExecutionContextFactory.createContext();
-		_ec.setAutoCreateVars(true); //w/o createvar inst
-		_pb = new BasicProgramBlock(null);
+		_ecm = new ExecutionContextMap();
 		_port = (port == -1) ?
 			Integer.parseInt(DMLConfig.DEFAULT_FEDERATED_PORT) : port;
 	}
@@ -65,7 +59,7 @@ public class FederatedWorker {
 							new ObjectDecoder(Integer.MAX_VALUE,
 								ClassResolvers.weakCachingResolver(ClassLoader.getSystemClassLoader())))
 						.addLast("ObjectEncoder", new ObjectEncoder())
-						.addLast("FederatedWorkerHandler", new FederatedWorkerHandler(_ec, _pb));
+						.addLast("FederatedWorkerHandler", new FederatedWorkerHandler(_ecm));
 				}
 			}).option(ChannelOption.SO_BACKLOG, 128).childOption(ChannelOption.SO_KEEPALIVE, true);
 		try {

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/opt/CostEstimatorHops.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/opt/CostEstimatorHops.java
@@ -58,6 +58,7 @@ public class CostEstimatorHops extends CostEstimator
 		
 		//handle specific cases 
 		double DEFAULT_MEM_REMOTE = OptimizerUtils.isSparkExecutionMode() ? DEFAULT_MEM_SP : 0;
+		boolean forcedExec =  DMLScript.getGlobalExecMode() == ExecMode.SINGLE_NODE || h.getForcedExecType()!=null;
 		
 		if( value >= DEFAULT_MEM_REMOTE )
 		{
@@ -67,7 +68,7 @@ public class CostEstimatorHops extends CostEstimator
 			}
 			//check for invalid cp memory estimate
 			else if ( h.getExecType()==ExecType.CP && value >= OptimizerUtils.getLocalMemBudget() ) {
-				if( DMLScript.getGlobalExecMode() != ExecMode.SINGLE_NODE && h.getForcedExecType()==null )
+				if( !forcedExec )
 					LOG.warn("Memory estimate larger than budget but CP exec type (op="+h.getOpString()+", name="+h.getName()+", memest="+h.getMemEstimate()+").");
 				value = DEFAULT_MEM_REMOTE;
 			}
@@ -84,7 +85,7 @@ public class CostEstimatorHops extends CostEstimator
 			value = DEFAULT_MEM_REMOTE;
 		}
 		
-		if( value <= 0 ) { //no mem estimate
+		if( value <= 0 && !forcedExec ) { //no mem estimate
 			LOG.warn("Cannot get memory estimate for hop (op="+h.getOpString()+", name="+h.getName()+", memest="+h.getMemEstimate()+").");
 			value = CostEstimator.DEFAULT_MEM_ESTIMATE_CP;
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -741,7 +741,7 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 			// no other variable in the symbol table points to the same Data object as that of input1.getName()
 			
 			//remove matrix object from cache
-			m.clearData();
+			m.clearData(ec.getTID());
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
@@ -69,15 +69,15 @@ public class AggregateBinaryFEDInstruction extends BinaryFEDInstruction {
 			if( mo2.getNumColumns() == 1 ) { //MV
 				FederatedRequest fr3 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
 				//execute federated operations and aggregate
-				Future<FederatedResponse>[] tmp = mo1.getFedMapping().execute(fr1, fr2, fr3);
+				Future<FederatedResponse>[] tmp = mo1.getFedMapping().execute(getTID(), fr1, fr2, fr3);
 				MatrixBlock ret = FederationUtils.rbind(tmp);
-				mo1.getFedMapping().cleanup(fr1.getID(), fr2.getID());
+				mo1.getFedMapping().cleanup(getTID(), fr1.getID(), fr2.getID());
 				ec.setMatrixOutput(output.getName(), ret);
 			}
 			else { //MM
 				//execute federated operations and aggregate
-				mo1.getFedMapping().execute(fr1, fr2);
-				mo1.getFedMapping().cleanup(fr1.getID());
+				mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
+				mo1.getFedMapping().cleanup(getTID(), fr1.getID());
 				MatrixObject out = ec.getMatrixObject(output);
 				out.getDataCharacteristics().set(mo1.getNumRows(), mo2.getNumColumns(), (int)mo1.getBlocksize());
 				out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID(), mo2.getNumColumns()));
@@ -91,9 +91,9 @@ public class AggregateBinaryFEDInstruction extends BinaryFEDInstruction {
 				new CPOperand[]{input1, input2}, new long[]{fr1[0].getID(), mo2.getFedMapping().getID()});
 			FederatedRequest fr3 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
 			//execute federated operations and aggregate
-			Future<FederatedResponse>[] tmp = mo2.getFedMapping().execute(fr1, fr2, fr3);
+			Future<FederatedResponse>[] tmp = mo2.getFedMapping().execute(getTID(), fr1, fr2, fr3);
 			MatrixBlock ret = FederationUtils.aggAdd(tmp);
-			mo2.getFedMapping().cleanup(fr1[0].getID(), fr2.getID());
+			mo2.getFedMapping().cleanup(getTID(), fr1[0].getID(), fr2.getID());
 			ec.setMatrixOutput(output.getName(), ret);
 		}
 		else { //other combinations

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
@@ -63,11 +63,11 @@ public class AggregateUnaryFEDInstruction extends UnaryFEDInstruction {
 		
 		//execute federated commands and cleanups
 		FederationMap map = in.getFedMapping();
-		Future<FederatedResponse>[] tmp = map.execute(fr1, fr2);
-		map.cleanup(fr1.getID());
+		Future<FederatedResponse>[] tmp = map.execute(getTID(), fr1, fr2);
 		if( output.isScalar() )
 			ec.setVariable(output.getName(), FederationUtils.aggScalar(aop, tmp));
 		else
 			ec.setMatrixOutput(output.getName(), FederationUtils.aggMatrix(aop, tmp, map));
+		map.cleanup(getTID(), fr1.getID());
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
@@ -80,7 +80,7 @@ public class AppendFEDInstruction extends BinaryFEDInstruction {
 			FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
 			FederatedRequest fr2 = FederationUtils.callInstruction(instString, output,
 				new CPOperand[]{input1, input2}, new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-			mo1.getFedMapping().execute(fr1, fr2);
+			mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
 			//derive new fed mapping for output
 			MatrixObject out = ec.getMatrixObject(output);
 			out.getDataCharacteristics().set(dc1.getRows(), dc1.getCols()+dc2.getCols(),

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
@@ -51,16 +51,16 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 			fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
 				new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
 			//execute federated instruction and cleanup intermediates
-			mo1.getFedMapping().execute(fr1, fr2);
-			mo1.getFedMapping().cleanup(fr1[0].getID());
+			mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
+			mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
 		}
 		else { //MM or MV col vector
 			FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
 			fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
 				new long[]{mo1.getFedMapping().getID(), fr1.getID()});
 			//execute federated instruction and cleanup intermediates
-			mo1.getFedMapping().execute(fr1, fr2);
-			mo1.getFedMapping().cleanup(fr1.getID());
+			mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
+			mo1.getFedMapping().cleanup(getTID(), fr1.getID());
 		}
 		
 		//derive new fed mapping for output

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixScalarFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixScalarFEDInstruction.java
@@ -46,10 +46,10 @@ public class BinaryMatrixScalarFEDInstruction extends BinaryFEDInstruction
 			new CPOperand[]{matrix, (fr1 != null)?scalar:null},
 			new long[]{mo.getFedMapping().getID(), (fr1 != null)?fr1.getID():-1});
 		
-		mo.getFedMapping().execute((fr1!=null) ?
+		mo.getFedMapping().execute(getTID(), true, (fr1!=null) ?
 			new FederatedRequest[]{fr1, fr2}: new FederatedRequest[]{fr2});
 		if( fr1 != null )
-			mo.getFedMapping().cleanup(fr1.getID());
+			mo.getFedMapping().cleanup(getTID(), fr1.getID());
 		
 		//derive new fed mapping for output
 		MatrixObject out = ec.getMatrixObject(output);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
@@ -39,6 +39,7 @@ public abstract class FEDInstruction extends Instruction {
 	
 	protected final FEDType _fedType;
 	protected final Operator _optr;
+	protected long _tid = -1; //main
 	
 	protected FEDInstruction(FEDType type, String opcode, String istr) {
 		this(type, null, opcode, istr);
@@ -58,6 +59,14 @@ public abstract class FEDInstruction extends Instruction {
 	
 	public FEDType getFEDInstructionType() {
 		return _fedType;
+	}
+	
+	public long getTID() {
+		return _tid;
+	}
+	
+	public void setTID(long tid) {
+		_tid = tid;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
@@ -99,7 +99,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 			MatrixObject mo = getTarget(ec);
 			FederatedRequest fr1 = FederationUtils.callInstruction(instString, output,
 				new CPOperand[]{getTargetOperand()}, new long[]{mo.getFedMapping().getID()});
-			mo.getFedMapping().execute(fr1);
+			mo.getFedMapping().execute(getTID(), true, fr1);
 			
 			//derive new fed mapping for output
 			MatrixObject out = ec.getMatrixObject(output);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/TsmmFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/TsmmFEDInstruction.java
@@ -69,9 +69,9 @@ public class TsmmFEDInstruction extends BinaryFEDInstruction {
 			FederatedRequest fr2 = new FederatedRequest(RequestType.GET_VAR, fr1.getID());
 			
 			//execute federated operations and aggregate
-			Future<FederatedResponse>[] tmp = mo1.getFedMapping().execute(fr1, fr2);
+			Future<FederatedResponse>[] tmp = mo1.getFedMapping().execute(getTID(), fr1, fr2);
 			MatrixBlock ret = FederationUtils.aggAdd(tmp);
-			mo1.getFedMapping().cleanup(fr1.getID());
+			mo1.getFedMapping().cleanup(getTID(), fr1.getID());
 			ec.setMatrixOutput(output.getName(), ret);
 		}
 		else { //other combinations

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -100,7 +100,7 @@ public abstract class AutomatedTestBase {
 	public static final boolean TEST_GPU = false;
 	public static final double GPU_TOLERANCE = 1e-9;
 
-	public static final int FED_WORKER_WAIT = 500; // in ms
+	public static final int FED_WORKER_WAIT = 750; // in ms
 
 	// With OpenJDK 8u242 on Windows, the new changes in JDK are not allowing
 	// to set the native library paths internally thus breaking the code.

--- a/src/test/java/org/apache/sysds/test/functions/federated/FederatedKmeansTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/FederatedKmeansTest.java
@@ -62,8 +62,7 @@ public class FederatedKmeansTest extends AutomatedTestBase {
 		// rows have to be even and > 1
 		return Arrays.asList(new Object[][] {
 			{10000, 10, 1}, {2000, 50, 1}, {1000, 100, 1},
-			//TODO support for multi-threaded federated interactions
-			//{10000, 10, 16}, {2000, 50, 16}, {1000, 100, 16}, //concurrent requests
+			{10000, 10, 4}, {2000, 50, 4}, {1000, 100, 4}, //concurrent requests
 		});
 	}
 


### PR DESCRIPTION
This patch fixes two major issues of request interference from multiple
coordinator threads.

First, we now properly maintain separate execution context at the
federated site for different request streams from parfor workers which
otherwise could interfer (e.g., on rmvar instructions for shared input
variables)

Second, even within a stream federated requests (e.g., execute and
cleanup) could out output each other if there are no data dependencies
or synchronization between them. We now added barriers for federated
requests wherever this was necessary.

Last, this patch also fixes unnecessary warning messages of the parfor
optimizer, specifically in a setting with forced singlenode execution.