### PR TITLE
[SYSTEMDS-2556,2560] Add federated Encoder impute support and improve Omit

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -100,9 +100,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 			
 			//select the response for the entire batch of requests
 			if (!tmp.isSuccessful()) {
-				log.error("Command " + request.getType() + " failed: " 
+				log.error("Command " + request.getType() + " failed: "
 					+ tmp.getErrorMessage() + "full command: \n" + request.toString());
-				response = (response == null || response.isSuccessful()) 
+				response = (response == null || response.isSuccessful())
 					? tmp : response; //return first error
 			}
 			else if( request.getType() == RequestType.GET_VAR ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -48,6 +48,7 @@ import org.apache.sysds.runtime.transform.encode.EncoderComposite;
 import org.apache.sysds.runtime.transform.encode.EncoderDummycode;
 import org.apache.sysds.runtime.transform.encode.EncoderFactory;
 import org.apache.sysds.runtime.transform.encode.EncoderFeatureHash;
+import org.apache.sysds.runtime.transform.encode.EncoderMVImpute;
 import org.apache.sysds.runtime.transform.encode.EncoderOmit;
 import org.apache.sysds.runtime.transform.encode.EncoderPassThrough;
 import org.apache.sysds.runtime.transform.encode.EncoderRecode;
@@ -102,7 +103,8 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 				new EncoderPassThrough(),
 				new EncoderBin(),
 				new EncoderDummycode(),
-				new EncoderOmit(true)));
+				new EncoderOmit(true),
+				new EncoderMVImpute()));
 		// first create encoders at the federated workers, then collect them and aggregate them to a single large
 		// encoder
 		FederationMap fedMapping = fin.getFedMapping();
@@ -120,7 +122,7 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 				Encoder encoder = (Encoder) response.getData()[0];
 				// merge this encoder into a composite encoder
 				synchronized(globalEncoder) {
-					globalEncoder.mergeAt(encoder, columnOffset);
+					globalEncoder.mergeAt(encoder, (int) (range.getBeginDims()[0] + 1), columnOffset);
 				}
 				// no synchronization necessary since names should anyway match
 				String[] subRangeColNames = (String[]) response.getData()[1];
@@ -152,7 +154,7 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 			IndexRange ixRange = new IndexRange(beginDims[0], endDims[0], beginDims[1], endDims[1]).add(1);// make 1-based
 
 			// update begin end dims (column part) considering columns added by dummycoding
-			globalEncoder.updateIndexRanges(beginDims, endDims);
+			globalEncoder.updateIndexRanges(range);
 
 			// get the encoder segment that is relevant for this federated worker
 			Encoder encoder = globalEncoder.subRangeEncoder(ixRange);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
@@ -266,7 +266,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 
 				// no synchronization necessary since names should anyway match
 				Encoder builtEncoder = (Encoder) response.getData()[0];
-				newOmit.mergeAt(builtEncoder, (int) (range.getBeginDims()[1] + 1));
+				newOmit.mergeAt(builtEncoder, (int) (range.getBeginDims()[0] + 1), (int) (range.getBeginDims()[1] + 1));
 			}
 			catch(Exception e) {
 				throw new DMLRuntimeException(e);

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.IndexRange;
@@ -177,9 +178,10 @@ public abstract class Encoder implements Serializable
 	 * other <code>Encoder</code>.
 	 * 
 	 * @param other the encoder that should be merged in
-	 * @param col   the position where it should be placed (1-based)
+	 * @param row   the row where it should be placed (1-based)
+	 * @param col   the col where it should be placed (1-based)
 	 */
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		throw new DMLRuntimeException(
 			this.getClass().getSimpleName() + " does not support merging with " + other.getClass().getSimpleName());
 	}
@@ -187,10 +189,9 @@ public abstract class Encoder implements Serializable
 	/**
 	 * Update index-ranges to after encoding. Note that only Dummycoding changes the ranges.
 	 *
-	 * @param beginDims the begin indexes before encoding
-	 * @param endDims   the end indexes before encoding
+	 * @param range the range before encoding
 	 */
-	public void updateIndexRanges(long[] beginDims, long[] endDims) {
+	public void updateIndexRanges(FederatedRange range) {
 		// do nothing - default
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderBin.java
@@ -169,7 +169,7 @@ public class EncoderBin extends Encoder
 	}
 	
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if(other instanceof EncoderBin) {
 			EncoderBin otherBin = (EncoderBin) other;
 
@@ -217,7 +217,7 @@ public class EncoderBin extends Encoder
 			}
 			return;
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderComposite.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.IndexRange;
@@ -117,7 +118,7 @@ public class EncoderComposite extends Encoder
 	}
 
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if (other instanceof EncoderComposite) {
 			EncoderComposite otherComposite = (EncoderComposite) other;
 			// TODO maybe assert that the _encoders never have the same type of encoder twice or more
@@ -125,7 +126,7 @@ public class EncoderComposite extends Encoder
 				boolean mergedIn = false;
 				for (Encoder encoder : _encoders) {
 					if (encoder.getClass() == otherEnc.getClass()) {
-						encoder.mergeAt(otherEnc, col);
+						encoder.mergeAt(otherEnc, row, col);
 						mergedIn = true;
 						break;
 					}
@@ -146,7 +147,7 @@ public class EncoderComposite extends Encoder
 		}
 		for (Encoder encoder : _encoders) {
 			if (encoder.getClass() == other.getClass()) {
-				encoder.mergeAt(other, col);
+				encoder.mergeAt(other, row, col);
 				// update dummycode encoder domain sizes based on distinctness information from other encoders
 				for (Encoder encDummy : _encoders) {
 					if (encDummy instanceof EncoderDummycode) {
@@ -157,13 +158,13 @@ public class EncoderComposite extends Encoder
 				return;
 			}
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 	
 	@Override
-	public void updateIndexRanges(long[] beginDims, long[] endDims) {
+	public void updateIndexRanges(FederatedRange range) {
 		for(Encoder enc : _encoders) {
-			enc.updateIndexRanges(beginDims, endDims);
+			enc.updateIndexRanges(range);
 		}
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderDummycode.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.transform.TfUtils.TfMethod;
@@ -128,7 +129,7 @@ public class EncoderDummycode extends Encoder
 	}
 
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if(other instanceof EncoderDummycode) {
 			mergeColumnInfo(other, col);
 
@@ -138,11 +139,13 @@ public class EncoderDummycode extends Encoder
 			Arrays.fill(_domainSizes, 0, _colList.length, 1);
 			return;
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 	
 	@Override
-	public void updateIndexRanges(long[] beginDims, long[] endDims) {
+	public void updateIndexRanges(FederatedRange range) {
+		long[] beginDims = range.getBeginDims();
+		long[] endDims = range.getEndDims();
 		long[] initialBegin = Arrays.copyOf(beginDims, beginDims.length);
 		long[] initialEnd = Arrays.copyOf(endDims, endDims.length);
 		for(int i = 0; i < _colList.length; i++) {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -104,7 +104,7 @@ public class EncoderFactory
 			if( !oIDs.isEmpty() )
 				lencoders.add(new EncoderOmit(jSpec, colnames, schema.length, minCol, maxCol));
 			if( !mvIDs.isEmpty() ) {
-				EncoderMVImpute ma = new EncoderMVImpute(jSpec, colnames, schema.length);
+				EncoderMVImpute ma = new EncoderMVImpute(jSpec, colnames, schema.length, minCol, maxCol);
 				ma.initRecodeIDList(rcIDs);
 				lencoders.add(ma);
 			}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFeatureHash.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFeatureHash.java
@@ -110,14 +110,14 @@ public class EncoderFeatureHash extends Encoder
 	}
 	
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if(other instanceof EncoderFeatureHash) {
 			mergeColumnInfo(other, col);
 			if (((EncoderFeatureHash) other)._K != 0 && _K == 0)
 				_K = ((EncoderFeatureHash) other)._K;
 			return;
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
@@ -19,259 +19,115 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
-import java.io.IOException;
-import java.util.BitSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONException;
 import org.apache.wink.json4j.JSONObject;
-import org.apache.sysds.runtime.functionobjects.CM;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.functionobjects.KahanPlus;
 import org.apache.sysds.runtime.functionobjects.Mean;
-import org.apache.sysds.runtime.instructions.cp.CM_COV_Object;
 import org.apache.sysds.runtime.instructions.cp.KahanObject;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-import org.apache.sysds.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
-import org.apache.sysds.runtime.transform.TfUtils;
 import org.apache.sysds.runtime.transform.TfUtils.TfMethod;
 import org.apache.sysds.runtime.transform.meta.TfMetaUtils;
+import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
-public class EncoderMVImpute extends Encoder 
+public class EncoderMVImpute extends Encoder
 {
 	private static final long serialVersionUID = 9057868620144662194L;
 
 	public enum MVMethod { INVALID, GLOBAL_MEAN, GLOBAL_MODE, CONSTANT }
 	
 	private MVMethod[] _mvMethodList = null;
-	private MVMethod[] _mvscMethodList = null; // scaling methods for attributes that are imputed and also scaled
-	
-	private BitSet _isMVScaled = null;
-	private CM _varFn = CM.getCMFnObject(AggregateOperationTypes.VARIANCE);		// function object that understands variance computation
 	
 	// objects required to compute mean and variance of all non-missing entries 
-	private Mean _meanFn = Mean.getMeanFnObject();  // function object that understands mean computation
+	private final Mean _meanFn = Mean.getMeanFnObject();  // function object that understands mean computation
 	private KahanObject[] _meanList = null;         // column-level means, computed so far
 	private long[] _countList = null;               // #of non-missing values
 	
-	private CM_COV_Object[] _varList = null;        // column-level variances, computed so far (for scaling)
-
-	private int[]           _scnomvList = null;        // List of attributes that are scaled but not imputed
-	private MVMethod[]      _scnomvMethodList = null;  // scaling methods: 0 for invalid; 1 for mean-subtraction; 2 for z-scoring
-	private KahanObject[]   _scnomvMeanList = null;    // column-level means, for attributes scaled but not imputed
-	private long[]          _scnomvCountList = null;   // #of non-missing values, for attributes scaled but not imputed
-	private CM_COV_Object[] _scnomvVarList = null;     // column-level variances, computed so far
-	
 	private String[] _replacementList = null; // replacements: for global_mean, mean; and for global_mode, recode id of mode category
-	private String[] _NAstrings = null;
 	private List<Integer> _rcList = null;
 	private HashMap<Integer,HashMap<String,Long>> _hist = null;
 	
 	public String[] getReplacements() { return _replacementList; }
 	public KahanObject[] getMeans()   { return _meanList; }
-	public CM_COV_Object[] getVars()  { return _varList; }
-	public KahanObject[] getMeans_scnomv()   { return _scnomvMeanList; }
-	public CM_COV_Object[] getVars_scnomv()  { return _scnomvVarList; }
 	
-	public EncoderMVImpute(JSONObject parsedSpec, String[] colnames, int clen) 
+	public EncoderMVImpute(JSONObject parsedSpec, String[] colnames, int clen, int minCol, int maxCol)
 		throws JSONException
 	{
 		super(null, clen);
 		
 		//handle column list
-		int[] collist = TfMetaUtils.parseJsonObjectIDList(parsedSpec, colnames, TfMethod.IMPUTE.toString(), -1, -1);
+		int[] collist = TfMetaUtils
+			.parseJsonObjectIDList(parsedSpec, colnames, TfMethod.IMPUTE.toString(), minCol, maxCol);
 		initColList(collist);
 	
 		//handle method list
-		parseMethodsAndReplacments(parsedSpec);
+		parseMethodsAndReplacements(parsedSpec, colnames, minCol);
 		
 		//create reuse histograms
 		_hist = new HashMap<>();
 	}
 	
-	public EncoderMVImpute(JSONObject parsedSpec, String[] colnames, String[] NAstrings, int clen)
-		throws JSONException 
-	{
-		super(null, clen);
-		boolean isMV = parsedSpec.containsKey(TfMethod.IMPUTE.toString());
-		boolean isSC = parsedSpec.containsKey(TfMethod.SCALE.toString());
-		_NAstrings = NAstrings;
-		
-		if(!isMV) {
-			// MV Impute is not applicable
-			_colList = null;
-			_mvMethodList = null;
-			_meanList = null;
-			_countList = null;
-			_replacementList = null;
-		}
-		else {
-			JSONObject mvobj = (JSONObject) parsedSpec.get(TfMethod.IMPUTE.toString());
-			JSONArray mvattrs = (JSONArray) mvobj.get(TfUtils.JSON_ATTRS);
-			JSONArray mvmthds = (JSONArray) mvobj.get(TfUtils.JSON_MTHD);
-			int mvLength = mvattrs.size();
-			
-			_colList = new int[mvLength];
-			_mvMethodList = new MVMethod[mvLength];
-			
-			_meanList = new KahanObject[mvLength];
-			_countList = new long[mvLength];
-			_varList = new CM_COV_Object[mvLength];
-			
-			_isMVScaled = new BitSet(_colList.length);
-			_isMVScaled.clear();
-			
-			for(int i=0; i < _colList.length; i++) {
-				_colList[i] = UtilFunctions.toInt(mvattrs.get(i));
-				_mvMethodList[i] = MVMethod.values()[UtilFunctions.toInt(mvmthds.get(i))]; 
-				_meanList[i] = new KahanObject(0, 0);
-			}
-			
-			_replacementList = new String[mvLength]; 	// contains replacements for all columns (scale and categorical)
-			
-			JSONArray constants = (JSONArray)mvobj.get(TfUtils.JSON_CONSTS);
-			for(int i=0; i < constants.size(); i++) {
-				if ( constants.get(i) == null )
-					_replacementList[i] = "NaN";
-				else
-					_replacementList[i] = constants.get(i).toString();
-			}
-		}
-		
-		// Handle scaled attributes
-		if ( !isSC )
-		{
-			// scaling is not applicable
-			_scnomvCountList = null;
-			_scnomvMeanList = null;
-			_scnomvVarList = null;
-		}
-		else
-		{
-			if ( _colList != null ) 
-				_mvscMethodList = new MVMethod[_colList.length];
-			
-			JSONObject scobj = (JSONObject) parsedSpec.get(TfMethod.SCALE.toString());
-			JSONArray scattrs = (JSONArray) scobj.get(TfUtils.JSON_ATTRS);
-			JSONArray scmthds = (JSONArray) scobj.get(TfUtils.JSON_MTHD);
-			int scLength = scattrs.size();
-			
-			int[] _allscaled = new int[scLength];
-			int scnomv = 0, colID;
-			byte mthd;
-			for(int i=0; i < scLength; i++)
-			{
-				colID = UtilFunctions.toInt(scattrs.get(i));
-				mthd = (byte) UtilFunctions.toInt(scmthds.get(i));
-				
-				_allscaled[i] = colID;
-				
-				// check if the attribute is also MV imputed
-				int mvidx = isApplicable(colID);
-				if(mvidx != -1)
-				{
-					_isMVScaled.set(mvidx);
-					_mvscMethodList[mvidx] = MVMethod.values()[mthd];
-					_varList[mvidx] = new CM_COV_Object();
-				}
-				else
-					scnomv++;	// count of scaled but not imputed 
-			}
-			
-			if(scnomv > 0)
-			{
-				_scnomvList = new int[scnomv];
-				_scnomvMethodList = new MVMethod[scnomv];
-	
-				_scnomvMeanList = new KahanObject[scnomv];
-				_scnomvCountList = new long[scnomv];
-				_scnomvVarList = new CM_COV_Object[scnomv];
-				
-				for(int i=0, idx=0; i < scLength; i++)
-				{
-					colID = UtilFunctions.toInt(scattrs.get(i));
-					mthd = (byte)UtilFunctions.toInt(scmthds.get(i));
-							
-					if(isApplicable(colID) == -1)
-					{	// scaled but not imputed
-						_scnomvList[idx] = colID;
-						_scnomvMethodList[idx] = MVMethod.values()[mthd];
-						_scnomvMeanList[idx] = new KahanObject(0, 0);
-						_scnomvVarList[idx] = new CM_COV_Object();
-						idx++;
-					}
-				}
-			}
-		}
+	public EncoderMVImpute() {
+		super(new int[0], 0);
 	}
-
-	private void parseMethodsAndReplacments(JSONObject parsedSpec) throws JSONException {
+	
+	
+	public EncoderMVImpute(int[] colList, MVMethod[] mvMethodList, String[] replacementList, KahanObject[] meanList,
+			long[] countList, List<Integer> rcList, int clen) {
+		super(colList, clen);
+		_mvMethodList = mvMethodList;
+		_replacementList = replacementList;
+		_meanList = meanList;
+		_countList = countList;
+		_rcList = rcList;
+	}
+	
+	private void parseMethodsAndReplacements(JSONObject parsedSpec, String[] colnames, int offset) throws JSONException {
 		JSONArray mvspec = (JSONArray) parsedSpec.get(TfMethod.IMPUTE.toString());
+		boolean ids = parsedSpec.containsKey("ids") && parsedSpec.getBoolean("ids");
+		// make space for all elements
 		_mvMethodList = new MVMethod[mvspec.size()];
 		_replacementList = new String[mvspec.size()];
 		_meanList = new KahanObject[mvspec.size()];
 		_countList = new long[mvspec.size()];
-		for(int i=0; i < mvspec.size(); i++) {
-			JSONObject mvobj = (JSONObject)mvspec.get(i);
-			_mvMethodList[i] = MVMethod.valueOf(mvobj.get("method").toString().toUpperCase()); 
-			if( _mvMethodList[i] == MVMethod.CONSTANT ) {
-				_replacementList[i] = mvobj.getString("value").toString();
-			}
-			_meanList[i] = new KahanObject(0, 0);
-		}
-	}
+		// sort for binary search
+		Arrays.sort(_colList);
 		
-	public void prepare(String[] words) throws IOException {
-		
-		try {
-			String w = null;
-			if(_colList != null)
-			for(int i=0; i <_colList.length; i++) {
-				int colID = _colList[i];
-				w = UtilFunctions.unquote(words[colID-1].trim());
-				
-				try {
-				if(!TfUtils.isNA(_NAstrings, w)) {
-					_countList[i]++;
-					
-					boolean computeMean = (_mvMethodList[i] == MVMethod.GLOBAL_MEAN || _isMVScaled.get(i) );
-					if(computeMean) {
-						// global_mean
-						double d = UtilFunctions.parseToDouble(w, UtilFunctions.defaultNaString);
-						_meanFn.execute2(_meanList[i], d, _countList[i]);
-						
-						if (_isMVScaled.get(i) && _mvscMethodList[i] == MVMethod.GLOBAL_MODE)
-							_varFn.execute(_varList[i], d);
-					}
-					else {
-						// global_mode or constant
-						// Nothing to do here. Mode is computed using recode maps.
-					}
+		int listIx = 0;
+		for(Object o : mvspec) {
+			JSONObject mvobj = (JSONObject) o;
+			int ixOffset = offset == -1 ? 0 : offset - 1;
+			// check for position -> -1 if not present
+			int pos = Arrays.binarySearch(_colList,
+				ids ? mvobj.getInt("id") - ixOffset : ArrayUtils.indexOf(colnames, mvobj.get("name")) + 1);
+			if(pos >= 0) {
+				// add to arrays
+				_mvMethodList[listIx] = MVMethod.valueOf(mvobj.get("method").toString().toUpperCase());
+				if(_mvMethodList[listIx] == MVMethod.CONSTANT) {
+					_replacementList[listIx] = mvobj.getString("value");
 				}
-				} catch (NumberFormatException e) 
-				{
-					throw new RuntimeException("Encountered \"" + w + "\" in column ID \"" + colID + "\", when expecting a numeric value. Consider adding \"" + w + "\" to na.strings, along with an appropriate imputation method.");
-				}
+				_meanList[listIx++] = new KahanObject(0, 0);
 			}
-			
-			// Compute mean and variance for attributes that are scaled but not imputed
-			if(_scnomvList != null)
-			for(int i=0; i < _scnomvList.length; i++) 
-			{
-				int colID = _scnomvList[i];
-				w = UtilFunctions.unquote(words[colID-1].trim());
-				double d = UtilFunctions.parseToDouble(w, UtilFunctions.defaultNaString);
-				_scnomvCountList[i]++; 		// not required, this is always equal to total #records processed
-				_meanFn.execute2(_scnomvMeanList[i], d, _scnomvCountList[i]);
-				if(_scnomvMethodList[i] == MVMethod.GLOBAL_MODE)
-					_varFn.execute(_scnomvVarList[i], d);
-			}
-		} catch(Exception e) {
-			throw new IOException(e);
 		}
+		// make arrays required size
+		_mvMethodList = Arrays.copyOf(_mvMethodList, listIx);
+		_replacementList = Arrays.copyOf(_replacementList, listIx);
+		_meanList = Arrays.copyOf(_meanList, listIx);
+		_countList = Arrays.copyOf(_countList, listIx);
 	}
 	
 	public MVMethod getMethod(int colID) {
@@ -349,6 +205,94 @@ public class EncoderMVImpute extends Encoder
 		}
 		return out;
 	}
+
+	@Override
+	public Encoder subRangeEncoder(IndexRange ixRange) {
+		Map<Integer, ColInfo> map = new HashMap<>();
+		for(int i = 0; i < _colList.length; i++) {
+			int col = _colList[i];
+			if(ixRange.inColRange(col))
+				map.put((int) (_colList[i] - (ixRange.colStart - 1)),
+					new ColInfo(_mvMethodList[i], _replacementList[i], _meanList[i], _countList[i], _hist.get(i)));
+		}
+		if(map.size() == 0)
+			// empty encoder -> sub range encoder does not exist
+			return null;
+
+		int[] colList = new int[map.size()];
+		MVMethod[] mvMethodList = new MVMethod[map.size()];
+		String[] replacementList = new String[map.size()];
+		KahanObject[] meanList = new KahanObject[map.size()];
+		long[] countList = new long[map.size()];
+
+		fillListsFromMap(map, colList, mvMethodList, replacementList, meanList, countList, _hist);
+
+		if(_rcList == null)
+			_rcList = new ArrayList<>();
+		List<Integer> rcList = _rcList.stream().filter(ixRange::inColRange).map(i -> (int) (i - (ixRange.colStart - 1)))
+			.collect(Collectors.toList());
+
+		return new EncoderMVImpute(colList, mvMethodList, replacementList, meanList, countList, rcList,
+			(int) ixRange.colSpan());
+	}
+
+	private void fillListsFromMap(Map<Integer, ColInfo> map, int[] colList, MVMethod[] mvMethodList,
+		String[] replacementList, KahanObject[] meanList, long[] countList,
+		HashMap<Integer, HashMap<String, Long>> hist) {
+		int i = 0;
+		for(Entry<Integer, ColInfo> entry : map.entrySet()) {
+			colList[i] = entry.getKey();
+			mvMethodList[i] = entry.getValue()._method;
+			replacementList[i] = entry.getValue()._replacement;
+			meanList[i] = entry.getValue()._mean;
+			countList[i++] = entry.getValue()._count;
+
+			hist.put(entry.getKey(), entry.getValue()._hist);
+		}
+	}
+
+	@Override
+	public void mergeAt(Encoder other, int row, int col) {
+		if(other instanceof EncoderMVImpute) {
+			EncoderMVImpute otherImpute = (EncoderMVImpute) other;
+			Map<Integer, ColInfo> map = new HashMap<>();
+			for(int i = 0; i < _colList.length; i++) {
+				map.put(_colList[i],
+					new ColInfo(_mvMethodList[i], _replacementList[i], _meanList[i], _countList[i], _hist.get(i + 1)));
+			}
+			for(int i = 0; i < other._colList.length; i++) {
+				int column = other._colList[i] + (col - 1);
+				ColInfo otherColInfo = new ColInfo(otherImpute._mvMethodList[i], otherImpute._replacementList[i],
+					otherImpute._meanList[i], otherImpute._countList[i], otherImpute._hist.get(i + 1));
+				ColInfo colInfo = map.get(column);
+				if(colInfo == null) {
+					map.put(column, otherColInfo);
+				}
+				else {
+					colInfo.merge(otherColInfo);
+				}
+			}
+
+			_colList = new int[map.size()];
+			_mvMethodList = new MVMethod[map.size()];
+			_replacementList = new String[map.size()];
+			_meanList = new KahanObject[map.size()];
+			_countList = new long[map.size()];
+			_hist = new HashMap<>();
+
+			fillListsFromMap(map, _colList, _mvMethodList, _replacementList, _meanList, _countList, _hist);
+			// update number of columns
+			_clen = Math.max(_clen, col - 1 + other._clen);
+
+			if(_rcList == null)
+				_rcList = new ArrayList<>();
+			Set<Integer> rcSet = new HashSet<>(_rcList);
+			rcSet.addAll(otherImpute._rcList.stream().map(i -> i + (col - 1)).collect(Collectors.toSet()));
+			_rcList = new ArrayList<>(rcSet);
+			return;
+		}
+		super.mergeAt(other, row, col);
+	}
 	
 	@Override
 	public FrameBlock getMetaData(FrameBlock out) {
@@ -390,5 +334,49 @@ public class EncoderMVImpute extends Encoder
 	 */
 	public HashMap<String,Long> getHistogram( int colID ) {
 		return _hist.get(colID);
+	}
+	
+	private static class ColInfo {
+		MVMethod _method;
+		String _replacement;
+		KahanObject _mean;
+		long _count;
+		HashMap<String, Long> _hist;
+
+		ColInfo(MVMethod method, String replacement, KahanObject mean, long count, HashMap<String, Long> hist) {
+			_method = method;
+			_replacement = replacement;
+			_mean = mean;
+			_count = count;
+			_hist = hist;
+		}
+
+		public void merge(ColInfo otherColInfo) {
+			if(_method != otherColInfo._method)
+				throw new DMLRuntimeException("Tried to merge two different impute methods: " + _method.name() + " vs. "
+					+ otherColInfo._method.name());
+			switch(_method) {
+				case CONSTANT:
+					assert _replacement.equals(otherColInfo._replacement);
+					break;
+				case GLOBAL_MEAN:
+					_mean._sum *= _count;
+					_mean._correction *= _count;
+					KahanPlus.getKahanPlusFnObject().execute(_mean, otherColInfo._mean._sum * otherColInfo._count);
+					KahanPlus.getKahanPlusFnObject().execute(_mean,
+						otherColInfo._mean._correction * otherColInfo._count);
+					_count += otherColInfo._count;
+					break;
+				case GLOBAL_MODE:
+					if (_hist == null)
+						_hist = new HashMap<>(otherColInfo._hist);
+					else
+						// add counts
+						_hist.replaceAll((key, count) -> count + otherColInfo._hist.getOrDefault(key, 0L));
+					break;
+				default:
+					throw new DMLRuntimeException("Method `" + _method.name() + "` not supported for federated impute");
+			}
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderPassThrough.java
@@ -88,12 +88,12 @@ public class EncoderPassThrough extends Encoder
 	}
 	
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if(other instanceof EncoderPassThrough) {
 			mergeColumnInfo(other, col);
 			return;
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderRecode.java
@@ -187,7 +187,7 @@ public class EncoderRecode extends Encoder
 	}
 
 	@Override
-	public void mergeAt(Encoder other, int col) {
+	public void mergeAt(Encoder other, int row, int col) {
 		if(other instanceof EncoderRecode) {
 			mergeColumnInfo(other, col);
 			
@@ -212,7 +212,7 @@ public class EncoderRecode extends Encoder
 			}
 			return;
 		}
-		super.mergeAt(other, col);
+		super.mergeAt(other, row, col);
 	}
 	
 	public int[] numDistinctValues() {

--- a/src/test/java/org/apache/sysds/test/functions/federated/transform/TransformFederatedEncodeApplyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/transform/TransformFederatedEncodeApplyTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.federated.transform;
 
+import java.io.IOException;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.FileFormat;
@@ -64,8 +65,8 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 
 	// dataset and transform tasks with missing values
 	private final static String DATASET2 = "homes/homes.csv";
-	// private final static String SPEC4 = "homes3/homes.tfspec_impute.json";
-	// private final static String SPEC4b = "homes3/homes.tfspec_impute2.json";
+	private final static String SPEC4 = "homes3/homes.tfspec_impute.json";
+	private final static String SPEC4b = "homes3/homes.tfspec_impute2.json";
 	private final static String SPEC5 = "homes3/homes.tfspec_omit.json";
 	private final static String SPEC5b = "homes3/homes.tfspec_omit2.json";
 
@@ -73,11 +74,7 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 	private static final int[] BIN_col8 = new int[] {1, 2, 2, 2, 2, 2, 3};
 
 	public enum TransformType {
-		RECODE, DUMMY, RECODE_DUMMY, BIN, BIN_DUMMY,
-		// IMPUTE,
-		OMIT,
-		HASH,
-		HASH_RECODE,
+		RECODE, DUMMY, RECODE_DUMMY, BIN, BIN_DUMMY, IMPUTE, OMIT, HASH, HASH_RECODE,
 	}
 
 	@Override
@@ -116,10 +113,10 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 		runTransformTest(TransformType.OMIT, false);
 	}
 
-	// @Test
-	// public void testHomesImputeIDsCSV() {
-	// runTransformTest(TransformType.IMPUTE, false);
-	// }
+	@Test
+	public void testHomesImputeIDsCSV() {
+		runTransformTest(TransformType.IMPUTE, false);
+	}
 
 	@Test
 	public void testHomesRecodeColnamesCSV() {
@@ -151,10 +148,10 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 		runTransformTest(TransformType.OMIT, true);
 	}
 
-	// @Test
-	// public void testHomesImputeColnamesCSV() {
-	// runTransformTest(TransformType.IMPUTE, true);
-	// }
+	@Test
+	public void testHomesImputeColnamesCSV() {
+		runTransformTest(TransformType.IMPUTE, true);
+	}
 
 	@Test
 	public void testHomesHashColnamesCSV() {
@@ -186,7 +183,7 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 			case RECODE: SPEC = colnames ? SPEC1b : SPEC1; DATASET = DATASET1; break;
 			case DUMMY: SPEC = colnames ? SPEC2b : SPEC2; DATASET = DATASET1; break;
 			case BIN: SPEC = colnames ? SPEC3b : SPEC3; DATASET = DATASET1; break;
-			// case IMPUTE: SPEC = colnames ? SPEC4b : SPEC4; DATASET = DATASET2; break;
+			case IMPUTE: SPEC = colnames ? SPEC4b : SPEC4; DATASET = DATASET2; break;
 			case OMIT: SPEC = colnames ? SPEC5b : SPEC5; DATASET = DATASET2; break;
 			case RECODE_DUMMY: SPEC = colnames ? SPEC6b : SPEC6; DATASET = DATASET1; break;
 			case BIN_DUMMY: SPEC = colnames ? SPEC7b : SPEC7; DATASET = DATASET1; break;
@@ -194,7 +191,7 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 			case HASH_RECODE: SPEC = colnames ? SPEC9b : SPEC9; DATASET = DATASET1; break;
 		}
 
-		Thread t1 = null, t2 = null;
+		Thread t1 = null, t2 = null, t3 = null, t4 = null;
 		try {
 			getAndLoadTestConfiguration(TEST_NAME1);
 
@@ -202,6 +199,10 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 			t1 = startLocalFedWorkerThread(port1);
 			int port2 = getRandomAvailablePort();
 			t2 = startLocalFedWorkerThread(port2);
+			int port3 = getRandomAvailablePort();
+			t3 = startLocalFedWorkerThread(port3);
+			int port4 = getRandomAvailablePort();
+			t4 = startLocalFedWorkerThread(port4);
 
 			FileFormatPropertiesCSV ffpCSV = new FileFormatPropertiesCSV(true, DataExpression.DEFAULT_DELIM_DELIMITER,
 				DataExpression.DEFAULT_DELIM_FILL, DataExpression.DEFAULT_DELIM_FILL_VALUE,
@@ -216,23 +217,49 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 			ffpCSV.setNAStrings(UtilFunctions.defaultNaString);
 			FrameWriter fw = FrameWriterFactory.createFrameWriter(FileFormat.CSV, ffpCSV);
 
-			FrameBlock A = new FrameBlock();
-			dataset.slice(0, dataset.getNumRows() - 1, 0, dataset.getNumColumns() / 2 - 1, A);
-			fw.writeFrameToHDFS(A, input("A"), A.getNumRows(), A.getNumColumns());
-			HDFSTool.writeMetaDataFile(input("A.mtd"), null, A.getSchema(), Types.DataType.FRAME,
-				new MatrixCharacteristics(A.getNumRows(), A.getNumColumns()), FileFormat.CSV, ffpCSV);
+			writeDatasetSlice(dataset,
+				fw,
+				ffpCSV,
+				"AH",
+				0,
+				dataset.getNumRows() / 2 - 1,
+				0,
+				dataset.getNumColumns() / 2 - 1);
 
-			FrameBlock B = new FrameBlock();
-			dataset.slice(0, dataset.getNumRows() - 1, dataset.getNumColumns() / 2, dataset.getNumColumns() - 1, B);
-			fw.writeFrameToHDFS(B, input("B"), B.getNumRows(), B.getNumColumns());
-			HDFSTool.writeMetaDataFile(input("B.mtd"), null, B.getSchema(), Types.DataType.FRAME,
-				new MatrixCharacteristics(B.getNumRows(), B.getNumColumns()), FileFormat.CSV, ffpCSV);
+			writeDatasetSlice(dataset,
+				fw,
+				ffpCSV,
+				"AL",
+				dataset.getNumRows() / 2,
+				dataset.getNumRows() - 1,
+				0,
+				dataset.getNumColumns() / 2 - 1);
+
+			writeDatasetSlice(dataset,
+				fw,
+				ffpCSV,
+				"BH",
+				0,
+				dataset.getNumRows() / 2 - 1,
+				dataset.getNumColumns() / 2,
+				dataset.getNumColumns() - 1);
+
+			writeDatasetSlice(dataset,
+				fw,
+				ffpCSV,
+				"BL",
+				dataset.getNumRows() / 2,
+				dataset.getNumRows() - 1,
+				dataset.getNumColumns() / 2,
+				dataset.getNumColumns() - 1);
 
 			fullDMLScriptName = HOME + TEST_NAME1 + ".dml";
-			programArgs = new String[] {"-nvargs", "in_A=" + TestUtils.federatedAddress(port1, input("A")),
-				"in_B=" + TestUtils.federatedAddress(port2, input("B")), "rows=" + dataset.getNumRows(),
-				"cols_A=" + A.getNumColumns(), "cols_B=" + B.getNumColumns(), "TFSPEC=" + HOME + "input/" + SPEC,
-				"TFDATA1=" + output("tfout1"), "TFDATA2=" + output("tfout2"), "OFMT=csv"};
+			programArgs = new String[] {"-nvargs", "in_AH=" + TestUtils.federatedAddress(port1, input("AH")),
+				"in_AL=" + TestUtils.federatedAddress(port2, input("AL")),
+				"in_BH=" + TestUtils.federatedAddress(port3, input("BH")),
+				"in_BL=" + TestUtils.federatedAddress(port4, input("BL")), "rows=" + dataset.getNumRows(),
+				"cols=" + dataset.getNumColumns(), "TFSPEC=" + HOME + "input/" + SPEC, "TFDATA1=" + output("tfout1"),
+				"TFDATA2=" + output("tfout2"), "OFMT=csv"};
 
 			runTest(true, false, null, -1);
 
@@ -266,8 +293,22 @@ public class TransformFederatedEncodeApplyTest extends AutomatedTestBase {
 			throw new RuntimeException(ex);
 		}
 		finally {
-			TestUtils.shutdownThreads(t1, t2);
+			TestUtils.shutdownThreads(t1, t2, t3, t4);
 			resetExecMode(rtold);
 		}
+	}
+
+	private void writeDatasetSlice(FrameBlock dataset, FrameWriter fw, FileFormatPropertiesCSV ffpCSV, String name,
+		int rl, int ru, int cl, int cu) throws IOException {
+		FrameBlock AH = new FrameBlock();
+		dataset.slice(rl, ru, cl, cu, AH);
+		fw.writeFrameToHDFS(AH, input(name), AH.getNumRows(), AH.getNumColumns());
+		HDFSTool.writeMetaDataFile(input(DataExpression.getMTDFileName(name)),
+			null,
+			AH.getSchema(),
+			Types.DataType.FRAME,
+			new MatrixCharacteristics(AH.getNumRows(), AH.getNumColumns()),
+			FileFormat.CSV,
+			ffpCSV);
 	}
 }

--- a/src/test/scripts/functions/transform/TransformFederatedEncodeApply.dml
+++ b/src/test/scripts/functions/transform/TransformFederatedEncodeApply.dml
@@ -19,9 +19,11 @@
 #
 #-------------------------------------------------------------
 
-F1 = federated(type="frame", addresses=list($in_A, $in_B), ranges=
-    list(list(0,0), list($rows, $cols_A), # A range
-    list(0, $cols_A), list($rows, $cols_A + $cols_B))); # B range
+F1 = federated(type="frame", addresses=list($in_AH, $in_AL, $in_BH, $in_BL), ranges=list(
+    list(0,0), list($rows / 2, $cols / 2), # AH range
+    list($rows / 2,0), list($rows, $cols / 2), # AL range
+    list(0,$cols / 2), list($rows / 2, $cols), # BH range
+    list($rows / 2,$cols / 2), list($rows, $cols))); # BL range
 
 jspec = read($TFSPEC, data_type="scalar", value_type="string");
 


### PR DESCRIPTION
Adds support for federated execution for the final encoder `EncoderMVImpute`. This should finish support for federated transform operations (perf and improvements being TODO).

## `EncoderMVImput`

Note that I removed quite a bit of code from `EncoderMVImpute` as it seems to not be in use at all, please confirm if this is fine.

## `EncoderOmit`

I added the perf improvement of the TODO, since omit anyway had some problems which needed a fix.