### PR TITLE
[SYSTEMDS-2651] Add faster multiple federated workers startup

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -155,9 +155,11 @@ public class FederatedData {
 			return promise;
 		}
 		catch (InterruptedException e) {
+			workerGroup.shutdownGracefully();
 			throw new DMLRuntimeException("Could not send federated operation.");
 		}
 		catch (Exception e) {
+			workerGroup.shutdownGracefully();
 			throw new DMLRuntimeException(e);
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/FedTestWorkers.java
+++ b/src/test/java/org/apache/sysds/test/FedTestWorkers.java
@@ -1,0 +1,82 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.sysds.test;
+
+import java.security.InvalidParameterException;
+import java.util.Arrays;
+
+import org.apache.sysds.runtime.DMLRuntimeException;
+
+/**
+ * This class is used for running federated tests. It will run the required workers, a single one as a thread and the
+ * rest as processes, this allows for easy debugging, while getting good performance.
+ */
+public class FedTestWorkers {
+	private final AutomatedTestBase _test;
+	private final int _numWorkers;
+	private int[] _ports = null;
+	private Thread _debugWorker = null;
+	private Process[] _remainingWorkers = null;
+	
+	/**
+	 * Create wrapper for federated workers and start it.
+	 * @param numWorkers the number of federated workers
+	 */
+	public FedTestWorkers(AutomatedTestBase test, int numWorkers) {
+		if (numWorkers < 1) {
+			throw new InvalidParameterException("at least 1 worker required");
+		}
+		_test = test;
+		_numWorkers = numWorkers;
+	}
+	
+	/**
+	 * Start the workers, returning the ports for them. The first port is the one of the worker running on the thread,
+	 * for which breakpoints can be set, all other workers will not stop at debug breakpoints.
+	 * @return ports
+	 */
+	public int[] start() throws Exception {
+		if (_ports != null &&  _ports.length != 0)
+			throw new DMLRuntimeException("Federated workers have to be stopped before starting again.");
+		_ports = new int[_numWorkers];
+		for (int i = 0; i < _numWorkers; i++)
+			_ports[i] = AutomatedTestBase.getRandomAvailablePort();
+		
+		// first start all processes, during their startup we start the thread and then wait for processes
+		_remainingWorkers = new Process[_numWorkers - 1];
+		for(int i = 0; i < _remainingWorkers.length; i++) {
+			_remainingWorkers[i] = _test.startLocalFedWorker(_ports[i + 1], false);
+		}
+		_debugWorker = _test.startLocalFedWorkerThread(_ports[0]);
+		for(int i = 1; i < _ports.length; i++) {
+			AutomatedTestBase.waitForFederatedWorker(_ports[i]);
+		}
+		return _ports;
+	}
+	
+	/**
+	 * Stop the workers.
+	 */
+	public void stop() {
+		TestUtils.shutdownThread(_debugWorker);
+		TestUtils.shutdownProcesses(_remainingWorkers);
+		_ports = new int[0];
+	}
+}

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -2603,9 +2603,9 @@ public class TestUtils
 			shutdownThread(t);
 	}
 
-	public static void shutdownThreads(Process... ts) {
+	public static void shutdownProcesses(Process... ts) {
 		for( Process t : ts )
-			shutdownThread(t);
+			shutdownProcess(t);
 	}
 	
 	public static void shutdownThread(Thread t) {
@@ -2621,7 +2621,7 @@ public class TestUtils
 		}
 	}
 
-	public static void shutdownThread(Process t) {
+	public static void shutdownProcess(Process t) {
 		// kill the worker
 		if( t != null ) {
 			Process d = t.destroyForcibly();

--- a/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedGLMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedGLMTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.federated.algorithms;
 
+import org.apache.sysds.test.FedTestWorkers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,17 +62,17 @@ public class FederatedGLMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedSinglenodeGLM() {
+	public void federatedSinglenodeGLM() throws Exception {
 		federatedGLM(Types.ExecMode.SINGLE_NODE);
 	}
 
 	@Test
-	public void federatedHybridGLM() {
+	public void federatedHybridGLM() throws Exception {
 		federatedGLM(Types.ExecMode.HYBRID);
 	}
 
 	
-	public void federatedGLM(Types.ExecMode execMode) {
+	public void federatedGLM(Types.ExecMode execMode) throws Exception {
 		ExecMode platformOld = setExecMode(execMode);
 
 		getAndLoadTestConfiguration(TEST_NAME);
@@ -90,12 +91,8 @@ public class FederatedGLMTest extends AutomatedTestBase {
 		writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
 		writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
 
-		// empty script name because we don't execute any script, just start the worker
-		fullDMLScriptName = "";
-		int port1 = getRandomAvailablePort();
-		int port2 = getRandomAvailablePort();
-		Thread t1 = startLocalFedWorkerThread(port1);
-		Thread t2 = startLocalFedWorkerThread(port2);
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
+		int[] ports = workers.start();
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -109,15 +106,14 @@ public class FederatedGLMTest extends AutomatedTestBase {
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-stats",
-			"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
+			"-nvargs", "in_X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(ports[1], input("X2")), "rows=" + rows, "cols=" + cols,
 			"in_Y=" + input("Y"), "out=" + output("Z")};
 		runTest(true, false, null, -1);
 
 		// compare via files
 		compareResults(1e-9);
-
-		TestUtils.shutdownThreads(t1, t2);
+		workers.stop();
 
 		// check for federated operations
 		Assert.assertTrue(heavyHittersContainsString("fed_ba+*"));

--- a/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedL2SVMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedL2SVMTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.federated.algorithms;
 
+import org.apache.sysds.test.FedTestWorkers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -59,7 +60,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCP() {
+	public void federatedL2SVMCP() throws Exception {
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE);
 	}
 
@@ -69,7 +70,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	 * @Test public void federatedL2SVMSP() { federatedL2SVM(Types.ExecMode.SPARK); }
 	 */
 
-	public void federatedL2SVM(Types.ExecMode execMode) {
+	public void federatedL2SVM(Types.ExecMode execMode) throws Exception {
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		Types.ExecMode platformOld = rtplatform;
 		rtplatform = execMode;
@@ -93,12 +94,8 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 		writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
 		writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
 
-		// empty script name because we don't execute any script, just start the worker
-		fullDMLScriptName = "";
-		int port1 = getRandomAvailablePort();
-		int port2 = getRandomAvailablePort();
-		Thread t1 = startLocalFedWorkerThread(port1);
-		Thread t2 = startLocalFedWorkerThread(port2);
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
+		int[] ports = workers.start();
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -111,15 +108,15 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[] {"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
+		programArgs = new String[] {"-nvargs", "in_X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(ports[1], input("X2")), "rows=" + rows, "cols=" + cols,
 			"in_Y=" + input("Y"), "out=" + output("Z")};
 		runTest(true, false, null, -1);
 
 		// compare via files
 		compareResults(1e-9);
 
-		TestUtils.shutdownThreads(t1, t2);
+		workers.stop();
 
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;

--- a/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedYL2SVMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedYL2SVMTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.federated.algorithms;
 
+import org.apache.sysds.test.FedTestWorkers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -61,7 +62,7 @@ public class FederatedYL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCP() {
+	public void federatedL2SVMCP() throws Exception {
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE);
 	}
 
@@ -71,7 +72,7 @@ public class FederatedYL2SVMTest extends AutomatedTestBase {
 	 * @Test public void federatedL2SVMSP() { federatedL2SVM(Types.ExecMode.SPARK); }
 	 */
 
-	public void federatedL2SVM(Types.ExecMode execMode) {
+	public void federatedL2SVM(Types.ExecMode execMode) throws Exception {
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		Types.ExecMode platformOld = rtplatform;
 		rtplatform = execMode;
@@ -100,12 +101,8 @@ public class FederatedYL2SVMTest extends AutomatedTestBase {
 		writeInputMatrixWithMTD("Y1", Y1, false, new MatrixCharacteristics(halfRows, 1, blocksize, halfRows));
 		writeInputMatrixWithMTD("Y2", Y2, false, new MatrixCharacteristics(halfRows, 1, blocksize, halfRows));
 
-		// empty script name because we don't execute any script, just start the worker
-		fullDMLScriptName = "";
-		int port1 = getRandomAvailablePort();
-		int port2 = getRandomAvailablePort();
-		Thread t1 = startLocalFedWorkerThread(port1);
-		Thread t2 = startLocalFedWorkerThread(port2);
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
+		int[] ports = workers.start();
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -118,16 +115,16 @@ public class FederatedYL2SVMTest extends AutomatedTestBase {
 
 		// Run actual dml script with federated matrixz
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[] {"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
-			"in_Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
-			"in_Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "out=" + output("Z")};
+		programArgs = new String[] {"-nvargs", "in_X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(ports[1], input("X2")), "rows=" + rows, "cols=" + cols,
+			"in_Y1=" + TestUtils.federatedAddress(ports[0], input("Y1")),
+			"in_Y2=" + TestUtils.federatedAddress(ports[1], input("Y2")), "out=" + output("Z")};
 		runTest(true, false, null, -1);
 
 		// compare via files
 		compareResults(1e-9);
 
-		TestUtils.shutdownThreads(t1, t2);
+		workers.stop();
 
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;

--- a/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedWriterTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedWriterTest.java
@@ -63,11 +63,11 @@ public class FederatedWriterTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedSinglenodeWrite() {
+	public void federatedSinglenodeWrite() throws Exception {
 		federatedWrite(ExecMode.SINGLE_NODE);
 	}
 
-	public void federatedWrite(ExecMode execMode) {
+	public void federatedWrite(ExecMode execMode) throws Exception {
 		ExecMode oldPlatform = setExecMode(execMode);
 		getAndLoadTestConfiguration(TEST_NAME);
 		setOutputBuffering(true);
@@ -112,7 +112,8 @@ public class FederatedWriterTest extends AutomatedTestBase {
 
 			// Verify output
 			Assert.assertEquals(Double.parseDouble(refOut.split("\n")[0]),
-				Double.parseDouble(out.split("\n")[0]), 0.00001);
+				Double.parseDouble(out.split("\n")[0]),
+				0.00001);
 		}
 		catch(Exception e) {
 			e.printStackTrace();

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedBinaryMatrixTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedBinaryMatrixTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.federated.primitives;
 
+import org.apache.sysds.test.FedTestWorkers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,14 +56,11 @@ public class FederatedBinaryMatrixTest extends AutomatedTestBase {
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {
 		// rows have to be even and > 1
-		return Arrays.asList(new Object[][] {
-            {2, 1000}, 
-            {10, 100}, {100, 10}, {1000, 1}, {10, 2000}, {2000, 10}
-        });
+		return Arrays.asList(new Object[][] {{2, 1000}, {10, 100}, {100, 10}, {1000, 1}, {10, 2000}, {2000, 10}});
 	}
 
 	@Test
-	public void federatedMultiplyCP() {
+	public void federatedMultiplyCP() throws Exception {
 		federatedMultiply(Types.ExecMode.SINGLE_NODE);
 	}
 
@@ -72,7 +70,7 @@ public class FederatedBinaryMatrixTest extends AutomatedTestBase {
 	 * @Test public void federatedMultiplySP() { federatedMultiply(Types.ExecMode.SPARK); }
 	 */
 
-	public void federatedMultiply(Types.ExecMode execMode) {
+	public void federatedMultiply(Types.ExecMode execMode) throws Exception {
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		Types.ExecMode platformOld = rtplatform;
 		rtplatform = execMode;
@@ -97,10 +95,8 @@ public class FederatedBinaryMatrixTest extends AutomatedTestBase {
 		writeInputMatrixWithMTD("Y1", Y1, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
 		writeInputMatrixWithMTD("Y2", Y2, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
 
-		int port1 = getRandomAvailablePort();
-		int port2 = getRandomAvailablePort();
-		Thread t1 = startLocalFedWorkerThread(port1);
-		Thread t2 = startLocalFedWorkerThread(port2);
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
+		int[] ports = workers.start();
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -113,16 +109,14 @@ public class FederatedBinaryMatrixTest extends AutomatedTestBase {
 
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[] {"-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"X2=" + TestUtils.federatedAddress(port2, input("X2")),
-			"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
-			"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+		programArgs = new String[] {"-nvargs", "X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+			"X2=" + TestUtils.federatedAddress(ports[1], input("X2")),
+			"Y1=" + TestUtils.federatedAddress(ports[0], input("Y1")),
+			"Y2=" + TestUtils.federatedAddress(ports[1], input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
 		runTest(true, false, null, -1);
 
 		// compare via files
 		compareResults(1e-9);
-
-		TestUtils.shutdownThreads(t1, t2);
 
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
@@ -22,6 +22,7 @@ package org.apache.sysds.test.functions.federated.primitives;
 import java.util.Arrays;
 import java.util.Collection;
 
+import java.util.concurrent.TimeoutException;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
@@ -63,16 +64,16 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedSinglenodeLogReg() {
+	public void federatedSinglenodeLogReg() throws TimeoutException {
 		federatedLogReg(Types.ExecMode.SINGLE_NODE);
 	}
 
 	@Test
-	public void federatedHybridLogReg() {
+	public void federatedHybridLogReg() throws TimeoutException {
 		federatedLogReg(Types.ExecMode.HYBRID);
 	}
 
-	public void federatedLogReg(Types.ExecMode execMode) {
+	public void federatedLogReg(Types.ExecMode execMode) throws TimeoutException {
 		ExecMode platformOld = setExecMode(execMode);
 
 		getAndLoadTestConfiguration(TEST_NAME);

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
@@ -22,12 +22,12 @@ package org.apache.sysds.test.functions.federated.primitives;
 import java.util.Arrays;
 import java.util.Collection;
 
-import java.util.concurrent.TimeoutException;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.HDFSTool;
 import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.FedTestWorkers;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Assert;
@@ -64,16 +64,16 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedSinglenodeLogReg() throws TimeoutException {
+	public void federatedSinglenodeLogReg() throws Exception {
 		federatedLogReg(Types.ExecMode.SINGLE_NODE);
 	}
 
 	@Test
-	public void federatedHybridLogReg() throws TimeoutException {
+	public void federatedHybridLogReg() throws Exception {
 		federatedLogReg(Types.ExecMode.HYBRID);
 	}
 
-	public void federatedLogReg(Types.ExecMode execMode) throws TimeoutException {
+	public void federatedLogReg(Types.ExecMode execMode) throws Exception {
 		ExecMode platformOld = setExecMode(execMode);
 
 		getAndLoadTestConfiguration(TEST_NAME);
@@ -92,11 +92,8 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 		writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
 		writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
 
-		// empty script name because we don't execute any script, just start the worker
-		fullDMLScriptName = "";
-		int port1 = getRandomAvailablePort();
-		int port2 = getRandomAvailablePort();
-		Process[] processes = startLocalFedWorkers(port1, port2);
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
+		int[] ports = workers.start();
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -110,15 +107,15 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-stats", "30", "-nvargs",
-			"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
+			"in_X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(ports[1], input("X2")), "rows=" + rows, "cols=" + cols,
 			"in_Y=" + input("Y"), "out=" + output("Z")};
 		runTest(true, false, null, -1);
 
 		// compare via files
 		compareResults(1e-9);
 
-		TestUtils.shutdownProcesses(processes);
+		workers.stop();
 
 		// check for federated operations
 		Assert.assertTrue("contains federated matrix mult", heavyHittersContainsString("fed_ba+*"));

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedStatisticsTest.java
@@ -95,8 +95,7 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 		fullDMLScriptName = "";
 		int port1 = getRandomAvailablePort();
 		int port2 = getRandomAvailablePort();
-		Thread t1 = startLocalFedWorkerThread(port1);
-		Thread t2 = startLocalFedWorkerThread(port2);
+		Process[] processes = startLocalFedWorkers(port1, port2);
 
 		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 		loadTestConfiguration(config);
@@ -118,7 +117,7 @@ public class FederatedStatisticsTest extends AutomatedTestBase {
 		// compare via files
 		compareResults(1e-9);
 
-		TestUtils.shutdownThreads(t1, t2);
+		TestUtils.shutdownProcesses(processes);
 
 		// check for federated operations
 		Assert.assertTrue("contains federated matrix mult", heavyHittersContainsString("fed_ba+*"));

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
@@ -202,7 +202,7 @@ public class FederatedWorkerHandlerTest extends AutomatedTestBase {
 		assertTrue("The privacy level " + privacyLevel.toString() + " should have been checked during execution",
 			checkedPrivacyConstraintsContains(privacyLevel));
 
-		TestUtils.shutdownThread(t);
+		TestUtils.shutdownProcess(t);
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
 	}
@@ -267,7 +267,7 @@ public class FederatedWorkerHandlerTest extends AutomatedTestBase {
 		assertTrue("Privacy constraint with level " + privacyLevel + " should have been checked during execution",
 			checkedPrivacyConstraintsContains(privacyLevel));
 
-		TestUtils.shutdownThread(t);
+		TestUtils.shutdownProcess(t);
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
 	}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
@@ -202,7 +202,7 @@ public class FederatedWorkerHandlerTest extends AutomatedTestBase {
 		assertTrue("The privacy level " + privacyLevel.toString() + " should have been checked during execution",
 			checkedPrivacyConstraintsContains(privacyLevel));
 
-		TestUtils.shutdownProcess(t);
+		TestUtils.shutdownThread(t);
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
 	}
@@ -267,7 +267,7 @@ public class FederatedWorkerHandlerTest extends AutomatedTestBase {
 		assertTrue("Privacy constraint with level " + privacyLevel + " should have been checked during execution",
 			checkedPrivacyConstraintsContains(privacyLevel));
 
-		TestUtils.shutdownProcess(t);
+		TestUtils.shutdownThread(t);
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
 	}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/FederatedL2SVMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/FederatedL2SVMTest.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.test.functions.privacy.algorithms;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.test.FedTestWorkers;
 import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
@@ -29,7 +30,6 @@ import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
-import org.apache.wink.json4j.JSONException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -54,7 +54,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	// PrivateAggregation Single Input
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationX1() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationX1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.PrivateAggregation,
@@ -62,7 +62,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationX2() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationX2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.PrivateAggregation,
@@ -70,7 +70,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationY() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationY() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.PrivateAggregation);
@@ -79,7 +79,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	// Private Single Input
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX1() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private,
@@ -87,7 +87,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX2() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private,
@@ -95,7 +95,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedY() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedY() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private);
@@ -104,7 +104,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	// Setting Privacy of Matrix (Throws Exception)
 
 	@Test
-	public void federatedL2SVMCPPrivateMatrixX1() throws JSONException {
+	public void federatedL2SVMCPPrivateMatrixX1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private,
@@ -112,7 +112,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateMatrixX2() throws JSONException {
+	public void federatedL2SVMCPPrivateMatrixX2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private,
@@ -120,7 +120,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateMatrixY() throws JSONException {
+	public void federatedL2SVMCPPrivateMatrixY() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private,
@@ -128,7 +128,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedAndMatrixX1() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedAndMatrixX1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private,
@@ -136,7 +136,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedAndMatrixX2() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedAndMatrixX2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private,
@@ -144,7 +144,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedAndMatrixY() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedAndMatrixY() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
 		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private,
@@ -154,7 +154,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	// Privacy Level Private Combinations
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX1X2() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX1X2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
@@ -163,7 +163,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX1Y() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX1Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
@@ -172,7 +172,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX2Y() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX2Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
@@ -181,7 +181,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateFederatedX1X2Y() throws JSONException {
+	public void federatedL2SVMCPPrivateFederatedX1X2Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
@@ -192,7 +192,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 
 	// Privacy Level PrivateAggregation Combinations
 	@Test
-	public void federatedL2SVMCPPrivateAggregationFederatedX1X2() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationFederatedX1X2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -201,7 +201,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationFederatedX1Y() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationFederatedX1Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -210,7 +210,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationFederatedX2Y() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationFederatedX2Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -219,7 +219,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationFederatedX1X2Y() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationFederatedX1X2Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -230,7 +230,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 
 	// Privacy Level Combinations
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1X2() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1X2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -239,7 +239,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1Y() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -248,7 +248,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2Y() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2Y() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -257,7 +257,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX1() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -266,7 +266,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX2() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX2() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -275,7 +275,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2X1() throws JSONException {
+	public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2X1() throws Exception {
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -286,7 +286,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	// Require Federated Workers to return matrix
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationX1Exception() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationX1Exception() throws Exception {
 		rows = 1000; cols = 1;
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -295,7 +295,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateAggregationX2Exception() throws JSONException {
+	public void federatedL2SVMCPPrivateAggregationX2Exception() throws Exception {
 		rows = 1000; cols = 1;
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
@@ -304,7 +304,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateX1Exception() throws JSONException {
+	public void federatedL2SVMCPPrivateX1Exception() throws Exception {
 		rows = 1000; cols = 1;
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
@@ -313,7 +313,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void federatedL2SVMCPPrivateX2Exception() throws JSONException {
+	public void federatedL2SVMCPPrivateX2Exception() throws Exception {
 		rows = 1000; cols = 1;
 		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
 		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
@@ -324,7 +324,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 	private void federatedL2SVMNoException(Types.ExecMode execMode, Map<String,
 			PrivacyConstraint> privacyConstraintsFederated, Map<String, PrivacyConstraint> privacyConstraintsMatrix,
 			PrivacyLevel expectedPrivacyLevel)
-		throws JSONException
+		throws Exception
 	{
 		federatedL2SVM(execMode, privacyConstraintsFederated, privacyConstraintsMatrix, expectedPrivacyLevel,
 			false, null, false, null);
@@ -332,8 +332,8 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 
 	private void federatedL2SVM(Types.ExecMode execMode, Map<String, PrivacyConstraint> privacyConstraintsFederated,
 			Map<String, PrivacyConstraint> privacyConstraintsMatrix, PrivacyLevel expectedPrivacyLevel, 
-			boolean exception1, Class<?> expectedException1, boolean exception2, Class<?> expectedException2 ) 
-		throws JSONException
+			boolean exception1, Class<?> expectedException1, boolean exception2, Class<?> expectedException2 )
+			throws Exception
 	{
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
 		Types.ExecMode platformOld = rtplatform;
@@ -341,8 +341,8 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 		if(rtplatform == Types.ExecMode.SPARK) {
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
 		}
-		Thread t1 = null, t2 = null;
 
+		FedTestWorkers workers = new FedTestWorkers(this, 2);
 		try {
 			getAndLoadTestConfiguration(TEST_NAME);
 			String HOME = SCRIPT_DIR + TEST_DIR;
@@ -378,12 +378,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 				writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
 			}
 
-			// empty script name because we don't execute any script, just start the worker
-			fullDMLScriptName = "";
-			int port1 = getRandomAvailablePort();
-			int port2 = getRandomAvailablePort();
-			t1 = startLocalFedWorkerThread(port1);
-			t2 = startLocalFedWorkerThread(port2);
+			int[] ports = workers.start();
 
 			TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 			loadTestConfiguration(config);
@@ -396,8 +391,8 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 			// Run actual dml script with federated matrix
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
 			programArgs = new String[] {"-checkPrivacy", 
-				"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-				"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
+				"-nvargs", "in_X1=" + TestUtils.federatedAddress(ports[0], input("X1")),
+				"in_X2=" + TestUtils.federatedAddress(ports[1], input("X2")), "rows=" + rows, "cols=" + cols,
 				"in_Y=" + input("Y"), "out=" + output("Z")};
 			
 			runTest(true, exception2, expectedException2, -1);
@@ -410,7 +405,7 @@ public class FederatedL2SVMTest extends AutomatedTestBase {
 				assert(checkedPrivacyConstraintsContains(expectedPrivacyLevel));
 		}
 		finally {
-			TestUtils.shutdownThreads(t1, t2);
+			workers.stop();
 			rtplatform = platformOld;
 			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
 		}


### PR DESCRIPTION
Adds a new function to start multiple federated workers. The function first starts multiple processes and then waits for all of them to be ready for a connection by pinging (by sending a `CLEAR`) them.

This method cannot be used for threads (running federated workers), because they share static variables, therefore their startup interferes with each other. Switching purely to processes should definitely be considered.