### PR TITLE
[WIP][SYSTEMDS-2550] implemented Externalizable for ListObjects

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
@@ -19,7 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.caching;
 
-import java.io.*;
+import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -35,13 +35,11 @@ import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.lops.Lop;
 import org.apache.sysds.runtime.DMLRuntimeException;
-import org.apache.sysds.runtime.controlprogram.ParForProgramBlock;
 import org.apache.sysds.runtime.controlprogram.ParForProgramBlock.PDataPartitionFormat;
 import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
-import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.spark.data.RDDObject;
 import org.apache.sysds.runtime.io.FileFormatProperties;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -63,7 +61,7 @@ import org.apache.sysds.runtime.util.IndexRange;
  * {@link MatrixBlock} object without informing its {@link MatrixObject} object.
  * 
  */
-public class MatrixObject extends CacheableData<MatrixBlock> implements Externalizable
+public class MatrixObject extends CacheableData<MatrixBlock>
 {
 	private static final long serialVersionUID = 6374712373206495637L;
 
@@ -87,14 +85,6 @@ public class MatrixObject extends CacheableData<MatrixBlock> implements External
 	private int _partitionSize = -1; //indicates n for BLOCKWISE_N
 	private String _partitionCacheName = null; //name of cache block
 	private MatrixBlock _partitionInMemory = null;
-
-	/**
-	 * No op constructor for Externalizable interface
-	 */
-	public MatrixObject () {
-		super(DataType.MATRIX, ValueType.UNKNOWN);
-	}
-
 	/**
 	 * Constructor that takes the value type and the HDFS filename.
 	 * 
@@ -118,6 +108,23 @@ public class MatrixObject extends CacheableData<MatrixBlock> implements External
 		_hdfsFileName = file;
 		_cache = null;
 		_data = null;
+	}
+
+	/**
+	 * Constructor that takes the value type, HDFS filename and associated metadata and a MatrixBlock
+	 * used for creation after serialization
+	 *
+	 * @param vt value type
+	 * @param file file name
+	 * @param mtd metadata
+	 * @param data matrix block data
+	 */
+	public MatrixObject( ValueType vt, String file, MetaData mtd, MatrixBlock data) {
+		super (DataType.MATRIX, vt);
+		_metaData = mtd;
+		_hdfsFileName = file;
+		_cache = null;
+		_data = data;
 	}
 	
 	/**
@@ -602,63 +609,5 @@ public class MatrixObject extends CacheableData<MatrixBlock> implements External
 		//lazy evaluation of pending transformations.
 		long newnnz = SparkExecutionContext.writeMatrixRDDtoHDFS(rdd, fname, fmt);
 		_metaData.getDataCharacteristics().setNonZeros(newnnz);
-	}
-
-	@Override
-	public void writeExternal(ObjectOutput out) throws IOException {
-		// redirect serialization to writable impl
-		// out.writeObject(getDataType());
-		// out.writeObject(getValueType());
-		out.writeUTF(getFileName());
-
-		MetaDataFormat md = (MetaDataFormat) getMetaData();
-		DataCharacteristics dc = md.getDataCharacteristics();
-		ParForProgramBlock.PartitionFormat partFormat = (getPartitionFormat()!=null) ? new ParForProgramBlock.PartitionFormat(
-				getPartitionFormat(),getPartitionSize()) : ParForProgramBlock.PartitionFormat.NONE;
-
-		out.writeObject(dc.getRows());
-		out.writeObject(dc.getCols());
-		out.writeObject(dc.getBlocksize());
-		out.writeObject(dc.getNonZeros());
-		out.writeObject(md.getFileFormat());
-		out.writeObject(partFormat);
-		out.writeObject(getUpdateType());
-		out.writeObject(isHDFSFileExists());
-		out.writeObject(isCleanupEnabled());
-
-		// pin and serialize MatrixBlock
-		out.writeObject(acquireReadAndRelease());
-	}
-
-	@Override
-	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-		// redirect deserialization to writable impl
-		// read everything in
-		// DataType dataType = (DataType) in.readObject();
-		// ValueType valueType = (ValueType) in.readObject();
-		String fileName = in.readUTF();
-
-		long rows = (long) in.readObject();
-		long cols = (long) in.readObject();
-		int blockSize = (int) in.readObject();
-		long nonZeros = (long) in.readObject();
-		FileFormat fileFormat = (FileFormat) in.readObject();
-		ParForProgramBlock.PartitionFormat partFormat = (ParForProgramBlock.PartitionFormat) in.readObject();
-		UpdateType updateType = (UpdateType) in.readObject();
-		Boolean isHDFSFileExists = (Boolean) in.readObject();
-		Boolean isCleanupEnabled = (Boolean) in.readObject();
-		MatrixBlock matrixBlock = (MatrixBlock) in.readObject();
-
-		// construct objects and set data
-		_hdfsFileName = fileName;
-		MatrixCharacteristics matrixCharacteristics = new MatrixCharacteristics(rows, cols, blockSize, nonZeros);
-		MetaDataFormat metaDataFormat = new MetaDataFormat(matrixCharacteristics, fileFormat);
-		setMetaData(metaDataFormat);
-		if(partFormat._dpf != PDataPartitionFormat.NONE )
-			setPartitioned( partFormat._dpf, partFormat._N );
-		setUpdateType(updateType);
-		setHDFSFileExists(isHDFSFileExists);
-		enableCleanup(isCleanupEnabled);
-		_data = matrixBlock;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
@@ -19,17 +19,30 @@
 
 package org.apache.sysds.runtime.instructions.cp;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.sysds.api.mlcontext.Matrix;
+import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.lops.compile.Dag;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.ParForProgramBlock;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.runtime.meta.MetaDataFormat;
 
-public class ListObject extends Data {
+public class ListObject extends Data implements Externalizable {
 	private static final long serialVersionUID = 3652422061598967358L;
 
 	private final List<Data> _data;
@@ -37,6 +50,14 @@ public class ListObject extends Data {
 	private List<String> _names = null;
 	private int _nCacheable;
 	private List<LineageItem> _lineage = null;
+
+	/*
+	 * No op constructor for Externalizable interface
+	 */
+	public ListObject() {
+		super(DataType.LIST, ValueType.UNKNOWN);
+		_data = new ArrayList<>();
+	}
 	
 	public ListObject(List<Data> data) {
 		this(data, null, null);
@@ -279,5 +300,121 @@ public class ListObject extends Data {
 		}
 		sb.append(")");
 		return sb.toString();
+	}
+
+	/**
+	 * Redirects the default java serialization via externalizable to our default
+	 * hadoop writable serialization for efficient broadcast/rdd serialization.
+	 *
+	 * @param out object output
+	 * @throws IOException if IOException occurs
+	 */
+	@Override
+	public void writeExternal(ObjectOutput out) throws IOException {
+		// write out length
+		out.writeInt(getLength());
+
+		// write out names for named list
+		out.writeBoolean(getNames() != null);
+		if(getNames() != null) {
+			for (int i = 0; i < getLength(); i++) {
+				out.writeObject(_names.get(i));
+			}
+		}
+
+		// write out data
+		for(int i = 0; i < getLength(); i++) {
+			Data d = getData(i);
+			out.writeObject(d.getDataType());
+			out.writeObject(d.getValueType());
+			switch(d.getDataType()) {
+				case LIST:
+					ListObject lo = (ListObject) d;
+					out.writeObject(lo);
+					break;
+				case MATRIX:
+					MatrixObject mo = (MatrixObject) d;
+					MetaDataFormat md = (MetaDataFormat) mo.getMetaData();
+					DataCharacteristics dc = md.getDataCharacteristics();
+
+					out.writeObject(dc.getRows());
+					out.writeObject(dc.getCols());
+					out.writeObject(dc.getBlocksize());
+					out.writeObject(dc.getNonZeros());
+					out.writeObject(md.getFileFormat());
+					out.writeObject(mo.acquireReadAndRelease());
+					break;
+				case SCALAR:
+					ScalarObject so = (ScalarObject) d;
+					out.writeObject(so.getStringValue());
+					break;
+				default:
+					throw new DMLRuntimeException("Unable to serialize datatype " + dataType);
+			}
+		}
+	}
+
+	/**
+	 * Redirects the default java serialization via externalizable to our default
+	 * hadoop writable serialization for efficient broadcast/rdd deserialization.
+	 *
+	 * @param in object input
+	 * @throws IOException if IOException occurs
+	 */
+	@Override
+	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+		// read in length
+		int length = in.readInt();
+
+		// read in names
+		Boolean names = in.readBoolean();
+		if(names) {
+			_names = new ArrayList<>();
+			for (int i = 0; i < length; i++) {
+				_names.add((String) in.readObject());
+			}
+		}
+
+		// read in data
+		for(int i = 0; i < length; i++) {
+			DataType dataType = (DataType) in.readObject();
+			ValueType valueType = (ValueType) in.readObject();
+			Data d;
+			switch(dataType) {
+				case LIST:
+					d = (ListObject) in.readObject();
+					break;
+				case MATRIX:
+					long rows = (long) in.readObject();
+					long cols = (long) in.readObject();
+					int blockSize = (int) in.readObject();
+					long nonZeros = (long) in.readObject();
+					Types.FileFormat fileFormat = (Types.FileFormat) in.readObject();
+
+					// construct objects and set meta data
+					MatrixCharacteristics matrixCharacteristics = new MatrixCharacteristics(rows, cols, blockSize, nonZeros);
+					MetaDataFormat metaDataFormat = new MetaDataFormat(matrixCharacteristics, fileFormat);
+					MatrixBlock matrixBlock = (MatrixBlock) in.readObject();
+
+					d = new MatrixObject(valueType, Dag.getNextUniqueVarname(Types.DataType.MATRIX), metaDataFormat, matrixBlock);
+					break;
+				case SCALAR:
+					String value = (String) in.readObject();
+					ScalarObject so;
+					switch (valueType) {
+						case INT64:     so = new IntObject(Long.parseLong(value)); break;
+						case FP64:  	so = new DoubleObject(Double.parseDouble(value)); break;
+						case BOOLEAN: 	so = new BooleanObject(Boolean.parseBoolean(value)); break;
+						case STRING:  	so = new StringObject(value); break;
+						default:
+							throw new DMLRuntimeException("Unable to parse valuetype " + valueType);
+					}
+					d = so;
+					break;
+				default:
+					throw new DMLRuntimeException("Unable to deserialize datatype " + dataType);
+			}
+			_data.add(d);
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
@@ -313,6 +313,8 @@ public class ListObject extends Data implements Externalizable {
 	public void writeExternal(ObjectOutput out) throws IOException {
 		// write out length
 		out.writeInt(getLength());
+		// write out num cacheable
+		out.writeInt(_nCacheable);
 
 		// write out names for named list
 		out.writeBoolean(getNames() != null);
@@ -365,6 +367,8 @@ public class ListObject extends Data implements Externalizable {
 	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
 		// read in length
 		int length = in.readInt();
+		// read in num cacheable
+		_nCacheable = in.readInt();
 
 		// read in names
 		Boolean names = in.readBoolean();

--- a/src/test/java/org/apache/sysds/test/component/paramserv/SerializationTest.java
+++ b/src/test/java/org/apache/sysds/test/component/paramserv/SerializationTest.java
@@ -19,7 +19,11 @@
 
 package org.apache.sysds.test.component.paramserv;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/src/test/java/org/apache/sysds/test/component/paramserv/SerializationTest.java
+++ b/src/test/java/org/apache/sysds/test/component/paramserv/SerializationTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.component.paramserv;
 
+import java.io.*;
 import java.util.Arrays;
 
 import org.junit.Assert;
@@ -31,6 +32,32 @@ import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.runtime.util.ProgramConverter;
 
 public class SerializationTest {
+
+	@Test
+	public void serializeMatrixObject() {
+		MatrixObject mo1 = generateDummyMatrix(10);
+		MatrixObject mo1Deserialized = null;
+
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		ObjectOutputStream out;
+
+		try {
+			out = new ObjectOutputStream(bos);
+			out.writeObject(mo1);
+			out.flush();
+			byte[] mo1Bytes = bos.toByteArray();
+
+			ByteArrayInputStream bis = new ByteArrayInputStream(mo1Bytes);
+			ObjectInput in = new ObjectInputStream(bis);
+			mo1Deserialized = (MatrixObject) in.readObject();
+		}
+	   	catch(Exception e){
+			assert(false);
+		}
+
+		Assert.assertTrue(Arrays.equals(mo1.acquireReadAndRelease().getDenseBlockValues(), mo1Deserialized.acquireReadAndRelease().getDenseBlockValues()));
+		Assert.assertEquals(mo1.getDataCharacteristics().getCols(), mo1Deserialized.getDataCharacteristics().getCols());
+	}
 
 	@Test
 	public void serializeUnnamedListObject() {


### PR DESCRIPTION
To transmit the parameter ListObject of MatrixObjects to the federated Workers it was necessary to serialize a list. This pull request also contains a unit test, with a recursive call by testing a list in a list. Also old code in the test was changed to a parameterized variant for brevity.