### PR TITLE
[MINOR] Move Privacy Handling of UDFs

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -300,6 +300,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		FederatedUDF udf = (FederatedUDF) request.getParam(0);
 		Data[] inputs = Arrays.stream(udf.getInputIDs())
 			.mapToObj(id -> ec.getVariable(String.valueOf(id)))
+			.map(PrivacyMonitor::handlePrivacy)
 			.toArray(Data[]::new);
 		
 		//execute user-defined function

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -190,7 +190,7 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 
 		@Override
 		public FederatedResponse execute(ExecutionContext ec, Data... data) {
-			FrameObject fo = (FrameObject) PrivacyMonitor.handlePrivacy(data[0]);
+			FrameObject fo = (FrameObject) data[0];
 			FrameBlock fb = fo.acquireRead();
 			String[] colNames = fb.getColumnNames();
 
@@ -220,8 +220,7 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 
 		@Override
 		public FederatedResponse execute(ExecutionContext ec, Data... data) {
-			FrameObject fo = (FrameObject) PrivacyMonitor.handlePrivacy(data[0]);
-			FrameBlock fb = fo.acquireReadAndRelease();
+			FrameBlock fb = ((FrameObject)data[0]).acquireReadAndRelease();
 
 			// apply transformation
 			MatrixBlock mbout = _encoder.apply(fb,

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
@@ -299,7 +299,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 		}
 
 		public FederatedResponse execute(ExecutionContext ec, Data... data) {
-			MatrixObject mo = (MatrixObject) PrivacyMonitor.handlePrivacy(data[0]);
+			MatrixObject mo = (MatrixObject) data[0];
 			MatrixBlock mb = mo.acquireRead();
 			String[] colNames = _meta.getColumnNames();
 
@@ -331,8 +331,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 
 		@Override
 		public FederatedResponse execute(ExecutionContext ec, Data... data) {
-			FrameObject fo = (FrameObject) PrivacyMonitor.handlePrivacy(data[0]);
-			FrameBlock fb = fo.acquireReadAndRelease();
+			FrameBlock fb = ((FrameObject)data[0]).acquireReadAndRelease();
 			// return column names
 			return new FederatedResponse(ResponseType.SUCCESS, new Object[] {fb.getColumnNames()});
 		}
@@ -350,8 +349,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 
 		@Override
 		public FederatedResponse execute(ExecutionContext ec, Data... data) {
-			FrameObject fo = (FrameObject) PrivacyMonitor.handlePrivacy(data[0]);
-			FrameBlock fb = fo.acquireReadAndRelease();
+			FrameBlock fb = ((FrameObject)data[0]).acquireReadAndRelease();
 			_encoder.build(fb);
 			return new FederatedResponse(ResponseType.SUCCESS, new Object[] {_encoder});
 		}


### PR DESCRIPTION
The privacy handling of UDFs is moved from the individual instruction classes to the FederatedWorkerHandler.
This will handle the privacy constraints of the input before any execution of the UDF and it will be easier to maintain since the call to the PrivacyMonitor does not have to be written in every "execute" implementation of FederatedUDF. 