### PR TITLE
[MINOR] Remove Exceptions From FederatedResponse

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -155,7 +155,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		catch (Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR,
 				new FederatedWorkerHandlerException("Exception of type "
-				+ ex.getClass() + " thrown when processing request", ex));
+				+ ex.getClass() + " thrown when processing request"));
 		}
 	}
 	
@@ -206,7 +206,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 			}
 		}
 		catch (Exception ex) {
-			throw new DMLRuntimeException(ex);
+			throw new DMLRuntimeException("Exception in reading metadata of: " + filename);
 		}
 		
 		//put meta data object in symbol table, read on first operation
@@ -287,7 +287,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(
-				"Exception of type " + ex.getClass() + " thrown when processing EXEC_INST request", ex));
+				"Exception of type " + ex.getClass() + " thrown when processing EXEC_INST request"));
 		}
 		return new FederatedResponse(ResponseType.SUCCESS_EMPTY);
 	}
@@ -308,7 +308,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(
-				"Exception of type " + ex.getClass() + " thrown when processing EXEC_UDF request", ex));
+				"Exception of type " + ex.getClass() + " thrown when processing EXEC_UDF request"));
 		}
 	}
 
@@ -318,7 +318,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(
-				"Exception of type " + ex.getClass() + " thrown when processing CLEAR request", ex));
+				"Exception of type " + ex.getClass() + " thrown when processing CLEAR request"));
 		}
 		return new FederatedResponse(ResponseType.SUCCESS_EMPTY);
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -205,6 +205,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 				fmt = FileFormat.safeValueOf(mtd.getString(DataExpression.FORMAT_TYPE));
 			}
 		}
+		catch (DMLPrivacyException | FederatedWorkerHandlerException ex){
+			throw ex;
+		}
 		catch (Exception ex) {
 			throw new DMLRuntimeException("Exception in reading metadata of: " + filename);
 		}
@@ -285,6 +288,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		try {
 			pb.execute(ec); //execute single instruction
 		}
+		catch(DMLPrivacyException | FederatedWorkerHandlerException ex){
+			throw ex;
+		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(
 				"Exception of type " + ex.getClass() + " thrown when processing EXEC_INST request"));
@@ -306,6 +312,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		try {
 			return udf.execute(ec, inputs);
 		}
+		catch(DMLPrivacyException | FederatedWorkerHandlerException ex){
+			throw ex;
+		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(
 				"Exception of type " + ex.getClass() + " thrown when processing EXEC_UDF request"));
@@ -315,6 +324,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 	private FederatedResponse execClear() {
 		try {
 			_ecm.clear();
+		}
+		catch(DMLPrivacyException | FederatedWorkerHandlerException ex){
+			throw ex;
 		}
 		catch(Exception ex) {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandlerException.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandlerException.java
@@ -37,7 +37,15 @@ public class FederatedWorkerHandlerException extends RuntimeException {
 	public FederatedWorkerHandlerException(String msg) {
 		super(msg);
 	}
-	
+
+	/**
+	 * Create new instance of FederatedWorkerHandlerException with a message
+	 * and a throwable representing the original cause of the exception.
+	 * This constructor should not be used unless the throwable @param t
+	 * does not expose any private data in any use case.
+	 * @param msg message describing the exception
+	 * @param t throwable representing the original cause of the exception
+	 */
 	public FederatedWorkerHandlerException(String msg, Throwable t) {
 		super(msg, t);
 	}

--- a/src/main/java/org/apache/sysds/runtime/privacy/DMLPrivacyException.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/DMLPrivacyException.java
@@ -27,15 +27,6 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 public class DMLPrivacyException extends DMLRuntimeException 
 {
 	private static final long serialVersionUID = 1L;
-
-	//prevent string concatenation of classname w/ stop message
-	private DMLPrivacyException(Exception e) {
-		super(e);
-	}
-
-	private DMLPrivacyException(String string, Exception ex){
-		super(string,ex);
-	}
 	
 	/**
 	 * This is the only valid constructor for DMLPrivacyException.


### PR DESCRIPTION
Exceptions added to the FederatedResponse risk exposing data from the federated worker. Exceptions need to be caught and then a new exception could be created and added to the FederatedResponse without all details from the original exception. 
An example of how to add an exception to the FederatedResponse without exposing data can be seen in "executeCommand" in FederatedWorkerHandler.java:

`catch (DMLPrivacyException | FederatedWorkerHandlerException ex) {return new FederatedResponse(ResponseType.ERROR, ex);}`

This code catches DMLPrivacyExceptions and FederatedWorkerHandlerExceptions and any other type of exception is handled by a different catch-block where the name of the exception class is put into the message of a FederatedWorkerHandlerException. In this way, we can throw DMLPrivacyExceptions and FederatedWorkerHandlerExceptions without including any private data in the exception message and all other exceptions will not be returned in the FederatedResponse. 