### PR TITLE
[MINOR] Python API hardening, and stability

### DIFF
--- a/src/main/java/org/apache/sysds/api/PythonDMLScript.java
+++ b/src/main/java/org/apache/sysds/api/PythonDMLScript.java
@@ -40,7 +40,13 @@ public class PythonDMLScript {
 	 * @param args Command line arguments.
 	 */
 	public static void main(String[] args) {
-		start(Integer.parseInt(args[0]));
+		if(args.length != 1) {
+			throw new IllegalArgumentException("Python DML Script should be initialized with a singe number argument");
+		}
+		else {
+			int port = Integer.parseInt(args[0]);
+			start(port);
+		}
 	}
 
 	private static void start(int port) {

--- a/src/test/java/org/apache/sysds/test/usertest/Base.java
+++ b/src/test/java/org/apache/sysds/test/usertest/Base.java
@@ -78,9 +78,12 @@ public class Base {
 
     public static Pair<String, String> runThread(String script) {
         String fullDMLScriptName = BASE_FOLDER + script;
+        return runThread(new String[]{"-f", fullDMLScriptName});
+    }
 
+    public static Pair<String, String> runThread(String[] args) {
         Thread t = new Thread(() -> {
-            DMLScript.main(new String[] {"-f", fullDMLScriptName});
+            DMLScript.main(args);
         });
         
         ByteArrayOutputStream buff = new ByteArrayOutputStream();

--- a/src/test/java/org/apache/sysds/test/usertest/UserInterfaceTest.java
+++ b/src/test/java/org/apache/sysds/test/usertest/UserInterfaceTest.java
@@ -46,8 +46,6 @@ public class UserInterfaceTest extends Base {
 	public void SyntaxError(){
 		Pair<String,String> res = runThread("SyntaxError.dml");
 		assertEquals("",res.getRight());
-		System.out.println(res.getLeft());
-		System.out.println(res.getRight());
 		assertTrue(res.getLeft().contains("An Error Occured :"));
 		assertTrue(res.getLeft().contains("[Syntax error]"));
 		assertTrue(res.getLeft().contains("ParseException --"));

--- a/src/test/java/org/apache/sysds/test/usertest/pythonapi/StartupTest.java
+++ b/src/test/java/org/apache/sysds/test/usertest/pythonapi/StartupTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.usertest.pythonapi;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.apache.sysds.api.PythonDMLScript;
+import org.junit.Test;
+
+/** Simple tests to verify startup of Python Gateway server happens without crashes */
+public class StartupTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStartupIncorrect_1() {
+        PythonDMLScript.main(new String[] {});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStartupIncorrect_2() {
+        PythonDMLScript.main(new String[] {""});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStartupIncorrect_3() {
+        PythonDMLScript.main(new String[] {"131", "131"});
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testStartupIncorrect_4() {
+        PythonDMLScript.main(new String[] {"Hello"});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStartupIncorrect_5() {
+        // Number out of range
+        PythonDMLScript.main(new String[] {"918757"});
+    }
+}


### PR DESCRIPTION
Minor changes in Python API startup for ease of startup if SystemDS is
installed somewhere else it will use that SystemDS.
This practically means that if you have SystemDS home set, it will allow
the python to use that SystemDS, while if it is not set, it will default
back to the installed jar files from the PIP install.

This is a debated topic in #992, where it is argued that it would make
it harder for a user if the PIP does not contain the jar files.

- Fix dual setup of systemds_context
- Added to usertest