### PR TITLE
[WIP][SYSTEMDS 2583,2586] Reuse of compressed (dedup) DAGs

### DIFF
--- a/src/main/java/org/apache/sysds/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysds/parser/StatementBlock.java
@@ -434,6 +434,10 @@ public class StatementBlock extends LiveVariableAnalysis implements ParseInfo
 		}
 		return outputs;
 	}
+	
+	public ArrayList<String> getUpdatedVars() {
+		return new ArrayList<String>(_updated.getVariableNames());
+	}
 
 	public static ArrayList<StatementBlock> mergeStatementBlocks(List<StatementBlock> sb){
 		if (sb == null || sb.isEmpty())

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
@@ -161,7 +161,7 @@ public class AggregateUnaryCPInstruction extends UnaryCPInstruction {
 				
 				LineageItem li = ec.getLineageItem(input1);
 				String out = !DMLScript.LINEAGE_DEDUP ? Explain.explain(li) :
-					Explain.explain(li) + LineageDedupUtils.mergeExplainDedupBlocks(ec);
+					Explain.explain(li) + "\n" + LineageDedupUtils.mergeExplainDedupBlocks(ec);
 				ec.setScalarOutput(output_name, new StringObject(out));
 				break;
 			}

--- a/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
@@ -53,7 +53,7 @@ public class Lineage {
 	}
 	
 	public void trace(Instruction inst, ExecutionContext ec) {
-		if (_activeDedupBlock == null || !_activeDedupBlock.isAllPathsTaken())
+		if (_activeDedupBlock == null || !ReuseCacheType.isNone() || !_activeDedupBlock.isAllPathsTaken())
 			_map.trace(inst, ec);
 	}
 	
@@ -61,11 +61,12 @@ public class Lineage {
 		if( _activeDedupBlock != null ) {
 			ArrayList<String> inputnames = pb.getStatementBlock().getInputstoSB();
 			LineageItem[] liinputs = LineageItemUtils.getLineageItemInputstoSB(inputnames, ec);
+			ArrayList<String> updatedVars = pb.getStatementBlock().getUpdatedVars();
 			long lpath = _activeDedupBlock.getPath();
-			LineageDedupUtils.setDedupMap(_activeDedupBlock, lpath);
-			LineageMap lm = _activeDedupBlock.getMap(lpath);
+			LineageMap lm = LineageDedupUtils.setDedupMap(_activeDedupBlock, lpath);
+			//LineageMap lm = _activeDedupBlock.getMap(lpath);
 			if (lm != null)
-				_map.processDedupItem(lm, lpath, liinputs, pb.getStatementBlock().getName());
+				_map.processDedupItem(lm, lpath, liinputs, updatedVars, pb.getStatementBlock().getName());
 		}
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -58,7 +58,7 @@ public class LineageCache
 	private static final Map<LineageItem, LineageCacheEntry> _cache = new HashMap<>();
 	private static final double CACHE_FRAC = 0.05; // 5% of JVM heap size
 	protected static final boolean DEBUG = false;
-
+	
 	static {
 		long maxMem = InfrastructureAnalyzer.getLocalMaxMemory();
 		LineageCacheEviction.setCacheLimit((long)(CACHE_FRAC * maxMem));

--- a/src/test/java/org/apache/sysds/test/functions/lineage/DedupReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/DedupReuseTest.java
@@ -19,15 +19,13 @@
 
 package org.apache.sysds.test.functions.lineage;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.recompile.Recompiler;
-import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
-import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.lineage.Lineage;
-import org.apache.sysds.runtime.lineage.LineageRecomputeUtils;
-import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.lineage.LineageCacheStatistics;
 import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -37,90 +35,52 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class LineageTraceDedupTest extends AutomatedTestBase
+public class DedupReuseTest extends AutomatedTestBase
 {
 	protected static final String TEST_DIR = "functions/lineage/";
-	protected static final String TEST_NAME = "LineageTraceDedup";
-	protected static final String TEST_NAME1 = "LineageTraceDedup1";
-	protected static final String TEST_NAME10 = "LineageTraceDedup10";
-	protected static final String TEST_NAME2 = "LineageTraceDedup2";
-	protected static final String TEST_NAME3 = "LineageTraceDedup3";
-	protected static final String TEST_NAME4 = "LineageTraceDedup4";
-	protected static final String TEST_NAME5 = "LineageTraceDedup5";
-	protected static final String TEST_NAME6 = "LineageTraceDedup6";
-	protected static final String TEST_NAME7 = "LineageTraceDedup7"; //nested if-else branches
-	protected static final String TEST_NAME8 = "LineageTraceDedup8"; //while loop
-	protected static final String TEST_NAME9 = "LineageTraceDedup9"; //while loop w/ if
-	protected static final String TEST_NAME11 = "LineageTraceDedup11"; //mini-batch
+	protected static final String TEST_NAME = "DedupReuse"; 
+	protected static final String TEST_NAME1 = "DedupReuse1"; 
+	protected static final String TEST_NAME2 = "DedupReuse2"; 
+	protected static final String TEST_NAME3 = "DedupReuse3"; 
+	protected static final String TEST_NAME4 = "DedupReuse4"; 
 
-	protected String TEST_CLASS_DIR = TEST_DIR + LineageTraceDedupTest.class.getSimpleName() + "/";
+	protected String TEST_CLASS_DIR = TEST_DIR + DedupReuseTest.class.getSimpleName() + "/";
 	
-	protected static final int numRecords = 10;
-	protected static final int numFeatures = 5;
+	protected static final int numRecords = 100;
+	protected static final int numFeatures = 50;
 	
 	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for(int i=1; i<=11; i++)
+		for(int i=1; i<=4; i++)
 			addTestConfiguration(TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i));
 	}
 	
 	@Test
 	public void testLineageTrace1() {
+		// Reuse single instruction from outside
 		testLineageTrace(TEST_NAME1);
 	}
 
 	@Test
-	public void testLineageTrace10() {
-		testLineageTrace(TEST_NAME10);
-	}
-	
-	@Test
 	public void testLineageTrace2() {
+		// Reuse all operations from a dedup loop to another dedup loop
 		testLineageTrace(TEST_NAME2);
 	}
 	
 	@Test
 	public void testLineageTrace3() {
+		// Reuse all operations from a non-dedup-loop to a dedup loop
 		testLineageTrace(TEST_NAME3);
 	}
-	
+
 	@Test
 	public void testLineageTrace4() {
+		// Reuse an operation for each iteration of a dedup loop
 		testLineageTrace(TEST_NAME4);
 	}
 	
-	@Test
-	public void testLineageTrace5() {
-		testLineageTrace(TEST_NAME5);
-	}
-	
-	@Test
-	public void testLineageTrace6() {
-		testLineageTrace(TEST_NAME6);
-	}
-
-	@Test
-	public void testLineageTrace7() {
-		testLineageTrace(TEST_NAME7);
-	}
-	
-	@Test
-	public void testLineageTrace8() {
-		testLineageTrace(TEST_NAME8);
-	}
-	
-	@Test
-	public void testLineageTrace9() {
-		testLineageTrace(TEST_NAME9);
-	}
-
-	@Test
-	public void testLineageTrace11() {
-		testLineageTrace(TEST_NAME11);
-	}
-
 	public void testLineageTrace(String testname) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
@@ -137,7 +97,21 @@ public class LineageTraceDedupTest extends AutomatedTestBase
 			fullDMLScriptName = getScript();
 			List<String> proArgs;
 
-			// w/o lineage deduplication
+			//w/o lineage deduplication
+			proArgs = new ArrayList<>();
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("reuse_full");
+			proArgs.add("-args");
+			proArgs.add(output("R"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<CellIndex, Double> orig = readDMLMatrixFromHDFS("R");
+			long hitCount_nd = LineageCacheStatistics.getInstHits();
+
+			//w/ lineage deduplication
 			proArgs = new ArrayList<>();
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
@@ -149,16 +123,13 @@ public class LineageTraceDedupTest extends AutomatedTestBase
 
 			Lineage.resetInternalState();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<CellIndex, Double> dedup = readDMLMatrixFromHDFS("R");
+			long hitCount_d = LineageCacheStatistics.getInstHits();
 
-			//deserialize, generate program and execute
-			String Rtrace = readDMLLineageFromHDFS("R");
-			String RDedupPatches = readDMLLineageDedupFromHDFS("R");
-			Data ret = LineageRecomputeUtils.parseNComputeLineageTrace(Rtrace, RDedupPatches);
-			
-			//match the original and recomputed results
-			HashMap<CellIndex, Double> orig = readDMLMatrixFromHDFS("R");
-			MatrixBlock recomputed = ((MatrixObject)ret).acquireReadAndRelease();
-			TestUtils.compareMatrices(orig, recomputed, 1e-6);
+			//match the results
+			TestUtils.compareMatrices(orig, dedup, 1e-6, "Original", "Dedup");
+			//compare cache hits
+			Assert.assertTrue(hitCount_nd == hitCount_d);
 		}
 		finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;

--- a/src/test/scripts/functions/lineage/DedupReuse1.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse1.dml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+k = 3 
+
+X1 = X + 1;
+while(FALSE) {}
+X1 = X1 + 1;
+while(FALSE) {}
+X1 = X1 + 1;
+tmp = t(X1) %*% X1; #reusable (inside loop)
+
+for(i in 1:3){
+  X = X + 1;
+  R = t(X) %*% X;
+}
+R = R + tmp;
+
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/DedupReuse2.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse2.dml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+# Reuse from deduplicated loop to deduplicated loop
+X1 = X;
+for(i in 1:3){
+  X1 = X1 + 1;
+  R1 = t(X1) %*% X1;
+}
+
+X2 = X;
+for(i in 1:3){
+  X2 = X2 + 1;
+  R2 = t(X2) %*% X2;
+}
+R = R1 + R2;
+
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/DedupReuse3.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse3.dml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+# Reuse from non-deduplicated loop to deduplicated loop
+X1 = X;
+for(i in 1:3){
+  X1 = X1 + 1;
+  while(FALSE){}    #stops deduplication for the 'for' loop
+  R1 = t(X1) %*% X1;
+}
+
+X2 = X;
+for(i in 1:3){
+  X2 = X2 + 1;
+  R2 = t(X2) %*% X2;
+}
+R = R1 + R2;
+
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/DedupReuse4.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse4.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+X1 = X;
+for(i in 1:3){
+  X = X + 1;
+  R = t(X1) %*% X1;  #reuse
+}
+
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch extends equals and hash of lineage items to support
dedup items, which in turn allow reuse of dedup blocks.
This implementation makes deduplication transparent to the reuse
logic. And this change doesn't add any extra overhead and keep
the constant time hash calculation of lineage items intact.