### PR TITLE
[MINOR] MKL native MM setNonZeros to number of cells

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixNative.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixNative.java
@@ -106,7 +106,7 @@ public class LibMatrixNative
 					Statistics.nativeLibMatrixMultTime += System.nanoTime() - start;
 					Statistics.numNativeLibMatrixMultCalls.increment();
 				}
-				ret.recomputeNonZeros();
+				ret.setNonZeros(m1.rlen * m1.clen);
 				if(examSparsity)
 					ret.examSparsity();
 				return;


### PR DESCRIPTION
This PR is sort of an question.

Is it okay for our MKL to assume that the output matrix is fully dense with all values !=0? 

If so then we have an potential improved performance.

I have observed up to 30% in some cases (most likely due to inter run variance) but around 10% on average, and it is because the native call to matrix multiplication has to transfer the matrix out and and then into java again and then afterwards it loops through all values to count 0's forcing another iteration through the matrix once more.