### PR TITLE
fix bug in CostEstimator.java

### DIFF
--- a/src/main/java/org/apache/sysds/hops/cost/CostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/CostEstimator.java
@@ -215,7 +215,7 @@ public abstract class CostEstimator
 				long rlen = Long.parseLong(parts[6]);
 				long clen = Long.parseLong(parts[7]);
 				int blen = Integer.parseInt(parts[8]);
-				long nnz = Long.parseLong(parts[10]);
+				long nnz = Long.parseLong(parts[9]);
 				VarStats vs = new VarStats(rlen, clen, blen, nnz, false);
 				stats.put(varname, vs);
 			}


### PR DESCRIPTION
When i use `CostEstimator` to estimate the time cost of a programblock, an  error occurred:

``` java
java.lang.NumberFormatException: For input string: "copy"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Long.parseLong(Long.java:692)
	at java.base/java.lang.Long.parseLong(Long.java:817)
	at org.apache.sysds.hops.cost.CostEstimator.maintainCPInstVariableStatistics(CostEstimator.java:218)
	at org.apache.sysds.hops.cost.CostEstimator.rGetTimeEstimate(CostEstimator.java:138)
	at org.apache.sysds.hops.cost.CostEstimator.getTimeEstimate(CostEstimator.java:89)
	at org.apache.sysds.hops.cost.CostEstimationWrapper.getTimeEstimate(CostEstimationWrapper.java:79)
```

Look at the source code in  `org.apache.sysds.hops.cost.CostEstimator.java`  from line 204 to line 221:

``` java
	private static void maintainCPInstVariableStatistics( CPInstruction inst, HashMap<String, VarStats> stats )
	{
		if( inst instanceof VariableCPInstruction )
		{
			String optype = inst.getOpcode();
			String[] parts = InstructionUtils.getInstructionParts(inst.toString());
			
			if( optype.equals("createvar") ) {
				if( parts.length<10 )
					return;
				String varname = parts[1];
				long rlen = Long.parseLong(parts[6]);
				long clen = Long.parseLong(parts[7]);
				int blen = Integer.parseInt(parts[8]);
				long nnz = Long.parseLong(parts[10]);
				VarStats vs = new VarStats(rlen, clen, blen, nnz, false);
				stats.put(varname, vs);
			}
		 }
		// ......
	 }
```

and  an example of  instruction:

``` 
CP createvar _mVar9 scratch_space//_p18828_192.168.1.151//_t0/temp0 true MATRIX binary -1 1 1000 -1 copy
```

The index of nnz is 10 in the source.

Actually, the index of nnz is 9. 

