### PR TITLE
[SYSTEMDS-2705] Federated Writer

### DIFF
--- a/.github/workflows/functionsTests.yml
+++ b/.github/workflows/functionsTests.yml
@@ -58,6 +58,7 @@ jobs:
           dnn,
           federated.algorithms,
           federated.primitives,
+          federated.io,
           federated.transform,
           frame,
           indexing,

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -1055,7 +1055,9 @@ public class DMLTranslator
 						// write output in binary block format
 						ae.setOutputParams(ae.getDim1(), ae.getDim2(), ae.getNnz(), ae.getUpdateType(), ConfigurationManager.getBlocksize());
 						break;
-						
+					case FEDERATED:
+						ae.setOutputParams(ae.getDim1(), ae.getDim2(), -1, ae.getUpdateType(), -1);
+						break;
 						default:
 							throw new LanguageException("Unrecognized file format: " + ae.getInputFormatType());
 					}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
@@ -560,7 +560,10 @@ public class MatrixObject extends CacheableData<MatrixBlock>
 		
 		MetaDataFormat iimd = (MetaDataFormat) _metaData;
 
-		if (_data != null)
+		if(this.isFederated() &&  FileFormat.safeValueOf(ofmt) == FileFormat.FEDERATED){
+			ReaderWriterFederated.write(fname,this._fedMapping);
+		}
+		else if (_data != null)
 		{
 			// Get the dimension information from the metadata stored within MatrixObject
 			DataCharacteristics mc = iimd.getDataCharacteristics();

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -37,8 +37,8 @@ import org.apache.sysds.common.Types;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
-import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
@@ -147,7 +147,7 @@ public class InitFEDInstruction extends FEDInstruction {
 			}
 		}
 		if (type.equalsIgnoreCase(FED_MATRIX_IDENTIFIER)) {
-			MatrixObject output = ec.getMatrixObject(_output);
+			CacheableData<?> output = ec.getCacheableData(_output);
 			output.getDataCharacteristics().setRows(usedDims[0]).setCols(usedDims[1]);
 			federateMatrix(output, feds);
 		}
@@ -204,7 +204,7 @@ public class InitFEDInstruction extends FEDInstruction {
 		}
 	}
 
-	public static void federateMatrix(MatrixObject output, List<Pair<FederatedRange, FederatedData>> workers) {
+	public static void federateMatrix(CacheableData<?> output, List<Pair<FederatedRange, FederatedData>> workers) {
 
 		Map<FederatedRange, FederatedData> fedMapping = new TreeMap<>();
 		for (Pair<FederatedRange, FederatedData> t : workers) {

--- a/src/test/scripts/functions/federated/io/FederatedReaderTestCreate.dml
+++ b/src/test/scripts/functions/federated/io/FederatedReaderTestCreate.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X1 = read($1)
+X2 = read($2)
+X = federated(addresses=list("LocalHost:" +$3 + "/" +$1, "LocalHost:" +$4+ "/" +$2),
+    ranges=list(list(0, 0), list(nrow(X1), ncol(X1)), list(nrow(X1), 0), list(nrow(X1) + nrow(X2), ncol(X1))))
+write(X, $5, format="federated")

--- a/src/test/scripts/functions/federated/io/FederatedReference.dml
+++ b/src/test/scripts/functions/federated/io/FederatedReference.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A = federated(
+    addresses=list($in_X1, $in_X2), 
+    ranges=list(list(0, 0), list($rows / 2, $cols), 
+    list($rows / 2, 0), list($rows, $cols)))
+s = sum(A)
+
+print(s)


### PR DESCRIPTION
This commit add the ability to save a federated matrix, But only one that
has UID 0. If the UID is 0 on the remote then we know that it is a matrix,
that have just been read from a file. Therefore we can without modifying
the remote workers save our json directly, and read normally this file.

Example:

X = federated(addresses=...,ranges=...)
write(X, "X_fed.json", format="federated")

After this you can read the federated matrix, and it will allocate as
federated using the workers.

read("X_fed.json")