### PR TITLE
[SYSTEMDS-2721] Add Federated SSL

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -25,6 +25,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.security.cert.CertificateException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -77,7 +78,6 @@ import org.apache.sysds.utils.NativeHelper;
 import org.apache.sysds.utils.Statistics;
 import org.apache.sysds.utils.Explain.ExplainCounts;
 import org.apache.sysds.utils.Explain.ExplainType;
-
 
 public class DMLScript 
 {
@@ -237,12 +237,17 @@ public class DMLScript
 				return true;
 			}
 			
-			if (dmlOptions.fedWorker) {
+			if(dmlOptions.fedWorker) {
 				loadConfiguration(fnameOptConfig);
-				new FederatedWorker(dmlOptions.fedWorkerPort).run();
+				try {
+					new FederatedWorker(dmlOptions.fedWorkerPort).run();
+				}
+				catch(CertificateException e) {
+					e.printStackTrace();
+				}
 				return true;
 			}
-			
+
 			LineageCacheConfig.setConfig(LINEAGE_REUSE);
 			LineageCacheConfig.setCachePolicy(LINEAGE_POLICY);
 

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -93,6 +93,7 @@ public class DMLConfig
 	public static final String PRINT_GPU_MEMORY_INFO = "sysds.gpu.print.memoryInfo";
 	public static final String EVICTION_SHADOW_BUFFERSIZE = "sysds.gpu.eviction.shadow.bufferSize";
 
+	public static final String USE_SSL_FEDERATED_COMMUNICATION = "sysds.federated.ssl"; // boolean
 	public static final int DEFAULT_FEDERATED_PORT = 4040; // borrowed default Spark Port
 	public static final int DEFAULT_NUMBER_OF_FEDERATED_WORKER_THREADS = 2;
 	
@@ -138,6 +139,7 @@ public class DMLConfig
 		_defaultVals.put(SYNCHRONIZE_GPU,        "false" );
 		_defaultVals.put(EAGER_CUDA_FREE,        "false" );
 		_defaultVals.put(FLOATING_POINT_PRECISION, "double" );
+		_defaultVals.put(USE_SSL_FEDERATED_COMMUNICATION, "false");
 	}
 	
 	public DMLConfig() {
@@ -385,7 +387,8 @@ public class DMLConfig
 			CODEGEN, CODEGEN_API, CODEGEN_COMPILER, CODEGEN_OPTIMIZER, CODEGEN_PLANCACHE, CODEGEN_LITERALS,
 			STATS_MAX_WRAP_LEN, PRINT_GPU_MEMORY_INFO,
 			AVAILABLE_GPUS, SYNCHRONIZE_GPU, EAGER_CUDA_FREE, FLOATING_POINT_PRECISION, GPU_EVICTION_POLICY, 
-			LOCAL_SPARK_NUM_THREADS, EVICTION_SHADOW_BUFFERSIZE, GPU_MEMORY_ALLOCATOR, GPU_MEMORY_UTILIZATION_FACTOR
+			LOCAL_SPARK_NUM_THREADS, EVICTION_SHADOW_BUFFERSIZE, GPU_MEMORY_ALLOCATOR, GPU_MEMORY_UTILIZATION_FACTOR,
+			USE_SSL_FEDERATED_COMMUNICATION
 		}; 
 		
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -19,10 +19,19 @@
 
 package org.apache.sysds.runtime.controlprogram.federated;
 
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.log4j.Logger;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
@@ -30,44 +39,54 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
-import org.apache.log4j.Logger;
-import org.apache.sysds.conf.DMLConfig;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 public class FederatedWorker {
 	protected static Logger log = Logger.getLogger(FederatedWorker.class);
 
 	private int _port;
 	private final ExecutionContextMap _ecm;
-	
+
 	public FederatedWorker(int port) {
 		_ecm = new ExecutionContextMap();
 		_port = (port == -1) ? DMLConfig.DEFAULT_FEDERATED_PORT : port;
 	}
 
-	public void run() {
+	public void run() throws CertificateException, SSLException {
 		log.info("Setting up Federated Worker");
 		EventLoopGroup bossGroup = new NioEventLoopGroup(1);
 		EventLoopGroup workerGroup = new NioEventLoopGroup(1);
 		ServerBootstrap b = new ServerBootstrap();
-		b.group(bossGroup, workerGroup).channel(NioServerSocketChannel.class)
-			.childHandler(new ChannelInitializer<SocketChannel>() {
-				@Override
-				public void initChannel(SocketChannel ch) {
-					ch.pipeline()
-						.addLast("ObjectDecoder",
-							new ObjectDecoder(Integer.MAX_VALUE,
-								ClassResolvers.weakCachingResolver(ClassLoader.getSystemClassLoader())))
-						.addLast("ObjectEncoder", new ObjectEncoder())
-						.addLast("FederatedWorkerHandler", new FederatedWorkerHandler(_ecm));
-				}
-			}).option(ChannelOption.SO_BACKLOG, 128).childOption(ChannelOption.SO_KEEPALIVE, true);
+		// TODO add ability to use real ssl files, not self signed certificates.
+		SelfSignedCertificate cert = new SelfSignedCertificate();
+		final SslContext cont2 = SslContextBuilder.forServer(cert.certificate(), cert.privateKey()).build();
+
 		try {
+			b.group(bossGroup, workerGroup).channel(NioServerSocketChannel.class)
+				.childHandler(new ChannelInitializer<SocketChannel>() {
+					@Override
+					public void initChannel(SocketChannel ch) {
+						ChannelPipeline cp = ch.pipeline();
+
+						if(ConfigurationManager.getDMLConfig()
+							.getBooleanValue(DMLConfig.USE_SSL_FEDERATED_COMMUNICATION)) {
+							cp.addLast(cont2.newHandler(ch.alloc()));
+						}
+						cp.addLast("ObjectDecoder",
+							new ObjectDecoder(Integer.MAX_VALUE,
+								ClassResolvers.weakCachingResolver(ClassLoader.getSystemClassLoader())));
+						cp.addLast("ObjectEncoder", new ObjectEncoder());
+						cp.addLast("FederatedWorkerHandler", new FederatedWorkerHandler(_ecm));
+					}
+				}).option(ChannelOption.SO_BACKLOG, 128).childOption(ChannelOption.SO_KEEPALIVE, true);
 			log.info("Starting Federated Worker server at port: " + _port);
 			ChannelFuture f = b.bind(_port).sync();
 			log.info("Started Federated Worker at port: " + _port);
 			f.channel().closeFuture().sync();
 		}
-		catch (InterruptedException e) {
+		catch(Exception e) {
 			log.info("Federated worker interrupted");
 		}
 		finally {

--- a/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedSSLTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedSSLTest.java
@@ -19,6 +19,7 @@
 package org.apache.sysds.test.functions.federated.io;
 
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -36,13 +37,16 @@ import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
 @net.jcip.annotations.NotThreadSafe
-public class FederatedReaderTest extends AutomatedTestBase {
+public class FederatedSSLTest extends AutomatedTestBase {
 
 	// private static final Log LOG = LogFactory.getLog(FederatedReaderTest.class.getName());
-	private final static String TEST_DIR = "functions/federated/ioR/";
+	// This test use the same scripts as the Federated Reader tests, just with SSL enabled.
+	private final static String TEST_DIR = "functions/federated/io/";
 	private final static String TEST_NAME = "FederatedReaderTest";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedReaderTest.class.getSimpleName() + "/";
 	private final static int blocksize = 1024;
+	private final static File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR + "SSLConfig.xml");
+
 	@Parameterized.Parameter()
 	public int rows;
 	@Parameterized.Parameter(1)
@@ -122,5 +126,16 @@ public class FederatedReaderTest extends AutomatedTestBase {
 		}
 
 		TestUtils.shutdownThreads(t1, t2);
+	}
+
+	/**
+	 * Override default configuration with custom test configuration to ensure
+	 * scratch space and local temporary directory locations are also updated.
+	 */
+	@Override
+	protected File getConfigTemplateFile() {
+		// Instrumentation in this test's output log to show custom configuration file used for template.
+		System.out.println("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/scripts/functions/federated/io/SSLConfig.xml
+++ b/src/test/scripts/functions/federated/io/SSLConfig.xml
@@ -1,0 +1,21 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+<root>
+    <sysds.federated.ssl>true</sysds.federated.ssl>
+</root>


### PR DESCRIPTION
Using a self signed SSL certificate, the communication using Netty becomes encrypted.
The initialization of the communication is not safe since anyone could construct a certificate on the server side (workers) and respond to the requests from the controller. But for an initial prototype it is fine.

To allow all communication to be valid anyway, the certificate is self signed, and trusted at the beginning. It is fine since we know that it is generated specifically for the communication we want from the federated site. And allows for encrypted answers to the controller.