### PR TITLE
[SYSTEMDS-2757] PCA Predict and Inverse

### DIFF
--- a/scripts/builtin/pca.dml
+++ b/scripts/builtin/pca.dml
@@ -30,16 +30,18 @@
 # ---------------------------------------------------------------------------------------------
 # Xout   Matrix  ---      Output feature matrix with K columns
 # Mout   Matrix  ---      Output dominant eigen vectors (can be used for projections)
+# Centering Matrix ---    The column means of the input, subtracted to construct the PCA
+# ScaleFactor Matrix ---  The Scaling of the values, to make each dimension same size.
 # ---------------------------------------------------------------------------------------------
 
 m_pca = function(Matrix[Double] X, Integer K=2, Boolean center=TRUE, Boolean scale=TRUE)
-  return (Matrix[Double] Xout, Matrix[Double] Mout) 
+  return (Matrix[Double] Xout, Matrix[Double] Mout, Matrix[Double] Centering, Matrix[Double] ScaleFactor) 
 {
   N = nrow(X);
   D = ncol(X);
 
   # perform z-scoring (centering and scaling)
-  X = scale(X, center, scale);
+  [X, Centering, ScaleFactor] = scale(X, center, scale);
 
   # co-variance matrix
   mu = colSums(X)/N;
@@ -61,4 +63,5 @@ m_pca = function(Matrix[Double] X, Integer K=2, Boolean center=TRUE, Boolean sca
   # Construct new data set by treating computed dominant eigenvectors as the basis vectors
   Xout = X %*% evec_dominant;
   Mout = evec_dominant;
+
 }

--- a/scripts/builtin/pcaInverse.dml
+++ b/scripts/builtin/pcaInverse.dml
@@ -1,0 +1,52 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Principal Component Analysis (PCA) for reconstruction of approximation of the original data.
+# 
+# This methods allows to reconstruct an approximation of the original matrix, and is usefull for
+# calculating how much information is lost in the PCA.
+#
+# ---------------------------------------------------------------------------------------------
+# NAME          TYPE    DEFAULT       MEANING
+# ---------------------------------------------------------------------------------------------
+# X             Matrix  ---           Input features that have PCA applied to them
+# Centering     Matrix  empty matrix  The column means of the PCA model, subtracted to construct the PCA
+# ScaleFactor   Matrix  empty matrix  The scaling of each dimension in the PCA model
+# ---------------------------------------------------------------------------------------------
+# Y             Matrix  ---           Output feature matrix reconstructing and approximation of the original matrix
+# ---------------------------------------------------------------------------------------------
+
+m_pcaInverse = function(Matrix[Double] Y, Matrix[Double] Clusters, 
+  Matrix[Double] Centering = matrix(0, rows= 0, cols=0), 
+  Matrix[Double] ScaleFactor = matrix(0, rows= 0, cols=0))
+  return (Matrix[Double] X) 
+{
+  X = Y %*% t(Clusters)
+
+  if(nrow(ScaleFactor) > 0 & ncol(ScaleFactor) > 0){
+    X = X * ScaleFactor
+  }
+
+  if(nrow(Centering) > 0 & ncol(Centering) > 0){
+    X = X + Centering
+  }
+
+}

--- a/scripts/builtin/pcaTransform.dml
+++ b/scripts/builtin/pcaTransform.dml
@@ -1,0 +1,51 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Principal Component Analysis (PCA) for dimensionality reduction prediciton
+#
+# This method is used to transpose data, which the PCA model was not trained on. To validate how good
+# The PCA is, and to apply in production. 
+#
+# ---------------------------------------------------------------------------------------------
+# NAME          TYPE    DEFAULT       MEANING
+# ---------------------------------------------------------------------------------------------
+# X             Matrix  ---           Input feature matrix
+# Centering     Matrix  empty matrix  The column means of the PCA model, subtracted to construct the PCA
+# ScaleFactor   Matrix  empty matrix  The scaling of each dimension in the PCA model
+# ---------------------------------------------------------------------------------------------
+# Y             Matrix  ---           Output feature matrix dimensionally reduced by PCA
+# ---------------------------------------------------------------------------------------------
+
+m_pcaTransform = function(Matrix[Double] X, Matrix[Double] Clusters,
+  Matrix[Double] Centering = matrix(0, rows= 0, cols=0), 
+  Matrix[Double] ScaleFactor = matrix(0, rows= 0, cols=0))
+  return (Matrix[Double] Y) 
+{
+
+  if(nrow(Centering) > 0 & ncol(Centering) > 0){
+    X = X - Centering
+  }
+  if(nrow(ScaleFactor) > 0 & ncol(ScaleFactor) > 0){
+    X = X / ScaleFactor
+  }
+
+  Y = X %*% Clusters
+}

--- a/scripts/builtin/scale.dml
+++ b/scripts/builtin/scale.dml
@@ -19,29 +19,50 @@
 #
 #-------------------------------------------------------------
 
-# Scale and center individual features in the input matrix 
-# (column-wise) using z-score to scale the values.
-# -----------------------------------------------------------------------------
-# NAME   TYPE    DEFAULT  MEANING
-# -----------------------------------------------------------------------------
-# X      Matrix  ---      Input feature matrix
-# center Boolean TRUE     Indicates whether or not to center the feature matrix
-# scale  Boolean TRUE     Indicates whether or not to scale the feature matrix
-# -----------------------------------------------------------------------------
-# Y            Matrix ---  Output feature matrix with K columns
-# -----------------------------------------------------------------------------
+# Scale and center individual features in the input matrix (column wise.) using z-score to scale the values.
+# ---------------------------------------------------------------------------------------------
+# NAME         TYPE      DEFAULT  MEANING
+# ---------------------------------------------------------------------------------------------
+# X            Matrix    ---      Input feature matrix
+# Center       Boolean   TRUE     Indicates whether or not to center the feature matrix
+# Scale        Boolean   TRUE     Indicates whether or not to scale the feature matrix
+# ---------------------------------------------------------------------------------------------
+# Y            Matrix    ---      Output feature matrix with K columns
+# ColMean      Matrix    ---      The column means of the input, subtracted if Center was TRUE
+# ScaleFactor  Matrix    ---      The Scaling of the values, to make each dimension have similar value ranges
+# ---------------------------------------------------------------------------------------------
 
-m_scale = function(Matrix[Double] X, Boolean center, Boolean scale) return (Matrix[Double] Y) {
-  if( center )
-    X = X - colMeans(X);
+m_scale = function(Matrix[Double] X, Boolean center, Boolean scale) 
+  return (Matrix[Double] Y, Matrix[Double] ColMean, Matrix[Double] ScaleFactor) 
+{
+  if(center){
+    ColMean = colMeans(X)
+    X =  X - ColMean
+  }
+  else {
+    # Allocate the ColMean as an empty matrix,
+    # to return something on the function call.
+    ColMean = matrix(0,rows=0,cols=0)
+  }
 
   if (scale) {
-    cvars = colSums(X^2)/(nrow(X)-1);
+    N = nrow(X)
 
-    #scale by std-dev and replace NaNs with 0's
-    X = replace(target=X/sqrt(cvars),
-      pattern=NaN, replacement=0);
+    ScaleFactor = sqrt(colSums(X^2)/(N-1))
+
+    # Replace entries in the scale factor that are 0 with 1.
+    # To avoid division by 0, introducing NaN to the ouput.
+    ScaleFactor = replace(target=ScaleFactor,
+      pattern=0, replacement=1);
+    
+    X = X/ScaleFactor
+
   }
-  
-  Y = X;
+  else{
+    # Allocate the Scale factor as an empty matrix,
+    # to return something on the function call.
+    ScaleFactor = matrix(0, rows= 0, cols=0)
+  }
+
+  Y = X
 }

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -164,6 +164,8 @@ public enum Builtins {
 	OUTLIER_SD("outlierBySd", true),
 	OUTLIER_IQR("outlierByIQR", true),
 	PCA("pca", true),
+	PCAINVERSE("pcaInverse", true),
+	PCATRANSFORM("pcaTransform", true),
 	PNMF("pnmf", true),
 	PPCA("ppca", true),
 	PPRED("ppred", false),

--- a/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedPCATest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedPCATest.java
@@ -69,17 +69,17 @@ public class FederatedPCATest extends AutomatedTestBase {
 
 	@Test
 	public void federatedPCASinglenode() {
-		federatedL2SVM(Types.ExecMode.SINGLE_NODE);
+		federatedPCA(Types.ExecMode.SINGLE_NODE);
 	}
 
 	@Test
 	public void federatedPCAHybrid() {
-		federatedL2SVM(Types.ExecMode.HYBRID);
+		federatedPCA(Types.ExecMode.HYBRID);
 	}
 
-	public void federatedL2SVM(Types.ExecMode execMode) {
+	public void federatedPCA(Types.ExecMode execMode) {
 		ExecMode platformOld = setExecMode(execMode);
-
+		setOutputBuffering(true);
 		getAndLoadTestConfiguration(TEST_NAME);
 		String HOME = SCRIPT_DIR + TEST_DIR;
 
@@ -114,7 +114,7 @@ public class FederatedPCATest extends AutomatedTestBase {
 		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
 		programArgs = new String[] {"-stats", "-args", input("X1"), input("X2"), input("X3"), input("X4"),
 			String.valueOf(scaleAndShift).toUpperCase(), expected("Z")};
-		runTest(true, false, null, -1);
+		runTest(null);
 
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
@@ -123,7 +123,7 @@ public class FederatedPCATest extends AutomatedTestBase {
 			"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
 			"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + cols,
 			"scaleAndShift=" + String.valueOf(scaleAndShift).toUpperCase(), "out=" + output("Z")};
-		runTest(true, false, null, -1);
+		runTest(null);
 
 		// compare via files
 		compareResults(1e-9);
@@ -138,7 +138,6 @@ public class FederatedPCATest extends AutomatedTestBase {
 			Assert.assertTrue(heavyHittersContainsString("fed_uacmean"));
 			Assert.assertTrue(heavyHittersContainsString("fed_-"));
 			Assert.assertTrue(heavyHittersContainsString("fed_/"));
-			Assert.assertTrue(heavyHittersContainsString("fed_replace"));
 		}
 
 		// check that federated input files are still existing

--- a/src/test/scripts/functions/federated/FederatedPCATest.dml
+++ b/src/test/scripts/functions/federated/FederatedPCATest.dml
@@ -22,5 +22,5 @@
 X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
 		list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)))
-[X2,M] = pca(X=X,  K=2, scale=$scaleAndShift, center=$scaleAndShift)
+[X2,M,c,s] = pca(X=X,  K=2, scale=$scaleAndShift, center=$scaleAndShift)
 write(X2, $out)

--- a/src/test/scripts/functions/federated/FederatedPCATestReference.dml
+++ b/src/test/scripts/functions/federated/FederatedPCATestReference.dml
@@ -20,5 +20,5 @@
 #-------------------------------------------------------------
 
 X = rbind(read($1), read($2), read($3), read($4));
-[X2,M] = pca(X=X,  K=2, scale=$5, center=$5)
+[X2,M,c,s] = pca(X=X,  K=2, scale=$5, center=$5)
 write(X2, $6)


### PR DESCRIPTION
Adds a predict function for PCA and an inverse function.

The predict is for unseen data, that the PCA was not trained for just like our other predict functions for other algorithms
The Inverse is to apply on an PCA reduced dataset, to reconstruct an approximation of the original data.

The second is added because PCA can be considered a classic Lossy compression algorithm, that gives an smaller, approximated matrix of the original data. It also allows us to calculate how well the given PCA fits to the dateset.