### PR TITLE
[BUGFIX] Federated LMCG Bug

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -135,6 +135,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 
 	private FederatedResponse executeCommand(FederatedRequest request) {
 		RequestType method = request.getType();
+		System.out.println(request.toString());
 		try {
 			switch(method) {
 				case READ_VAR:

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -135,7 +135,6 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 
 	private FederatedResponse executeCommand(FederatedRequest request) {
 		RequestType method = request.getType();
-		System.out.println(request.toString());
 		try {
 			switch(method) {
 				case READ_VAR:

--- a/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinLmTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinLmTest.java
@@ -130,7 +130,7 @@ public class BuiltinLmTest extends AutomatedTestBase
 
 
 			fullDMLScriptName = HOME + dml_test_name + ".dml";
-			programArgs = new String[]{"-args", input("A"), input("B"), output("C") };
+			programArgs = new String[]{"-explain", "-args", input("A"), input("B"), output("C") };
 			fullRScriptName = HOME + TEST_NAME + ".R";
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " "  + expectedDir();
 

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
@@ -24,6 +24,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedWorkerHandler;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.lops.LopProperties.ExecType;
@@ -36,9 +37,9 @@ import java.util.HashMap;
 
 public class FederatedLmCGTest extends AutomatedTestBase
 {
-	private final static String TEST_NAME = "lm";
+	private final static String TEST_NAME = "lmCGFederated";
 	private final static String TEST_DIR = "functions/privacy/";
-	private static final String TEST_CLASS_DIR = TEST_DIR + "FederatedLmCG" + "/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + FederatedLmCGTest.class.getSimpleName() + "/";
 
 	private final static double eps = 1e-10;
 	private final static int rows = 10;
@@ -49,7 +50,7 @@ public class FederatedLmCGTest extends AutomatedTestBase
 
 	@Override
 	public void setUp() {
-		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"}));
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"C"}));
 	}
 
 	@Test
@@ -73,11 +74,13 @@ public class FederatedLmCGTest extends AutomatedTestBase
 	}
 
 	@Test
+	@Ignore
 	public void testLmMatrixDenseSPlmCG() {
 		runLmTest(false, ExecType.SPARK, true);
 	}
 
 	@Test
+	@Ignore
 	public void testLmMatrixSparseSPlmCG() {
 		runLmTest(true, ExecType.SPARK, true);
 	}
@@ -131,21 +134,15 @@ public class FederatedLmCGTest extends AutomatedTestBase
 			//generate actual dataset
 			int halfRows = rows / 2;
 			double[][] X1 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 7);
-			//writeInputMatrixWithMTD("X1", X1, new DataCharacteristics(), new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
-			writeInputMatrixWithMTD("X1", X1, false, new MatrixCharacteristics(halfRows, cols, (long) sparsity), new PrivacyConstraint(
-				PrivacyConstraint.PrivacyLevel.PrivateAggregation));
-			//writeInputMatrixWithMTD("X1", X1, false);
+			writeInputMatrixWithMTD("X1", X1, false);
 			double[][] X2 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 8);
-			//writeInputMatrixWithMTD("X2", X2, false);
-			writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, (long) sparsity), new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+			writeInputMatrixWithMTD("X2", X2, false);
 
 			if ( doubleFederated ){
 				double[][] y1 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 3);
 				double[][] y2 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 4);
-				writeInputMatrixWithMTD("y1", y1, false, new MatrixCharacteristics(halfRows, 1), new PrivacyConstraint(
-					PrivacyConstraint.PrivacyLevel.PrivateAggregation));
-				writeInputMatrixWithMTD("y2", y2, false, new MatrixCharacteristics(halfRows, 1), new PrivacyConstraint(
-					PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+				writeInputMatrixWithMTD("y1", y1, false);
+				writeInputMatrixWithMTD("y2", y2, false);
 			} else {
 				double[][] y = getRandomMatrix(rows, 1, 0, 10, 1.0, 3);
 				writeInputMatrixWithMTD("y", y, false);

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.privacy;
+
+import org.apache.log4j.Logger;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedWorkerHandler;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+import org.junit.Test;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.lops.LopProperties.ExecType;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+
+import java.util.HashMap;
+
+public class FederatedLmCGTest extends AutomatedTestBase
+{
+	private final static String TEST_NAME = "lm";
+	private final static String TEST_DIR = "functions/privacy/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + "FederatedLmCG" + "/";
+
+	private final static double eps = 1e-10;
+	private final static int rows = 10;
+	private final static int cols = 3;
+	private final static double spSparse = 0.3;
+	private final static double spDense = 0.7;
+	private final static int blocksize = 1024;
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"B"}));
+	}
+
+	@Test
+	public void testLmMatrixDenseCPlmCG1() {
+		runLmTest(false, ExecType.CP, false);
+	}
+
+	@Test
+	public void testLmMatrixSparseCPlmCG1() {
+		runLmTest(true, ExecType.CP, false);
+	}
+
+	@Test
+	public void testLmMatrixDenseCPlmCG2() {
+		runLmTest(false, ExecType.CP, true);
+	}
+
+	@Test
+	public void testLmMatrixSparseCPlmCG2() {
+		runLmTest(true, ExecType.CP, true);
+	}
+
+	@Test
+	public void testLmMatrixDenseSPlmCG() {
+		runLmTest(false, ExecType.SPARK, true);
+	}
+
+	@Test
+	public void testLmMatrixSparseSPlmCG() {
+		runLmTest(true, ExecType.SPARK, true);
+	}
+
+	private void runLmTest(boolean sparse, ExecType instType, boolean doubleFederated)
+	{
+		ExecMode platformOld = setExecMode(instType);
+
+		Thread t1 = null;
+		Thread t2 = null;
+
+		try
+		{
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+			double sparsity = sparse ? spSparse : spDense;
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+
+			int port1 = getRandomAvailablePort();
+			int port2 = getRandomAvailablePort();
+			t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+			t2 = startLocalFedWorkerThread(port2);
+
+			if ( doubleFederated ){
+				fullDMLScriptName = HOME + "FederatedLmCG2" + ".dml";
+			} else {
+				fullDMLScriptName = HOME + "FederatedLmCG" + ".dml";
+			}
+
+			if (doubleFederated){
+				programArgs = new String[]{
+					"-explain",
+					"-nvargs",
+					"X1="+TestUtils.federatedAddress(port1, input("X1")),
+					"X2="+TestUtils.federatedAddress(port2, input("X2")),
+					"y1=" + TestUtils.federatedAddress(port1, input("y1")),
+					"y2=" + TestUtils.federatedAddress(port2, input("y2")),
+					"C="+output("C"),
+					"r=" + rows, "c=" + cols};
+			} else {
+				programArgs = new String[]{
+					"-explain",
+					"-nvargs",
+					"X1="+TestUtils.federatedAddress(port1, input("X1")),
+					"X2="+TestUtils.federatedAddress(port2, input("X2")),
+					"y=" + input("y"),
+					"C="+output("C"),
+					"r=" + rows, "c=" + cols};
+			}
+
+			//generate actual dataset
+			int halfRows = rows / 2;
+			double[][] X1 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 7);
+			//writeInputMatrixWithMTD("X1", X1, new DataCharacteristics(), new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+			writeInputMatrixWithMTD("X1", X1, false, new MatrixCharacteristics(halfRows, cols, (long) sparsity), new PrivacyConstraint(
+				PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+			//writeInputMatrixWithMTD("X1", X1, false);
+			double[][] X2 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 8);
+			//writeInputMatrixWithMTD("X2", X2, false);
+			writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, (long) sparsity), new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+
+			if ( doubleFederated ){
+				double[][] y1 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 3);
+				double[][] y2 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 4);
+				writeInputMatrixWithMTD("y1", y1, false, new MatrixCharacteristics(halfRows, 1), new PrivacyConstraint(
+					PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+				writeInputMatrixWithMTD("y2", y2, false, new MatrixCharacteristics(halfRows, 1), new PrivacyConstraint(
+					PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+			} else {
+				double[][] y = getRandomMatrix(rows, 1, 0, 10, 1.0, 3);
+				writeInputMatrixWithMTD("y", y, false);
+			}
+
+			runTest(true, false, null, -1);
+
+
+			HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("C");
+			System.out.println(dmlfile.values());
+
+			TestUtils.shutdownThreads(t1, t2);
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/privacy/FederatedLmCG.dml
+++ b/src/test/scripts/functions/privacy/FederatedLmCG.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = federated(addresses=list($X1, $X2),
+        ranges=list(list(0, 0), list($r / 2, $c), list($r / 2, 0), list($r, $c)))
+y = read($y)
+C = lmCG(X = X, y = y, reg = 1e-12, verbose=FALSE)
+write(C, $C)
+

--- a/src/test/scripts/functions/privacy/FederatedLmCG2.dml
+++ b/src/test/scripts/functions/privacy/FederatedLmCG2.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = federated(addresses=list($X1, $X2),
+              ranges=list(list(0, 0), list($r / 2, $c), list($r / 2, 0), list($r, $c)))
+y = federated(addresses=list($y1, $y2),
+              ranges=list(list(0, 0), list($r / 2, 0), list($r / 2, 0), list($r, 0)))
+C = lmCG(X = X, y = y, reg = 1e-12, maxi = 2, verbose=FALSE)
+write(C, $C)
+


### PR DESCRIPTION
This PR provides a test case where rewrites are not applied in the federated execution of LMCG. 
One test case with X and y as federated data on two workers are FederatedLmCGTest.testLmMatrixDenseCPlmCG2. The execution for instance has the instruction `CP r' X.MATRIX.FP64 _mVar205.MATRIX.FP64 8`. 