### PR TITLE
[SYSTEMDS-2792] Sparse Overlapping Matrix

### DIFF
--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -125,7 +125,7 @@ public class DMLConfig
 		_defaultVals.put(COMPRESSED_LINALG,      Compression.CompressConfig.AUTO.name() );
 		_defaultVals.put(COMPRESSED_LOSSY,       "false" );
 		_defaultVals.put(COMPRESSED_VALID_COMPRESSIONS, "DDC,OLE,RLE");
-		_defaultVals.put(COMPRESSED_OVERLAPPING, "false" );
+		_defaultVals.put(COMPRESSED_OVERLAPPING, "true" );
 		_defaultVals.put(COMPRESSED_SAMPLING_RATIO, "0.01");
 		_defaultVals.put(COMPRESSED_COCODE,      "COST");
 		_defaultVals.put(COMPRESSED_TRANSPOSE,   "auto");

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -26,7 +26,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -51,40 +50,22 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroupConverter;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupIO;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupValue;
-import org.apache.sysds.runtime.compress.colgroup.DenseRowIterator;
-import org.apache.sysds.runtime.compress.colgroup.SparseRowIterator;
 import org.apache.sysds.runtime.compress.lib.LibBinaryCellOp;
 import org.apache.sysds.runtime.compress.lib.LibCompAgg;
 import org.apache.sysds.runtime.compress.lib.LibLeftMultBy;
-import org.apache.sysds.runtime.compress.lib.LibRelationalOp;
 import org.apache.sysds.runtime.compress.lib.LibRightMultBy;
 import org.apache.sysds.runtime.compress.lib.LibScalar;
-import org.apache.sysds.runtime.compress.utils.ColumnGroupIterator;
 import org.apache.sysds.runtime.compress.utils.LinearAlgebraUtils;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.Timing;
 import org.apache.sysds.runtime.data.SparseBlock;
-import org.apache.sysds.runtime.data.SparseRow;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
-import org.apache.sysds.runtime.functionobjects.Divide;
-import org.apache.sysds.runtime.functionobjects.Equals;
-import org.apache.sysds.runtime.functionobjects.GreaterThan;
-import org.apache.sysds.runtime.functionobjects.GreaterThanEquals;
 import org.apache.sysds.runtime.functionobjects.KahanPlus;
 import org.apache.sysds.runtime.functionobjects.KahanPlusSq;
-import org.apache.sysds.runtime.functionobjects.LessThan;
-import org.apache.sysds.runtime.functionobjects.LessThanEquals;
 import org.apache.sysds.runtime.functionobjects.Mean;
-import org.apache.sysds.runtime.functionobjects.Minus;
-import org.apache.sysds.runtime.functionobjects.MinusMultiply;
 import org.apache.sysds.runtime.functionobjects.Multiply;
-import org.apache.sysds.runtime.functionobjects.NotEquals;
-import org.apache.sysds.runtime.functionobjects.Plus;
-import org.apache.sysds.runtime.functionobjects.PlusMultiply;
 import org.apache.sysds.runtime.functionobjects.SwapIndex;
-import org.apache.sysds.runtime.matrix.data.IJV;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell;
-import org.apache.sysds.runtime.matrix.data.LibMatrixBincell.BinaryAccessType;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
@@ -362,100 +343,14 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 		write(os);
 	}
 
-	public Iterator<IJV> getIterator(int rl, int ru, boolean inclZeros) {
-		return getIterator(rl, ru, 0, _colGroups.size(), inclZeros);
-	}
-
-	public Iterator<IJV> getIterator(int rl, int ru, int cgl, int cgu, boolean inclZeros) {
-		return new ColumnGroupIterator(rl, ru, cgl, cgu, inclZeros, _colGroups);
-	}
-
-	public Iterator<double[]> getDenseRowIterator(int rl, int ru) {
-		return new DenseRowIterator(rl, ru, _colGroups, clen);
-	}
-
-	public Iterator<SparseRow> getSparseRowIterator(int rl, int ru) {
-		return new SparseRowIterator(rl, ru, _colGroups, clen);
-	}
-
-	public int[] countNonZerosPerRow(int rl, int ru) {
-		int[] rnnz = new int[ru - rl];
-		if(!isOverlapping()) {
-
-			for(ColGroup grp : _colGroups)
-				grp.countNonZerosPerRow(rnnz, rl, ru);
-			return rnnz;
-		}
-		else {
-			LOG.warn(
-				"Not good to calculate number of non zeros in segment when overlapping compressed returning as if fully dense");
-			Arrays.fill(rnnz, getNumColumns());
-			return rnnz;
-		}
-	}
-
 	@Override
 	public MatrixBlock scalarOperations(ScalarOperator sop, MatrixValue result) {
-		// Special case handling of overlapping relational operations
-		if(isOverlapping() &&
-			(sop.fn instanceof LessThan || sop.fn instanceof LessThanEquals || sop.fn instanceof GreaterThan ||
-				sop.fn instanceof GreaterThanEquals || sop.fn instanceof Equals || sop.fn instanceof NotEquals)) {
-			MatrixBlock ret = LibRelationalOp.relationalOperation(sop, this, isOverlapping());
-
-			result = ret;
-			return ret;
-		}
-
-		if(isOverlapping() && (!(sop.fn instanceof Multiply || sop.fn instanceof Divide || sop.fn instanceof Plus ||
-			sop.fn instanceof Minus))) {
-			LOG.warn("scalar overlapping not supported for op: " + sop.fn);
-			MatrixBlock m1d = decompress(sop.getNumThreads());
-			return m1d.scalarOperations(sop, result);
-		}
-
-		CompressedMatrixBlock ret = null;
-		if(result == null || !(result instanceof CompressedMatrixBlock))
-			ret = new CompressedMatrixBlock(getNumRows(), getNumColumns(), sparse);
-		return LibScalar.scalarOperations(sop, this, ret, isOverlapping());
+		return LibScalar.scalarOperations(sop, this, result);
 	}
 
 	@Override
 	public MatrixBlock binaryOperations(BinaryOperator op, MatrixValue thatValue, MatrixValue result) {
-
-		MatrixBlock that = getUncompressed(thatValue);
-		if(!LibMatrixBincell.isValidDimensionsBinary(this, that)) {
-			throw new DMLRuntimeException("Block sizes are not matched for binary " + "cell operations: " + this.rlen
-				+ "x" + this.clen + " vs " + that.getNumRows() + "x" + that.getNumColumns());
-		}
-
-		BinaryAccessType atype = LibMatrixBincell.getBinaryAccessType(this, that);
-
-		if(atype == BinaryAccessType.MATRIX_COL_VECTOR || atype == BinaryAccessType.MATRIX_MATRIX) {
-			MatrixBlock ret = LibBinaryCellOp.binaryMVPlusCol(this, that, op);
-			result = ret;
-			return ret;
-		}
-		else if(!(op.fn instanceof Multiply || op.fn instanceof Divide || op.fn instanceof Plus ||
-			op.fn instanceof Minus || op.fn instanceof MinusMultiply || op.fn instanceof PlusMultiply)) {
-			LOG.warn("Decompressing since Binary Ops" + op.fn + " is not supported compressed");
-			MatrixBlock m2 = getUncompressed(this);
-			MatrixBlock ret = m2.binaryOperations(op, thatValue, result);
-			result = ret;
-			return ret;
-		}
-		else {
-			CompressedMatrixBlock ret = null;
-			if(result == null || !(result instanceof CompressedMatrixBlock))
-				ret = new CompressedMatrixBlock(getNumRows(), getNumColumns(), sparse);
-			else {
-				ret = (CompressedMatrixBlock) result;
-				ret.reset(rlen, clen);
-			}
-			result = LibBinaryCellOp.bincellOp(this, that, ret, op);
-			result = ret;
-			return ret;
-		}
-
+		return LibBinaryCellOp.binaryOperations(op, this, thatValue, result);
 	}
 
 	@Override
@@ -553,87 +448,44 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 	public MatrixBlock aggregateBinaryOperations(MatrixBlock m1, MatrixBlock m2, MatrixBlock ret,
 		AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
 
-		MatrixBlock that;
-		// Handle if the matrix block inputs are transposed, but not compressed
-		// in general this is safe to do, since the decompression would cost more than the transpose.
-		if(!(m1 instanceof CompressedMatrixBlock) && transposeLeft) {
-			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
-			m1 = m1.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+		if(m1 instanceof CompressedMatrixBlock && m2 instanceof CompressedMatrixBlock) {
+			return doubleCompressedAggregateBinaryOperations((CompressedMatrixBlock) m1,
+				(CompressedMatrixBlock) m2,
+				ret,
+				op,
+				transposeLeft,
+				transposeRight);
 		}
-		else if(!(m2 instanceof CompressedMatrixBlock) && transposeRight) {
+		boolean transposeOutput = false;
+		if(transposeLeft || transposeRight) {
 			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
-			m2 = m2.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
-		}
-		// Handle the case of both sides being compressed.
-		else if(m1 instanceof CompressedMatrixBlock && m2 instanceof CompressedMatrixBlock) {
-			// Both sides are compressed but none of them are transposed.
-			if(!transposeLeft && !transposeRight) {
-				// If both are not transposed, decompress the right hand side. to enable compressed overlapping output.
-				LOG.warn("Matrix decompression from multiplying two compressed matrices.");
-				m2 = getUncompressed(m2);
-			}
-			else if(transposeLeft && !transposeRight) {
-				// ideal situation
-				// if(m1.getNumColumns() * ((CompressedMatrixBlock) m1).getColGroups().size() < m2.getNumColumns() *
-				// ((CompressedMatrixBlock) m2).getColGroups().size()) {
-				if(m1.getNumColumns() > m2.getNumColumns()) {
-					LOG.error("case 1");
-					ret = LibLeftMultBy.leftMultByMatrix(((CompressedMatrixBlock) m1).getColGroups(),
-						m2,
-						ret,
-						true,
-						true,
-						m1.getNumColumns(),
-						((CompressedMatrixBlock) m1).isOverlapping(),
-						op.getNumThreads(),
-						((CompressedMatrixBlock) m1).getMaxNumValues());
-					ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
-					ret = ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
-					return ret;
-				}
-				else {
-					LOG.error("case 2");
-					return LibLeftMultBy.leftMultByMatrix(((CompressedMatrixBlock) m2).getColGroups(),
-						m1,
-						ret,
-						true,
-						true,
-						m2.getNumColumns(),
-						((CompressedMatrixBlock) m2).isOverlapping(),
-						op.getNumThreads(),
-						((CompressedMatrixBlock) m2).getMaxNumValues());
 
-				}
+			if((m1 instanceof CompressedMatrixBlock && transposeLeft) ||
+				(m2 instanceof CompressedMatrixBlock && transposeRight)) {
+				// change operation from m1 %*% m2 -> t( t(m2) %*% t(m1) )
+				transposeOutput = true;
+				MatrixBlock tmp = m1;
+				m1 = m2;
+				m2 = tmp;
+				boolean tmpLeft = transposeLeft;
+				transposeLeft = !transposeRight;
+				transposeRight = !tmpLeft;
+
 			}
-			else if(!transposeLeft && transposeRight) {
-				throw new DMLCompressionException("Not Implemented compressed Matrix Mult, to produce larger matrix");
-				// worst situation since it blows up the result matrix in number of rows in either compressed matrix.
+
+			if(!(m1 instanceof CompressedMatrixBlock) && transposeLeft) {
+				m1 = new MatrixBlock().copyShallow(m1).reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+				transposeLeft = false;
 			}
-			else {
-				ret = aggregateBinaryOperations(m2, m1, ret, op);
-				ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
-				return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+			else if(!(m2 instanceof CompressedMatrixBlock) && transposeRight) {
+				m2 = new MatrixBlock().copyShallow(m2).reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+				transposeRight = false;
 			}
-		}
-		// Handle if the transpose is on the compressed matrix!
-		// to implement this we need to store a boolean specifying that the compressed matrix is transposed, and then
-		// in all operations check this boolean for if the matrix is in a transposed setting.
-		// The benefit of this is that it would allow us to use our right matrix multiplication and continue with
-		// overlapping intermediates.
-		else if(m1 instanceof CompressedMatrixBlock && transposeLeft) {
-			LOG.warn("transposing inverse to avoid decompress because left hand side is compressed");
-			// change operation from t(m1) %*% m2 -> t( t(m2) %*% m1 )
-			ret = ((CompressedMatrixBlock) m1).aggregateBinaryOperations(m2, m1, ret, op, true, false);
-			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
-			return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
-		}
-		else if(m2 instanceof CompressedMatrixBlock && transposeRight) {
-			throw new DMLCompressionException("Not Implemented compressed right transpose matrix multiplication");
 		}
 
 		// setup meta data (dimensions, sparsity)
 		boolean right = (m1 == this);
-		that = right ? m2 : m1;
+		MatrixBlock that = right ? m2 : m1;
 		if(!right && m2 != this) {
 			throw new DMLRuntimeException(
 				"Invalid inputs for aggregate Binary Operation which expect either m1 or m2 to be equal to the object calling");
@@ -643,21 +495,50 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 		if(right) {
 			boolean allowOverlap = ConfigurationManager.getDMLConfig()
 				.getBooleanValue(DMLConfig.COMPRESSED_OVERLAPPING);
-			return LibRightMultBy
+			ret = LibRightMultBy
 				.rightMultByMatrix(_colGroups, that, ret, op.getNumThreads(), getMaxNumValues(), allowOverlap);
 		}
 		else {
-			return LibLeftMultBy.leftMultByMatrix(_colGroups,
-				that,
-				ret,
-				false,
-				true,
-				m2.getNumColumns(),
-				isOverlapping(),
-				op.getNumThreads(),
-				getMaxNumValues());
+			ret = LibLeftMultBy.leftMultByMatrix(this, that,ret, op.getNumThreads());
 		}
 
+		if(transposeOutput) {
+			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
+			return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+		}
+		else
+			return ret;
+
+	}
+
+	private MatrixBlock doubleCompressedAggregateBinaryOperations(CompressedMatrixBlock m1, CompressedMatrixBlock m2,
+		MatrixBlock ret, AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
+
+		if(!transposeLeft && !transposeRight) {
+			// If both are not transposed, decompress the right hand side. to enable compressed overlapping output.
+			LOG.warn("Matrix decompression from multiplying two compressed matrices.");
+			return aggregateBinaryOperations(m1, getUncompressed(m2), ret, op, transposeLeft, transposeRight);
+		}
+		else if(transposeLeft && !transposeRight) {
+			// Select witch compressed matrix to decompress.
+			if(m1.getNumColumns() > m2.getNumColumns()) {
+				ret = LibLeftMultBy.leftMultByMatrixTransposed(m1, m2, ret, op.getNumThreads());
+				ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
+				return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+			}
+			else 
+				return LibLeftMultBy.leftMultByMatrixTransposed(m2, m1, ret, op.getNumThreads());
+			
+		}
+		else if(!transposeLeft && transposeRight) {
+			throw new DMLCompressionException("Not Implemented compressed Matrix Mult, to produce larger matrix");
+			// worst situation since it blows up the result matrix in number of rows in either compressed matrix.
+		}
+		else {
+			ret = aggregateBinaryOperations(m2, m1, ret, op);
+			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
+			return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
+		}
 	}
 
 	@Override
@@ -710,13 +591,6 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 		MatrixBlock ret = (MatrixBlock) result;
 		ret.allocateDenseBlock();
 
-		if(overlappingColGroups &&
-			(op.aggOp.increOp.fn instanceof KahanPlusSq || (op.aggOp.increOp.fn instanceof Builtin &&
-				(((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN ||
-					((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX)))) {
-			return LibCompAgg.aggregateUnaryOverlapping(this, ret, op, blen, indexesIn, inCP);
-		}
-
 		return LibCompAgg.aggregateUnary(this, ret, op, blen, indexesIn, inCP);
 	}
 
@@ -750,37 +624,24 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 
 	@Override
 	public MatrixBlock replaceOperations(MatrixValue result, double pattern, double replacement) {
-		// if(Double.isNaN(pattern)) {
-		// LOG.debug("Skipping replace op because nan is not posible for compressed matrices");
-		// result = this;
-		// return this;
-		// }
-		// else {
-
 		printDecompressWarning("replaceOperations " + pattern + "  -> " + replacement);
-		LOG.error("Overlapping? : " + isOverlapping());
+		LOG.error("Overlapping? : " + isOverlapping() + " If not then wite a proper replace command");
 		MatrixBlock tmp = getUncompressed(this);
 		return tmp.replaceOperations(result, pattern, replacement);
-		// }
 	}
 
 	@Override
 	public MatrixBlock reorgOperations(ReorgOperator op, MatrixValue ret, int startRow, int startColumn, int length) {
 		printDecompressWarning(op.getClass().getSimpleName() + " -- " + op.fn.getClass().getSimpleName());
-		LOG.error("transposeSize:" + this.getNumRows() + "  " + this.getNumColumns());
+		// TODO make transposed decompress.
 		MatrixBlock tmp = decompress(op.getNumThreads());
 		return tmp.reorgOperations(op, ret, startRow, startColumn, length);
-	}
-
-	public boolean hasUncompressedColGroup() {
-		return getUncompressedColGroup() != null;
 	}
 
 	public ColGroupUncompressed getUncompressedColGroup() {
 		for(ColGroup grp : _colGroups)
 			if(grp instanceof ColGroupUncompressed)
 				return (ColGroupUncompressed) grp;
-
 		return null;
 	}
 
@@ -837,7 +698,7 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 
 			// decompress row partition
 			for(ColGroup grp : _colGroups)
-				grp.decompressToBlockSafe(_ret, _rl, _ru, _rl, grp.getValues(), false);
+				grp.decompressToBlockSafe(_ret, _rl, _ru, grp.getValues(), false);
 
 			// post processing (sort due to append)
 			if(_ret.isInSparseFormat())
@@ -852,9 +713,12 @@ public class CompressedMatrixBlock extends AbstractCompressedMatrixBlock {
 		StringBuilder sb = new StringBuilder();
 		sb.append("\nCompressed Matrix:");
 		sb.append("\nCols:" + getNumColumns() + " Rows:" + getNumRows());
-		for(ColGroup cg : _colGroups) {
-			sb.append("\n" + cg);
-		}
+		if(_colGroups != null)
+			for(ColGroup cg : _colGroups) {
+				sb.append("\n" + cg);
+			}
+		else
+			sb.append("EmptyColGroups");
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -62,7 +62,6 @@ public class CompressedMatrixBlockFactory {
 		return compress(mb, k, new CompressionSettingsBuilder().create());
 	}
 
-
 	/**
 	 * The main method for compressing the input matrix.
 	 * 
@@ -103,8 +102,8 @@ public class CompressedMatrixBlockFactory {
 		// where a column is compressible if ratio > 1.
 		MatrixBlock shallowCopy = new MatrixBlock().copyShallow(mb);
 		// Construct sample-based size estimator
-		CompressedSizeEstimator sizeEstimator = CompressedSizeEstimatorFactory
-			.getSizeEstimator(shallowCopy, compSettings, false);
+		CompressedSizeEstimator sizeEstimator = CompressedSizeEstimatorFactory.getSizeEstimator(shallowCopy,
+			compSettings);
 		CompressedSizeInfo sizeInfos = sizeEstimator.computeCompressedSizeInfos(k);
 
 		if(compSettings.investigateEstimate)
@@ -123,8 +122,9 @@ public class CompressedMatrixBlockFactory {
 			return new ImmutablePair<>(new MatrixBlock().copyShallow(mb), _stats);
 		}
 		// --------------------------------------------------
-		if(sizeInfos.colsC.size() != mb.getNumColumns()){
-			throw new DMLCompressionException("Invalid number of columns is:" +  sizeInfos.colsC.size() + " and should be: " + mb.getNumColumns());
+		if(sizeInfos.colsC.size() != mb.getNumColumns()) {
+			throw new DMLCompressionException(
+				"Invalid number of columns is:" + sizeInfos.colsC.size() + " and should be: " + mb.getNumColumns());
 		}
 		// --------------------------------------------------
 		// PHASE : Grouping columns

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -55,11 +55,6 @@ public abstract class ColGroupDDC extends ColGroupValue {
 	}
 
 	@Override
-	public void decompressToBlock(MatrixBlock target, int rl, int ru, int off, double[] values) {
-		decompressToBlockSafe(target, rl, ru, off, values, true);
-	}
-
-	@Override
 	public void decompressToBlockSafe(MatrixBlock target, int rl, int ru, int offT, double[] values, boolean safe) {
 		final int nCol = getNumCols();
 		double[] c = target.getDenseBlockValues();
@@ -272,14 +267,7 @@ public abstract class ColGroupDDC extends ColGroupValue {
 		postScaling(values, vals, c, numVals, row, numCols);
 	}
 
-	@Override
-	public void leftMultByRowVector(double[] a, double[] result, int numVals) {
-		numVals = getNumValues();
-		double[] values = getValues();
 
-		leftMultByRowVector(a, result, numVals, values);
-
-	}
 
 	public double[] preAggregate(double[] a, int numVals) {
 		return preAggregate(a, numVals, 0);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC1.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC1.java
@@ -25,11 +25,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.utils.ABitmap;
 import org.apache.sysds.runtime.compress.utils.LinearAlgebraUtils;
-import org.apache.sysds.runtime.data.SparseRow;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 
@@ -103,21 +101,9 @@ public class ColGroupDDC1 extends ColGroupDDC {
 	}
 
 	@Override
-	public void rightMultByMatrix(double[] preAggregatedB, double[] c, int thatNrColumns, int rl, int ru, int cl,
-		int cu) {
-		LinearAlgebraUtils.vectListAddDDC(preAggregatedB, c, _data, rl, ru, cl, cu, thatNrColumns, getNumValues());
-	}
-
-	@Override
-	public void rightMultBySparseMatrix(SparseRow[] rows, double[] c, int numVals, double[] dictVals, int nrColumns,
-		int rl, int ru) {
-		if(rows.length > 1) {
-			throw new NotImplementedException("Not Implemented CoCoded right Sparse Multiply");
-		}
-		for(int i = 0; i < rows[0].size(); i++) {
-			double[] vals = sparsePreaggValues(numVals, rows[0].values()[i], false, dictVals);
-			LinearAlgebraUtils.vectListAdd(vals, c, _data, rl, ru, rows[0].indexes()[i] * _numRows);
-		}
+	public void rightMultByMatrix(int[] outputColumns, double[] preAggregatedB, double[] c, int thatNrColumns, int rl,
+	int ru) {
+		LinearAlgebraUtils.vectListAddDDC(outputColumns, preAggregatedB, c, _data, rl, ru, thatNrColumns, getNumValues());
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC2.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC2.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.utils.ABitmap;
 import org.apache.sysds.runtime.compress.utils.LinearAlgebraUtils;
-import org.apache.sysds.runtime.data.SparseRow;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 
@@ -125,19 +124,11 @@ public class ColGroupDDC2 extends ColGroupDDC {
 	}
 
 	@Override
-	public void rightMultByMatrix(double[] preAggregatedB, double[] c, int thatNrColumns, int rl, int ru, int cl,
-		int cu) {
-		LinearAlgebraUtils.vectListAddDDC(preAggregatedB, c, _data, rl, ru, cl, cu, thatNrColumns, getNumValues());
+	public void rightMultByMatrix(int[] outputColumns, double[] preAggregatedB, double[] c, int thatNrColumns, int rl,
+	int ru) {
+		LinearAlgebraUtils.vectListAddDDC(outputColumns, preAggregatedB, c, _data, rl, ru, thatNrColumns, getNumValues());
 	}
 
-	@Override
-	public void rightMultBySparseMatrix(SparseRow[] rows, double[] c, int numVals, double[] dictVals, int nrColumns,
-		int rl, int ru) {
-		for(int i = 0; i < rows[0].size(); i++) {
-			double[] vals = sparsePreaggValues(numVals, rows[0].values()[i], false, dictVals);
-			LinearAlgebraUtils.vectListAdd(vals, c, _data, rl, ru, rows[0].indexes()[i] * _numRows);
-		}
-	}
 
 	@Override
 	public void write(DataOutput out) throws IOException {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.DMLCompressionException;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.data.SparseBlock.Type;
-import org.apache.sysds.runtime.data.SparseRow;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.ReduceRow;
 import org.apache.sysds.runtime.matrix.data.IJV;
@@ -200,10 +199,7 @@ public class ColGroupUncompressed extends ColGroup {
 		return ColGroupSizes.estimateInMemorySizeUncompressed(_numRows, getNumCols(), _data.getSparsity());
 	}
 
-	@Override
-	public void decompressToBlock(MatrixBlock target, int rl, int ru) {
-		decompressToBlock(target, rl, ru, rl);
-	}
+
 
 	@Override
 	public void decompressToBlock(MatrixBlock target, int rl, int ru, int offT) {
@@ -320,19 +316,14 @@ public class ColGroupUncompressed extends ColGroup {
 		LibMatrixMult.matrixMult(_data, subMatrix, result);
 	}
 
-	public void rightMultByMatrix(double[] preAggregatedB, double[] c, int thatNrColumns, int rl, int ru, int cl,
-		int cu) {
+	public void rightMultByMatrix(int[] outputColumns, double[] preAggregatedB, double[] c, int thatNrColumns, int rl,
+		int ru) {
 		throw new NotImplementedException("Should not be called use other matrix function for uncompressed columns");
 	}
 
-	@Override
-	public void rightMultBySparseMatrix(SparseRow[] rows, double[] c, int numVals, double[] dictVals, int nrColumns,
-		int rl, int ru) {
-		throw new NotImplementedException("Should not be called use other matrix function for uncompressed columns");
-	}
 
 	@Override
-	public void leftMultByRowVector(double[] vector, double[] c, int numVals) {
+	public void leftMultByRowVector(double[] vector, double[] c) {
 		throw new NotImplementedException("Should not be called use other matrix function for uncompressed columns");
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorFactory.java
@@ -29,24 +29,23 @@ public class CompressedSizeEstimatorFactory {
 
 	private static final int minimumSampleSize = 2000;
 
-	public static CompressedSizeEstimator getSizeEstimator(MatrixBlock data, CompressionSettings compSettings,
-		boolean transposed) {
-		long elements = transposed ? data.getNumColumns() : data.getNumRows();
-		elements = data.getNonZeros() / (transposed ? data.getNumRows() : data.getNumColumns());
+	public static CompressedSizeEstimator getSizeEstimator(MatrixBlock data, CompressionSettings compSettings) {
+		long elements = compSettings.transposed ? data.getNumColumns() : data.getNumRows();
+		elements = data.getNonZeros() / (compSettings.transposed ? data.getNumRows() : data.getNumColumns());
 		CompressedSizeEstimator est;
 
 		// Calculate the sample size.
 		// If the sample size is very small, set it to the minimum size
 		int sampleSize = Math.max((int) Math.ceil(elements * compSettings.samplingRatio), minimumSampleSize);
 		if(compSettings.samplingRatio >= 1.0 || elements < minimumSampleSize || sampleSize > elements) {
-			est = new CompressedSizeEstimatorExact(data, compSettings, transposed);
+			est = new CompressedSizeEstimatorExact(data, compSettings, compSettings.transposed);
 		}
 		else {
 			int[] sampleRows = CompressedSizeEstimatorSample.getSortedUniformSample(
-				transposed ? data.getNumColumns() : data.getNumRows(),
+				compSettings.transposed ? data.getNumColumns() : data.getNumRows(),
 				sampleSize,
 				compSettings.seed);
-				est = new CompressedSizeEstimatorSample(data, compSettings, sampleRows, transposed);
+				est = new CompressedSizeEstimatorSample(data, compSettings, sampleRows, compSettings.transposed);
 		}
 
 		LOG.debug(est);

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/LibBinaryCellOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/LibBinaryCellOp.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.DMLCompressionException;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.compress.AbstractCompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.colgroup.ADictionary;
@@ -44,11 +45,15 @@ import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Divide;
 import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.functionobjects.MinusMultiply;
 import org.apache.sysds.runtime.functionobjects.Multiply;
 import org.apache.sysds.runtime.functionobjects.Plus;
+import org.apache.sysds.runtime.functionobjects.PlusMultiply;
+import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell.BinaryAccessType;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
 import org.apache.sysds.runtime.util.CommonThreadPool;
@@ -57,74 +62,96 @@ public class LibBinaryCellOp {
 
 	private static final Log LOG = LogFactory.getLog(LibBinaryCellOp.class.getName());
 
-	/**
-	 * matrix-matrix binary operations, MM, MV
-	 * 
-	 * @param m1  Input matrix in compressed format to perform the operator on using m2
-	 * @param m2  Input matrix 2 to use cell-wise on m1
-	 * @param ret Result matrix to be returned in the operation.
-	 * @param op  Binary operator such as multiply, add, less than, etc.
-	 * @return The ret matrix, modified appropriately.
-	 */
-	public static MatrixBlock bincellOp(CompressedMatrixBlock m1, MatrixBlock m2, CompressedMatrixBlock ret,
+	public static MatrixBlock binaryOperations(BinaryOperator op, CompressedMatrixBlock m1, MatrixValue thatValue,
+		MatrixValue result) {
+		MatrixBlock that = AbstractCompressedMatrixBlock.getUncompressed(thatValue);
+		LibMatrixBincell.isValidDimensionsBinary(m1, that);
+
+		return selectProcessingBasedOnAccessType(op, m1, that, thatValue, result);
+	}
+
+	private static MatrixBlock selectProcessingBasedOnAccessType(BinaryOperator op, CompressedMatrixBlock m1,
+		MatrixBlock that, MatrixValue thatValue, MatrixValue result) {
+		BinaryAccessType atype = LibMatrixBincell.getBinaryAccessType(m1, that);
+
+		if(atype == BinaryAccessType.MATRIX_COL_VECTOR || atype == BinaryAccessType.MATRIX_MATRIX)
+			return binaryMVCol(m1, that, op);
+		else if(isSupportedBinaryCellOp(op.fn))
+			return bincellOp(m1, that, setupCompressedReturnMatrixBlock(m1, result), op);
+		else {
+			LOG.warn("Decompressing since Binary Ops" + op.fn + " is not supported compressed");
+			return AbstractCompressedMatrixBlock.getUncompressed(m1).binaryOperations(op, thatValue, result);
+		}
+	}
+
+	private static boolean isSupportedBinaryCellOp(ValueFunction fn) {
+		return fn instanceof Multiply || fn instanceof Divide || fn instanceof Plus || fn instanceof Minus ||
+			fn instanceof MinusMultiply || fn instanceof PlusMultiply;
+	}
+
+	private static CompressedMatrixBlock setupCompressedReturnMatrixBlock(CompressedMatrixBlock m1,
+		MatrixValue result) {
+		CompressedMatrixBlock ret = null;
+		if(result == null || !(result instanceof CompressedMatrixBlock))
+			ret = new CompressedMatrixBlock(m1.getNumRows(), m1.getNumColumns(), false);
+		else {
+			ret = (CompressedMatrixBlock) result;
+			ret.reset(m1.getNumRows(), m1.getNumColumns());
+		}
+		return ret;
+	}
+
+	private static MatrixBlock bincellOp(CompressedMatrixBlock m1, MatrixBlock m2, CompressedMatrixBlock ret,
+		BinaryOperator op) {
+		if(isValidForOverlappingBinaryCellOperations(m1, op))
+			overlappingBinaryCellOp(m1, m2, ret, op);
+		else
+			nonOverlappingBinaryCellOp(m1, m2, ret, op);
+		return ret;
+
+	}
+
+	private static void nonOverlappingBinaryCellOp(CompressedMatrixBlock m1, MatrixBlock m2, CompressedMatrixBlock ret,
 		BinaryOperator op) {
 
 		BinaryAccessType atype = LibMatrixBincell.getBinaryAccessType(m1, m2);
+		switch(atype) {
+			case MATRIX_ROW_VECTOR:
+				// Verify if it is okay to include all OuterVectorVector ops here.
+				binaryMVRow(m1, m2, ret, op);
+				return;
+			case OUTER_VECTOR_VECTOR:
+				if(m2.getNumRows() == 1 && m2.getNumColumns() == 1) {
+					LibScalar.scalarOperations(new RightScalarOperator(op.fn, m2.quickGetValue(0, 0)), m1, ret);
+				}
+				return;
+			default:
+				LOG.warn("Inefficient Decompression for " + op + "  " + atype);
+				m1.decompress().binaryOperations(op, m2, ret);
 
-		if(m1.isOverlapping() && !(op.fn instanceof Multiply || op.fn instanceof Divide)) {
-			if(op.fn instanceof Plus || op.fn instanceof Minus) {
-				return binaryMVPlusStack(m1, m2, ret, op);
-			}
-			else {
-				throw new NotImplementedException(op + " not implemented for CLA");
-			}
+		}
+	}
 
+	private static boolean isValidForOverlappingBinaryCellOperations(CompressedMatrixBlock m1, BinaryOperator op) {
+		return m1.isOverlapping() && !(op.fn instanceof Multiply || op.fn instanceof Divide);
+	}
+
+	private static void overlappingBinaryCellOp(CompressedMatrixBlock m1, MatrixBlock m2, CompressedMatrixBlock ret,
+		BinaryOperator op) {
+		if(op.fn instanceof Plus || op.fn instanceof Minus) {
+
+			binaryMVPlusStack(m1, m2, ret, op);
 		}
 		else {
-			switch(atype) {
-				case MATRIX_ROW_VECTOR:
-					// Verify if it is okay to include all OuterVectorVector ops here.
-					return binaryMVRow(m1, m2, ret, op);
-
-				case OUTER_VECTOR_VECTOR:
-					if(m2.getNumRows() == 1 && m2.getNumColumns() == 1) {
-						return LibScalar.scalarOperations(new RightScalarOperator(op.fn, m2.quickGetValue(0, 0)),
-							m1,
-							ret,
-							m1.isOverlapping());
-					}
-				default:
-					LOG.warn("Inefficient Decompression for " + op + "  " + atype);
-					MatrixBlock m1d = m1.decompress();
-					return m1d.binaryOperations(op, m2, ret);
-
-			}
+			throw new NotImplementedException(op + " not implemented for CLA");
 		}
-
 	}
 
 	protected static CompressedMatrixBlock binaryMVRow(CompressedMatrixBlock m1, MatrixBlock m2,
 		CompressedMatrixBlock ret, BinaryOperator op) {
 
-		// Apply the operation to each of the column groups.
-		// Most implementations will only modify metadata.
 		List<ColGroup> oldColGroups = m1.getColGroups();
-		double[] v = m2.getDenseBlockValues();
-		if(v == null) {
-			SparseBlock sb = m2.getSparseBlock();
-			if(sb == null) {
-				throw new DMLRuntimeException("Unknown matrix block type");
-			}
-			else {
-				// make the row a dense vector...
-				double[] spV = sb.values(0);
-				int[] spI = sb.indexes(0);
-				v = new double[m2.getNumColumns()];
-				for(int i = sb.pos(0); i < sb.size(0); i++) {
-					v[spI[i]] = spV[i];
-				}
-			}
-		}
+		double[] v = forceMatrixBlockToDense(m2);
 		boolean sparseSafe = true;
 		for(double x : v) {
 			if(op.fn.execute(0.0, x) != 0.0) {
@@ -164,6 +191,29 @@ public class LibBinaryCellOp {
 
 	}
 
+	private static double[] forceMatrixBlockToDense(MatrixBlock m2) {
+		double[] v;
+		if(m2.isInSparseFormat()) {
+			SparseBlock sb = m2.getSparseBlock();
+			if(sb == null) {
+				throw new DMLRuntimeException("Unknown matrix block type");
+			}
+			else {
+				double[] spV = sb.values(0);
+				int[] spI = sb.indexes(0);
+				v = new double[m2.getNumColumns()];
+				for(int i = sb.pos(0); i < sb.size(0); i++) {
+					v[spI[i]] = spV[i];
+				}
+			}
+		}
+		else
+			v = m2.getDenseBlockValues();
+
+		return v;
+
+	}
+
 	protected static CompressedMatrixBlock binaryMVPlusStack(CompressedMatrixBlock m1, MatrixBlock m2,
 		CompressedMatrixBlock ret, BinaryOperator op) {
 		List<ColGroup> oldColGroups = m1.getColGroups();
@@ -194,13 +244,10 @@ public class LibBinaryCellOp {
 		return ret;
 	}
 
-	public static MatrixBlock binaryMVPlusCol(CompressedMatrixBlock m1, MatrixBlock m2, BinaryOperator op) {
-		if(m1.getNumRows() != m2.getNumRows())
-			throw new DMLRuntimeException("Invalid number of rows in input. Should be equal for m1 and m2 but are : "
-				+ m1.getNumRows() + " " + m2.getNumRows());
+	private static MatrixBlock binaryMVCol(CompressedMatrixBlock m1, MatrixBlock m2, BinaryOperator op) {
 
 		MatrixBlock ret = new MatrixBlock(m1.getNumRows(), m1.getNumColumns(), false, -1).allocateBlock();
-		// LOG.error(Arrays.toString(m2.getDenseBlockValues()));
+
 		final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
 		int k = OptimizerUtils.getConstrainedNumThreads(-1);
 		ExecutorService pool = CommonThreadPool.get(k);
@@ -208,8 +255,7 @@ public class LibBinaryCellOp {
 
 		try {
 			for(int i = 0; i * blkz < m1.getNumRows(); i++) {
-				tasks.add(new BinaryMVColTask(m1.getColGroups(), m2, ret, i * blkz,
-					Math.min(m1.getNumRows(), (i + 1) * blkz), op));
+				tasks.add(new BinaryMVColTask(m1, m2, ret, i * blkz, Math.min(m1.getNumRows(), (i + 1) * blkz), op));
 			}
 			long nnz = 0;
 			for(Future<Integer> f : pool.invokeAll(tasks))
@@ -226,16 +272,16 @@ public class LibBinaryCellOp {
 	}
 
 	private static class BinaryMVColTask implements Callable<Integer> {
-		private final List<ColGroup> _groups;
 		private final int _rl;
 		private final int _ru;
+		private final CompressedMatrixBlock _m1;
 		private final MatrixBlock _m2;
 		private final MatrixBlock _ret;
 		private final BinaryOperator _op;
 
-		protected BinaryMVColTask(List<ColGroup> groups, MatrixBlock m2, MatrixBlock ret, int rl, int ru,
+		protected BinaryMVColTask(CompressedMatrixBlock m1, MatrixBlock m2, MatrixBlock ret, int rl, int ru,
 			BinaryOperator op) {
-			_groups = groups;
+			_m1 = m1;
 			_m2 = m2;
 			_ret = ret;
 			_op = op;
@@ -245,25 +291,20 @@ public class LibBinaryCellOp {
 
 		@Override
 		public Integer call() {
-			List<Integer> columns = new ArrayList<>();
-			for(ColGroup g : _groups) {
+			for(ColGroup g : _m1.getColGroups()) {
 				// unsafe decompress, since we count nonzeros afterwards.
-				g.decompressToBlockSafe(_ret, _rl, _ru, _rl, g.getValues(), false);
-				for(int i: g.getColIndices()){
-					columns.add(i);
-				}
+				g.decompressToBlockSafe(_ret, _rl, _ru, g.getValues(), false);
 			}
 
 			int nnz = 0;
 			DenseBlock db = _ret.getDenseBlock();
 			for(int row = _rl; row < _ru; row++) {
 				double vr = _m2.quickGetValue(row, 0);
-				for(int col : columns) {
+				for(int col = 0; col < _m1.getNumColumns(); col++) {
 					double v = _op.fn.execute(_ret.quickGetValue(row, col), vr);
 					nnz += (v != 0) ? 1 : 0;
 					db.set(row, col, v);
 				}
-
 			}
 
 			return nnz;

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/LibCompAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/LibCompAgg.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressionSettings;
@@ -35,6 +33,7 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroup;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
+import org.apache.sysds.runtime.functionobjects.IndexFunction;
 import org.apache.sysds.runtime.functionobjects.KahanFunction;
 import org.apache.sysds.runtime.functionobjects.KahanPlus;
 import org.apache.sysds.runtime.functionobjects.KahanPlusSq;
@@ -54,12 +53,10 @@ import org.apache.sysds.runtime.util.CommonThreadPool;
 
 public class LibCompAgg {
 
-    private static final Log LOG = LogFactory.getLog(LibCompAgg.class.getName());
+    // private static final Log LOG = LogFactory.getLog(LibCompAgg.class.getName());
 
-    /** Threshold for when to parallelize the aggregation functions. */
-    private static final long MIN_PAR_AGG_THRESHOLD = 8 * 1024 * 1024; // 8MB
+    private static final long MIN_PAR_AGG_THRESHOLD = 8 * 1024 * 1024;
 
-    /** Thread pool matrix Block for materializing decompressed groups. */
     private static ThreadLocal<MatrixBlock> memPool = new ThreadLocal<MatrixBlock>() {
         @Override
         protected MatrixBlock initialValue() {
@@ -67,156 +64,109 @@ public class LibCompAgg {
         }
     };
 
-    public static MatrixBlock aggregateUnary(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op,
-        int blen, MatrixIndexes indexesIn, boolean inCP) {
-
-        fillStart(ret, op);
-
-        // core unary aggregate
-        if(op.getNumThreads() > 1 && m1.getExactSizeOnDisk() > MIN_PAR_AGG_THRESHOLD) {
-            // multi-threaded execution of all groups
-            ArrayList<ColGroup>[] grpParts = createStaticTaskPartitioning(m1.getColGroups(),
-                (op.indexFn instanceof ReduceCol) ? 1 : op.getNumThreads(),
-                false);
-
-            ColGroupUncompressed uc = m1.getUncompressedColGroup();
-
-            try {
-                // compute uncompressed column group in parallel (otherwise bottleneck)
-                if(uc != null)
-                    uc.unaryAggregateOperations(op, ret);
-                // compute all compressed column groups
-                ExecutorService pool = CommonThreadPool.get(op.getNumThreads());
-                ArrayList<UnaryAggregateTask> tasks = new ArrayList<>();
-                if(op.indexFn instanceof ReduceCol && grpParts.length > 0) {
-                    final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
-                    int blklen = Math.min((int) Math.ceil((double) m1.getNumRows() / op.getNumThreads()), blkz / 2);
-                    blklen += (blklen % blkz != 0) ? blkz - blklen % blkz : 0;
-                    for(int i = 0; i < op.getNumThreads() & i * blklen < m1.getNumRows(); i++) {
-                        tasks.add(new UnaryAggregateTask(grpParts[0], ret, i * blklen,
-                            Math.min((i + 1) * blklen, m1.getNumRows()), op, m1.getNumColumns()));
-
-                    }
-                }
-                else
-                    for(ArrayList<ColGroup> grp : grpParts) {
-                        if(grp != null)
-                            tasks.add(new UnaryAggregateTask(grp, ret, 0, m1.getNumRows(), op, m1.getNumColumns()));
-                    }
-                List<Future<MatrixBlock>> rtasks = pool.invokeAll(tasks);
-                pool.shutdown();
-
-                // aggregate partial results
-                if(op.indexFn instanceof ReduceAll) {
-                    if(op.aggOp.increOp.fn instanceof KahanFunction) {
-                        KahanObject kbuff = new KahanObject(ret.quickGetValue(0, 0), 0);
-                        for(Future<MatrixBlock> rtask : rtasks) {
-                            double tmp = rtask.get().quickGetValue(0, 0);
-                            ((KahanFunction) op.aggOp.increOp.fn).execute2(kbuff, tmp);
-                        }
-                        ret.quickSetValue(0, 0, kbuff._sum);
-                    }
-                    else if(op.aggOp.increOp.fn instanceof Mean) {
-                        double val = ret.quickGetValue(0, 0);
-                        for(Future<MatrixBlock> rtask : rtasks) {
-                            double tmp = rtask.get().quickGetValue(0, 0);
-                            val = val + tmp;
-                        }
-                        ret.quickSetValue(0, 0, val);
-                    }
-                    else {
-                        double val = ret.quickGetValue(0, 0);
-                        for(Future<MatrixBlock> rtask : rtasks) {
-                            double tmp = rtask.get().quickGetValue(0, 0);
-                            val = op.aggOp.increOp.fn.execute(val, tmp);
-                        }
-                        ret.quickSetValue(0, 0, val);
-                    }
-                }
-            }
-            catch(InterruptedException | ExecutionException e) {
-                throw new DMLRuntimeException(e);
-            }
-        }
-        else {
-            if(m1.getColGroups() != null) {
-                for(ColGroup grp : m1.getColGroups())
-                    if(grp instanceof ColGroupUncompressed)
-                        ((ColGroupUncompressed) grp).unaryAggregateOperations(op, ret);
-                aggregateUnaryOperations(op, m1.getColGroups(), ret, 0, m1.getNumRows(), m1.getNumColumns());
-            }
-        }
-
-        // special handling zeros for rowmins/rowmax
-        // if(op.getNumThreads() == 1 && op.indexFn instanceof ReduceCol && op.aggOp.increOp.fn instanceof Builtin) {
-        // int[] rnnz = new int[m1.getNumRows()];
-        // for(ColGroup grp : m1.getColGroups())
-        // grp.countNonZerosPerRow(rnnz, 0, m1.getNumRows());
-        // Builtin builtin = (Builtin) op.aggOp.increOp.fn;
-        // for(int i = 0; i < m1.getNumRows(); i++)
-        // if(rnnz[i] < m1.getNumColumns())
-        // ret.quickSetValue(i, 0, builtin.execute(ret.quickGetValue(i, 0), 0));
-        // }
-
-        // special handling of mean
-        if(op.aggOp.increOp.fn instanceof Mean) {
-            if(op.indexFn instanceof ReduceAll) {
-                ret.quickSetValue(0, 0, ret.quickGetValue(0, 0) / (m1.getNumColumns() * m1.getNumRows()));
-            }
-            else if(op.indexFn instanceof ReduceCol) {
-                for(int i = 0; i < m1.getNumRows(); i++) {
-                    ret.quickSetValue(i, 0, ret.quickGetValue(i, 0) / m1.getNumColumns());
-                }
-            }
-            else if(op.indexFn instanceof ReduceRow)
-                for(int i = 0; i < m1.getNumColumns(); i++) {
-                    ret.quickSetValue(0, i, ret.quickGetValue(0, i) / m1.getNumRows());
-                }
-        }
-
-        // drop correction if necessary
-        if(op.aggOp.existsCorrection() && inCP)
-            ret.dropLastRowsOrColumns(op.aggOp.correction);
-
-        ret.recomputeNonZeros();
-        return ret;
-    }
-
-    public static MatrixBlock aggregateUnaryOverlapping(CompressedMatrixBlock m1, MatrixBlock ret,
+    public static MatrixBlock aggregateUnary(CompressedMatrixBlock inputMatrix, MatrixBlock outputMatrix,
         AggregateUnaryOperator op, int blen, MatrixIndexes indexesIn, boolean inCP) {
 
-        if(!(op.aggOp.increOp.fn instanceof KahanPlusSq || (op.aggOp.increOp.fn instanceof Builtin &&
-            (((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN ||
-                ((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX)))) {
-            throw new DMLRuntimeException("Overlapping aggregates is not valid for op: " + op.aggOp.increOp.fn);
+        if(inputMatrix.getColGroups() != null) {
+            fillStart(outputMatrix, op);
+
+            if(inputMatrix.isOverlapping() &&
+                (op.aggOp.increOp.fn instanceof KahanPlusSq || (op.aggOp.increOp.fn instanceof Builtin &&
+                    (((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN ||
+                        ((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX))))
+                aggregateUnaryOverlapping(inputMatrix, outputMatrix, op, indexesIn, inCP);
+            else
+                aggregateUnaryNormalCompressedMatrixBlock(inputMatrix, outputMatrix, op, blen, indexesIn, inCP);
         }
 
-        fillStart(ret, op);
+        if(op.aggOp.existsCorrection() && inCP)
+            outputMatrix.dropLastRowsOrColumns(op.aggOp.correction);
+
+        outputMatrix.recomputeNonZeros();
+        memPool.remove();
+
+        return outputMatrix;
+    }
+
+    private static void aggregateUnaryNormalCompressedMatrixBlock(CompressedMatrixBlock inputMatrix,
+        MatrixBlock outputMatrix, AggregateUnaryOperator op, int blen, MatrixIndexes indexesIn, boolean inCP) {
+
+        aggregateUncompressedColGroups(inputMatrix, outputMatrix, op);
+
+        if(isValidForParallelProcessing(inputMatrix, op))
+            tryToAggregateInParallel(inputMatrix, outputMatrix, op);
+        else
+            aggregateSingleThreaded(inputMatrix, outputMatrix, op);
+
+        postProcessAggregate(inputMatrix, outputMatrix, op);
+
+    }
+
+    private static boolean isValidForParallelProcessing(CompressedMatrixBlock m1, AggregateUnaryOperator op) {
+        return op.getNumThreads() > 1 && m1.getExactSizeOnDisk() > MIN_PAR_AGG_THRESHOLD;
+    }
+
+    private static void aggregateUncompressedColGroups(CompressedMatrixBlock m1, MatrixBlock ret,
+        AggregateUnaryOperator op) {
+        ColGroupUncompressed uc = m1.getUncompressedColGroup();
+        if(uc != null)
+            uc.unaryAggregateOperations(op, ret);
+    }
+
+    private static void tryToAggregateInParallel(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op) {
+        int k = getNumberOfThreadsToUse(op);
+        if(k == 1)
+            aggregateUnaryOperations(op, m1.getColGroups(), ret, 0, m1.getNumRows(), m1.getNumColumns());
+        else
+            aggregateInParallel(m1, ret, op, k);
+
+    }
+
+    private static void aggregateInParallel(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op,
+        int k) {
+
+        List<List<ColGroup>> grpParts = createTaskPartitionNotIncludingUncompressable(m1.getColGroups(), k);
+
+        ExecutorService pool = CommonThreadPool.get(op.getNumThreads());
+        ArrayList<UnaryAggregateTask> tasks = new ArrayList<>();
 
         try {
             // compute all compressed column groups
-            ExecutorService pool = CommonThreadPool.get(op.getNumThreads());
-            ArrayList<UnaryAggregateOverlappingTask> tasks = new ArrayList<>();
-            final int blklen = Math.min(m1.getNumRows() / op.getNumThreads(), CompressionSettings.BITMAP_BLOCK_SZ);
-            LOG.error("BlockSize : " + blklen);
+            if(op.indexFn instanceof ReduceCol && grpParts.size() > 0) {
+                final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
+                int blklen = Math.min((int) Math.ceil((double) m1.getNumRows() / op.getNumThreads()), blkz / 2);
+                blklen += (blklen % blkz != 0) ? blkz - blklen % blkz : 0;
+                for(int i = 0; i < op.getNumThreads() & i * blklen < m1.getNumRows(); i++) {
+                    tasks.add(new UnaryAggregateTask(grpParts.get(0), ret, i * blklen,
+                        Math.min((i + 1) * blklen, m1.getNumRows()), op, m1.getNumColumns()));
 
-            for(int i = 0; i * blklen < m1.getNumRows(); i++) {
-                tasks.add(new UnaryAggregateOverlappingTask(m1.getColGroups(), ret, i * blklen,
-                    Math.min((i + 1) * blklen, m1.getNumRows()), op));
+                }
             }
-
+            else
+                for(List<ColGroup> grp : grpParts) {
+                    if(grp != null)
+                        tasks.add(new UnaryAggregateTask(grp, ret, 0, m1.getNumRows(), op, m1.getNumColumns()));
+                }
             List<Future<MatrixBlock>> rtasks = pool.invokeAll(tasks);
             pool.shutdown();
 
-            if(op.indexFn instanceof ReduceAll || (ret.getNumColumns() == 1 && ret.getNumRows() == 1)) {
+            // aggregate partial results
+            if(op.indexFn instanceof ReduceAll) {
                 if(op.aggOp.increOp.fn instanceof KahanFunction) {
                     KahanObject kbuff = new KahanObject(ret.quickGetValue(0, 0), 0);
-                    KahanPlus kplus = KahanPlus.getKahanPlusFnObject();
                     for(Future<MatrixBlock> rtask : rtasks) {
                         double tmp = rtask.get().quickGetValue(0, 0);
-                        kplus.execute2(kbuff, tmp);
+                        ((KahanFunction) op.aggOp.increOp.fn).execute2(kbuff, tmp);
                     }
                     ret.quickSetValue(0, 0, kbuff._sum);
+                }
+                else if(op.aggOp.increOp.fn instanceof Mean) {
+                    double val = ret.quickGetValue(0, 0);
+                    for(Future<MatrixBlock> rtask : rtasks) {
+                        double tmp = rtask.get().quickGetValue(0, 0);
+                        val = val + tmp;
+                    }
+                    ret.quickSetValue(0, 0, val);
                 }
                 else {
                     double val = ret.quickGetValue(0, 0);
@@ -226,77 +176,166 @@ public class LibCompAgg {
                     }
                     ret.quickSetValue(0, 0, val);
                 }
-
-                ret.recomputeNonZeros();
             }
-            // else if(op.indexFn instanceof ReduceCol) {
-            // long nnz = 0;
-            // for(int i = 0; i * blklen < m1.getNumRows(); i++) {
-            // MatrixBlock tmp = rtasks.get(i).get();
-            // for(int row = 0, off = i * blklen; row < tmp.getNumRows(); row++, off++) {
-            // ret.quickSetValue(off, 0, tmp.quickGetValue(row, 0));
-            // nnz += ret.quickGetValue(off, 0) == 0 ? 0 : 1;
-            // }
-            // }
-            // ret.setNonZeros(nnz);
-            // }
-            else {
-                for(Future<MatrixBlock> rtask : rtasks) {
-                    LibMatrixBincell.bincellOp(rtask.get(),
-                        ret,
-                        ret,
-                        (op.aggOp.increOp.fn instanceof KahanFunction) ? new BinaryOperator(
-                            Plus.getPlusFnObject()) : op.aggOp.increOp);
-                }
-            }
-            memPool.remove();
         }
         catch(InterruptedException | ExecutionException e) {
             throw new DMLRuntimeException(e);
         }
-        if(op.aggOp.existsCorrection() && inCP)
-            ret.dropLastRowsOrColumns(op.aggOp.correction);
-
-        return ret;
     }
 
-    @SuppressWarnings("unchecked")
-    private static ArrayList<ColGroup>[] createStaticTaskPartitioning(List<ColGroup> colGroups, int k,
-        boolean inclUncompressed) {
-        // special case: single uncompressed col group
-        if(colGroups.size() == 1 && colGroups.get(0) instanceof ColGroupUncompressed) {
-            return new ArrayList[0];
+    private static void aggregateSingleThreaded(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op) {
+        aggregateUnaryOperations(op, m1.getColGroups(), ret, 0, m1.getNumRows(), m1.getNumColumns());
+    }
+
+    private static void divideByNumberOfCellsForMean(CompressedMatrixBlock m1, MatrixBlock ret, IndexFunction idxFn) {
+        if(idxFn instanceof ReduceAll)
+            divideByNumberOfCellsForMeanAll(m1, ret);
+        else if(idxFn instanceof ReduceCol)
+            divideByNumberOfCellsForMeanRows(m1, ret);
+        else if(idxFn instanceof ReduceRow)
+            divideByNumberOfCellsForMeanCols(m1, ret);
+    }
+
+    private static void divideByNumberOfCellsForMeanRows(CompressedMatrixBlock m1, MatrixBlock ret) {
+        for(int i = 0; i < m1.getNumRows(); i++) {
+            ret.quickSetValue(i, 0, ret.quickGetValue(i, 0) / m1.getNumColumns());
+        }
+    }
+
+    private static void divideByNumberOfCellsForMeanCols(CompressedMatrixBlock m1, MatrixBlock ret) {
+        for(int i = 0; i < m1.getNumColumns(); i++) {
+            ret.quickSetValue(0, i, ret.quickGetValue(0, i) / m1.getNumRows());
+        }
+    }
+
+    private static void divideByNumberOfCellsForMeanAll(CompressedMatrixBlock m1, MatrixBlock ret) {
+        ret.quickSetValue(0, 0, ret.quickGetValue(0, 0) / (m1.getNumColumns() * m1.getNumRows()));
+    }
+
+    private static void postProcessAggregate(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op) {
+        if(op.aggOp.increOp.fn instanceof Mean)
+            divideByNumberOfCellsForMean(m1, ret, op.indexFn);
+
+    }
+
+    private static void aggregateUnaryOverlapping(CompressedMatrixBlock m1, MatrixBlock ret, AggregateUnaryOperator op,
+        MatrixIndexes indexesIn, boolean inCP) {
+
+        try {
+            List<Future<MatrixBlock>> rtasks = generateUnaryAggregateOverlappingFutures(m1, ret, op);
+            reduceOverlappingFutures(rtasks, ret, op);
+        }
+        catch(InterruptedException | ExecutionException e) {
+            throw new DMLRuntimeException(e);
         }
 
-        // initialize round robin col group distribution
-        // (static task partitioning to reduce mem requirements/final agg)
+    }
+
+    private static void reduceOverlappingFutures(List<Future<MatrixBlock>> rtasks, MatrixBlock ret,
+        AggregateUnaryOperator op) throws InterruptedException, ExecutionException {
+        if(isReduceAll(ret, op.indexFn))
+            reduceAllOverlappingFutures(rtasks, ret, op);
+        else if(op.indexFn instanceof ReduceRow)
+            reduceColOverlappingFutures(rtasks, ret, op);
+        else
+            reduceRowOverlappingFutures(rtasks, ret, op);
+    }
+
+    private static void reduceColOverlappingFutures(List<Future<MatrixBlock>> rtasks, MatrixBlock ret,
+        AggregateUnaryOperator op) throws InterruptedException, ExecutionException {
+        for(Future<MatrixBlock> rtask : rtasks) {
+            LibMatrixBincell.bincellOp(rtask.get(),
+                ret,
+                ret,
+                (op.aggOp.increOp.fn instanceof KahanFunction) ? new BinaryOperator(
+                    Plus.getPlusFnObject()) : op.aggOp.increOp);
+        }
+    }
+
+    private static void reduceRowOverlappingFutures(List<Future<MatrixBlock>> rtasks, MatrixBlock ret,
+        AggregateUnaryOperator op) throws InterruptedException, ExecutionException {
+        for(Future<MatrixBlock> rtask : rtasks) {
+            rtask.get();
+        }
+    }
+
+    private static boolean isReduceAll(MatrixBlock ret, IndexFunction idxFn) {
+        return idxFn instanceof ReduceAll || (ret.getNumColumns() == 1 && ret.getNumRows() == 1);
+    }
+
+    private static void reduceAllOverlappingFutures(List<Future<MatrixBlock>> rtasks, MatrixBlock ret,
+        AggregateUnaryOperator op) throws InterruptedException, ExecutionException {
+
+        if(op.aggOp.increOp.fn instanceof KahanFunction) {
+            KahanObject kbuff = new KahanObject(ret.quickGetValue(0, 0), 0);
+            KahanPlus kplus = KahanPlus.getKahanPlusFnObject();
+            for(Future<MatrixBlock> rtask : rtasks) {
+                double tmp = rtask.get().quickGetValue(0, 0);
+
+                kplus.execute2(kbuff, tmp);
+            }
+            ret.quickSetValue(0, 0, kbuff._sum);
+        }
+        else {
+            double val = ret.quickGetValue(0, 0);
+            for(Future<MatrixBlock> rtask : rtasks) {
+                double tmp = rtask.get().quickGetValue(0, 0);
+                val = op.aggOp.increOp.fn.execute(val, tmp);
+
+            }
+            ret.quickSetValue(0, 0, val);
+        }
+    }
+
+    private static List<Future<MatrixBlock>> generateUnaryAggregateOverlappingFutures(CompressedMatrixBlock m1,
+        MatrixBlock ret, AggregateUnaryOperator op) throws InterruptedException {
+
+        ExecutorService pool = CommonThreadPool.get(op.getNumThreads());
+        ArrayList<UnaryAggregateOverlappingTask> tasks = new ArrayList<>();
+
+        final int blklen = Math.min(m1.getNumRows() / op.getNumThreads(), CompressionSettings.BITMAP_BLOCK_SZ);
+
+        for(int i = 0; i * blklen < m1.getNumRows(); i++)
+            tasks.add(new UnaryAggregateOverlappingTask(m1, ret, i * blklen,
+                Math.min((i + 1) * blklen, m1.getNumRows()), op));
+
+        List<Future<MatrixBlock>> futures = pool.invokeAll(tasks);
+        pool.shutdown();
+        return futures;
+    }
+
+    private static List<List<ColGroup>> createTaskPartitionNotIncludingUncompressable(List<ColGroup> colGroups, int k) {
         int numTasks = Math.min(k, colGroups.size());
-        ArrayList<ColGroup>[] grpParts = new ArrayList[numTasks];
+        List<List<ColGroup>> grpParts = new ArrayList<>();
+        for(int i = 0; i < numTasks; i++) {
+            grpParts.add(new ArrayList<>());
+        }
         int pos = 0;
         for(ColGroup grp : colGroups) {
-            if(grpParts[pos] == null)
-                grpParts[pos] = new ArrayList<>();
-            if(inclUncompressed || !(grp instanceof ColGroupUncompressed)) {
-                grpParts[pos].add(grp);
-                pos = (pos == numTasks - 1) ? 0 : pos + 1;
+            if(!(grp instanceof ColGroupUncompressed)) {
+                List<ColGroup> g = grpParts.get(pos);
+                g.add(grp);
+                pos = (pos + 1) % numTasks;
             }
         }
 
         return grpParts;
     }
 
+    private static int getNumberOfThreadsToUse(AggregateUnaryOperator op) {
+        return (op.indexFn instanceof ReduceCol) ? 1 : op.getNumThreads();
+    }
+
     private static void aggregateUnaryOperations(AggregateUnaryOperator op, List<ColGroup> groups, MatrixBlock ret,
         int rl, int ru, int numColumns) {
 
-        // note: UC group never passed into this function
-        // double[] c = ret.getDenseBlockValues();
         int[] rnnz = (op.indexFn instanceof ReduceCol && op.aggOp.increOp.fn instanceof Builtin) ? new int[ru -
             rl] : null;
         int numberDenseColumns = 0;
-        for(ColGroup grp : groups){
+        for(ColGroup grp : groups) {
             if(grp != null && !(grp instanceof ColGroupUncompressed)) {
                 grp.unaryAggregateOperations(op, ret, rl, ru);
-                if(grp.isDense()){
+                if(grp.isDense()) {
                     numberDenseColumns += grp.getNumCols();
                 }
                 else if(op.indexFn instanceof ReduceCol && op.aggOp.increOp.fn instanceof Builtin) {
@@ -314,6 +353,25 @@ public class LibCompAgg {
 
         }
 
+    }
+
+    private static void fillStart(MatrixBlock ret, AggregateUnaryOperator op) {
+        if(op.aggOp.increOp.fn instanceof Builtin) {
+            Double val = null;
+            switch(((Builtin) op.aggOp.increOp.fn).getBuiltinCode()) {
+                case MAX:
+                    val = Double.NEGATIVE_INFINITY;
+                    break;
+                case MIN:
+                    val = Double.POSITIVE_INFINITY;
+                    break;
+                default:
+                    break;
+            }
+            if(val != null) {
+                ret.getDenseBlock().set(val);
+            }
+        }
     }
 
     private static class UnaryAggregateTask implements Callable<MatrixBlock> {
@@ -355,73 +413,87 @@ public class LibCompAgg {
     }
 
     private static class UnaryAggregateOverlappingTask implements Callable<MatrixBlock> {
-        private final List<ColGroup> _groups;
+        private final CompressedMatrixBlock _m1;
         private final int _rl;
         private final int _ru;
         private final MatrixBlock _ret;
         private final AggregateUnaryOperator _op;
 
-        protected UnaryAggregateOverlappingTask(List<ColGroup> groups, MatrixBlock ret, int rl, int ru,
+        protected UnaryAggregateOverlappingTask(CompressedMatrixBlock m1, MatrixBlock ret, int rl, int ru,
             AggregateUnaryOperator op) {
-            _groups = groups;
+            _m1 = m1;
             _op = op;
             _rl = rl;
             _ru = ru;
-            if(_op.indexFn instanceof ReduceAll) {
-                _ret = new MatrixBlock(ret.getNumRows(), ret.getNumColumns(), false);
-                _ret.allocateDenseBlock();
-            }
-            else if(_op.indexFn instanceof ReduceCol) {
-                _ret = new MatrixBlock(ru - rl, 1, false);
-                _ret.allocateDenseBlock();
+            _ret = ret;
+
+        }
+
+        private MatrixBlock setupOutputMatrix() {
+            MatrixBlock outputBlock;
+            if(_op.indexFn instanceof ReduceAll)
+                outputBlock = new MatrixBlock(_ret.getNumRows(), _ret.getNumColumns(), false).allocateDenseBlock();
+            else if(_op.indexFn instanceof ReduceCol)
+                outputBlock = new MatrixBlock(_ru - _rl, _ret.getNumColumns(), false).allocateDenseBlock();
+            else
+                outputBlock = new MatrixBlock(_ret.getNumRows(), _ret.getNumColumns(), false).allocateDenseBlock();
+
+            if(_op.aggOp.increOp.fn instanceof Builtin)
+                if(_op.indexFn instanceof ReduceCol)
+                    System.arraycopy(_ret.getDenseBlockValues(),
+                        _rl * _ret.getNumColumns(),
+                        outputBlock.getDenseBlockValues(),
+                        0,
+                        outputBlock.getDenseBlockValues().length);
+                else
+                    System.arraycopy(_ret.getDenseBlockValues(),
+                        0,
+                        outputBlock.getDenseBlockValues(),
+                        0,
+                        _ret.getDenseBlockValues().length);
+
+            return outputBlock;
+        }
+
+        private MatrixBlock getTmp() {
+            MatrixBlock tmp = memPool.get();
+            if(tmp == null) {
+                memPool.set(new MatrixBlock(_ru - _rl, _m1.getNumColumns(), false, -1).allocateBlock());
+                tmp = memPool.get();
             }
             else {
-                _ret = new MatrixBlock(ret.getNumRows(), ret.getNumColumns(), false);
-                _ret.allocateDenseBlock();
+                tmp = memPool.get();
+                tmp.reset(_ru - _rl, _m1.getNumColumns(), false, -1);
             }
-            if(_op.aggOp.increOp.fn instanceof Builtin) {
-                System.arraycopy(ret
-                    .getDenseBlockValues(), 0, _ret.getDenseBlockValues(), 0, _ret.getDenseBlockValues().length);
-            }
+            return tmp;
+        }
 
+        private MatrixBlock decompressToTemp() {
+            MatrixBlock tmp = getTmp();
+            for(ColGroup g : _m1.getColGroups())
+                g.decompressToBlockSafe(tmp, _rl, _ru, 0, g.getValues(), false);
+            tmp.setNonZeros(_rl + _ru);
+            return tmp;
         }
 
         @Override
         public MatrixBlock call() {
-            MatrixBlock tmp = memPool.get();
-            if(tmp == null) {
-                memPool.set(new MatrixBlock(_ru - _rl, _groups.get(0).getNumCols(), false, -1).allocateBlock());
-                tmp = memPool.get();
+            MatrixBlock tmp = decompressToTemp();
+
+            MatrixBlock outputBlock = setupOutputMatrix();
+            LibMatrixAgg.aggregateUnaryMatrix(tmp, outputBlock, _op);
+
+            if(_op.indexFn instanceof ReduceCol) {
+                double[] retValues = _ret.getDenseBlockValues();
+                int currentIndex = _rl * _ret.getNumColumns();
+                double[] outputBlockValues = outputBlock.getDenseBlockValues();
+                System.arraycopy(outputBlockValues, 0, retValues, currentIndex, outputBlockValues.length);
+
+                return null;
             }
             else {
-                tmp = memPool.get();
-                tmp.reset(_ru - _rl, _groups.get(0).getNumCols(), false, -1);
-            }
 
-            for(ColGroup g : _groups) {
-                g.decompressToBlockSafe(tmp, _rl, _ru, 0, g.getValues(), false);
-            }
-
-            LibMatrixAgg.aggregateUnaryMatrix(tmp, _ret, _op);
-            return _ret;
-        }
-    }
-
-    private static void fillStart(MatrixBlock ret, AggregateUnaryOperator op) {
-        if(op.aggOp.increOp.fn instanceof Builtin) {
-            Double val = null;
-            switch(((Builtin) op.aggOp.increOp.fn).getBuiltinCode()) {
-                case MAX:
-                    val = Double.NEGATIVE_INFINITY;
-                    break;
-                case MIN:
-                    val = Double.POSITIVE_INFINITY;
-                    break;
-                default:
-                    break;
-            }
-            if(val != null) {
-                ret.getDenseBlock().set(val);
+                return outputBlock;
             }
         }
     }

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/LibRightMultBy.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/LibRightMultBy.java
@@ -37,8 +37,6 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroup;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupOLE;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupValue;
-import org.apache.sysds.runtime.data.DenseBlock;
-import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 
@@ -65,51 +63,65 @@ public class LibRightMultBy {
 		}
 		that = that instanceof CompressedMatrixBlock ? ((CompressedMatrixBlock) that).decompress(k) : that;
 
-		boolean containsUncompressable = false;
+		if(allowOverlappingOutput(colGroups, allowOverlap)) {
+			return rightMultByMatrixOverlapping(colGroups, that, ret, k, v);
+		}
+		else {
+			return rightMultByMatrixNonOverlapping(colGroups, that, ret, k, v);
+		}
+	}
+
+	private static boolean allowOverlappingOutput(List<ColGroup> colGroups, boolean allowOverlap) {
+		if(!allowOverlap) {
+			LOG.debug("Not Overlapping because it is not allowed");
+			return false;
+		}
 		int distinctCount = 0;
 		for(ColGroup g : colGroups) {
 			if(g instanceof ColGroupValue) {
 				distinctCount += ((ColGroupValue) g).getNumValues();
 			}
 			else {
-				containsUncompressable = true;
+				LOG.debug("Not Overlapping because there is an un-compressible column group");
+				return false;
 			}
 		}
 		int rl = colGroups.get(0).getNumRows();
+		boolean allow = distinctCount <= rl / 2;
+		if(!allow) {
+			LOG.debug("Not Allowing Overlap because of number of distinct items in compression");
+		}
+		return allow;
+
+	}
+
+	private static MatrixBlock rightMultByMatrixNonOverlapping(List<ColGroup> colGroups, MatrixBlock that,
+		MatrixBlock ret, int k, Pair<Integer, int[]> v) {
+
+		int rl = colGroups.get(0).getNumRows();
 		int cl = that.getNumColumns();
-		if(!allowOverlap || (containsUncompressable || distinctCount >= rl / 4)) {
-			LOG.info("outputting non overlapping matrix right mm");
-			if(ret == null)
-				ret = new MatrixBlock(rl, cl, false, rl * cl);
-			else if(!(ret.getNumColumns() == cl && ret.getNumRows() == rl && ret.isAllocated()))
-				ret.reset(rl, cl, false, rl * cl);
-			ret.allocateDenseBlock();
-			if(that.isInSparseFormat()) {
-				ret = rightMultBySparseMatrix(colGroups, that, ret, k, v);
-			}
-			else {
-				ret = rightMultByDenseMatrix(colGroups, that, ret, k, v);
-			}
-			ret.setNonZeros(ret.getNumColumns() * ret.getNumRows());
-		}
-		else {
-			LOG.debug("Outputting Overlapping Matrix");
-			// Create an overlapping compressed Matrix Block.
-			ret = new CompressedMatrixBlock(true);
-			ret.setNumColumns(cl);
-			ret.setNumRows(rl);
-			CompressedMatrixBlock retC = (CompressedMatrixBlock) ret;
-			retC.setOverlapping(true);
-			if(that.isInSparseFormat()) {
-				ret = rightMultBySparseMatrixCompressed(colGroups, that, retC, k, v);
-			}
-			else {
-				ret = rightMultByDenseMatrixCompressed(colGroups, that, retC, k, v);
-			}
-		}
-
+		if(ret == null)
+			ret = new MatrixBlock(rl, cl, false, rl * cl);
+		else if(!(ret.getNumColumns() == cl && ret.getNumRows() == rl && ret.isAllocated()))
+			ret.reset(rl, cl, false, rl * cl);
+		ret.allocateDenseBlock();
+		ret = rightMultByMatrix(colGroups, that, ret, k, v);
+		ret.setNonZeros(ret.getNumColumns() * ret.getNumRows());
 		return ret;
+	}
 
+	private static MatrixBlock rightMultByMatrixOverlapping(List<ColGroup> colGroups, MatrixBlock that, MatrixBlock ret,
+		int k, Pair<Integer, int[]> v) {
+		int rl = colGroups.get(0).getNumRows();
+		int cl = that.getNumColumns();
+		// Create an overlapping compressed Matrix Block.
+		ret = new CompressedMatrixBlock(true);
+		ret.setNumColumns(cl);
+		ret.setNumRows(rl);
+		CompressedMatrixBlock retC = (CompressedMatrixBlock) ret;
+		retC.setOverlapping(true);
+		ret = rightMultByMatrixCompressed(colGroups, that, retC, k, v);
+		return ret;
 	}
 
 	/**
@@ -183,68 +195,10 @@ public class LibRightMultBy {
 		result.recomputeNonZeros();
 	}
 
-	private static MatrixBlock rightMultBySparseMatrix(List<ColGroup> colGroups, MatrixBlock that, MatrixBlock ret,
-		int k, Pair<Integer, int[]> v) {
-		SparseBlock sb = that.getSparseBlock();
+	private static MatrixBlock rightMultByMatrix(List<ColGroup> colGroups, MatrixBlock that, MatrixBlock ret, int k,
+		Pair<Integer, int[]> v) {
+
 		double[] retV = ret.getDenseBlockValues();
-
-		if(sb == null)
-			throw new DMLRuntimeException("Invalid Right Mult by Sparse matrix, input matrix was dense");
-
-		for(ColGroup grp : colGroups) {
-			if(grp instanceof ColGroupUncompressed)
-				((ColGroupUncompressed) grp).rightMultByMatrix(that, ret, 0, ret.getNumColumns());
-		}
-
-		// Pair<Integer, int[]> v = Util.getMaxNumValues(colGroups);
-		// if(k == 1) {
-		for(int j = 0; j < colGroups.size(); j++) {
-			double[] preAggregatedB = ((ColGroupValue) colGroups.get(j)).preaggValues(v.getRight()[j],
-				sb,
-				colGroups.get(j).getValues(),
-				0,
-				that.getNumColumns(),
-				that.getNumColumns());
-			colGroups.get(j).rightMultByMatrix(preAggregatedB,
-				retV,
-				that.getNumColumns(),
-				0,
-				ret.getNumRows(),
-				0,
-				that.getNumColumns());
-
-		}
-		// }
-		// else {
-		// ExecutorService pool = CommonThreadPool.get(k);
-		// ArrayList<RightMultBySparseMatrixTask> tasks = new ArrayList<>();
-		// try {
-
-		// for(int j = 0; j < ret.getNumColumns(); j += CompressionSettings.BITMAP_BLOCK_SZ) {
-		// tasks.add(new RightMultBySparseMatrixTask(colGroups, retV, sb, materialized, v, numColumns, j,
-		// Math.min(j + CompressionSettings.BITMAP_BLOCK_SZ, ret.getNumColumns())));
-		// }
-
-		// List<Future<Object>> futures = pool.invokeAll(tasks);
-		// pool.shutdown();
-		// for(Future<Object> future : futures)
-		// future.get();
-		// }
-		// catch(InterruptedException | ExecutionException e) {
-		// throw new DMLRuntimeException(e);
-		// }
-		// }
-
-		return ret;
-	}
-
-	private static MatrixBlock rightMultByDenseMatrix(List<ColGroup> colGroups, MatrixBlock that, MatrixBlock ret,
-		int k, Pair<Integer, int[]> v) {
-
-		// long StartTime = System.currentTimeMillis();
-		DenseBlock db = that.getDenseBlock();
-		double[] retV = ret.getDenseBlockValues();
-		double[] thatV;
 
 		for(ColGroup grp : colGroups) {
 			if(grp instanceof ColGroupUncompressed) {
@@ -253,60 +207,50 @@ public class LibRightMultBy {
 		}
 
 		if(k == 1) {
-			int colBlockSize = 128;
-			ColGroupValue.setupThreadLocalMemory(colBlockSize * v.getLeft());
-			for(int b = 0; b < db.numBlocks(); b++) {
-				// int blockSize = db.blockSize(b);
-				thatV = db.valuesAt(b);
-				for(int j = 0; j < colGroups.size(); j++) {
-					for(int i = 0; i < that.getNumColumns(); i += colBlockSize) {
-						if(colGroups.get(j) instanceof ColGroupValue) {
-							double[] preAggregatedB = ((ColGroupValue) colGroups.get(j)).preaggValues(v.getRight()[j],
-								thatV,
-								colGroups.get(j).getValues(),
-								i,
-								Math.min(i + colBlockSize, that.getNumColumns()),
-								that.getNumColumns());
-							int blklenRows = CompressionSettings.BITMAP_BLOCK_SZ;
-							for(int n = 0; n * blklenRows < ret.getNumRows(); n++) {
-								colGroups.get(j).rightMultByMatrix(preAggregatedB,
-									retV,
-									that.getNumColumns(),
-									n * blklenRows,
-									Math.min((n + 1) * blklenRows, ret.getNumRows()),
-									i,
-									Math.min(i + colBlockSize, that.getNumColumns()));
-							}
-						}
+			for(int j = 0; j < colGroups.size(); j++) {
+				if(colGroups.get(j) instanceof ColGroupValue) {
+					Pair<int[], double[]> preAggregatedB = ((ColGroupValue) colGroups.get(j)).preaggValues(
+						v.getRight()[j],
+						that,
+						colGroups.get(j).getValues(),
+						0,
+						that.getNumColumns(),
+						that.getNumColumns());
+					int blklenRows = CompressionSettings.BITMAP_BLOCK_SZ;
+					for(int n = 0; n * blklenRows < ret.getNumRows(); n++) {
+						colGroups.get(j).rightMultByMatrix(preAggregatedB.getLeft(),
+							preAggregatedB.getRight(),
+							retV,
+							that.getNumColumns(),
+							n * blklenRows,
+							Math.min((n + 1) * blklenRows, ret.getNumRows()));
 					}
 				}
+
 			}
-			ColGroupValue.cleanupThreadLocalMemory();
+
 		}
 		else {
-			thatV = db.valuesAt(0);
 			ExecutorService pool = CommonThreadPool.get(k);
 			ArrayList<RightMatrixMultTask> tasks = new ArrayList<>();
-			ArrayList<RightMatrixPreAggregateTask> preTask = new ArrayList<>(colGroups.size());
-			// Pair<Integer, int[]> v;
-			final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
-			int blklenRows = (int) (Math.ceil((double) ret.getNumRows() / (2 * k)));
 
+			final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
+			int blklenRows = Math.max(blkz, (int) (Math.ceil((double) ret.getNumRows() / (2 * k))));
+			// int blklenRows = ret.getNumRows();
+			blklenRows = 4 * blkz;
 			try {
-				List<Future<double[]>> ag = pool.invokeAll(preAggregate(colGroups, thatV, that, preTask, v));
+				List<Future<Pair<int[], double[]>>> ag = pool.invokeAll(preAggregate(colGroups, that, that, v));
 				// DDC and RLE
 				for(int j = 0; j * blklenRows < ret.getNumRows(); j++) {
 					RightMatrixMultTask rmmt = new RightMatrixMultTask(colGroups, retV, ag, v, that.getNumColumns(),
-						j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()), 0, that.getNumColumns(),
-						false);
+						j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()), false);
 					tasks.add(rmmt);
 				}
-				blklenRows += (blklenRows % blkz != 0) ? blkz - blklenRows % blkz : 0;
+				// blklenRows = // (blklenRows % blkz != 0) ? blkz - blklenRows % blkz : 0;
 				// OLE!
 				for(int j = 0; j * blklenRows < ret.getNumRows(); j++) {
 					RightMatrixMultTask rmmt = new RightMatrixMultTask(colGroups, retV, ag, v, that.getNumColumns(),
-						j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()), 0, that.getNumColumns(),
-						true);
+						j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()), true);
 					tasks.add(rmmt);
 				}
 				for(Future<Object> future : pool.invokeAll(tasks))
@@ -322,11 +266,8 @@ public class LibRightMultBy {
 		return ret;
 	}
 
-	private static MatrixBlock rightMultByDenseMatrixCompressed(List<ColGroup> colGroups, MatrixBlock that,
+	private static MatrixBlock rightMultByMatrixCompressed(List<ColGroup> colGroups, MatrixBlock that,
 		CompressedMatrixBlock ret, int k, Pair<Integer, int[]> v) {
-
-		DenseBlock db = that.getDenseBlock();
-		double[] thatV;
 
 		for(ColGroup grp : colGroups) {
 			if(grp instanceof ColGroupUncompressed) {
@@ -335,34 +276,25 @@ public class LibRightMultBy {
 			}
 		}
 
-		thatV = db.valuesAt(0);
 		List<ColGroup> retCg = new ArrayList<>();
-		int[] newColIndexes = new int[that.getNumColumns()];
-		for(int i = 0; i < that.getNumColumns(); i++) {
-			newColIndexes[i] = i;
-		}
 		if(k == 1) {
 			for(int j = 0; j < colGroups.size(); j++) {
 				ColGroupValue g = (ColGroupValue) colGroups.get(j);
-				double[] preAggregatedB = g.preaggValues(v.getRight()[j],
-					thatV,
-					g.getValues(),
-					0,
-					that.getNumColumns(),
-					that.getNumColumns(),
-					new double[v.getRight()[j] * that.getNumColumns()]);
-				retCg.add(g.copyAndSet(newColIndexes, preAggregatedB));
+				Pair<int[], double[]> preAggregatedB = g
+					.preaggValues(v.getRight()[j], that, g.getValues(), 0, that.getNumColumns(), that.getNumColumns());
+				retCg.add(g.copyAndSet(preAggregatedB.getLeft(), preAggregatedB.getRight()));
 			}
 		}
 		else {
-			thatV = db.valuesAt(0);
 			ExecutorService pool = CommonThreadPool.get(k);
-			ArrayList<RightMatrixPreAggregateTask> preTask = new ArrayList<>(colGroups.size());
 
 			try {
-				List<Future<double[]>> ag = pool.invokeAll(preAggregate(colGroups, thatV, that, preTask, v));
+				List<Future<Pair<int[], double[]>>> ag = pool.invokeAll(preAggregate(colGroups, that, that, v));
+
 				for(int j = 0; j < colGroups.size(); j++) {
-					retCg.add(((ColGroupValue) colGroups.get(j)).copyAndSet(newColIndexes, ag.get(j).get()));
+					Pair<int[], double[]> preAggregates = ag.get(j).get();
+					retCg.add(((ColGroupValue) colGroups.get(j)).copyAndSet(preAggregates.getLeft(),
+						preAggregates.getRight()));
 				}
 			}
 			catch(InterruptedException | ExecutionException e) {
@@ -376,79 +308,13 @@ public class LibRightMultBy {
 		return ret;
 	}
 
-	private static MatrixBlock rightMultBySparseMatrixCompressed(List<ColGroup> colGroups, MatrixBlock that,
-		CompressedMatrixBlock ret, int k, Pair<Integer, int[]> v) {
-
-		SparseBlock sb = that.getSparseBlock();
-		if(sb == null) {
-			throw new DMLRuntimeException(
-				"right Mult By sparse Matrix compressed should only be called with an sparse input");
-		}
-
-		for(ColGroup grp : colGroups) {
-			if(grp instanceof ColGroupUncompressed) {
-				throw new DMLCompressionException(
-					"Right Mult by dense with compressed output is not efficient to do with uncompressed Compressed ColGroups and therefore not supported.");
-			}
-		}
-
-		List<ColGroup> retCg = new ArrayList<>();
-		int[] newColIndexes = new int[that.getNumColumns()];
-		for(int i = 0; i < that.getNumColumns(); i++) {
-			newColIndexes[i] = i;
-		}
-		if(k == 1) {
-			for(int j = 0; j < colGroups.size(); j++) {
-				ColGroupValue g = (ColGroupValue) colGroups.get(j);
-				double[] preAggregatedB = g.preaggValues(v.getRight()[j] / g.getNumCols(),
-					sb,
-					colGroups.get(j).getValues(),
-					0,
-					that.getNumColumns(),
-					that.getNumColumns(),
-					new double[v.getRight()[j] * that.getNumColumns()]);
-				retCg.add(g.copyAndSet(newColIndexes, preAggregatedB));
-			}
-		}
-		else {
-			ExecutorService pool = CommonThreadPool.get(k);
-			ArrayList<RightMatrixPreAggregateSparseTask> preTask = new ArrayList<>(colGroups.size());
-
-			try {
-				List<Future<double[]>> ag = pool.invokeAll(preAggregate(colGroups, sb, that, preTask, v));
-				for(int j = 0; j < colGroups.size(); j++) {
-					retCg.add(((ColGroupValue) colGroups.get(j)).copyAndSet(newColIndexes, ag.get(j).get()));
-				}
-			}
-			catch(InterruptedException | ExecutionException e) {
-				throw new DMLRuntimeException(e);
-			}
-		}
-		ret.allocateColGroupList(retCg);
-		ret.setOverlapping(true);
-		ret.setNonZeros(-1);
-
-		return ret;
-	}
-
-	private static ArrayList<RightMatrixPreAggregateTask> preAggregate(List<ColGroup> colGroups, double[] thatV,
-		MatrixBlock that, ArrayList<RightMatrixPreAggregateTask> preTask, Pair<Integer, int[]> v) {
+	private static ArrayList<RightMatrixPreAggregateTask> preAggregate(List<ColGroup> colGroups, MatrixBlock b,
+		MatrixBlock that, Pair<Integer, int[]> v) {
+		ArrayList<RightMatrixPreAggregateTask> preTask = new ArrayList<>(colGroups.size());
 		preTask.clear();
 		for(int h = 0; h < colGroups.size(); h++) {
 			RightMatrixPreAggregateTask pAggT = new RightMatrixPreAggregateTask((ColGroupValue) colGroups.get(h),
-				v.getRight()[h], thatV, colGroups.get(h).getValues(), 0, that.getNumColumns(), that.getNumColumns());
-			preTask.add(pAggT);
-		}
-		return preTask;
-	}
-
-	private static ArrayList<RightMatrixPreAggregateSparseTask> preAggregate(List<ColGroup> colGroups, SparseBlock sb,
-		MatrixBlock that, ArrayList<RightMatrixPreAggregateSparseTask> preTask, Pair<Integer, int[]> v) {
-		preTask.clear();
-		for(int h = 0; h < colGroups.size(); h++) {
-			RightMatrixPreAggregateSparseTask pAggT = new RightMatrixPreAggregateSparseTask(
-				(ColGroupValue) colGroups.get(h), v.getRight()[h] / colGroups.get(h).getNumCols(), sb,
-				colGroups.get(h).getValues(), 0, that.getNumColumns(), that.getNumColumns());
+				v.getRight()[h], b, colGroups.get(h).getValues(), 0, that.getNumColumns(), that.getNumColumns());
 			preTask.add(pAggT);
 		}
 		return preTask;
@@ -496,18 +362,16 @@ public class LibRightMultBy {
 		private final List<ColGroup> _colGroups;
 		// private final double[] _thatV;
 		private final double[] _retV;
-		private final List<Future<double[]>> _aggB;
+		private final List<Future<Pair<int[], double[]>>> _aggB;
 		private final Pair<Integer, int[]> _v;
 		private final int _numColumns;
 
 		private final int _rl;
 		private final int _ru;
-		private final int _cl;
-		private final int _cu;
 		private final boolean _skipOle;
 
-		protected RightMatrixMultTask(List<ColGroup> groups, double[] retV, List<Future<double[]>> aggB,
-			Pair<Integer, int[]> v, int numColumns, int rl, int ru, int cl, int cu, boolean skipOle) {
+		protected RightMatrixMultTask(List<ColGroup> groups, double[] retV, List<Future<Pair<int[], double[]>>> aggB,
+			Pair<Integer, int[]> v, int numColumns, int rl, int ru, boolean skipOle) {
 			_colGroups = groups;
 			// _thatV = thatV;
 			_retV = retV;
@@ -516,8 +380,6 @@ public class LibRightMultBy {
 			_numColumns = numColumns;
 			_rl = rl;
 			_ru = ru;
-			_cl = cl;
-			_cu = cu;
 			_skipOle = skipOle;
 		}
 
@@ -526,16 +388,17 @@ public class LibRightMultBy {
 			try {
 				ColGroupValue.setupThreadLocalMemory((_v.getLeft()));
 				for(int j = 0; j < _colGroups.size(); j++) {
+					Pair<int[], double[]> aggb = _aggB.get(j).get();
 					if(_colGroups.get(j) instanceof ColGroupOLE) {
 						if(_skipOle) {
 							_colGroups.get(j)
-								.rightMultByMatrix(_aggB.get(j).get(), _retV, _numColumns, _rl, _ru, _cl, _cu);
+								.rightMultByMatrix(aggb.getLeft(), aggb.getRight(), _retV, _numColumns, _rl, _ru);
 						}
 					}
 					else {
 						if(!_skipOle) {
 							_colGroups.get(j)
-								.rightMultByMatrix(_aggB.get(j).get(), _retV, _numColumns, _rl, _ru, _cl, _cu);
+								.rightMultByMatrix(aggb.getLeft(), aggb.getRight(), _retV, _numColumns, _rl, _ru);
 						}
 					}
 				}
@@ -543,23 +406,23 @@ public class LibRightMultBy {
 				return null;
 			}
 			catch(Exception e) {
-				LOG.error(e);
+				e.printStackTrace();
 				throw new DMLRuntimeException(e);
 			}
 		}
 	}
 
-	private static class RightMatrixPreAggregateTask implements Callable<double[]> {
+	private static class RightMatrixPreAggregateTask implements Callable<Pair<int[], double[]>> {
 		private final ColGroupValue _colGroup;
 		private final int _numVals;
-		private final double[] _b;
+		private final MatrixBlock _b;
 		private final double[] _dict;
 
 		private final int _cl;
 		private final int _cu;
 		private final int _cut;
 
-		protected RightMatrixPreAggregateTask(ColGroupValue colGroup, int numVals, double[] b, double[] dict, int cl,
+		protected RightMatrixPreAggregateTask(ColGroupValue colGroup, int numVals, MatrixBlock b, double[] dict, int cl,
 			int cu, int cut) {
 			_colGroup = colGroup;
 			_numVals = numVals;
@@ -571,40 +434,7 @@ public class LibRightMultBy {
 		}
 
 		@Override
-		public double[] call() {
-			try {
-				return _colGroup.preaggValues(_numVals, _b, _dict, _cl, _cu, _cut);
-			}
-			catch(Exception e) {
-				LOG.error(e);
-				throw new DMLRuntimeException(e);
-			}
-		}
-	}
-
-	private static class RightMatrixPreAggregateSparseTask implements Callable<double[]> {
-		private final ColGroupValue _colGroup;
-		private final int _numVals;
-		private final SparseBlock _b;
-		private final double[] _dict;
-
-		private final int _cl;
-		private final int _cu;
-		private final int _cut;
-
-		protected RightMatrixPreAggregateSparseTask(ColGroupValue colGroup, int numVals, SparseBlock b, double[] dict,
-			int cl, int cu, int cut) {
-			_colGroup = colGroup;
-			_numVals = numVals;
-			_b = b;
-			_dict = dict;
-			_cl = cl;
-			_cu = cu;
-			_cut = cut;
-		}
-
-		@Override
-		public double[] call() {
+		public Pair<int[], double[]> call() {
 			try {
 				return _colGroup.preaggValues(_numVals, _b, _dict, _cl, _cu, _cut);
 			}

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/LinearAlgebraUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/LinearAlgebraUtils.java
@@ -147,26 +147,26 @@ public class LinearAlgebraUtils {
 		}
 	}
 
-	public static void vectListAddDDC(final double[] values, double[] c, byte[] bix, final int rl, final int ru,
-		final int cl, final int cu, final int cut, final int numVals) {
+	public static void vectListAddDDC(int[] outputColumns, double[] values, double[] c, byte[] bix, int rl, int ru,
+		int cut, int numVals) {
 
 		for(int j = rl, off = rl * cut; j < ru; j++, off += cut) {
 			int rowIdx = (bix[j] & 0xFF);
 			if(rowIdx < numVals)
-				for(int k = cl, h = rowIdx * (cu - cl); k < cu; k++, h++) {
-					// LOG.error((off + k) + " \t" + h);
-					c[off + k] += values[h];
-				}
+				for(int k = 0; k < outputColumns.length; k++)
+					c[off + outputColumns[k]] += values[rowIdx * outputColumns.length + k];
+
 		}
 	}
 
-	public static void vectListAddDDC(final double[] values, double[] c, char[] bix, final int rl, final int ru,
-		final int cl, final int cu, final int cut, final int numVals) {
+	public static void vectListAddDDC(int[] outputColumns, double[] values, double[] c, char[] bix, int rl, int ru,
+		int cut, int numVals) {
 		for(int j = rl, off = rl * cut; j < ru; j++, off += cut) {
 			int rowIdx = bix[j];
 			if(rowIdx < numVals)
-				for(int k = cl, h = rowIdx * (cu - cl); k < cu; k++, h++)
-					c[off + k] += values[h];
+				for(int k = 0; k < outputColumns.length; k++)
+					c[off + outputColumns[k]] += values[rowIdx * outputColumns.length + k];
+
 		}
 	}
 
@@ -182,11 +182,19 @@ public class LinearAlgebraUtils {
 	 * @param cut    The total number of columns in c.
 	 * @param valOff The offset into the values list to start reading from.
 	 */
-	public static void vectListAdd(final double[] values, double[] c, final int rl, final int ru, final int cl,
-		final int cu, final int cut, final int valOff) {
+	public static void vectListAdd(double[] values, double[] c, int rl, int ru, int cl, int cu, int cut, int valOff) {
 		for(int j = rl, off = rl * cut; j < ru; j++, off += cut) {
 			for(int k = cl, h = valOff; k < cu; k++, h++)
 				c[off + k] += values[h];
+		}
+	}
+
+	public static void vectListAdd(double[] preAggregatedValues, double[] c, int rl, int ru, int[] outputColumns, int cut,
+		int n) {
+		n = n * outputColumns.length;
+		for(int j = rl, off = rl * cut; j < ru; j++, off += cut) {
+			for(int k = 0; k < outputColumns.length; k ++)
+				c[off + outputColumns[k]] += preAggregatedValues[n + k];
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixBincell.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixBincell.java
@@ -164,7 +164,7 @@ public class LibMatrixBincell
 			return BinaryAccessType.INVALID;
 	}
 
-	public static boolean isValidDimensionsBinary(MatrixBlock m1, MatrixBlock m2)
+	public static void isValidDimensionsBinary(MatrixBlock m1, MatrixBlock m2)
 	{
 		int rlen1 = m1.rlen;
 		int clen1 = m1.clen;
@@ -176,11 +176,15 @@ public class LibMatrixBincell
 		//2) MV operations w/ V either being a right-hand-side column or row vector 
 		//  (where one dimension needs to match and the other dimension is 1)
 		//3) VV outer vector operations w/ a common dimension of 1 
-		
-		return (   (rlen1 == rlen2 && clen1==clen2)            //MM 
-				|| (rlen1 == rlen2 && clen1 > 1 && clen2 == 1) //MVc
-				|| (clen1 == clen2 && rlen1 > 1 && rlen2 == 1) //MVr
-				|| (clen1 == 1 && rlen2 == 1 ) );              //VV
+		boolean isValid = (   (rlen1 == rlen2 && clen1==clen2)            //MM 
+							|| (rlen1 == rlen2 && clen1 > 1 && clen2 == 1) //MVc
+							|| (clen1 == clen2 && rlen1 > 1 && rlen2 == 1) //MVr
+							|| (clen1 == 1 && rlen2 == 1 ) );              //VV
+
+		if( !isValid ) {
+			throw new RuntimeException("Block sizes are not matched for binary " +
+					"cell operations: " + m1.rlen + "x" + m1.clen + " vs " + m2.rlen + "x" + m2.clen);
+		}
 	}
 
 	public static boolean isSparseSafeDivide(BinaryOperator op, MatrixBlock rhs)

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -2819,10 +2819,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	public MatrixBlock binaryOperations(BinaryOperator op, MatrixValue thatValue, MatrixValue result) {
 		MatrixBlock that = checkType(thatValue);
 		MatrixBlock ret = checkType(result);
-		if( !LibMatrixBincell.isValidDimensionsBinary(this, that) ) {
-			throw new RuntimeException("Block sizes are not matched for binary " +
-					"cell operations: "+this.rlen+"x"+this.clen+" vs "+ that.rlen+"x"+that.clen);
-		}
+		LibMatrixBincell.isValidDimensionsBinary(this, that);
 		
 		//compute output dimensions
 		boolean outer = (LibMatrixBincell.getBinaryAccessType(this, that)
@@ -2846,10 +2843,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	@Override
 	public MatrixBlock binaryOperationsInPlace(BinaryOperator op, MatrixValue thatValue) {
 		MatrixBlock that=checkType(thatValue);
-		if( !LibMatrixBincell.isValidDimensionsBinary(this, that) ) {
-			throw new RuntimeException("block sizes are not matched for binary " +
-					"cell operations: "+this.rlen+"*"+this.clen+" vs "+ that.rlen+"*"+that.clen);
-		}
+		LibMatrixBincell.isValidDimensionsBinary(this, that);
 	
 		//estimate output sparsity
 		SparsityEstimate resultSparse = estimateSparsityOnBinary(this, that, op);

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -756,8 +756,7 @@ public class TestUtils
 	}
 
 	public static void compareMatrices(double[][] expectedMatrix, double[][] actualMatrix, double epsilon, String message){
-		assertTrue(message+"\n The number of columns in the matrixes should be equal", expectedMatrix.length == actualMatrix.length);
-		assertTrue(message+"\n The number of rows in the matrixes should be equal", expectedMatrix[0].length == actualMatrix[0].length);
+		assertEqualColsAndRows(expectedMatrix,actualMatrix);
 		compareMatrices(expectedMatrix, actualMatrix, expectedMatrix.length, expectedMatrix[0].length, epsilon, message);
 	}
 	
@@ -795,8 +794,7 @@ public class TestUtils
 
 	public static void compareMatricesBitAvgDistance(double[][] expectedMatrix, double[][] actualMatrix,
 			long maxUnitsOfLeastPrecision, long maxAvgDistance, String message){
-		assertTrue("The number of columns in the matrixes should be equal", expectedMatrix.length == actualMatrix.length);
-		assertTrue("The number of rows in the matrixes should be equal", expectedMatrix[0].length == actualMatrix[0].length);
+		assertEqualColsAndRows(expectedMatrix,actualMatrix);
 		compareMatricesBitAvgDistance(expectedMatrix, actualMatrix, expectedMatrix.length, actualMatrix[0].length, 
 			maxUnitsOfLeastPrecision, maxAvgDistance, message);
 	}
@@ -848,20 +846,27 @@ public class TestUtils
 		return min / max;
 	}
 
-
+	private static void assertEqualColsAndRows(double[][] expectedMatrix, double[][] actualMatrix){
+		assertTrue("The number of columns in the matrixes should be equal :" 
+			+ expectedMatrix.length  + "  "
+			+ actualMatrix.length, 
+			expectedMatrix.length == actualMatrix.length);
+		assertTrue("The number of rows in the matrixes should be equal" 
+			+ expectedMatrix[0].length  + "  " 
+			+ actualMatrix[0].length, 
+			expectedMatrix[0].length == actualMatrix[0].length);
+	}
 
 	public static void compareMatricesPercentageDistance(double[][] expectedMatrix, double[][] actualMatrix,  
 			double percentDistanceAllowed, double maxAveragePercentDistance,  String message){
-		assertTrue("The number of columns in the matrixes should be equal", expectedMatrix.length == actualMatrix.length);
-		assertTrue("The number of rows in the matrixes should be equal", expectedMatrix[0].length == actualMatrix[0].length);
+		assertEqualColsAndRows(expectedMatrix,actualMatrix);
 		compareMatricesPercentageDistance(expectedMatrix, actualMatrix, expectedMatrix.length, expectedMatrix[0].length,
 			percentDistanceAllowed, maxAveragePercentDistance, message, false);
 	}
 
 	public static void compareMatricesPercentageDistance(double[][] expectedMatrix, double[][] actualMatrix,  
 			double percentDistanceAllowed, double maxAveragePercentDistance,  String message, boolean ignoreZero){
-		assertTrue("The number of columns in the matrixes should be equal", expectedMatrix.length == actualMatrix.length);
-		assertTrue("The number of rows in the matrixes should be equal", expectedMatrix[0].length == actualMatrix[0].length);
+		assertEqualColsAndRows(expectedMatrix,actualMatrix);
 		compareMatricesPercentageDistance(expectedMatrix, actualMatrix, expectedMatrix.length, expectedMatrix[0].length,
 			percentDistanceAllowed, maxAveragePercentDistance, message, ignoreZero);
 	}

--- a/src/test/java/org/apache/sysds/test/component/compress/AbstractCompressedUnaryTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/AbstractCompressedUnaryTests.java
@@ -185,10 +185,10 @@ public abstract class AbstractCompressedUnaryTests extends CompressedTestBase {
 			int dim2 = (aggType == AggType.COLSUMS || aggType == AggType.COLSUMSSQ || aggType == AggType.COLMAXS ||
 				aggType == AggType.COLMINS || aggType == AggType.COLMEAN) ? cols : 1;
 
-			assertTrue("dim 1 is equal in non compressed res", d1.length == dim1);
-			assertTrue("dim 1 is equal in compressed res", d2.length == dim1);
-			assertTrue("dim 2 is equal in non compressed res", d1[0].length == dim2);
-			assertTrue("dim 2 is equal in compressed res", d2[0].length == dim2);
+			assertTrue("dim 1 is not equal in non compressed res  is: " + d1.length    + "  Should be: " +  dim1, d1.length    == dim1);
+			assertTrue("dim 1 is not equal in compressed res      is: " + d2.length    + "  Should be: " +  dim1, d2.length    == dim1);
+			assertTrue("dim 2 is not equal in non compressed res  is: " + d1[0].length + "  Should be: " +  dim2, d1[0].length == dim2);
+			assertTrue("dim 2 is not equal in compressed res      is: " + d2[0].length + "  Should be: " +  dim2, d2[0].length == dim2);
 
 			String css = this.toString();
 			if(compressionSettings.lossy) {

--- a/src/test/java/org/apache/sysds/test/component/compress/InvalidInputTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/InvalidInputTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress;
+
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.operators.AggregateBinaryOperator;
+import org.junit.Test;
+
+public class InvalidInputTest {
+
+    @Test(expected = DMLRuntimeException.class)
+    public void invalidAggregateBinaryOperationsNoneOfTheInputsIsCallingObject(){
+        int k = InfrastructureAnalyzer.getLocalParallelism();
+        MatrixBlock a = new MatrixBlock(10,5,true);
+        MatrixBlock b = new MatrixBlock(5,10,true);
+        // Not the typical way of allocating a Compressed Matrix Block
+        MatrixBlock c = new CompressedMatrixBlock(10, 4, true); 
+        AggregateBinaryOperator abop = InstructionUtils.getMatMultOperator(k);
+        c.aggregateBinaryOperations(a, b, new MatrixBlock(), abop);
+    }
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/ParCompressedMatrixTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/ParCompressedMatrixTest.java
@@ -43,7 +43,9 @@ public class ParCompressedMatrixTest extends AbstractCompressedUnaryTests {
 	public ParCompressedMatrixTest(SparsityType sparType, ValueType valType, ValueRange valRange,
 		CompressionSettings compressionSettings, MatrixTypology matrixTypology, OverLapping ov) {
 		super(sparType, valType, valRange, compressionSettings, matrixTypology, ov,
-			InfrastructureAnalyzer.getLocalParallelism());
+			2);
+		// super(sparType, valType, valRange, compressionSettings, matrixTypology, ov,
+		// 	InfrastructureAnalyzer.getLocalParallelism());
 	}
 
 	@Override

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateTest.java
@@ -93,7 +93,8 @@ public abstract class JolEstimateTest {
 	public void compressedSizeInfoEstimatorExact() {
 		try {
 			CompressionSettings cs = new CompressionSettingsBuilder().setSamplingRatio(1.0).setValidCompressions(EnumSet.of(getCT())).create();
-			CompressedSizeEstimator cse = CompressedSizeEstimatorFactory.getSizeEstimator(mbt, cs, true);
+			cs.transposed = true;
+			CompressedSizeEstimator cse = CompressedSizeEstimatorFactory.getSizeEstimator(mbt, cs);
 
 			CompressedSizeInfoColGroup csi = cse.estimateCompressedColGroupSize();
 			long estimateCSI = csi.getCompressionSize(getCT());
@@ -119,7 +120,8 @@ public abstract class JolEstimateTest {
 	public void compressedSizeInfoEstimatorExactLossy() {
 		try {
 			// CompressionSettings cs = new CompressionSettings(1.0);
-			CompressedSizeEstimator cse = CompressedSizeEstimatorFactory.getSizeEstimator(mbt, csl, true);
+			csl.transposed = true;
+			CompressedSizeEstimator cse = CompressedSizeEstimatorFactory.getSizeEstimator(mbt, csl);
 			CompressedSizeInfoColGroup csi = cse.estimateCompressedColGroupSize();
 			long estimateCSI = csi.getCompressionSize(getCT());
 			long estimateObject = cgl.estimateInMemorySize();


### PR DESCRIPTION
This commit change the Overlapping matrix to drastically reduce decompression time in cases of right hand side sparse matrix multiplication.

Other than this many of the methods are cleaned up, and isolated behind cleaner APIs for specific operations on Compressed Matrices.