### PR TITLE
[SYSTEMDS-2798] Builtin (de)compress function 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,7 @@
 						</executions>
 						<configuration>
 							<excludes>
+								<exclude>scripts/perftest/results/**</exclude>
 								<exclude>.gitignore</exclude>
 								<exclude>.gitmodules</exclude>
 								<exclude>.repository/</exclude>

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -79,6 +79,8 @@ public enum Builtins {
 	COLSUM("colSums", false),
 	COLVAR("colVars", false),
 	COMPONENTS("components", true),
+	COMPRESS("compress", false),
+	DECOMPRESS("decompress", false),
 	CONV2D("conv2d", false),
 	CONV2D_BACKWARD_FILTER("conv2d_backward_filter", false),
 	CONV2D_BACKWARD_DATA("conv2d_backward_data", false),

--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -207,6 +207,8 @@ public class Types
 		SIGMOID, //sigmoid function: 1 / (1 + exp(-X))
 		LOG_NZ, //sparse-safe log; ppred(X,0,"!=")*log(X)
 		
+		COMPRESS, DECOMPRESS, 
+
 		//low-level operators //TODO used?
 		MULT2, MINUS1_MULT, MINUS_RIGHT, 
 		POW2, SUBTRACT_NZ;
@@ -235,6 +237,8 @@ public class Types
 				case CUMSUM:          return "ucumk+";
 				case CUMSUMPROD:      return "ucumk+*";
 				case COLNAMES:        return "colnames";
+				case COMPRESS:        return "compress";
+				case DECOMPRESS:      return "decompress";
 				case DETECTSCHEMA:    return "detectSchema";
 				case MULT2:           return "*2";
 				case NOT:             return "!";

--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -206,6 +206,12 @@ public class OptimizerUtils
 	 */
 	public static final boolean ALLOW_COMBINE_FILE_INPUT_FORMAT = true;
 
+	/**
+	 * This variable allows for insertion of Compress and decompress in the dml script from the user.
+	 * This is added because we want to have a way to test, and verify the correct placement of compress and decompress commands.
+	 */
+	public static final boolean ALLOW_SCRIPT_LEVEL_COMPRESS_COMMAND = true;
+
 	//////////////////////
 	// Optimizer levels //
 	//////////////////////

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -446,7 +446,9 @@ public class UnaryOp extends MultiThreadedHop
 	public boolean isExpensiveUnaryOperation()  {
 		return (_op == OpOp1.EXP 
 			|| _op == OpOp1.LOG
-			|| _op == OpOp1.SIGMOID);
+			|| _op == OpOp1.SIGMOID
+			|| _op == OpOp1.COMPRESS
+			|| _op == OpOp1.DECOMPRESS);
 	}
 	
 	public boolean isMetadataOperation() {

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -19,6 +19,11 @@
 
 package org.apache.sysds.parser;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -26,15 +31,11 @@ import org.apache.sysds.common.Builtins;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.parser.LanguageException.LanguageErrorCodes;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.DnnUtils;
 import org.apache.sysds.runtime.util.UtilFunctions;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 
 public class BuiltinFunctionExpression extends DataIdentifier 
 {
@@ -1573,7 +1574,20 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			output.setBlocksize (id.getBlocksize());
 
 			break;
-
+		case COMPRESS:
+		case DECOMPRESS:
+			if(OptimizerUtils.ALLOW_SCRIPT_LEVEL_COMPRESS_COMMAND){
+				checkNumParameters(1);
+				checkMatrixParam(getFirstExpr());
+				output.setDataType(DataType.MATRIX);
+				output.setDimensions(id.getDim2(), id.getDim1());
+				output.setBlocksize (id.getBlocksize());
+				output.setValueType(id.getValueType());
+			}
+			else
+				raiseValidateError("Compress instruction not allowed in dml script");
+			
+			break;
 		default:
 			if( isMathFunction() ) {
 				checkMathFunctionParam();

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -2481,6 +2481,12 @@ public class DMLTranslator
 		case CAST_AS_BOOLEAN:
 			currBuiltinOp = new UnaryOp(target.getName(), target.getDataType(), ValueType.BOOLEAN, OpOp1.CAST_AS_BOOLEAN, expr);
 			break;
+		case COMPRESS:
+			currBuiltinOp = new UnaryOp(target.getName(), target.getDataType(), ValueType.FP64, OpOp1.COMPRESS, expr);
+			break;
+		case DECOMPRESS:
+			currBuiltinOp = new UnaryOp(target.getName(), target.getDataType(), ValueType.FP64, OpOp1.DECOMPRESS, expr);
+			break;
 
 		// Boolean binary
 		case XOR:
@@ -2691,7 +2697,6 @@ public class DMLTranslator
 			setBlockSizeAndRefreshSizeInfo(expr, currBuiltinOp);
 			break;
 		}
-		
 		default:
 			throw new ParseException("Unsupported builtin function type: "+source.getOpCode());
 		}

--- a/src/test/java/org/apache/sysds/test/functions/compress/compressInstruction.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/compressInstruction.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.compress;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.lops.LopProperties;
+import org.apache.sysds.lops.LopProperties.ExecType;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.utils.DMLCompressionStatistics;
+import org.apache.sysds.utils.Statistics;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class compressInstruction extends AutomatedTestBase {
+
+    protected String getTestClassDir() {
+        return getTestDir() + this.getClass().getSimpleName() + "/";
+    }
+
+    protected String getTestName() {
+        return "compress";
+    }
+
+    protected String getTestDir() {
+        return "functions/compress/compressInstruction/";
+    }
+
+    @Test
+    public void empty() {
+
+    }
+
+    @Test
+    public void testCompressInstruction_01() {
+        compressTest(1, 1000, 0.2, ExecType.CP, 0, 5, 0, 1, "01");
+    }
+
+    @Test
+    public void testCompressInstruction_02() {
+        compressTest(1, 1000, 0.2, ExecType.CP, 0, 5, 1, 1, "02");
+    }
+
+    public void compressTest(int cols, int rows, double sparsity, LopProperties.ExecType instType, int min, int max,
+        int decompressionCountExpected, int compressionCountsExpected, String name) {
+
+        Types.ExecMode platformOld = setExecMode(instType);
+        try {
+
+            loadTestConfiguration(getTestConfiguration(getTestName()));
+
+            fullDMLScriptName = SCRIPT_DIR + "/" + getTestDir() + "compress_" + name + ".dml";
+
+            programArgs = new String[] {"-stats", "100", "-nvargs", "cols=" + cols, "rows=" + rows,
+                "sparsity=" + sparsity, "min=" + min, "max= " + max};
+
+            runTest(null);
+
+            int decompressCount = 0;
+            decompressCount += DMLCompressionStatistics.getDecompressionCount();
+            decompressCount += DMLCompressionStatistics.getDecompressionSTCount();
+            long compressionCount = Statistics.getCPHeavyHitterCount("compress");
+
+            Assert.assertEquals(compressionCount, compressionCountsExpected);
+            Assert.assertEquals(decompressionCountExpected, decompressCount);
+
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+            assertTrue("Exception in execution: " + e.getMessage(), false);
+        }
+        finally {
+            rtplatform = platformOld;
+        }
+    }
+
+    @Override
+    public void setUp() {
+        TestUtils.clearAssertionInformation();
+        addTestConfiguration(getTestName(), new TestConfiguration(getTestClassDir(), getTestName()));
+    }
+
+}

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressBase.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressBase.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.sysds.test.functions.compress;
+package org.apache.sysds.test.functions.compress.configuration;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressCost.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressCost.java
@@ -17,16 +17,18 @@
  * under the License.
  */
 
-package org.apache.sysds.test.functions.compress;
+package org.apache.sysds.test.functions.compress.configuration;
 
 import java.io.File;
 
-public class CompressLossy extends CompressForce {
+import org.junit.Test;
+
+public class CompressCost extends CompressBase {
 
 	public String TEST_NAME = "compress";
-	public String TEST_DIR = "functions/compress/force/lossy/";
-	public String TEST_CLASS_DIR = TEST_DIR + CompressLossy.class.getSimpleName() + "/";
-	private String TEST_CONF = "SystemDS-config-compress-lossy.xml";
+	public String TEST_DIR = "functions/compress/cost/";
+	public String TEST_CLASS_DIR = TEST_DIR + CompressCost.class.getSimpleName() + "/";
+	private String TEST_CONF = "SystemDS-config-compress-cost.xml";
 	private File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 
 	protected String getTestClassDir() {
@@ -39,6 +41,21 @@ public class CompressLossy extends CompressForce {
 
 	protected String getTestDir() {
 		return TEST_DIR;
+	}
+
+	@Test
+	public void testTranspose() {
+		transpose(0, 0);
+	}
+
+	@Test
+	public void testSum() {
+		sum(0, 0);
+	}
+
+	@Test
+	public void testRowAggregate() {
+		rowAggregate(0, 0);
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressForce.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressForce.java
@@ -17,16 +17,18 @@
  * under the License.
  */
 
-package org.apache.sysds.test.functions.compress;
+package org.apache.sysds.test.functions.compress.configuration;
 
 import java.io.File;
 
-public class CompressLossyCost extends CompressCost {
+import org.junit.Test;
+
+public class CompressForce extends CompressBase {
 
 	public String TEST_NAME = "compress";
-	public String TEST_DIR = "functions/compress/cost/lossy";
-	public String TEST_CLASS_DIR = TEST_DIR + CompressLossyCost.class.getSimpleName() + "/";
-	private String TEST_CONF = "SystemDS-config-compress-lossy-cost.xml";
+	public String TEST_DIR = "functions/compress/force/";
+	public String TEST_CLASS_DIR = TEST_DIR + CompressForce.class.getSimpleName() + "/";
+	private String TEST_CONF = "SystemDS-config-compress.xml";
 	private File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 
 	protected String getTestClassDir() {
@@ -39,6 +41,21 @@ public class CompressLossyCost extends CompressCost {
 
 	protected String getTestDir() {
 		return TEST_DIR;
+	}
+
+	@Test
+	public void testTranspose() {
+		transpose(1, 1);
+	}
+
+	@Test
+	public void testSum(){
+		sum(0,1);
+	}
+	
+	@Test
+	public void testRowAggregate() {
+		rowAggregate(0,1);
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressLossy.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressLossy.java
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-package org.apache.sysds.test.functions.compress;
+package org.apache.sysds.test.functions.compress.configuration;
 
 import java.io.File;
 
-import org.junit.Test;
-
-public class CompressForce extends CompressBase {
+public class CompressLossy extends CompressForce {
 
 	public String TEST_NAME = "compress";
-	public String TEST_DIR = "functions/compress/force/";
-	public String TEST_CLASS_DIR = TEST_DIR + CompressForce.class.getSimpleName() + "/";
-	private String TEST_CONF = "SystemDS-config-compress.xml";
+	public String TEST_DIR = "functions/compress/force/lossy/";
+	public String TEST_CLASS_DIR = TEST_DIR + CompressLossy.class.getSimpleName() + "/";
+	private String TEST_CONF = "SystemDS-config-compress-lossy.xml";
 	private File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 
 	protected String getTestClassDir() {
@@ -41,21 +39,6 @@ public class CompressForce extends CompressBase {
 
 	protected String getTestDir() {
 		return TEST_DIR;
-	}
-
-	@Test
-	public void testTranspose() {
-		transpose(1, 1);
-	}
-
-	@Test
-	public void testSum(){
-		sum(0,1);
-	}
-	
-	@Test
-	public void testRowAggregate() {
-		rowAggregate(0,1);
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressLossyCost.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressLossyCost.java
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-package org.apache.sysds.test.functions.compress;
+package org.apache.sysds.test.functions.compress.configuration;
 
 import java.io.File;
 
-import org.junit.Test;
-
-public class CompressCost extends CompressBase {
+public class CompressLossyCost extends CompressCost {
 
 	public String TEST_NAME = "compress";
-	public String TEST_DIR = "functions/compress/cost/";
-	public String TEST_CLASS_DIR = TEST_DIR + CompressCost.class.getSimpleName() + "/";
-	private String TEST_CONF = "SystemDS-config-compress-cost.xml";
+	public String TEST_DIR = "functions/compress/cost/lossy";
+	public String TEST_CLASS_DIR = TEST_DIR + CompressLossyCost.class.getSimpleName() + "/";
+	private String TEST_CONF = "SystemDS-config-compress-lossy-cost.xml";
 	private File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
 
 	protected String getTestClassDir() {
@@ -41,21 +39,6 @@ public class CompressCost extends CompressBase {
 
 	protected String getTestDir() {
 		return TEST_DIR;
-	}
-
-	@Test
-	public void testTranspose() {
-		transpose(0, 0);
-	}
-
-	@Test
-	public void testSum() {
-		sum(0, 0);
-	}
-
-	@Test
-	public void testRowAggregate() {
-		rowAggregate(0, 0);
 	}
 
 	/**

--- a/src/test/scripts/functions/compress/compressInstruction/compress_01.dml
+++ b/src/test/scripts/functions/compress/compressInstruction/compress_01.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A = rand(rows=$rows, cols=$cols, sparsity=$sparsity, min=$min, max=$max)
+A = round(A)
+A = compress(A)
+
+print(sum(A))

--- a/src/test/scripts/functions/compress/compressInstruction/compress_02.dml
+++ b/src/test/scripts/functions/compress/compressInstruction/compress_02.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A = rand(rows=$rows, cols=$cols, sparsity=$sparsity, min=$min, max=$max)
+A = round(A)
+A = compress(A)
+A = decompress(A)
+print(sum(A))


### PR DESCRIPTION
Dedicated script level functions to compress and decompress a matrix.

Currently i have hidden these behind a compile time boolean, that allows the introduction of these commands.
Unfortunately, since it is a compile time flag, the tests added would fail if set to false which is what we want in the end.
If someone have an idea in witch i can achieve:

1. The instructions are not allowed per default.
2. The instructions are allowed for tests.
3. The instructions are allowed if actively enabled.

I'm considering adding it as an Variable in our DMLConfig, but this just increase the number of parameters there.