### PR TITLE
[SYSTEMDS-2799] Lineage tracing and reuse of federated UDFs

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedUDF.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedUDF.java
@@ -20,11 +20,13 @@
 package org.apache.sysds.runtime.controlprogram.federated;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageTraceable;
 
-public abstract class FederatedUDF implements Serializable {
+public abstract class FederatedUDF implements Serializable, LineageTraceable {
 	private static final long serialVersionUID = 799416525191257308L;
 	
 	private final long[] _inputIDs;
@@ -35,6 +37,10 @@ public abstract class FederatedUDF implements Serializable {
 	
 	public final long[] getInputIDs() {
 		return _inputIDs;
+	}
+
+	public List<Long> getOutputIds() {
+		return null;
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -48,8 +48,11 @@ import org.apache.sysds.runtime.instructions.cp.ListObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
+import org.apache.sysds.runtime.lineage.LineageCache;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
 import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.meta.MetaDataFormat;
 import org.apache.sysds.runtime.privacy.DMLPrivacyException;
@@ -271,7 +274,6 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		// set variable and construct empty response
 		ec.setVariable(varname, data);
 		if (DMLScript.LINEAGE)
-			// TODO: Identify MO uniquely. Use Adler32 checksum.
 			ec.getLineage().set(varname, new LineageItem(String.valueOf(request.getChecksum(0))));
 
 		return new FederatedResponse(ResponseType.SUCCESS_EMPTY);
@@ -340,10 +342,24 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		FederatedUDF udf = (FederatedUDF) request.getParam(0);
 		Data[] inputs = Arrays.stream(udf.getInputIDs()).mapToObj(id -> ec.getVariable(String.valueOf(id)))
 			.map(PrivacyMonitor::handlePrivacy).toArray(Data[]::new);
-
-		// execute user-defined function
+		
+		// trace lineage
+		if (DMLScript.LINEAGE)
+			LineageItemUtils.traceFedUDF(ec, udf);
+		
+		// reuse or execute user-defined function
 		try {
-			return udf.execute(ec, inputs);
+			// reuse UDF outputs if available in lineage cache
+			if (LineageCache.reuse(udf, ec))
+				return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS_EMPTY);
+
+			// else execute the UDF
+			long t0 = !ReuseCacheType.isNone() ? System.nanoTime() : 0;
+			FederatedResponse res = udf.execute(ec, inputs);
+			long t1 = !ReuseCacheType.isNone() ? System.nanoTime() : 0;
+			//cacheUDFOutputs(udf, inputs, t1-t0, ec);
+			LineageCache.putValue(udf, ec, t1-t0);
+			return res;
 		}
 		catch(DMLPrivacyException | FederatedWorkerHandlerException ex){
 			throw ex;
@@ -354,7 +370,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 			return new FederatedResponse(ResponseType.ERROR, new FederatedWorkerHandlerException(msg));
 		}
 	}
-
+	
 	private FederatedResponse execClear() {
 		try {
 			_ecm.clear();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.controlprogram.paramserv;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.parser.DataIdentifier;
@@ -50,6 +51,7 @@ import org.apache.sysds.runtime.instructions.cp.ListObject;
 import org.apache.sysds.runtime.instructions.cp.StringObject;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.util.ProgramConverter;
 
 import java.util.ArrayList;
@@ -224,6 +226,11 @@ public class FederatedPSControlThread extends PSWorker implements Callable<Void>
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
 		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	/**
@@ -270,6 +277,11 @@ public class FederatedPSControlThread extends PSWorker implements Callable<Void>
 			ParamservUtils.cleanupListObject(ec, Statement.PS_HYPER_PARAMS);
 			
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 
@@ -530,6 +542,11 @@ public class FederatedPSControlThread extends PSWorker implements Callable<Void>
 			ParamservUtils.cleanupListObject(ec, Statement.PS_MODEL);
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, accGradients);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/BalanceToAvgFederatedScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/BalanceToAvgFederatedScheme.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -28,6 +29,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.paramserv.ParamservUtils;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 
@@ -114,6 +116,11 @@ public class BalanceToAvgFederatedScheme extends DataPartitionFederatedScheme {
 			}
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/ReplicateToMaxFederatedScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/ReplicateToMaxFederatedScheme.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -28,6 +29,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.paramserv.ParamservUtils;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 
@@ -112,6 +114,11 @@ public class ReplicateToMaxFederatedScheme extends DataPartitionFederatedScheme 
 			}
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/ShuffleFederatedScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/ShuffleFederatedScheme.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -28,6 +29,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.paramserv.ParamservUtils;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 import java.util.List;
@@ -94,6 +96,11 @@ public class ShuffleFederatedScheme extends DataPartitionFederatedScheme {
 			shuffle(features, permutationMatrixBlock);
 			shuffle(labels, permutationMatrixBlock);
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/SubsampleToMinFederatedScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/SubsampleToMinFederatedScheme.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -28,6 +29,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.paramserv.ParamservUtils;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 
@@ -111,6 +113,11 @@ public class SubsampleToMinFederatedScheme extends DataPartitionFederatedScheme 
 			}
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
@@ -444,6 +444,14 @@ public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
 			return Pair.of(output.getName(), new LineageItem(getOpcode(),
 				LineageItemUtils.getLineage(ec, target, max, dir, cast, ignore)));
 		}
+		else if (opcode.equalsIgnoreCase("lowertri") || opcode.equalsIgnoreCase("uppertri")) {
+			CPOperand target = getTargetOperand();
+			CPOperand lower = getBoolLiteral("lowertri");
+			CPOperand diag = getBoolLiteral("diag");
+			CPOperand values = getBoolLiteral("values");
+			return Pair.of(output.getName(), new LineageItem(getOpcode(),
+				LineageItemUtils.getLineage(ec, target, lower, diag, values)));
+		}
 		else if (opcode.equalsIgnoreCase("transformdecode") ||
 				opcode.equalsIgnoreCase("transformapply")) {
 			CPOperand target = new CPOperand(params.get("target"), ValueType.FP64, DataType.FRAME);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CentralMomentFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CentralMomentFEDInstruction.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
@@ -39,149 +40,165 @@ import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.CMOperator;
 
 public class CentralMomentFEDInstruction extends AggregateUnaryFEDInstruction {
 
-    private CentralMomentFEDInstruction(CMOperator cm, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
-                                       String opcode, String str) {
-        super(cm, in1, in2, in3, out, opcode, str);
-    }
+	private CentralMomentFEDInstruction(CMOperator cm, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
+			String opcode, String str) {
+		super(cm, in1, in2, in3, out, opcode, str);
+	}
 
-    public static CentralMomentFEDInstruction parseInstruction(String str) {
-        CPOperand in1 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
-        CPOperand in2 = null;
-        CPOperand in3 = null;
-        CPOperand out = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
+	public static CentralMomentFEDInstruction parseInstruction(String str) {
+		CPOperand in1 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
+		CPOperand in2 = null;
+		CPOperand in3 = null;
+		CPOperand out = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
 
-        String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
-        String opcode = parts[0];
+		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
+		String opcode = parts[0];
 
-        //check supported opcode
-        if( !opcode.equalsIgnoreCase("cm") ) {
-            throw new DMLRuntimeException("Unsupported opcode "+opcode);
-        }
+		// check supported opcode
+		if (!opcode.equalsIgnoreCase("cm")) {
+			throw new DMLRuntimeException("Unsupported opcode " + opcode);
+		}
 
-        if ( parts.length == 4 ) {
-            // Example: CP.cm.mVar0.Var1.mVar2; (without weights)
-            in2 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
-            parseUnaryInstruction(str, in1, in2, out);
-        }
-        else if ( parts.length == 5) {
-            // CP.cm.mVar0.mVar1.Var2.mVar3; (with weights)
-            in2 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
-            in3 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
-            parseUnaryInstruction(str, in1, in2, in3, out);
-        }
+		if (parts.length == 4) {
+			// Example: CP.cm.mVar0.Var1.mVar2; (without weights)
+			in2 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
+			parseUnaryInstruction(str, in1, in2, out);
+		}
+		else if (parts.length == 5) {
+			// CP.cm.mVar0.mVar1.Var2.mVar3; (with weights)
+			in2 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
+			in3 = new CPOperand("", Types.ValueType.UNKNOWN, Types.DataType.UNKNOWN);
+			parseUnaryInstruction(str, in1, in2, in3, out);
+		}
 
-        /*
-         * Exact order of the central moment MAY NOT be known at compilation time.
-         * We first try to parse the second argument as an integer, and if we fail,
-         * we simply pass -1 so that getCMAggOpType() picks up AggregateOperationTypes.INVALID.
-         * It must be updated at run time in processInstruction() method.
-         */
+		/*
+		 * Exact order of the central moment MAY NOT be known at compilation time. We
+		 * first try to parse the second argument as an integer, and if we fail, we
+		 * simply pass -1 so that getCMAggOpType() picks up
+		 * AggregateOperationTypes.INVALID. It must be updated at run time in
+		 * processInstruction() method.
+		 */
 
-        int cmOrder;
-        try {
-            if ( in3 == null ) {
-                cmOrder = Integer.parseInt(in2.getName());
-            }
-            else {
-                cmOrder = Integer.parseInt(in3.getName());
-            }
-        } catch(NumberFormatException e) {
-            cmOrder = -1; // unknown at compilation time
-        }
+		int cmOrder;
+		try {
+			if (in3 == null) {
+				cmOrder = Integer.parseInt(in2.getName());
+			}
+			else {
+				cmOrder = Integer.parseInt(in3.getName());
+			}
+		}
+		catch (NumberFormatException e) {
+			cmOrder = -1; // unknown at compilation time
+		}
 
-        CMOperator.AggregateOperationTypes opType = CMOperator.getCMAggOpType(cmOrder);
-        CMOperator cm = new CMOperator(CM.getCMFnObject(opType), opType);
-        return new CentralMomentFEDInstruction(cm, in1, in2, in3, out, opcode, str);
-    }
+		CMOperator.AggregateOperationTypes opType = CMOperator.getCMAggOpType(cmOrder);
+		CMOperator cm = new CMOperator(CM.getCMFnObject(opType), opType);
+		return new CentralMomentFEDInstruction(cm, in1, in2, in3, out, opcode, str);
+	}
 
-    @Override
-    public void processInstruction( ExecutionContext ec ) {
-        MatrixObject mo = ec.getMatrixObject(input1.getName());
-        ScalarObject order = ec.getScalarInput(input3==null ? input2 : input3);
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		MatrixObject mo = ec.getMatrixObject(input1.getName());
+		ScalarObject order = ec.getScalarInput(input3 == null ? input2 : input3);
 
-        CMOperator cm_op = ((CMOperator) _optr);
-        if(cm_op.getAggOpType() == CMOperator.AggregateOperationTypes.INVALID)
-            cm_op = cm_op.setCMAggOp((int) order.getLongValue());
+		CMOperator cm_op = ((CMOperator) _optr);
+		if (cm_op.getAggOpType() == CMOperator.AggregateOperationTypes.INVALID)
+			cm_op = cm_op.setCMAggOp((int) order.getLongValue());
 
-        FederationMap fedMapping = mo.getFedMapping();
-        List<CM_COV_Object> globalCmobj = new ArrayList<>();
+		FederationMap fedMapping = mo.getFedMapping();
+		List<CM_COV_Object> globalCmobj = new ArrayList<>();
 
-        long varID = FederationUtils.getNextFedDataID();
-        CMOperator finalCm_op = cm_op;
-        fedMapping.mapParallel(varID, (range, data) -> {
+		long varID = FederationUtils.getNextFedDataID();
+		CMOperator finalCm_op = cm_op;
+		fedMapping.mapParallel(varID, (range, data) -> {
 
-            FederatedResponse response;
-            try {
-                if (input3 == null ) {
-                    response = data.executeFederatedOperation(
-                        new FederatedRequest(FederatedRequest.RequestType.EXEC_UDF, -1,
-                            new CentralMomentFEDInstruction.CMFunction(data.getVarID(), finalCm_op))).get();
-                } else {
-                    MatrixBlock wtBlock = ec.getMatrixInput(input2.getName());
+			FederatedResponse response;
+			try {
+				if (input3 == null) {
+					response = data
+							.executeFederatedOperation(new FederatedRequest(FederatedRequest.RequestType.EXEC_UDF, -1,
+									new CentralMomentFEDInstruction.CMFunction(data.getVarID(), finalCm_op)))
+							.get();
+				}
+				else {
+					MatrixBlock wtBlock = ec.getMatrixInput(input2.getName());
 
-                    response = data.executeFederatedOperation(
-                        new FederatedRequest(FederatedRequest.RequestType.EXEC_UDF, -1,
-                            new CentralMomentFEDInstruction.CMWeightsFunction(data.getVarID(), finalCm_op, wtBlock))).get();
-                }
+					response = data.executeFederatedOperation(new FederatedRequest(
+							FederatedRequest.RequestType.EXEC_UDF, -1,
+							new CentralMomentFEDInstruction.CMWeightsFunction(data.getVarID(), finalCm_op, wtBlock)))
+							.get();
+				}
 
-                if(!response.isSuccessful())
-                    response.throwExceptionFromResponse();
-               synchronized(globalCmobj) {
-                   globalCmobj.add((CM_COV_Object) response.getData()[0]);
-               }
-            }
-            catch(Exception e) {
-                throw new DMLRuntimeException(e);
-            }
-            return null;
-        });
+				if (!response.isSuccessful())
+					response.throwExceptionFromResponse();
+				synchronized (globalCmobj) {
+					globalCmobj.add((CM_COV_Object) response.getData()[0]);
+				}
+			}
+			catch (Exception e) {
+				throw new DMLRuntimeException(e);
+			}
+			return null;
+		});
 
-        Optional<CM_COV_Object> res = globalCmobj.stream().reduce((arg0, arg1) -> (CM_COV_Object) finalCm_op.fn.execute(arg0, arg1));
-        try {
-            ec.setScalarOutput(output.getName(), new DoubleObject(res.get().getRequiredResult(finalCm_op)));
-        }
-        catch(Exception e) {
-            throw new DMLRuntimeException(e);
-        }
-    }
+		Optional<CM_COV_Object> res = globalCmobj.stream()
+				.reduce((arg0, arg1) -> (CM_COV_Object) finalCm_op.fn.execute(arg0, arg1));
+		try {
+			ec.setScalarOutput(output.getName(), new DoubleObject(res.get().getRequiredResult(finalCm_op)));
+		}
+		catch (Exception e) {
+			throw new DMLRuntimeException(e);
+		}
+	}
 
-    private static class CMFunction extends FederatedUDF {
-        private static final long serialVersionUID = 7460149207607220994L;
-        private final CMOperator _op;
+	private static class CMFunction extends FederatedUDF {
+		private static final long serialVersionUID = 7460149207607220994L;
+		private final CMOperator _op;
 
-        public CMFunction (long input, CMOperator op) {
-            super(new long[] {input});
-            _op = op;
-        }
+		public CMFunction(long input, CMOperator op) {
+			super(new long[] {input});
+			_op = op;
+		}
 
-        @Override
-        public FederatedResponse execute(ExecutionContext ec, Data... data) {
-            MatrixBlock mb = ((MatrixObject) data[0]).acquireReadAndRelease();
-            return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, mb.cmOperations(_op));
-        }
-    }
+		@Override
+		public FederatedResponse execute(ExecutionContext ec, Data... data) {
+			MatrixBlock mb = ((MatrixObject) data[0]).acquireReadAndRelease();
+			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, mb.cmOperations(_op));
+		}
 
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
+	}
 
-    private static class CMWeightsFunction extends FederatedUDF {
-        private static final long serialVersionUID = -3685746246551622021L;
-        private final CMOperator _op;
-        private final MatrixBlock _weights;
+	private static class CMWeightsFunction extends FederatedUDF {
+		private static final long serialVersionUID = -3685746246551622021L;
+		private final CMOperator _op;
+		private final MatrixBlock _weights;
 
-        protected CMWeightsFunction(long input, CMOperator op, MatrixBlock weights) {
-            super(new long[] {input});
-            _op = op;
-            _weights = weights;
-        }
+		protected CMWeightsFunction(long input, CMOperator op, MatrixBlock weights) {
+			super(new long[] {input});
+			_op = op;
+			_weights = weights;
+		}
 
-        @Override
-        public FederatedResponse execute(ExecutionContext ec, Data... data) {
-            MatrixBlock mb = ((MatrixObject) data[0]).acquireReadAndRelease();
-            return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, mb.cmOperations(_op, _weights));
-        }
-    }
+		@Override
+		public FederatedResponse execute(ExecutionContext ec, Data... data) {
+			MatrixBlock mb = ((MatrixObject) data[0]).acquireReadAndRelease();
+			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, mb.cmOperations(_op, _weights));
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.Future;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
@@ -38,6 +39,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -212,6 +214,11 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 			// create federated response
 			return new FederatedResponse(ResponseType.SUCCESS, new Object[] {encoder, fb.getColumnNames()});
 		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	public static class ExecuteFrameEncoder extends FederatedUDF {
@@ -241,6 +248,11 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 		
 			// return id handle
 			return new FederatedResponse(ResponseType.SUCCESS_EMPTY);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
@@ -22,6 +22,7 @@ package org.apache.sysds.runtime.instructions.fed;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.lops.PickByCount.OperationTypes;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
@@ -36,6 +37,7 @@ import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
@@ -176,6 +178,11 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 					new Object[] {picked});
 			}
 		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	private static class IQM extends FederatedUDF {
@@ -191,6 +198,10 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS,
 				new Object[] {mb.interQuartileMean()});
 		}
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	private static class Median extends FederatedUDF {
@@ -205,6 +216,10 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 			MatrixBlock mb = ((MatrixObject)data[0]).acquireReadAndRelease();
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS,
 				new Object[] {mb.median()});
+		}
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantileSortFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantileSortFEDInstruction.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.instructions.fed;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.lops.SortKeys;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -32,6 +33,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 public class QuantileSortFEDInstruction extends UnaryFEDInstruction{
@@ -158,6 +160,10 @@ public class QuantileSortFEDInstruction extends UnaryFEDInstruction{
 			ec.setVariable(String.valueOf(_outputID), mout);
 			// return schema
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS_EMPTY);
+		}
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
@@ -22,6 +22,7 @@ package org.apache.sysds.runtime.instructions.fed;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
@@ -38,6 +39,7 @@ import org.apache.sysds.runtime.functionobjects.SwapIndex;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
@@ -263,6 +265,11 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, new int[]{res.getNumRows(), res.getNumColumns()});
 		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	private static class DiagMatrix extends FederatedUDF {
@@ -301,6 +308,11 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 			ec.setVariable(String.valueOf(_outputID), mout);
 
 			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, new int[]{res.getNumRows(), res.getNumColumns()});
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -43,7 +43,7 @@ public class LineageCacheConfig
 		"uamean", "max", "min", "ifelse", "-", "sqrt", ">", "uak+", "<=",
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
 		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
-		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm"
+		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri"
 		//TODO: Reuse everything. 
 	};
 	private static String[] REUSE_OPCODES  = new String[] {};

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.lineage;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
@@ -47,6 +48,7 @@ import org.apache.sysds.lops.compile.Dag;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionParser;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
@@ -136,6 +138,25 @@ public class LineageItemUtils {
 	public static LineageItem[] getLineage(ExecutionContext ec, CPOperand... operands) {
 		return Arrays.stream(operands).filter(c -> c!=null)
 			.map(c -> ec.getLineage().getOrCreate(c)).toArray(LineageItem[]::new);
+	}
+	
+	public static void traceFedUDF(ExecutionContext ec, FederatedUDF udf) {
+		if (udf.getLineageItem(ec) == null)
+			//TODO: trace all UDFs
+			return;
+
+		if (!(udf instanceof LineageTraceable))
+			throw new DMLRuntimeException("Unknown Federated UDF (" + udf.getClass().getSimpleName() + ") traced.");
+		LineageTraceable ludf = (LineageTraceable) udf;
+		if (ludf.hasSingleLineage()) {
+			Pair<String, LineageItem> item = udf.getLineageItem(ec);
+			ec.getLineage().set(item.getKey(), item.getValue());
+		}
+		else {
+			Pair<String, LineageItem>[] items = udf.getLineageItems(ec);
+			for (Pair<String, LineageItem> item : items)
+				ec.getLineage().set(item.getKey(), item.getValue());
+		}
 	}
 	
 	public static void constructLineageFromHops(Hop[] roots, String claName, Hop[] inputs, HashMap<Long, Hop> spoofmap) {

--- a/src/test/java/org/apache/sysds/test/functions/lineage/FedUDFReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/FedUDFReuseTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.lineage;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.lineage.LineageCacheStatistics;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(value = Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
+public class FedUDFReuseTest extends AutomatedTestBase {
+	private final static String TEST_NAME1 = "FedUdfReuse1";
+
+	private final static String TEST_DIR = "functions/lineage/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + FedUDFReuseTest.class.getSimpleName() + "/";
+
+	private final static int blocksize = 1024;
+	@Parameterized.Parameter()
+	public int rows;
+	@Parameterized.Parameter(1)
+	public int cols;
+
+	@Parameterized.Parameter(2)
+	public boolean rowPartitioned;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			{20, 20, true}
+		});
+	}
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"S"}));
+	}
+
+	@Test
+	public void testTriUDFReuseCP() {
+		runTriUDFReuse(ExecMode.SINGLE_NODE);
+	}
+	
+	private void runTriUDFReuse(ExecMode execMode) {
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		ExecMode platformOld = rtplatform;
+		String TEST_NAME = TEST_NAME1;
+
+		if(rtplatform == ExecMode.SPARK)
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+
+		getAndLoadTestConfiguration(TEST_NAME);
+		String HOME = SCRIPT_DIR + TEST_DIR;
+
+		// write input matrices
+		int r = rows;
+		int c = cols / 4;
+		if(rowPartitioned) {
+			r = rows / 4;
+			c = cols;
+		}
+
+		double[][] X1 = getRandomMatrix(r, c, 1, 5, 1, 3);
+		double[][] X2 = getRandomMatrix(r, c, 1, 5, 1, 7);
+		double[][] X3 = getRandomMatrix(r, c, 1, 5, 1, 8);
+		double[][] X4 = getRandomMatrix(r, c, 1, 5, 1, 9);
+
+		MatrixCharacteristics mc = new MatrixCharacteristics(r, c, blocksize, r * c);
+		writeInputMatrixWithMTD("X1", X1, false, mc);
+		writeInputMatrixWithMTD("X2", X2, false, mc);
+		writeInputMatrixWithMTD("X3", X3, false, mc);
+		writeInputMatrixWithMTD("X4", X4, false, mc);
+
+		// empty script name because we don't execute any script, just start the worker
+		fullDMLScriptName = "";
+		int port1 = getRandomAvailablePort();
+		int port2 = getRandomAvailablePort();
+		int port3 = getRandomAvailablePort();
+		int port4 = getRandomAvailablePort();
+		String[] otherargs = new String[] {"-lineage", "reuse_full"};
+		Lineage.resetInternalState();
+		Thread t1 = startLocalFedWorkerThread(port1, otherargs, FED_WORKER_WAIT_S);
+		Thread t2 = startLocalFedWorkerThread(port2, otherargs, FED_WORKER_WAIT_S);
+		Thread t3 = startLocalFedWorkerThread(port3, otherargs, FED_WORKER_WAIT_S);
+		Thread t4 = startLocalFedWorkerThread(port4, otherargs);
+
+		rtplatform = execMode;
+		if(rtplatform == ExecMode.SPARK) {
+			System.out.println(7);
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+		}
+		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
+		loadTestConfiguration(config);
+
+		// Run reference dml script with normal matrix
+		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+		programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-args", 
+			input("X1"), input("X2"), input("X3"), input("X4"),
+			Boolean.toString(rowPartitioned).toUpperCase(), expected("S")};
+		runTest(null);
+
+		// Run actual dml script with federated matrix
+		fullDMLScriptName = HOME + TEST_NAME + ".dml";
+		programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-nvargs",
+			"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
+			"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
+			"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + cols,
+			"rP=" + Boolean.toString(rowPartitioned).toUpperCase(), "out_S=" + output("S")};
+
+		runTest(null);
+
+		// compare via files
+		compareResults(1e-9);
+		// check if lowertri is federated
+		Assert.assertTrue(heavyHittersContainsString("fed_lowertri"));
+		// assert reuse count
+		Assert.assertTrue(LineageCacheStatistics.getInstHits() > 0);
+
+		TestUtils.shutdownThreads(t1, t2, t3, t4);
+
+		rtplatform = platformOld;
+		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+	}
+}
+

--- a/src/test/scripts/functions/lineage/FedUdfReuse1.dml
+++ b/src/test/scripts/functions/lineage/FedUdfReuse1.dml
@@ -1,0 +1,34 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+if ($rP) {
+    A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+        ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
+    		list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)));
+  } else {
+    A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+            ranges=list(list(0, 0), list($rows, $cols/4), list(0,$cols/4), list($rows, $cols/2),
+            	list(0,$cols/2), list($rows, 3*($cols/4)), list(0, 3*($cols/4)), list($rows, $cols)));
+    }
+
+for (i in 1:10)
+  s = lower.tri(target=A, diag=FALSE, values=TRUE);
+write(s, $out_S);

--- a/src/test/scripts/functions/lineage/FedUdfReuse1Reference.dml
+++ b/src/test/scripts/functions/lineage/FedUdfReuse1Reference.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+if($5) { A = rbind(read($1), read($2), read($3), read($4)); }
+else { A = cbind(read($1), read($2), read($3), read($4));}
+
+for (i in 1:10)
+  s = lower.tri(target=A, diag=FALSE, values=TRUE);
+
+write(s, $6);


### PR DESCRIPTION
This patch builds the foundation of lineage tracing and reuse
of federated UDFs, and adds a test which calls lower.tri in a
loop and reuse the outputs of Tri UDF in the workers.
The core idea is to treat a UDF as an instruction which always
produces the same results for same inputs.