### PR TITLE
[SYSTEMDS-2801] Rewrite rule to remove (par)for-loops over empty sequences.

### DIFF
--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -124,6 +124,13 @@ public class OptimizerUtils
 	 */
 	public static boolean ALLOW_BRANCH_REMOVAL = true;
 	
+	/**
+	 * Enables the removal of (par)for-loops when from, to, and increment are constants
+	 * (original literals or results of constant folding) and lead to an empty sequence,
+	 * i.e., (par)for-loops without a single iteration.
+	 */
+	public static boolean ALLOW_FOR_LOOP_REMOVAL = true;
+
 	public static boolean ALLOW_AUTO_VECTORIZATION = true;
 	
 	/**
@@ -300,6 +307,7 @@ public class OptimizerUtils
 				ALLOW_INTER_PROCEDURAL_ANALYSIS = false;
 				IPA_NUM_REPETITIONS = 1;
 				ALLOW_BRANCH_REMOVAL = false;
+				ALLOW_FOR_LOOP_REMOVAL = false;
 				ALLOW_SUM_PRODUCT_REWRITES = false;
 				break;
 			// opt level 1: memory-based (no advanced rewrites)	
@@ -312,6 +320,7 @@ public class OptimizerUtils
 				ALLOW_INTER_PROCEDURAL_ANALYSIS = false;
 				IPA_NUM_REPETITIONS = 1;
 				ALLOW_BRANCH_REMOVAL = false;
+				ALLOW_FOR_LOOP_REMOVAL = false;
 				ALLOW_SUM_PRODUCT_REWRITES = false;
 				ALLOW_LOOP_UPDATE_IN_PLACE = false;
 				break;
@@ -366,6 +375,7 @@ public class OptimizerUtils
 		ALLOW_ALGEBRAIC_SIMPLIFICATION = true;
 		ALLOW_AUTO_VECTORIZATION = true;
 		ALLOW_BRANCH_REMOVAL = true;
+		ALLOW_FOR_LOOP_REMOVAL = true;
 		ALLOW_CONSTANT_FOLDING = true;
 		ALLOW_COMMON_SUBEXPRESSION_ELIMINATION = true;
 		ALLOW_INTER_PROCEDURAL_ANALYSIS = true;

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
@@ -90,10 +90,12 @@ public class ProgramRewriter
 			_dagRuleSet.add( new RewriteInjectSparkPReadCheckpointing()          ); //dependency: reblock
 			
 			//add statement block rewrite rules
- 			if( OptimizerUtils.ALLOW_BRANCH_REMOVAL ) {
+			if( OptimizerUtils.ALLOW_BRANCH_REMOVAL )
 				_sbRuleSet.add(  new RewriteRemoveUnnecessaryBranches()          ); //dependency: constant folding
-				_sbRuleSet.add(  new RewriteMergeBlockSequence()                 ); //dependency: remove branches
-			}
+			if( OptimizerUtils.ALLOW_FOR_LOOP_REMOVAL )
+				_sbRuleSet.add(  new RewriteRemoveForLoopEmptySequence()         ); //dependency: constant folding
+			if( OptimizerUtils.ALLOW_BRANCH_REMOVAL || OptimizerUtils.ALLOW_FOR_LOOP_REMOVAL )
+				_sbRuleSet.add(  new RewriteMergeBlockSequence()                 ); //dependency: remove branches, remove for-loops
 			_sbRuleSet.add(      new RewriteCompressedReblock()                  ); // Compression Rewrite
  			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS )
  				_sbRuleSet.add(  new RewriteSplitDagUnknownCSVRead()             ); //dependency: reblock, merge blocks

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteRemoveForLoopEmptySequence.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteRemoveForLoopEmptySequence.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.rewrite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.LiteralOp;
+import org.apache.sysds.parser.ForStatementBlock;
+import org.apache.sysds.parser.StatementBlock;
+
+/**
+ * Rule: Simplify program structure by removing (par)for statements iterating over
+ * an empty sequence, i.e., (par)for-loops without a single iteration.
+ */
+public class RewriteRemoveForLoopEmptySequence extends StatementBlockRewriteRule {
+
+	@Override
+	public boolean createsSplitDag() {
+		return false;
+	}
+
+	@Override
+	public List<StatementBlock> rewriteStatementBlock(StatementBlock sb, ProgramRewriteStatus state) {
+		ArrayList<StatementBlock> ret = new ArrayList<>();
+		
+		if( sb instanceof ForStatementBlock )
+		{
+			ForStatementBlock fsb = (ForStatementBlock) sb;
+			Hop incr = fsb.getIncrementHops();
+			
+			//consider rewrite if the increment was specified
+			if( incr != null ) {
+				Hop from = fsb.getFromHops().getInput().get(0);
+				Hop to = fsb.getToHops().getInput().get(0);
+				incr = incr.getInput().get(0);
+				
+				//consider rewrite if from, to, and incr are literal ops (constant values)
+				if( from instanceof LiteralOp && to instanceof LiteralOp && incr instanceof LiteralOp )
+				{
+					LiteralOp litfrom = (LiteralOp) from;
+					LiteralOp litto = (LiteralOp) to;
+					LiteralOp litincr = (LiteralOp) incr;
+					
+					long longfrom = HopRewriteUtils.getIntValue(litfrom);
+					long longto = HopRewriteUtils.getIntValue(litto);
+					long longincr = HopRewriteUtils.getIntValue(litincr);
+					
+					//keep original sb (sequence not empty)
+					if( longincr > 0 ? longfrom <= longto : longfrom >= longto )
+						ret.add(sb);
+					else //remove for-loop (add nothing)
+						LOG.debug("Applied removeForLoopEmptySequence (lines "+sb.getBeginLine()+"-"+sb.getEndLine()+").");
+				}
+				else //keep original sb (non-constant sequence)
+					ret.add( sb );
+			}
+			else //keep original sb (sequence not empty)
+				ret.add( sb );
+		}
+		else //keep original sb (no for)
+			ret.add( sb );
+		
+		return ret;
+	}
+
+	@Override
+	public List<StatementBlock> rewriteStatementBlocks(List<StatementBlock> sbs, ProgramRewriteStatus state) {
+		return sbs;
+	}
+
+}


### PR DESCRIPTION
This commit adds a new StatementBlockRewriteRule removing (par)for-loops which are known to iterate over an empty sequence, and, thus, will not perform a single iteration. This works if the loop's from, to, and increment are constants (possibly DML script arguments, and after constant folding). Furthermore, OptimizerUtils has a new flag determining whether this rule shall be applied. In ProgramRewriter's default rule sequence, this new rule is inserted directly after the removal of unnecessary branches, since they have a lot in common. Merging subsequent blocks is done once afterwards if any of removing unnecessary branches or removing
(par)for-loops shall be applied.