### PR TITLE
[SYSTEMDS-2812] Conv1D

### DIFF
--- a/scripts/nn/layers/conv1d.dml
+++ b/scripts/nn/layers/conv1d.dml
@@ -21,7 +21,27 @@
 
 source("scripts/nn/util.dml") as util
 
-forward = function(matrix[double] input, matrix[double] filter, int pad, int stride, int numImg, int numChannels, int imgSize, int numFilters, int filterSize, matrix[double] bias)
+forward = function(matrix[double] input, matrix[double] filter, int pad, int stride, int numInput, int numChannels, int inputWidth, int numFilters, int filterSize, matrix[double] bias)
     return (matrix[double] out) {
-  out = conv2d(input, filter, padding=[pad,pad], stride=[stride, stride], input_shape=[numImg,numChannels,1,imgSize], filter_shape=[numFilters,numChannels,1,filterSize], bias=bias)
+  /*
+  * Computes the forward pass for a 1D spatial convolutional layer
+  * by reshaping the input to fit conv2d.
+  *
+  * Inputs:
+  *  - input: Inputs, of shape (N, C*W).
+  *  - filter: Weights, of shape (F, C*W).
+  *  - pad: Padding for left and right sides of input elements.
+  *  - stride: Stride for moving filter.
+  *  - numInput: Number of input elements N
+  *  - numChannels: Number of input channels (dimensionality of input depth).
+  *  - inputWidth: Input width.
+  *  - numFilters: Number of filters F
+  *  - filterSize: Filter width.
+  *  - bias: Biases, of shape (F, 1).
+  *
+  * Outputs:
+  *  - out: Outputs, of shape (N, F*Wout).
+  *  - Wout: Output width.
+  */
+  out = conv2d(input, filter, padding=[0,pad], stride=[1, stride], input_shape=[numInput,numChannels,1,inputWidth], filter_shape=[numFilters,numChannels,1,filterSize], bias=bias)
 }

--- a/scripts/nn/layers/conv1d.dml
+++ b/scripts/nn/layers/conv1d.dml
@@ -21,7 +21,7 @@
 
 source("scripts/nn/util.dml") as util
 
-forward = function(matrix[double] input, matrix[double] filter, int pad, int stride, int numInput, int numChannels, int inputWidth, int numFilters, int filterSize, matrix[double] bias)
+forward = function(matrix[double] input, matrix[double] filter, int pad, int stride, int numInput, int numChannels, int inputWidth, int numFilters, int filterSize)
     return (matrix[double] out) {
   /*
   * Computes the forward pass for a 1D spatial convolutional layer
@@ -37,11 +37,55 @@ forward = function(matrix[double] input, matrix[double] filter, int pad, int str
   *  - inputWidth: Input width.
   *  - numFilters: Number of filters F
   *  - filterSize: Filter width.
-  *  - bias: Biases, of shape (F, 1).
   *
   * Outputs:
   *  - out: Outputs, of shape (N, F*Wout).
-  *  - Wout: Output width.
   */
-  out = conv2d(input, filter, padding=[0,pad], stride=[1, stride], input_shape=[numInput,numChannels,1,inputWidth], filter_shape=[numFilters,numChannels,1,filterSize], bias=bias)
+  out = conv2d(input, filter, padding=[0,pad], stride=[1, stride], input_shape=[numInput,numChannels,1,inputWidth], filter_shape=[numFilters,numChannels,1,filterSize])
+}
+
+backward_data = function(matrix[double] filter, matrix[double] dout, int pad, int stride, int numInput, int numChannels, int inputWidth, int numFilters, int filterSize)
+    return (matrix[double] out) {
+  /*
+  * Computes the backward pass regarding the input data for a 1D spatial convolutional layer
+  * by reshaping the input to fit conv2d backward data pass.
+  *
+  * Inputs:
+  *  - filter: Weights, of shape (F, C*W).
+  *  - dout: Output of the forward pass
+  *  - pad: Padding for left and right sides of input elements.
+  *  - stride: Stride for moving filter.
+  *  - numInput: Number of input elements N
+  *  - numChannels: Number of input channels (dimensionality of input depth).
+  *  - inputWidth: Input width.
+  *  - numFilters: Number of filters F
+  *  - filterSize: Filter width.
+  *
+  * Outputs:
+  *  - out: gradients based on the input data of the convolution.
+  */
+  out = conv2d_backward_data(filter, dout, stride=[1, stride], padding=[0, pad], input_shape=[numInput, numChannels, 1, inputWidth], filter_shape=[numFilters, numChannels, 1, filterSize] )
+}
+
+backward_filter = function(matrix[double] input, matrix[double] dout, int pad, int stride, int numInput, int numChannels, int inputWidth, int numFilters, int filterSize)
+    return (matrix[double] out) {
+  /*
+  * Computes the backward pass regarding the filter for a 1D spatial convolutional layer
+  * by reshaping the input to fit conv2d backward data pass.
+  *
+  * Inputs:
+  *  - input: Inputs, of shape (N, C*W).
+  *  - dout: Output of the forward pass
+  *  - pad: Padding for left and right sides of input elements.
+  *  - stride: Stride for moving filter.
+  *  - numInput: Number of input elements N
+  *  - numChannels: Number of input channels (dimensionality of input depth).
+  *  - inputWidth: Input width.
+  *  - numFilters: Number of filters F
+  *  - filterSize: Filter width.
+  *
+  * Outputs:
+  *  - out: gradients bsaed on the filter of the convolution.
+  */
+  out = conv2d_backward_filter(input, dout, stride=[1, stride], padding=[0, pad], input_shape=[numInput, numChannels, 1, inputWidth], filter_shape=[numFilters, numChannels, 1, filterSize] )
 }

--- a/scripts/nn/layers/conv1d.dml
+++ b/scripts/nn/layers/conv1d.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+source("scripts/nn/util.dml") as util
+
+forward = function(matrix[double] input, matrix[double] filter, int pad, int stride, int numImg, int numChannels, int imgSize, int numFilters, int filterSize, matrix[double] bias)
+    return (matrix[double] out) {
+  out = conv2d(input, filter, padding=[pad,pad], stride=[stride, stride], input_shape=[numImg,numChannels,1,imgSize], filter_shape=[numFilters,numChannels,1,filterSize], bias=bias)
+}

--- a/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.test.functions.dnn;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.lops.LopProperties.ExecType;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+
+public class Conv1DTest extends AutomatedTestBase
+{
+	private final static String TEST_NAME = "Conv1DTest";
+	private final static String TEST_DIR = "functions/tensor/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + Conv1DTest.class.getSimpleName() + "/";
+	private final static double epsilon=0.0000000001;
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"output"}));
+	}
+
+	@Test
+	public void testSimpleConv1DDenseSingleBatchSingleChannelSingleFilter(){
+		int numImg = 4; int imgSize = 4; int numChannels = 1; int numFilters = 1; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense1() {
+		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+
+	@Test
+	public void testConv1DDense2() {
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense3() {
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense4() {
+		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense5() {
+		int numImg = 3; int imgSize = 8; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense6() {
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense7() {
+		int numImg = 3; int imgSize = 64; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DSparse1a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse2a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse3a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse4a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse5a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse6a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse7a() {
+		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse1b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse2b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse3b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse4b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse5b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse6b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse7b() {
+		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	// --------------------------------------------
+
+
+	@Test
+	public void testConv1DDense1SP()
+	{
+		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense2SP()
+	{
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense3SP()
+	{
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense4SP()
+	{
+		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense5SP()
+	{
+		int numImg = 3; int imgSize = 8; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense6SP()
+	{
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DDense7SP()
+	{
+		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+	}
+
+	@Test
+	public void testConv1DSparse1SP()
+	{
+		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
+	}
+
+	@Test
+	public void testConv1DSparse2SP()
+	{
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	@Test
+	public void testConv1DSparse3SP()
+	{
+		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
+	}
+
+	public void testConv1DSparse4SP()
+	{
+		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, true);
+	}
+
+	public void runConv1DTest( ExecType et, int imgSize, int numImg, int numChannels, int numFilters,
+		int filterSize, int stride, int pad, boolean sparse1, boolean sparse2)
+	{
+		ExecMode platformOld = rtplatform;
+		switch( et ){
+			case SPARK: rtplatform = ExecMode.SPARK; break;
+			default: rtplatform = ExecMode.HYBRID; break;
+		}
+		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+		if( rtplatform == ExecMode.SPARK )
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+
+		try
+		{
+			String sparseVal1 = String.valueOf(sparse1).toUpperCase();
+			String sparseVal2 = String.valueOf(sparse2).toUpperCase();
+			getAndLoadTestConfiguration(TEST_NAME);
+
+			String SCRIPT_HOME = SCRIPT_DIR + TEST_DIR + TEST_NAME;
+			fullDMLScriptName = SCRIPT_HOME + ".dml";
+
+			programArgs = new String[] {
+				"-nvargs",
+				"imgSize=" + imgSize,
+				"numImg=" + numImg,
+				"numChannels=" + numChannels,
+				"numFilters=" + numFilters,
+				"filterSize=" + filterSize,
+				"stride=" + stride,
+				"pad=" + pad,
+				"output=" + output("output"),
+				"sparseVal1=" + sparseVal1,
+				"sparseVal2=" + sparseVal2
+			};
+
+			/*fullRScriptName = SCRIPT_HOME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + imgSize + " " + numImg +
+				" " + numChannels + " " + numFilters +
+				" " + filterSize + " " + stride + " " + pad + " " + expectedDir() +
+				" " + sparseVal1 + " " + sparseVal2;*/
+
+			// Run DML and R scripts
+			runTest(true, false, null, -1);
+			//runRScript(true);
+
+			//HashMap<CellIndex, Double> bHM = readRMatrixFromExpectedDir("B");
+			HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("output");
+			//TestUtils.compareMatrices(dmlfile, bHM, epsilon, "B-DML", "B-R");
+			System.out.println(dmlfile.toString());
+		}
+		finally {
+			rtplatform = platformOld;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		}
+	}
+}
+

--- a/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
@@ -19,6 +19,7 @@
 package org.apache.sysds.test.functions.dnn;
 
 import java.util.HashMap;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
@@ -44,218 +45,116 @@ public class Conv1DTest extends AutomatedTestBase
 
 	@Test
 	public void testSimpleConv1DDenseSingleBatchSingleChannelSingleFilter(){
-		int numImg = 4; int imgSize = 4; int numChannels = 1; int numFilters = 1; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		int numImg = 1; int imgSize = 4; int numChannels = 1; int numFilters = 1; int filterSize = 2; int stride = 1; int pad = 0;
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		expected.put(new CellIndex(1,1), 3.0);
+		expected.put(new CellIndex(1,2), 5.0);
+		expected.put(new CellIndex(1,3), 7.0);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+	}
+
+	private void fillExpected(HashMap<CellIndex, Double> expected, int rowNum, int rowLength, double value1, double value2){
+		for ( int m = 1; m <= rowLength; m+=2){
+			expected.put(new CellIndex(rowNum,m), value1);
+			expected.put(new CellIndex(rowNum,m+1), value2);
+		}
 	}
 
 	@Test
 	public void testConv1DDense1() {
 		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpected(expected, 1, 6, 21.0, 39.0);
+		fillExpected(expected, 2, 6, 75.0, 93.0);
+		fillExpected(expected, 3, 6, 129.0, 147.0);
+		fillExpected(expected, 4, 6, 183.0, 201.0);
+		fillExpected(expected, 5, 6, 237.0, 255.0);
+
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
+	private void fillExpectedRepeated(HashMap<CellIndex, Double> expected,int repetitionNum, double[] values, int row){
+		int colPointer = 1;
+		for (int i = 1; i <= repetitionNum;i++){
+			for(double value : values) {
+				expected.put(new CellIndex(row, colPointer), value);
+				colPointer++;
+			}
+		}
+	}
 
 	@Test
 	public void testConv1DDense2() {
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected, 3, new double[]{136.,264.,392.,520.},1);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
 	@Test
 	public void testConv1DDense3() {
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected, 3, new double[]{78.,200.,328.,456.,414.},1);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
 	@Test
 	public void testConv1DDense4() {
 		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected,3,new double[]{1.,5.,9.,13.,17.,10.},1);
+		fillExpectedRepeated(expected,3,new double[]{11.,25.,29.,33.,37.,20.},2);
+		fillExpectedRepeated(expected,3,new double[]{21.,45.,49.,53.,57.,30.},3);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
 	@Test
 	public void testConv1DDense5() {
 		int numImg = 3; int imgSize = 8; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected,3,new double[]{3.,10.,21.,33.,45.,57.,69.,81.,58.,31.},1);
+		fillExpectedRepeated(expected,3,new double[]{35.,74.,117.,129.,141.,153.,165.,177.,122.,63.},2);
+		fillExpectedRepeated(expected,3,new double[]{67.,138.,213.,225.,237.,249.,261.,273.,186.,95.},3);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
 	@Test
 	public void testConv1DDense6() {
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected,3,new double[]{136.,200.,264.,328.,392.,456.,520.},1);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false,expected);
 	}
 
 	@Test
 	public void testConv1DDense7() {
 		int numImg = 3; int imgSize = 64; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		double[] firstExpected = IntStream.iterate(3,n -> n+2).limit(63).mapToDouble(i->(double)i).toArray();
+		double[] secondExpected = IntStream.iterate(131,n -> n+2).limit(63).mapToDouble(i->(double)i).toArray();
+		double[] thirdExpected = IntStream.iterate(259,n -> n+2).limit(63).mapToDouble(i->(double)i).toArray();
+		fillExpectedRepeated(expected,3,firstExpected,1);
+		fillExpectedRepeated(expected,3,secondExpected,2);
+		fillExpectedRepeated(expected,3,thirdExpected,3);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
-
-	@Test
-	public void testConv1DSparse1a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse2a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse3a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse4a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse5a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse6a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse7a() {
-		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse1b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse2b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse3b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse4b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse5b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse6b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse7b() {
-		int numImg = 64; int imgSize = 16; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	// --------------------------------------------
-
 
 	@Test
 	public void testConv1DDense1SP()
 	{
 		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense2SP()
-	{
-		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense3SP()
-	{
-		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense4SP()
-	{
-		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense5SP()
-	{
-		int numImg = 3; int imgSize = 8; int numChannels = 2; int numFilters = 3; int filterSize = 3; int stride = 1; int pad = 2;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense6SP()
-	{
-		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DDense7SP()
-	{
-		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false);
-	}
-
-	@Test
-	public void testConv1DSparse1SP()
-	{
-		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 6; int filterSize = 2; int stride = 1; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, true);
-	}
-
-	@Test
-	public void testConv1DSparse2SP()
-	{
-		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	@Test
-	public void testConv1DSparse3SP()
-	{
-		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, false);
-	}
-
-	public void testConv1DSparse4SP()
-	{
-		int numImg = 3; int imgSize = 10; int numChannels = 1; int numFilters = 3; int filterSize = 2; int stride = 2; int pad = 1;
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, true, true);
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpected(expected, 1, 12, 21.0, 39.0);
+		fillExpected(expected, 2, 12, 75.0, 93.0);
+		fillExpected(expected, 3, 12, 129.0, 147.0);
+		fillExpected(expected, 4, 12, 183.0, 201.0);
+		fillExpected(expected, 5, 12, 237.0, 255.0);
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
 	}
 
 	public void runConv1DTest( ExecType et, int imgSize, int numImg, int numChannels, int numFilters,
-		int filterSize, int stride, int pad, boolean sparse1, boolean sparse2)
+		int filterSize, int stride, int pad, boolean sparse1, boolean sparse2, HashMap<CellIndex, Double> expected)
 	{
 		ExecMode platformOld = rtplatform;
 		switch( et ){
@@ -289,20 +188,13 @@ public class Conv1DTest extends AutomatedTestBase
 				"sparseVal2=" + sparseVal2
 			};
 
-			/*fullRScriptName = SCRIPT_HOME + ".R";
-			rCmd = "Rscript" + " " + fullRScriptName + " " + imgSize + " " + numImg +
-				" " + numChannels + " " + numFilters +
-				" " + filterSize + " " + stride + " " + pad + " " + expectedDir() +
-				" " + sparseVal1 + " " + sparseVal2;*/
-
-			// Run DML and R scripts
+			// Run DML
 			runTest(true, false, null, -1);
-			//runRScript(true);
 
-			//HashMap<CellIndex, Double> bHM = readRMatrixFromExpectedDir("B");
 			HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("output");
-			//TestUtils.compareMatrices(dmlfile, bHM, epsilon, "B-DML", "B-R");
 			System.out.println(dmlfile.toString());
+			if ( expected != null)
+				TestUtils.compareMatrices(dmlfile, expected, epsilon, "B-DML", "B-R");
 		}
 		finally {
 			rtplatform = platformOld;

--- a/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/dnn/Conv1DTest.java
@@ -32,7 +32,9 @@ import org.apache.sysds.test.TestUtils;
 
 public class Conv1DTest extends AutomatedTestBase
 {
-	private final static String TEST_NAME = "Conv1DTest";
+	private final static String TEST_NAME_1 = "Conv1DTest";
+	private final static String TEST_NAME_2 = "Conv1DBackwardDataTest";
+	private final static String TEST_NAME_3 = "Conv1DBackwardFilterTest";
 	private final static String TEST_DIR = "functions/tensor/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + Conv1DTest.class.getSimpleName() + "/";
 	private final static double epsilon=0.0000000001;
@@ -40,7 +42,9 @@ public class Conv1DTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"output"}));
+		addTestConfiguration(TEST_NAME_1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_1, new String[] {"output"}));
+		addTestConfiguration(TEST_NAME_2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_2, new String[] {"output"}));
+		addTestConfiguration(TEST_NAME_3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_3, new String[] {"output"}));
 	}
 
 	@Test
@@ -50,14 +54,7 @@ public class Conv1DTest extends AutomatedTestBase
 		expected.put(new CellIndex(1,1), 3.0);
 		expected.put(new CellIndex(1,2), 5.0);
 		expected.put(new CellIndex(1,3), 7.0);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
-	}
-
-	private void fillExpected(HashMap<CellIndex, Double> expected, int rowNum, int rowLength, double value1, double value2){
-		for ( int m = 1; m <= rowLength; m+=2){
-			expected.put(new CellIndex(rowNum,m), value1);
-			expected.put(new CellIndex(rowNum,m+1), value2);
-		}
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -70,17 +67,7 @@ public class Conv1DTest extends AutomatedTestBase
 		fillExpected(expected, 4, 6, 183.0, 201.0);
 		fillExpected(expected, 5, 6, 237.0, 255.0);
 
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
-	}
-
-	private void fillExpectedRepeated(HashMap<CellIndex, Double> expected,int repetitionNum, double[] values, int row){
-		int colPointer = 1;
-		for (int i = 1; i <= repetitionNum;i++){
-			for(double value : values) {
-				expected.put(new CellIndex(row, colPointer), value);
-				colPointer++;
-			}
-		}
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -88,7 +75,7 @@ public class Conv1DTest extends AutomatedTestBase
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 0;
 		HashMap<CellIndex, Double> expected = new HashMap<>();
 		fillExpectedRepeated(expected, 3, new double[]{136.,264.,392.,520.},1);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -96,7 +83,7 @@ public class Conv1DTest extends AutomatedTestBase
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 2; int pad = 1;
 		HashMap<CellIndex, Double> expected = new HashMap<>();
 		fillExpectedRepeated(expected, 3, new double[]{78.,200.,328.,456.,414.},1);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -106,7 +93,7 @@ public class Conv1DTest extends AutomatedTestBase
 		fillExpectedRepeated(expected,3,new double[]{1.,5.,9.,13.,17.,10.},1);
 		fillExpectedRepeated(expected,3,new double[]{11.,25.,29.,33.,37.,20.},2);
 		fillExpectedRepeated(expected,3,new double[]{21.,45.,49.,53.,57.,30.},3);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -116,7 +103,7 @@ public class Conv1DTest extends AutomatedTestBase
 		fillExpectedRepeated(expected,3,new double[]{3.,10.,21.,33.,45.,57.,69.,81.,58.,31.},1);
 		fillExpectedRepeated(expected,3,new double[]{35.,74.,117.,129.,141.,153.,165.,177.,122.,63.},2);
 		fillExpectedRepeated(expected,3,new double[]{67.,138.,213.,225.,237.,249.,261.,273.,186.,95.},3);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -124,7 +111,7 @@ public class Conv1DTest extends AutomatedTestBase
 		int numImg = 1; int imgSize = 10; int numChannels = 4; int numFilters = 3; int filterSize = 4; int stride = 1; int pad = 0;
 		HashMap<CellIndex, Double> expected = new HashMap<>();
 		fillExpectedRepeated(expected,3,new double[]{136.,200.,264.,328.,392.,456.,520.},1);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false,expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -137,7 +124,7 @@ public class Conv1DTest extends AutomatedTestBase
 		fillExpectedRepeated(expected,3,firstExpected,1);
 		fillExpectedRepeated(expected,3,secondExpected,2);
 		fillExpectedRepeated(expected,3,thirdExpected,3);
-		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
 	}
 
 	@Test
@@ -150,11 +137,67 @@ public class Conv1DTest extends AutomatedTestBase
 		fillExpected(expected, 3, 12, 129.0, 147.0);
 		fillExpected(expected, 4, 12, 183.0, 201.0);
 		fillExpected(expected, 5, 12, 237.0, 255.0);
-		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, false, false, expected);
+		runConv1DTest(ExecType.SPARK, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_1);
+	}
+
+	@Test
+	public void testConv1DBackwardDataDense1() {
+		int numImg = 5; int imgSize = 3; int numChannels = 3; int numFilters = 3; int filterSize = 1; int stride = 1; int pad = 0;
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeated(expected,3,new double[]{6.,15.,24.},1);
+		fillExpectedRepeated(expected,3,new double[]{33.,42.,51.},2);
+		fillExpectedRepeated(expected,3,new double[]{60.,69.,78.},3);
+		fillExpectedRepeated(expected,3,new double[]{87.,96.,105.},4);
+		fillExpectedRepeated(expected,3,new double[]{114.,123.,132.},5);
+
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_2);
+	}
+
+	@Test
+	public void testConv1DBackwardFilterDense1() {
+		int numImg = 2; int imgSize = 3; int numChannels = 2; int numFilters = 3; int filterSize = 1; int stride = 1; int pad = 0;
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeatedCol(expected,3,new double[]{608.,686.});
+
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_3);
+	}
+
+	@Test
+	public void testConv1DBackwardFilterDense2() {
+		int numImg = 2; int imgSize = 3; int numChannels = 2; int numFilters = 3; int filterSize = 2; int stride = 1; int pad = 0;
+		HashMap<CellIndex, Double> expected = new HashMap<>();
+		fillExpectedRepeatedCol(expected,3,new double[]{680.,888.,784.,992.});
+
+		runConv1DTest(ExecType.CP, imgSize, numImg, numChannels, numFilters, filterSize, stride, pad, expected, TEST_NAME_3);
+	}
+
+	private void fillExpected(HashMap<CellIndex, Double> expected, int rowNum, int rowLength, double value1, double value2){
+		for ( int m = 1; m <= rowLength; m+=2){
+			expected.put(new CellIndex(rowNum,m), value1);
+			expected.put(new CellIndex(rowNum,m+1), value2);
+		}
+	}
+
+	private void fillExpectedRepeated(HashMap<CellIndex, Double> expected,int repetitionNum, double[] values, int row){
+		int colPointer = 1;
+		for (int i = 1; i <= repetitionNum;i++){
+			for(double value : values) {
+				expected.put(new CellIndex(row, colPointer), value);
+				colPointer++;
+			}
+		}
+	}
+
+	private void fillExpectedRepeatedCol(HashMap<CellIndex, Double> expected,int repetitionRows, double[] values){
+		for ( int i = 1; i <= repetitionRows; i++){
+			for ( int j = 1; j <= values.length; j++ ){
+				expected.put(new CellIndex(i,j), values[j-1]);
+			}
+		}
 	}
 
 	public void runConv1DTest( ExecType et, int imgSize, int numImg, int numChannels, int numFilters,
-		int filterSize, int stride, int pad, boolean sparse1, boolean sparse2, HashMap<CellIndex, Double> expected)
+		int filterSize, int stride, int pad, HashMap<CellIndex, Double> expected, String TEST_NAME)
 	{
 		ExecMode platformOld = rtplatform;
 		switch( et ){
@@ -167,8 +210,6 @@ public class Conv1DTest extends AutomatedTestBase
 
 		try
 		{
-			String sparseVal1 = String.valueOf(sparse1).toUpperCase();
-			String sparseVal2 = String.valueOf(sparse2).toUpperCase();
 			getAndLoadTestConfiguration(TEST_NAME);
 
 			String SCRIPT_HOME = SCRIPT_DIR + TEST_DIR + TEST_NAME;
@@ -183,9 +224,7 @@ public class Conv1DTest extends AutomatedTestBase
 				"filterSize=" + filterSize,
 				"stride=" + stride,
 				"pad=" + pad,
-				"output=" + output("output"),
-				"sparseVal1=" + sparseVal1,
-				"sparseVal2=" + sparseVal2
+				"output=" + output("output")
 			};
 
 			// Run DML

--- a/src/test/scripts/functions/tensor/Conv1DBackwardDataTest.dml
+++ b/src/test/scripts/functions/tensor/Conv1DBackwardDataTest.dml
@@ -33,12 +33,12 @@ colBuild = rowBuild
 if ( $numImg > 1 ){
   for ( j in 2:$numImg ){
     rowBuild = seq((j-1)*$imgSize*$numChannels+1,j*$imgSize*$numChannels,$numChannels)
-  if ( $numChannels > 1 ){
-    for ( i in 2:$numChannels ){
-      rowBuild = rbind(rowBuild, seq((j-1)*$imgSize*$numChannels+i,j*$numChannels*$imgSize,$numChannels))
+    if ( $numChannels > 1 ){
+      for ( i in 2:$numChannels ){
+        rowBuild = rbind(rowBuild, seq((j-1)*$imgSize*$numChannels+i,j*$numChannels*$imgSize,$numChannels))
+      }
     }
-  }
-  colBuild = cbind(colBuild, rowBuild)
+    colBuild = cbind(colBuild, rowBuild)
   }
 }
 
@@ -46,8 +46,7 @@ if ( $numImg > 1 ){
 x = t(colBuild)
 w=matrix(1,rows=$numFilters, cols=$numChannels*$filterSize)
 
-# Call function
-output = conv1d::forward(x, w, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize)
+output = conv1d::backward_data(w, x, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize)
 
 #Write output
 write(output, $output, format="text")

--- a/src/test/scripts/functions/tensor/Conv1DBackwardFilterTest.dml
+++ b/src/test/scripts/functions/tensor/Conv1DBackwardFilterTest.dml
@@ -33,21 +33,20 @@ colBuild = rowBuild
 if ( $numImg > 1 ){
   for ( j in 2:$numImg ){
     rowBuild = seq((j-1)*$imgSize*$numChannels+1,j*$imgSize*$numChannels,$numChannels)
-  if ( $numChannels > 1 ){
-    for ( i in 2:$numChannels ){
-      rowBuild = rbind(rowBuild, seq((j-1)*$imgSize*$numChannels+i,j*$numChannels*$imgSize,$numChannels))
+    if ( $numChannels > 1 ){
+      for ( i in 2:$numChannels ){
+        rowBuild = rbind(rowBuild, seq((j-1)*$imgSize*$numChannels+i,j*$numChannels*$imgSize,$numChannels))
+      }
     }
-  }
-  colBuild = cbind(colBuild, rowBuild)
+    colBuild = cbind(colBuild, rowBuild)
   }
 }
 
 # Set input variables
 x = t(colBuild)
 w=matrix(1,rows=$numFilters, cols=$numChannels*$filterSize)
+dout = conv1d::forward(x, w, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize)
 
-# Call function
-output = conv1d::forward(x, w, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize)
-
+output = conv1d::backward_filter(x, dout, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize)
 #Write output
 write(output, $output, format="text")

--- a/src/test/scripts/functions/tensor/Conv1DTest.dml
+++ b/src/test/scripts/functions/tensor/Conv1DTest.dml
@@ -1,0 +1,65 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+source("scripts/nn/layers/conv1d.dml") as conv1d
+
+#print("Input: " + $imgSize + ", " + $numImg + ", " + $numChannels + ", " + $numFilters + ", " + $filterSize + ", " + $stride + ", " + $pad);
+# Assumption: NCW image format
+x=matrix(seq(1, $numImg*$numChannels*$imgSize), rows=$numImg, cols=$numChannels*$imgSize)
+w=matrix(seq(1, $numFilters*$numChannels*$filterSize), rows=$numFilters, cols=$numChannels*$filterSize)
+b=matrix(seq(1, $numFilters), rows=$numFilters, cols=1)
+
+if($sparseVal1) {
+zero_mask = (x - mean(x)*1.5) > 0
+x = x * zero_mask
+}
+else {
+x = x - mean(x)
+}
+if($sparseVal2) {
+zero_mask = (w - mean(w)*1.5) > 0
+w = w * zero_mask
+}
+else {
+w = w - mean(w)
+}
+#print("x")
+#print("rows: " + nrow(x))
+#print("cols: " + ncol(x))
+#print(toString(x))
+
+#print("w")
+#print("rows: " + nrow(w))
+#print("cols: " + ncol(w))
+#print(toString(w))
+
+#print("b")
+#print("rows: " + nrow(b))
+#print("cols: " + ncol(b))
+#print(toString(b))
+output = conv1d::forward(x, w, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize, b)
+#output = bias_add(output, b)
+print("output")
+print("rows: " + nrow(output))
+print("cols: " + ncol(output))
+print(toString(output))
+
+write(output, $output, format="text")

--- a/src/test/scripts/functions/tensor/Conv1DTest.dml
+++ b/src/test/scripts/functions/tensor/Conv1DTest.dml
@@ -21,45 +21,34 @@
 
 source("scripts/nn/layers/conv1d.dml") as conv1d
 
-#print("Input: " + $imgSize + ", " + $numImg + ", " + $numChannels + ", " + $numFilters + ", " + $filterSize + ", " + $stride + ", " + $pad);
-# Assumption: NCW image format
-x=matrix(seq(1, $numImg*$numChannels*$imgSize), rows=$numImg, cols=$numChannels*$imgSize)
-w=matrix(seq(1, $numFilters*$numChannels*$filterSize), rows=$numFilters, cols=$numChannels*$filterSize)
+# Build input
+rowBuild = seq(1,$numChannels*$imgSize,$numChannels)
+if ( $numChannels > 1 & $imgSize > 1 ){
+  for ( i in 2:$numChannels ){
+    rowBuild = rbind(rowBuild, seq(i,$numChannels*$imgSize,$numChannels))
+  }
+}
+
+colBuild = rowBuild
+if ( $numImg > 1 ){
+  for ( j in 2:$numImg ){
+    rowBuild = seq((j-1)*$imgSize*$numChannels+1,j*$imgSize*$numChannels,$numChannels)
+  if ( $numChannels > 1 ){
+    for ( i in 2:$numChannels ){
+      rowBuild = rbind(rowBuild, seq((j-1)*$imgSize*$numChannels+i,j*$numChannels*$imgSize,$numChannels))
+    }
+  }
+  colBuild = cbind(colBuild, rowBuild)
+  }
+}
+
+# Set input variables
+x = t(colBuild)
+w=matrix(1,rows=$numFilters, cols=$numChannels*$filterSize)
 b=matrix(seq(1, $numFilters), rows=$numFilters, cols=1)
 
-if($sparseVal1) {
-zero_mask = (x - mean(x)*1.5) > 0
-x = x * zero_mask
-}
-else {
-x = x - mean(x)
-}
-if($sparseVal2) {
-zero_mask = (w - mean(w)*1.5) > 0
-w = w * zero_mask
-}
-else {
-w = w - mean(w)
-}
-#print("x")
-#print("rows: " + nrow(x))
-#print("cols: " + ncol(x))
-#print(toString(x))
-
-#print("w")
-#print("rows: " + nrow(w))
-#print("cols: " + ncol(w))
-#print(toString(w))
-
-#print("b")
-#print("rows: " + nrow(b))
-#print("cols: " + ncol(b))
-#print(toString(b))
+# Call function
 output = conv1d::forward(x, w, $pad, $stride, $numImg, $numChannels, $imgSize, $numFilters, $filterSize, b)
-#output = bias_add(output, b)
-print("output")
-print("rows: " + nrow(output))
-print("cols: " + ncol(output))
-print(toString(output))
 
+#Write output
 write(output, $output, format="text")


### PR DESCRIPTION
Initial implementation of Conv1D using the existing Conv2D implementation. 

Conv1D is implemented in DML with three functions: 
- forward, represents the forward pass (equivalent to the conv2d builtin)
- backward_data, represents the backward pass regarding the input data (equivalent to conv2d_backward_data)
- backward_filter, represents the backward pass regarding the filter (equivalent to conv2d_backward_filter)

The tests are loosely based on the Conv2D tests, but the Conv1D tests do not use R for comparison. 