### PR TITLE
[SYSTEMDS-2799] Update UDF reuse, add Fed pipeline reuse test

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -350,9 +350,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		// reuse or execute user-defined function
 		try {
 			// reuse UDF outputs if available in lineage cache
-			if (LineageCache.reuse(udf, ec))
-				return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS_EMPTY);
-				//FIXME: few UDFs (e.g. Rdiag, DiagMatrix) return additional data with response
+			FederatedResponse reuse = LineageCache.reuse(udf, ec);
+			if (reuse.isSuccessful())
+				return reuse;
 
 			// else execute the UDF
 			long t0 = !ReuseCacheType.isNone() ? System.nanoTime() : 0;

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
@@ -239,7 +239,7 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 		return new RdiagResult(diagFedMap, dcs);
 	}
 
-	private static class Rdiag extends FederatedUDF {
+	public static class Rdiag extends FederatedUDF {
 
 		private static final long serialVersionUID = -3466926635958851402L;
 		private final long _outputID;
@@ -293,7 +293,7 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 		}
 	}
 
-	private static class DiagMatrix extends FederatedUDF {
+	public static class DiagMatrix extends FederatedUDF {
 
 		private static final long serialVersionUID = -3466926635958851402L;
 		private final long _outputID;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -200,12 +200,22 @@ public class LineageCacheConfig
 	}
 	
 	private static boolean isVectorAppend(Instruction inst, ExecutionContext ec) {
-		ComputationCPInstruction cpinst = (ComputationCPInstruction) inst;
-		if( !cpinst.input1.isMatrix() || !cpinst.input2.isMatrix() )
-			return false;
-		long c1 = ec.getMatrixObject(cpinst.input1).getNumColumns();
-		long c2 = ec.getMatrixObject(cpinst.input2).getNumColumns();
-		return(c1 == 1 || c2 == 1);
+		if (inst instanceof ComputationFEDInstruction) {
+			ComputationFEDInstruction fedinst = (ComputationFEDInstruction) inst;
+			if (!fedinst.input1.isMatrix() || !fedinst.input2.isMatrix())
+				return false;
+			long c1 = ec.getMatrixObject(fedinst.input1).getNumColumns();
+			long c2 = ec.getMatrixObject(fedinst.input2).getNumColumns();
+			return(c1 == 1 || c2 == 1);
+		}
+		else { //CPInstruction
+			ComputationCPInstruction cpinst = (ComputationCPInstruction) inst;
+			if( !cpinst.input1.isMatrix() || !cpinst.input2.isMatrix() )
+				return false;
+			long c1 = ec.getMatrixObject(cpinst.input1).getNumColumns();
+			long c2 = ec.getMatrixObject(cpinst.input2).getNumColumns();
+			return(c1 == 1 || c2 == 1);
+		}
 	}
 	
 	public static boolean isOutputFederated(Instruction inst, Data data) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
@@ -47,7 +47,9 @@ import org.apache.sysds.lops.UnaryCP;
 import org.apache.sysds.lops.compile.Dag;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionParser;
@@ -56,6 +58,8 @@ import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DataGenCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
+import org.apache.sysds.runtime.instructions.fed.ReorgFEDInstruction.DiagMatrix;
+import org.apache.sysds.runtime.instructions.fed.ReorgFEDInstruction.Rdiag;
 import org.apache.sysds.runtime.util.HDFSTool;
 
 import java.io.IOException;
@@ -157,6 +161,14 @@ public class LineageItemUtils {
 			for (Pair<String, LineageItem> item : items)
 				ec.getLineage().set(item.getKey(), item.getValue());
 		}
+	}
+	
+	public static FederatedResponse setUDFResponse(FederatedUDF udf, MatrixObject mo) {
+		if (udf instanceof DiagMatrix || udf instanceof Rdiag)
+			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, 
+					new int[]{(int) mo.getNumRows(), (int) mo.getNumColumns()});
+		
+		return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS_EMPTY);
 	}
 	
 	public static void constructLineageFromHops(Hop[] roots, String claName, Hop[] inputs, HashMap<Long, Hop> spoofmap) {

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageFedReuseAlg.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageFedReuseAlg.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.lineage;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.matrix.data.LibMatrixMult;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.transform.encode.EncoderRecode;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.utils.Statistics;
+import org.junit.Test;
+
+@net.jcip.annotations.NotThreadSafe
+public class LineageFedReuseAlg extends AutomatedTestBase {
+
+	private final static String TEST_DIR = "functions/lineage/";
+	private final static String TEST_NAME1 = "FedLmPipelineReuse";
+	private final static String TEST_CLASS_DIR = TEST_DIR + LineageFedReuseAlg.class.getSimpleName() + "/";
+
+	public int rows = 10000;
+	public int cols = 100;
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"Z"}));
+	}
+
+	@Test
+	public void federatedLmPipelineContinguous() {
+		federatedLmPipeline(Types.ExecMode.SINGLE_NODE, true, TEST_NAME1);
+	}
+
+	@Test
+	public void federatedLmPipelineSampled() {
+		federatedLmPipeline(Types.ExecMode.SINGLE_NODE, false, TEST_NAME1);
+	}
+
+	public void federatedLmPipeline(ExecMode execMode, boolean contSplits, String TEST_NAME) {
+		ExecMode oldExec = setExecMode(execMode);
+		boolean oldSort = EncoderRecode.SORT_RECODE_MAP;
+		EncoderRecode.SORT_RECODE_MAP = true;
+
+		getAndLoadTestConfiguration(TEST_NAME);
+		String HOME = SCRIPT_DIR + TEST_DIR;
+
+		try {
+			// generated lm data
+			MatrixBlock X = MatrixBlock.randOperations(rows, cols, 1.0, 0, 1, "uniform", 7);
+			MatrixBlock w = MatrixBlock.randOperations(cols, 1, 1.0, 0, 1, "uniform", 3);
+			MatrixBlock y = new MatrixBlock(rows, 1, false).allocateBlock();
+			LibMatrixMult.matrixMult(X, w, y);
+			MatrixBlock c = MatrixBlock.randOperations(rows, 1, 1.0, 1, 50, "uniform", 23);
+			MatrixBlock rc = c.unaryOperations(InstructionUtils.parseUnaryOperator("round"), new MatrixBlock());
+			X = rc.append(X, new MatrixBlock(), true);
+
+			// We have two matrices handled by a single federated worker
+			int quarterRows = rows / 2;
+			int[] k = new int[] {quarterRows - 1, quarterRows, rows - 1, 0, 0, 0, 0};
+			writeInputMatrixWithMTD("X1", X.slice(0, k[0]), false);
+			writeInputMatrixWithMTD("X2", X.slice(k[1], k[2]), false);
+			writeInputMatrixWithMTD("X3", X.slice(k[3], k[4]), false);
+			writeInputMatrixWithMTD("X4", X.slice(k[5], k[6]), false);
+			writeInputMatrixWithMTD("Y", y, false);
+
+			int port1 = getRandomAvailablePort();
+			int port2 = getRandomAvailablePort();
+			int port3 = getRandomAvailablePort();
+			int port4 = getRandomAvailablePort();
+			String[] otherargs = new String[] {"-lineage", "reuse_full"};
+			Thread t1 = startLocalFedWorkerThread(port1, otherargs, FED_WORKER_WAIT_S);
+			Thread t2 = startLocalFedWorkerThread(port2, otherargs);
+
+			TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
+			loadTestConfiguration(config);
+
+			// Run with federated matrix and without reuse
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-stats", "20", 
+				"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
+				"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + (cols + 1),
+				"in_Y=" + input("Y"), "cont=" + String.valueOf(contSplits).toUpperCase(), "out=" + expected("Z")};
+			runTest(true, false, null, -1);
+			long tsmmCount = Statistics.getCPHeavyHitterCount("tsmm");
+			long fed_tsmmCount = Statistics.getCPHeavyHitterCount("fed_tsmm");
+			long mmCount = Statistics.getCPHeavyHitterCount("ba+*");
+			long fed_mmCount = Statistics.getCPHeavyHitterCount("fed_ba+*");
+
+			// Run with federated matrix and with reuse
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-stats", "20", "-lineage", "reuse_full", 
+				"-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
+				"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + (cols + 1),
+				"in_Y=" + input("Y"), "cont=" + String.valueOf(contSplits).toUpperCase(), "out=" + output("Z")};
+			Lineage.resetInternalState();
+			runTest(true, false, null, -1);
+			long tsmmCount_reuse = Statistics.getCPHeavyHitterCount("tsmm");
+			long fed_tsmmCount_reuse = Statistics.getCPHeavyHitterCount("fed_tsmm");
+			long mmCount_reuse = Statistics.getCPHeavyHitterCount("ba+*");
+			long fed_mmCount_reuse = Statistics.getCPHeavyHitterCount("fed_ba+*");
+
+			// compare results 
+			compareResults(1e-2);
+			// compare potentially reused instruction counts
+			assertTrue(tsmmCount > tsmmCount_reuse);
+			assertTrue(fed_tsmmCount > fed_tsmmCount_reuse);
+			assertTrue(mmCount > mmCount_reuse);
+			assertTrue(fed_mmCount > fed_mmCount_reuse);
+
+			TestUtils.shutdownThreads(t1, t2);
+		}
+		finally {
+			resetExecMode(oldExec);
+			EncoderRecode.SORT_RECODE_MAP = oldSort;
+		}
+	}
+}

--- a/src/test/scripts/functions/lineage/FedLmPipelineReuse.dml
+++ b/src/test/scripts/functions/lineage/FedLmPipelineReuse.dml
@@ -1,0 +1,57 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+Fin = federated(addresses=list($in_X1, $in_X2),
+    ranges=list(list(0, 0), list($rows / 2, $cols), list($rows / 2, 0), list($rows, $cols)))
+y = read($in_Y)
+
+# one hot encoding categorical, other passthrough
+Fall = as.frame(Fin)
+jspec = "{ ids:true, dummycode:[1] }"
+[X,M] = transformencode(target=Fall, spec=jspec)
+print("ncol(X) = "+ncol(X))
+
+# clipping out of value ranges
+colSD = colSds(X)
+colMean = (colMeans(X))
+upperBound = colMean + 1.5 * colSD
+lowerBound = colMean - 1.5 * colSD
+outFilter = (X < lowerBound) | (X > upperBound)
+X = X - outFilter*X + outFilter*colMeans(X);
+
+# normalization
+X = scale(X=X, center=TRUE, scale=TRUE);
+
+# split training and testing
+[Xtrain , Xtest, ytrain, ytest] = split(X=X, Y=y, cont=$cont, seed=7)
+
+# train regression model with different hyperparameters
+for (i in 1:10) {
+  reg = 1e-3 + (0 * 0.001);
+  B = lm(X=Xtrain, y=ytrain, icpt=1, reg=reg, tol=1e-9, verbose=TRUE);
+  # TODO: find the best beta
+}
+
+# model evaluation on test split
+yhat = lmPredict(X=Xtest, B=B, icpt=1, ytest=ytest, verbose=TRUE);
+
+# write trained model and meta data
+write(B, $out)


### PR DESCRIPTION
This patch handles reusing those UDFs that return metadata
with federated SUCCESS response (e.g. Rdiag, DiagMatrix).
Furthermore, this adds a test to reuse a full federated
pipeline having tasks such as preprocessing and
hyperparameter tuning (LM).