### PR TITLE
[SYSTEMDS-XXXX] Federated Binary Element-wise Operations

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
@@ -23,16 +23,12 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
-import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
-import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap.FType;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
-import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
-import java.util.concurrent.Future;
 
 public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 {
@@ -56,7 +52,6 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 
 		//execute federated operation on mo1 or mo2
 		FederatedRequest fr2 = null;
-		// Future<FederatedResponse>[] response = null;
 		if( mo2.isFederated() ) {
 			if(mo1.isFederated() && mo1.getFedMapping().isAligned(mo2.getFedMapping(), false)) {
 				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
@@ -68,18 +63,11 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 					+ "federated right input are only supported for special cases yet.");
 			}
 		}
-		else {
-			boolean isRowPartitioned = mo1.isFederated(FType.ROW);
-
-			if(!isRowPartitioned && !mo1.isFederated(FType.COL)) {
-				throw new DMLRuntimeException("Matrix-matrix binary operations only "
-					+ "supported with a row partitioned or column partitioned federated "
-					+ " input.");
-			}
-
-			if(mo1.isFederated(FType.ROW))
-			{
-				if(mo2.getNumRows() == 1 && mo2.getNumColumns() > 1) { //MV row vector
+		else { // matrix-matrix binary operations -> lhs fed input -> fed output
+			if(mo1.isFederated(FType.FULL))
+			{ // full federated (row and col)
+				if(mo1.getFedMapping().getSize() == 1)
+				{ // only one partition (MM on a single fed worker)
 					FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
 					fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
 					new long[]{mo1.getFedMapping().getID(), fr1.getID()});
@@ -87,114 +75,40 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 					//execute federated instruction and cleanup intermediates
 					mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
 				}
-				else { // MM and MV col vector
-					FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
-					fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-						new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-					FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-					//execute federated instruction and cleanup intermediates
-					mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+				else
+				{
+					throw new DMLRuntimeException("Matrix-matrix binary operations with a full partitioned federated input with multiple partitions are not supported yet.");
 				}
 			}
-			else if(mo1.isFederated(FType.COL))
-			{
-				// FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
-				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-				// 	new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-				// // get partial results from federated workers
-				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
-				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
-				// //execute federated instruction and cleanup intermediates
-				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
-
-				// FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
-				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-				// 	new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-				// // get partial results from federated workers
-				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
-				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-				// //execute federated instruction and cleanup intermediates
-				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
-
-				// FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, true);
-				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-				// 	new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-				// // get partial results from federated workers
-				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
-				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-				// //execute federated instruction and cleanup intermediates
-				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
-
-
-				// // get partial results from federated workers
-				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
-
-				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
+			else if((mo1.isFederated(FType.ROW) && mo2.getNumRows() == 1 && mo2.getNumColumns() > 1)
+				|| (mo1.isFederated(FType.COL) && mo2.getNumRows() > 1 && mo2.getNumColumns() == 1))
+			{ // MV row partitioned row vector, MV col partitioned col vector
+				FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
+				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+				new long[]{mo1.getFedMapping().getID(), fr1.getID()});
+				FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
+				//execute federated instruction and cleanup intermediates
+				mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
 			}
-
-			// //matrix-matrix binary operations -> lhs fed input -> fed output
-			// if(mo2.getNumRows() > 1 && mo2.getNumColumns() == 1 && mo1.isFederated(FType.ROW) ) { //MV col vector
-			// 	FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
-			// 	fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-			// 		new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-			// 	FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-			// 	//execute federated instruction and cleanup intermediates
-			// 	mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-			// }
-			// else if(mo2.getNumRows() == 1 && mo2.getNumColumns() > 1) { //MV row vector
-			// 	assert false: "BinaryMatrixMatrixFEDInstruction.java";
-			// 	FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
-			// 	fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-			// 		new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-			// 	FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
-			// 	//execute federated instruction and cleanup intermediates
-			// 	mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-			// }
-			// else { //MM
-			// 	if(mo1.isFederated(FType.ROW)) {
-			// 		assert false: "BinaryMatrixMatrixFEDInstruction.java:101 - size: " + mo1.getFedMapping().getSize();
-			// 		FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
-			// 		fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-			// 			new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-			// 		FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-			// 		//execute federated instruction and cleanup intermediates
-			// 		mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-			// 	}
-			// 	else {
-			// 		FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
-			// 		fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-			// 			new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-			// 		FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
-			// 		//execute federated instruction and cleanup intermediates
-			// 		mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-			// 	}
-			// }
+			else if(mo1.isFederated(FType.ROW) ^ mo1.isFederated(FType.COL))
+			{ // row partitioned MM or col partitioned MM
+				FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
+				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+					new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
+				FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
+				//execute federated instruction and cleanup intermediates
+				mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			}
+			else
+			{
+				throw new DMLRuntimeException("Matrix-matrix binary operations are only supported with a row partitioned or column partitioned federated input yet.");
+			}
 		}
 
-		if(mo1.isFederated(FType.ROW))
-		{
-			// derive new fed mapping for output
-			MatrixObject out = ec.getMatrixObject(output);
+		// derive new fed mapping for output
+		MatrixObject out = ec.getMatrixObject(output);
 
-			out.getDataCharacteristics().set(mo1.getDataCharacteristics());
-			out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
-		}
-		else if(mo1.isFederated(FType.COL))
-		{
-			// derive new fed mapping for output
-			MatrixObject out = ec.getMatrixObject(output);
-
-			out.getDataCharacteristics().set(mo1.getDataCharacteristics());
-			out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
-
-
-			// MatrixBlock[] res_mb = null;
-			// try {
-			// 	 res_mb = FederationUtils.getResults(response);
-			// } catch(Exception e) {
-			// 	assert false: "BinaryMatrixMatrixFEDInstruction.java:242 - failure in getResults\n" + e.toString();
-			// }
-			// assert false: "BinaryMatrixMatrixFEDInstruction.java:240 - res_mb size: " + res_mb.length;
-		}
+		out.getDataCharacteristics().set(mo1.getDataCharacteristics());
+		out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
@@ -23,11 +23,16 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap.FType;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
+
+import java.util.concurrent.Future;
 
 public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 {
@@ -51,6 +56,7 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 
 		//execute federated operation on mo1 or mo2
 		FederatedRequest fr2 = null;
+		// Future<FederatedResponse>[] response = null;
 		if( mo2.isFederated() ) {
 			if(mo1.isFederated() && mo1.getFedMapping().isAligned(mo2.getFedMapping(), false)) {
 				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
@@ -63,25 +69,25 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 			}
 		}
 		else {
-			//matrix-matrix binary operations -> lhs fed input -> fed output
-			if(mo2.getNumRows() > 1 && mo2.getNumColumns() == 1 ) { //MV col vector
-				FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
-				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-					new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
-				FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
-				//execute federated instruction and cleanup intermediates
-				mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			boolean isRowPartitioned = mo1.isFederated(FType.ROW);
+
+			if(!isRowPartitioned && !mo1.isFederated(FType.COL)) {
+				throw new DMLRuntimeException("Matrix-matrix binary operations only "
+					+ "supported with a row partitioned or column partitioned federated "
+					+ " input.");
 			}
-			else if(mo2.getNumRows() == 1 && mo2.getNumColumns() > 1) { //MV row vector
-				FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
-				fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+
+			if(mo1.isFederated(FType.ROW))
+			{
+				if(mo2.getNumRows() == 1 && mo2.getNumColumns() > 1) { //MV row vector
+					FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
+					fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
 					new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-				FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
-				//execute federated instruction and cleanup intermediates
-				mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-			}
-			else { //MM
-				if(mo1.isFederated(FType.ROW)) {
+					FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
+					//execute federated instruction and cleanup intermediates
+					mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+				}
+				else { // MM and MV col vector
 					FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
 					fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
 						new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
@@ -89,20 +95,106 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 					//execute federated instruction and cleanup intermediates
 					mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
 				}
-				else {
-					FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
-					fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
-						new long[]{mo1.getFedMapping().getID(), fr1.getID()});
-					FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
-					//execute federated instruction and cleanup intermediates
-					mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-				}
 			}
+			else if(mo1.isFederated(FType.COL))
+			{
+				// FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
+				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+				// 	new long[]{mo1.getFedMapping().getID(), fr1.getID()});
+				// // get partial results from federated workers
+				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
+				// //execute federated instruction and cleanup intermediates
+				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
+
+				// FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
+				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+				// 	new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
+				// // get partial results from federated workers
+				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
+				// //execute federated instruction and cleanup intermediates
+				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
+
+				// FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, true);
+				// fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+				// 	new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
+				// // get partial results from federated workers
+				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+				// FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
+				// //execute federated instruction and cleanup intermediates
+				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2, frGet1, fr3);
+
+
+				// // get partial results from federated workers
+				// FederatedRequest frGet1 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+
+				// response = mo1.getFedMapping().execute(getTID(), true, fr1, fr2);
+			}
+
+			// //matrix-matrix binary operations -> lhs fed input -> fed output
+			// if(mo2.getNumRows() > 1 && mo2.getNumColumns() == 1 && mo1.isFederated(FType.ROW) ) { //MV col vector
+			// 	FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
+			// 	fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+			// 		new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
+			// 	FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
+			// 	//execute federated instruction and cleanup intermediates
+			// 	mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			// }
+			// else if(mo2.getNumRows() == 1 && mo2.getNumColumns() > 1) { //MV row vector
+			// 	assert false: "BinaryMatrixMatrixFEDInstruction.java";
+			// 	FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
+			// 	fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+			// 		new long[]{mo1.getFedMapping().getID(), fr1.getID()});
+			// 	FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
+			// 	//execute federated instruction and cleanup intermediates
+			// 	mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			// }
+			// else { //MM
+			// 	if(mo1.isFederated(FType.ROW)) {
+			// 		assert false: "BinaryMatrixMatrixFEDInstruction.java:101 - size: " + mo1.getFedMapping().getSize();
+			// 		FederatedRequest[] fr1 = mo1.getFedMapping().broadcastSliced(mo2, false);
+			// 		fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+			// 			new long[]{mo1.getFedMapping().getID(), fr1[0].getID()});
+			// 		FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1[0].getID());
+			// 		//execute federated instruction and cleanup intermediates
+			// 		mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			// 	}
+			// 	else {
+			// 		FederatedRequest fr1 = mo1.getFedMapping().broadcast(mo2);
+			// 		fr2 = FederationUtils.callInstruction(instString, output, new CPOperand[]{input1, input2},
+			// 			new long[]{mo1.getFedMapping().getID(), fr1.getID()});
+			// 		FederatedRequest fr3 = mo1.getFedMapping().cleanup(getTID(), fr1.getID());
+			// 		//execute federated instruction and cleanup intermediates
+			// 		mo1.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+			// 	}
+			// }
 		}
 
-		//derive new fed mapping for output
-		MatrixObject out = ec.getMatrixObject(output);
-		out.getDataCharacteristics().set(mo1.getDataCharacteristics());
-		out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
+		if(mo1.isFederated(FType.ROW))
+		{
+			// derive new fed mapping for output
+			MatrixObject out = ec.getMatrixObject(output);
+
+			out.getDataCharacteristics().set(mo1.getDataCharacteristics());
+			out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
+		}
+		else if(mo1.isFederated(FType.COL))
+		{
+			// derive new fed mapping for output
+			MatrixObject out = ec.getMatrixObject(output);
+
+			out.getDataCharacteristics().set(mo1.getDataCharacteristics());
+			out.setFedMapping(mo1.getFedMapping().copyWithNewID(fr2.getID()));
+
+
+			// MatrixBlock[] res_mb = null;
+			// try {
+			// 	 res_mb = FederationUtils.getResults(response);
+			// } catch(Exception e) {
+			// 	assert false: "BinaryMatrixMatrixFEDInstruction.java:242 - failure in getResults\n" + e.toString();
+			// }
+			// assert false: "BinaryMatrixMatrixFEDInstruction.java:240 - res_mb size: " + res_mb.length;
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
@@ -44,6 +44,7 @@ import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction.VariableOp
 import org.apache.sysds.runtime.instructions.spark.AggregateUnarySPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGAlignedSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.BinaryMatrixBVectorSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinaryMatrixMatrixSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinaryMatrixScalarSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinarySPInstruction;
@@ -261,6 +262,7 @@ public class FEDInstructionUtils {
 			}
 			else if (inst instanceof BinaryMatrixScalarSPInstruction
 				|| inst instanceof BinaryMatrixMatrixSPInstruction
+				|| inst instanceof BinaryMatrixBVectorSPInstruction
 				|| inst instanceof BinaryTensorTensorSPInstruction
 				|| inst instanceof BinaryTensorTensorBroadcastSPInstruction) {
 				BinarySPInstruction instruction = (BinarySPInstruction) inst;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTest.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTest.dml
@@ -19,8 +19,18 @@
 #
 #-------------------------------------------------------------
 
-X = federated(addresses=list($in_X1, $in_X2),
-  ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+if($in_sfw) { # single federated worker
+  X = federated(addresses=list($in_X1),
+    ranges=list(list(0, 0), list($rows, $cols)));
+}
+else if($in_rp) { # row partitioned
+  X = federated(addresses=list($in_X1, $in_X2),
+    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+}
+else { # column partitioned
+  X = federated(addresses=list($in_X1, $in_X2),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2)));
+}
 
 Y = read($in_Y);
 op_type = $in_op_type;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTest.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTest.dml
@@ -19,17 +19,26 @@
 #
 #-------------------------------------------------------------
 
-if($in_sfw) { # single federated worker
+fed_type = $in_fed_type;
+
+if(fed_type == 0) { # single federated worker
   X = federated(addresses=list($in_X1),
     ranges=list(list(0, 0), list($rows, $cols)));
 }
-else if($in_rp) { # row partitioned
-  X = federated(addresses=list($in_X1, $in_X2),
-    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+else if(fed_type == 1) { # row partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols),
+      list($rows * 2, 0), list($rows * 3, $cols), list($rows * 3, 0), list($rows * 4, $cols)));
 }
-else { # column partitioned
-  X = federated(addresses=list($in_X1, $in_X2),
-    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2)));
+else if(fed_type == 2) { # col partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2),
+      list(0, $cols * 2), list($rows, $cols * 3), list(0, $cols * 3), list($rows, $cols * 4)));
+}
+else if(fed_type == 3) { # full partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2),
+      list($rows, 0), list($rows * 2, $cols), list($rows, $cols), list($rows * 2, $cols * 2)));
 }
 
 Y = read($in_Y);

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTestReference.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTestReference.dml
@@ -19,14 +19,19 @@
 #
 #-------------------------------------------------------------
 
-if($in_sfw) { # single federated worker
+fed_type = $in_fed_type;
+
+if(fed_type == 0) { # single federated worker
   X = read($in_X1);
 }
-else if($in_rp) { # row partitioned
-  X = rbind(read($in_X1), read($in_X2));
+else if(fed_type == 1) { # row partitioned
+  X = rbind(read($in_X1), read($in_X2), read($in_X3), read($in_X4));
 }
-else { # column partitioned
-  X = cbind(read($in_X1), read($in_X2));
+else if(fed_type == 2) { # col partitioned
+  X = cbind(read($in_X1), read($in_X2), read($in_X3), read($in_X4));
+}
+else if(fed_type == 3) { # full partitioned
+  X = rbind(cbind(read($in_X1), read($in_X2)), cbind(read($in_X3), read($in_X4)));
 }
 
 Y = read($in_Y);

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTestReference.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixMatrixTestReference.dml
@@ -19,7 +19,15 @@
 #
 #-------------------------------------------------------------
 
-X = rbind(read($in_X1), read($in_X2));
+if($in_sfw) { # single federated worker
+  X = read($in_X1);
+}
+else if($in_rp) { # row partitioned
+  X = rbind(read($in_X1), read($in_X2));
+}
+else { # column partitioned
+  X = cbind(read($in_X1), read($in_X2));
+}
 
 Y = read($in_Y);
 op_type = $in_op_type;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTest.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTest.dml
@@ -19,17 +19,26 @@
 #
 #-------------------------------------------------------------
 
-if($in_sfw) { # single federated worker
+fed_type = $in_fed_type;
+
+if(fed_type == 0) { # single federated worker
   X = federated(addresses=list($in_X1),
     ranges=list(list(0, 0), list($rows, $cols)));
 }
-else if($in_rp) { # row partitioned
-  X = federated(addresses=list($in_X1, $in_X2),
-    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+else if(fed_type == 1) { # row partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols),
+      list($rows * 2, 0), list($rows * 3, $cols), list($rows * 3, 0), list($rows * 4, $cols)));
 }
-else { # column partitioned
-  X = federated(addresses=list($in_X1, $in_X2),
-    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2)));
+else if(fed_type == 2) { # col partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2),
+      list(0, $cols * 2), list($rows, $cols * 3), list(0, $cols * 3), list($rows, $cols * 4)));
+}
+else if(fed_type == 3) { # full partitioned
+  X = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2),
+      list($rows, 0), list($rows * 2, $cols), list($rows, $cols), list($rows * 2, $cols * 2)));
 }
 
 y = $in_Y;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTest.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTest.dml
@@ -19,8 +19,18 @@
 #
 #-------------------------------------------------------------
 
-X = federated(addresses=list($in_X1, $in_X2),
-  ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+if($in_sfw) { # single federated worker
+  X = federated(addresses=list($in_X1),
+    ranges=list(list(0, 0), list($rows, $cols)));
+}
+else if($in_rp) { # row partitioned
+  X = federated(addresses=list($in_X1, $in_X2),
+    ranges=list(list(0, 0), list($rows, $cols), list($rows, 0), list($rows * 2, $cols)));
+}
+else { # column partitioned
+  X = federated(addresses=list($in_X1, $in_X2),
+    ranges=list(list(0, 0), list($rows, $cols), list(0, $cols), list($rows, $cols * 2)));
+}
 
 y = $in_Y;
 op_type = $in_op_type;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTestReference.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTestReference.dml
@@ -19,14 +19,19 @@
 #
 #-------------------------------------------------------------
 
-if($in_sfw) { # single federated worker
+fed_type = $in_fed_type;
+
+if(fed_type == 0) { # single federated worker
   X = read($in_X1);
 }
-else if($in_rp) { # row partitioned
-  X = rbind(read($in_X1), read($in_X2));
+else if(fed_type == 1) { # row partitioned
+  X = rbind(read($in_X1), read($in_X2), read($in_X3), read($in_X4));
 }
-else { # column partitioned
-  X = cbind(read($in_X1), read($in_X2));
+else if(fed_type == 2) { # col partitioned
+  X = cbind(read($in_X1), read($in_X2), read($in_X3), read($in_X4));
+}
+else if(fed_type == 3) { # full partitioned
+  X = rbind(cbind(read($in_X1), read($in_X2)), cbind(read($in_X3), read($in_X4)));
 }
 
 y = $in_Y;

--- a/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTestReference.dml
+++ b/src/test/scripts/functions/federated/binary/FederatedLogicalMatrixScalarTestReference.dml
@@ -19,7 +19,15 @@
 #
 #-------------------------------------------------------------
 
-X = rbind(read($in_X1), read($in_X2));
+if($in_sfw) { # single federated worker
+  X = read($in_X1);
+}
+else if($in_rp) { # row partitioned
+  X = rbind(read($in_X1), read($in_X2));
+}
+else { # column partitioned
+  X = cbind(read($in_X1), read($in_X2));
+}
 
 y = $in_Y;
 op_type = $in_op_type;


### PR DESCRIPTION
Hi,
This PR includes a cleanup over the FederatedBinaryMatrixMatrixInstruction in order to support all the edge cases and also column partitioned federated input. I've extended the FederatedLogicalTest to test all the edge cases.

Note: The test class includes also tests for full partitioned federated input (outcommented because we do not support it yet) but I would keep the functionality of testing full partitioned input for eventual future improvements where we add support for it.

Thanks for review :)

PS: There are a lot of different data configurations inside the test, most of them outcommented because of the test performance, but all of them are facing different edge cases of federated binary operations.