### PR TITLE
[SYSTEMDS 2582,2583] Reuse of compressed lineage DAGs

### DIFF
--- a/src/main/java/org/apache/sysds/parser/ForStatementBlock.java
+++ b/src/main/java/org/apache/sysds/parser/ForStatementBlock.java
@@ -21,6 +21,7 @@ package org.apache.sysds.parser;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.Hop;
@@ -282,11 +283,12 @@ public class ForStatementBlock extends StatementBlock
 		// By calling getInputstoSB on all the child statement blocks,
 		// we remove the variables only read in the for predicate but
 		// never used in the body from the input list.
-		ArrayList<String> inputs = new ArrayList<>();
+		HashSet<String> inputs = new HashSet<>();
 		ForStatement fstmt = (ForStatement)_statements.get(0);
 		for (StatementBlock sb : fstmt.getBody())
 			inputs.addAll(sb.getInputstoSB());
-		return inputs;
+		// Hashset ensures no duplicates in the variable list
+		return new ArrayList<>(inputs);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
@@ -53,7 +53,7 @@ public class Lineage {
 	}
 	
 	public void trace(Instruction inst, ExecutionContext ec) {
-		if (_activeDedupBlock == null || !_activeDedupBlock.isAllPathsTaken())
+		if (_activeDedupBlock == null || !_activeDedupBlock.isAllPathsTaken() || !LineageCacheConfig.ReuseCacheType.isNone())
 			_map.trace(inst, ec);
 	}
 	
@@ -62,10 +62,10 @@ public class Lineage {
 			ArrayList<String> inputnames = pb.getStatementBlock().getInputstoSB();
 			LineageItem[] liinputs = LineageItemUtils.getLineageItemInputstoSB(inputnames, ec);
 			long lpath = _activeDedupBlock.getPath();
-			LineageDedupUtils.setDedupMap(_activeDedupBlock, lpath);
+			Map<String, Integer> dedupPatchHashList = LineageDedupUtils.setDedupMap(_activeDedupBlock, lpath);
 			LineageMap lm = _activeDedupBlock.getMap(lpath);
 			if (lm != null)
-				_map.processDedupItem(lm, lpath, liinputs, pb.getStatementBlock().getName());
+				_map.processDedupItem(lm, lpath, liinputs, pb.getStatementBlock().getName(), dedupPatchHashList);
 		}
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageDedupUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageDedupUtils.java
@@ -20,7 +20,10 @@
 package org.apache.sysds.runtime.lineage;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 
 import org.apache.sysds.runtime.controlprogram.BasicProgramBlock;
@@ -92,11 +95,11 @@ public class LineageDedupUtils {
 	}
 	
 	public static void setNewDedupPatch(LineageDedupBlock ldb, ProgramBlock fpb, ExecutionContext ec) {
-		// no need to trace anymore if all the paths are taken, 
+		// No need to trace anymore if all the paths are taken, 
 		// instead reuse the stored maps for this and future interations
-		// NOTE: this optimization saves redundant tracing, but that
-		//       kills reuse opportunities
-		if (ldb.isAllPathsTaken())
+		// But, tracing is required if reuse is enabled, even though the traced 
+		// lineage map is discarded after each iteration (if all paths are taken)
+		if (ldb.isAllPathsTaken() && LineageCacheConfig.ReuseCacheType.isNone())
 			return;
 
 		// copy the input LineageItems of the loop-body
@@ -121,14 +124,25 @@ public class LineageDedupUtils {
 		ec.setLineage(_mainLineage);
 	}
 	
-	public static void setDedupMap(LineageDedupBlock ldb, long takenPath) {
+	public static Map<String, Integer> setDedupMap(LineageDedupBlock ldb, long takenPath) {
 		// if this iteration took a new path, store the corresponding map
 		if (ldb.getMap(takenPath) == null) {
 			LineageMap patchMap = _tmpLineage.getLineageMap();
-			// Cut the DAGs at placeholders
-			cutAtPlaceholder(patchMap);
+			// Clean unused variables, and cut the DAGs at placeholders
+			cleanDedupMap(patchMap);
 			ldb.setMap(takenPath, patchMap);
 		}
+		// Copy and return the hash values of all the roots
+		if (!LineageCacheConfig.ReuseCacheType.isNone()) {
+			Map<String, Integer> dedupPatchHashList = new HashMap<>();
+			LineageMap patchMap = _tmpLineage.getLineageMap();
+			for (Map.Entry<String, LineageItem> litem : patchMap.getTraces().entrySet()) {
+				if (!litem.getValue().isPlaceholder())
+					dedupPatchHashList.put(litem.getKey(), litem.getValue().hashCode());
+			}
+			return dedupPatchHashList;
+		}
+		return null;
 	}
 	
 	private static void initLocalLineage(ExecutionContext ec) {
@@ -168,16 +182,23 @@ public class LineageDedupUtils {
 		return sb.toString();
 	}
 	
-	public static void cutAtPlaceholder(LineageMap lmap) {
+	private static void cleanDedupMap(LineageMap lmap) {
 		// Gather all the DAG roots and cut each at placeholder
+		Set<String> emptyRoots = new HashSet<>();
 		for (Map.Entry<String, LineageItem> litem : lmap.getTraces().entrySet()) {
 			LineageItem root = litem.getValue();
+			// Clean empty DAG roots such as iterator i
+			if (root.isPlaceholder()) {
+				emptyRoots.add(litem.getKey());
+				continue;
+			}
 			root.resetVisitStatusNR();
 			cutAtPlaceholder(root);
 		}
+		lmap.getTraces().keySet().removeAll(emptyRoots);
 	}
 	
-	public static void cutAtPlaceholder(LineageItem root) {
+	private static void cutAtPlaceholder(LineageItem root) {
 		Stack<LineageItem> q = new Stack<>();
 		q.push(root);
 		while (!q.empty()) {
@@ -185,7 +206,7 @@ public class LineageDedupUtils {
 			if (tmp.isVisited())
 				continue;
 
-			if (tmp.getOpcode().startsWith(LineageItemUtils.LPLACEHOLDER)) {
+			if (tmp.isPlaceholder()) {
 				// set inputs to null
 				tmp.resetInputs();
 				tmp.setVisited();

--- a/src/test/java/org/apache/sysds/test/functions/lineage/DedupReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/DedupReuseTest.java
@@ -19,104 +19,130 @@
 
 package org.apache.sysds.test.functions.lineage;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.hops.recompile.Recompiler;
+import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.lineage.LineageCacheStatistics;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.sysds.hops.OptimizerUtils;
-import org.apache.sysds.hops.recompile.Recompiler;
-import org.apache.sysds.runtime.lineage.Lineage;
-import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
-import org.apache.sysds.runtime.matrix.data.MatrixValue;
-import org.apache.sysds.test.TestConfiguration;
-import org.apache.sysds.test.TestUtils;
-import org.junit.Test;
-
-public class FullReuseTest extends LineageBase {
-	
+public class DedupReuseTest extends AutomatedTestBase
+{
 	protected static final String TEST_DIR = "functions/lineage/";
-	protected static final String TEST_NAME1 = "FullReuse1";
-	protected static final String TEST_NAME2 = "FullReuse2";
-	protected static final String TEST_NAME3 = "FullReuse3";
-	protected static final String TEST_NAME4 = "FullReuse4";
-	protected String TEST_CLASS_DIR = TEST_DIR + FullReuseTest.class.getSimpleName() + "/";
+	protected static final String TEST_NAME = "DedupReuse"; 
+	protected static final String TEST_NAME1 = "DedupReuse1"; 
+	protected static final String TEST_NAME2 = "DedupReuse2"; 
+	protected static final String TEST_NAME3 = "DedupReuse3"; 
+	protected static final String TEST_NAME4 = "DedupReuse4"; 
+	protected static final String TEST_NAME5 = "DedupReuse5"; 
+
+	protected String TEST_CLASS_DIR = TEST_DIR + DedupReuseTest.class.getSimpleName() + "/";
+	
+	protected static final int numRecords = 100;
+	protected static final int numFeatures = 50;
+	
 	
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1));
-		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2));
-		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3));
-		addTestConfiguration(TEST_NAME4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4));
+		for(int i=1; i<=5; i++)
+			addTestConfiguration(TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i));
 	}
 	
 	@Test
 	public void testLineageTrace1() {
+		// Reuse operations from outside to a dedup-loop
 		testLineageTrace(TEST_NAME1);
-	}
-	
-	@Test
-	public void testLineageTrace2() {
-		testLineageTrace(TEST_NAME2);
 	}
 
 	@Test
+	public void testLineageTrace5() {
+		// Reuse operations from outside to a dedup-loop
+		testLineageTrace(TEST_NAME5);
+	}
+
+	@Test
+	public void testLineageTrace2() {
+		// Reuse all operations from a dedup loop to another dedup loop
+		testLineageTrace(TEST_NAME2);
+	}
+	
+	@Test
 	public void testLineageTrace3() {
+		// Reuse all operations from a non-dedup-loop to a dedup loop
 		testLineageTrace(TEST_NAME3);
 	}
 
 	@Test
-	public void testLineageTrace4() {    //caching scalar
+	public void testLineageTrace4() {
+		// Reuse an operation for each iteration of a dedup loop
 		testLineageTrace(TEST_NAME4);
 	}
 	
 	public void testLineageTrace(String testname) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		Types.ExecMode old_rtplatform = AutomatedTestBase.rtplatform;
 		
 		try {
-			LOG.debug("------------ BEGIN " + testname + "------------");
+			System.out.println("------------ BEGIN " + testname + "------------");
 			
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
+			AutomatedTestBase.rtplatform = Types.ExecMode.SINGLE_NODE;
 			
 			getAndLoadTestConfiguration(testname);
 			fullDMLScriptName = getScript();
-			
-			// Without lineage-based reuse enabled
-			List<String> proArgs = new ArrayList<>();
+			List<String> proArgs;
+
+			//w/o lineage deduplication
+			proArgs = new ArrayList<>();
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
+			proArgs.add("reuse_full");
 			proArgs.add("-args");
-			proArgs.add(output("X"));
+			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
-			
+
 			Lineage.resetInternalState();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
-			HashMap<MatrixValue.CellIndex, Double> X_orig = readDMLMatrixFromOutputDir("X");
-			
-			// With lineage-based reuse enabled
-			proArgs.clear();
+			HashMap<CellIndex, Double> orig = readDMLMatrixFromOutputDir("R");
+			long hitCount_nd = LineageCacheStatistics.getInstHits();
+
+			//w/ lineage deduplication
+			proArgs = new ArrayList<>();
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
-			proArgs.add(ReuseCacheType.REUSE_FULL.name().toLowerCase());
-			//proArgs.add("dedup");
+			proArgs.add("reuse_full");
+			proArgs.add("dedup");
 			proArgs.add("-args");
-			proArgs.add(output("X"));
+			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
-			
+
 			Lineage.resetInternalState();
-			Lineage.setLinReuseFull();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
-			HashMap<MatrixValue.CellIndex, Double> X_reused = readDMLMatrixFromOutputDir("X");
-			Lineage.setLinReuseNone();
-			
-			TestUtils.compareMatrices(X_orig, X_reused, 1e-6, "Origin", "Reused");
+			HashMap<CellIndex, Double> dedup = readDMLMatrixFromOutputDir("R");
+			long hitCount_d = LineageCacheStatistics.getInstHits();
+
+			//match the results
+			TestUtils.compareMatrices(orig, dedup, 1e-6, "Original", "Dedup");
+			//compare cache hits
+			Assert.assertTrue(hitCount_nd >= hitCount_d); //FIXME
 		}
 		finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
-			Recompiler.reinitRecompiler();
+			AutomatedTestBase.rtplatform = old_rtplatform;
+			Recompiler.reinitRecompiler(); 
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageTraceDedupTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageTraceDedupTest.java
@@ -141,6 +141,7 @@ public class LineageTraceDedupTest extends LineageBase
 			proArgs = new ArrayList<>();
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
+			proArgs.add("reuse_full"); //test reuse + deduplication
 			proArgs.add("dedup");
 			proArgs.add("-args");
 			proArgs.add(output("R"));

--- a/src/test/scripts/functions/lineage/DedupReuse1.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse1.dml
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+k = 3
+
+X1 = X + 1;
+while(FALSE) {}
+X1 = X1 + 1;
+while(FALSE) {}
+X1 = X1 + 1;
+tmp = t(X1) %*% X1; #reusable (inside loop)
+
+for(i in 1:3){
+  X = X + 1;
+  R = t(X) %*% X;
+}
+R = R + tmp;
+
+write(R, $1, format="text");

--- a/src/test/scripts/functions/lineage/DedupReuse2.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse2.dml
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+# Reuse from one deduplicated loop to another deduplicated loop
+X1 = X;
+for(i in 1:3){
+  X1 = X1 + 1;
+  R1 = t(X1) %*% X1;
+}
+
+X2 = X;
+for(i in 1:3){
+  X2 = X2 + 1;
+  R2 = t(X2) %*% X2;
+}
+R = R1 + R2;
+
+write(R, $1, format="text");

--- a/src/test/scripts/functions/lineage/DedupReuse3.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse3.dml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+# Reuse from non-deduplicated loop to deduplicated loop
+X1 = X;
+for(i in 1:3){
+  X1 = X1 + 1;
+  while(FALSE){}    #stops deduplication for the 'for' loop
+  R1 = t(X1) %*% X1;
+}
+
+X2 = X;
+for(i in 1:3){
+  X2 = X2 + 1;
+  R2 = t(X2) %*% X2;
+}
+R = R1 + R2;
+
+write(R, $1, format="text");

--- a/src/test/scripts/functions/lineage/DedupReuse4.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse4.dml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rand(rows=1024, cols=1024, seed=42);
+
+X1 = X;
+for(i in 1:3){
+  X = X + 1;
+  R = t(X1) %*% X1;  #reuse
+}
+
+write(R, $1, format="text");

--- a/src/test/scripts/functions/lineage/DedupReuse5.dml
+++ b/src/test/scripts/functions/lineage/DedupReuse5.dml
@@ -1,0 +1,45 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+r = 100000
+c = 100
+
+X = rand(rows=r, cols=c, seed=42);
+y = rand(rows=r, cols=1, seed=43);
+
+j = 5 
+R = matrix(0, c, j+1);
+
+A = t(X) %*% X + diag(matrix(1, rows=ncol(X), cols=1));
+b = t(X) %*% y;
+beta = solve(A, b);
+R[,j+1] = beta;
+  
+# reuse from the outside of the loop
+for(i in 1:j) {
+  lambda = i;
+  A = t(X) %*% X + diag(matrix(lambda, rows=ncol(X), cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+  R[,i] = beta;
+}
+
+write(R, $1, format="text");


### PR DESCRIPTION
This patch extends hash and equal of lineage items to support
dedup nodes -- which also enables reuse with deduplication.
This patch brings a substantial amount of changes in deduplication
and lineage DAG comparison logic to support all the possible
cases. Even though all the basic tests are passing on this patch, we
need extensive experiments to confirm the robustness of this change.