### PR TITLE
Fixed MVIImpute mode_global crash if most values are missing

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
@@ -178,7 +178,7 @@ public class EncoderMVImpute extends Encoder
 							_hist.get(colID) : new HashMap<>();
 					for( int i=0; i<in.getNumRows(); i++ ) {
 						String key = String.valueOf(in.get(i, colID-1));
-						if( key != null && !key.isEmpty() ) {
+						if(!key.equals("null") && !key.isEmpty() ) {
 							Long val = hist.get(key);
 							hist.put(key, (val!=null) ? val+1 : 1);
 						}


### PR DESCRIPTION
MVIImpute mode_global failed if most values are missing since check was performed on null and not "null". Resulting in the string "null" being passed to Double.parseDouble in the apply step later.