### PR TITLE
[MINOR] null was not checked in EncoderMVImpute for Global mean

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
@@ -166,9 +166,13 @@ public class EncoderMVImpute extends Encoder
 				if( _mvMethodList[j] == MVMethod.GLOBAL_MEAN ) {
 					//compute global column mean (scale)
 					long off = _countList[j];
-					for( int i=0; i<in.getNumRows(); i++ )
+					for( int i=0; i<in.getNumRows(); i++ ){
+						Object key = in.get(i, colID-1);
+						if(key == null)
+							continue;
 						_meanFn.execute2(_meanList[j], UtilFunctions.objectToDouble(
-							in.getSchema()[colID-1], in.get(i, colID-1)), off+i+1);
+								in.getSchema()[colID-1], key), off+i+1);
+					}
 					_replacementList[j] = String.valueOf(_meanList[j]._sum);
 					_countList[j] += in.getNumRows();
 				}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
@@ -168,8 +168,10 @@ public class EncoderMVImpute extends Encoder
 					long off = _countList[j];
 					for( int i=0; i<in.getNumRows(); i++ ){
 						Object key = in.get(i, colID-1);
-						if(key == null)
+						if(key == null){
+							off--;
 							continue;
+						}
 						_meanFn.execute2(_meanList[j], UtilFunctions.objectToDouble(
 								in.getSchema()[colID-1], key), off+i+1);
 					}

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -3056,4 +3056,13 @@ public class TestUtils
 
 		return y;
 	}
+
+	public static boolean containsNan(double[][] data, int col) {
+		for (double[] datum : data)
+			if (Double.isNaN(datum[col]))
+				return true;
+		return false;
+	}
+
+
 }

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.test.functions.transform;
 
-import org.apache.sysds.runtime.util.UtilFunctions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysds.api.DMLScript;

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.functions.transform;
 
+import org.apache.sysds.runtime.util.UtilFunctions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
@@ -431,6 +432,10 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase
 							1:0, R1[i][10+j], 1e-8);
 					}
 				}
+			} else if (type == TransformType.IMPUTE){
+				// Column 8 had GLOBAL_MEAN applied
+				Assert.assertFalse(TestUtils.containsNan(R1, 8));
+				Assert.assertFalse(TestUtils.containsNan(R2, 8));
 			}
 		}
 		catch(Exception ex) {


### PR DESCRIPTION
There was no null check so the replacement was always "NaN" since objectToDouble returns NaN if null is given, resulting in the mean always being NaN if a value is missing.

Also added check in Test so the column is checked for NaNs