### PR TITLE
[SYSTEMDS-2885] CLA MMChain Optimization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<jcuda.version>10.2.0</jcuda.version>
 		<!-->Testing settings<!-->
 		<maven.test.skip>true</maven.test.skip>
+		<rerun.failing.tests.count>2</rerun.failing.tests.count>
 		<jacoco.skip>true</jacoco.skip>
 		<automatedtestbase.outputbuffering>false</automatedtestbase.outputbuffering>
 		<argLine>-Xms4g -Xmx4g -Xmn400m</argLine>
@@ -293,7 +294,7 @@
 					<reuseForks>false</reuseForks>
 					<reportFormat>brief</reportFormat>
 					<trimStackTrace>true</trimStackTrace>
-					<rerunFailingTestsCount>2</rerunFailingTestsCount>
+					<rerunFailingTestsCount>${rerun.failing.tests.count}</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
 

--- a/scripts/builtin/l2svmPredict.dml
+++ b/scripts/builtin/l2svmPredict.dml
@@ -1,0 +1,56 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+#
+#
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# X               Double  ---         matrix X of feature vectors to classify
+# W               Double  ---         matrix of the trained variables
+# verbose         Boolean FALSE       Set to true if one wants print statements.
+# ---------------------------------------------------------------------------------------------
+# OUTPUT:
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# Y^              Double  ---         Classification Labels Raw, meaning not modified to clean
+#                                     Labeles of 1's and -1's
+# Y               Double  ---         Classification Labels Maxed to ones and zeros.
+
+
+m_l2svmPredict = function(Matrix[Double] X, Matrix[Double] W, Boolean verbose = FALSE)
+  return(Matrix[Double] YRaw, Matrix[Double] Y)
+{
+  if(ncol(X) != nrow(W)){
+    if(ncol(X) + 1 != nrow(W)){
+      stop("l2svm Predict: Invalid shape of W ["+ncol(W)+","+nrow(W)+"] or X ["+ncol(X)+","+nrow(X)+"]")
+    }
+    YRaw = X %*% W[1:ncol(X),] + W[ncol(X)+1,]
+    Y = rowIndexMax(YRaw)
+  }
+  else{
+    YRaw = X %*% W
+    Y = rowIndexMax(YRaw)
+  }
+}

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -144,6 +144,7 @@ public enum Builtins {
 	KNN("knn", true),
 	DECISIONTREE("decisionTree", true),
 	L2SVM("l2svm", true),
+	L2SVMPREDICT("l2svmPredict", true),
 	LASSO("lasso", true),
 	LENGTH("length", false),
 	LINEAGE("lineage", false),

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -126,7 +126,7 @@ public class DMLConfig
 		_defaultVals.put(CP_PARALLEL_IO,         "true" );
 		_defaultVals.put(COMPRESSED_LINALG,      Compression.CompressConfig.FALSE.name() );
 		_defaultVals.put(COMPRESSED_LOSSY,       "false" );
-		_defaultVals.put(COMPRESSED_VALID_COMPRESSIONS, "SDC,DDC,OLE,RLE");
+		_defaultVals.put(COMPRESSED_VALID_COMPRESSIONS, "SDC,DDC,RLE");
 		_defaultVals.put(COMPRESSED_OVERLAPPING, "true" );
 		_defaultVals.put(COMPRESSED_SAMPLING_RATIO, "0.01");
 		_defaultVals.put(COMPRESSED_COCODE,      "COST");

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -107,15 +107,13 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	protected List<AColGroup> _colGroups;
 
 	/**
-	 * list of lengths of dictionaries, including a longest length in left variable.
-	 * Note Should not be called directly since it is constructed on first use, on
-	 * calls to : getMaxNumValues()
+	 * list of lengths of dictionaries, including a longest length in left variable. Note should not be called directly
+	 * since it is constructed on first use, on calls to : getMaxNumValues()
 	 */
 	protected Pair<Integer, int[]> v = null;
 
 	/**
-	 * Boolean specifying if the colGroups are overlapping each other. This happens
-	 * after a right matrix multiplication.
+	 * Boolean specifying if the colGroups are overlapping each other. This happens after a right matrix multiplication.
 	 */
 	protected boolean overlappingColGroups = false;
 
@@ -140,8 +138,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	/**
 	 * Main constructor for building a block from scratch.
 	 * 
-	 * Use with caution, since it constructs an empty matrix block with nothing
-	 * inside.
+	 * Use with caution, since it constructs an empty matrix block with nothing inside.
 	 * 
 	 * @param rl number of rows in the block
 	 * @param cl number of columns
@@ -154,8 +151,8 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	/**
-	 * "Copy" constructor to populate this compressed block with the uncompressed
-	 * metadata contents of a conventional block. Does not compress the block.
+	 * "Copy" constructor to populate this compressed block with the uncompressed metadata contents of a conventional
+	 * block. Does not compress the block.
 	 * 
 	 * @param that matrix block
 	 */
@@ -173,15 +170,15 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		nonZeros = that.getNonZeros();
 
 		_colGroups = new ArrayList<>();
-		for (AColGroup cg : that._colGroups)
+		for(AColGroup cg : that._colGroups)
 			_colGroups.add(cg.copy());
 
 		overlappingColGroups = that.overlappingColGroups;
 	}
 
 	public boolean isSingleUncompressedGroup() {
-		return (_colGroups != null && _colGroups.size() == 1
-				&& _colGroups.get(0).getCompType() == CompressionType.UNCOMPRESSED);
+		return(_colGroups != null && _colGroups.size() == 1 &&
+			_colGroups.get(0).getCompType() == CompressionType.UNCOMPRESSED);
 	}
 
 	public void allocateColGroup(AColGroup cg) {
@@ -224,19 +221,20 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		// }
 
 		// core decompression (append if sparse)
-		for (AColGroup grp : _colGroups)
+		for(AColGroup grp : _colGroups)
 			grp.decompressToBlockUnSafe(ret, 0, rlen, 0, grp.getValues());
 
 		// post-processing (for append in decompress)
-		if (ret.getNonZeros() == -1 || nonZeros == -1) {
+		if(ret.getNonZeros() == -1 || nonZeros == -1) {
 			ret.recomputeNonZeros();
-		} else {
+		}
+		else {
 			ret.setNonZeros(nonZeros);
 		}
-		if (ret.isInSparseFormat())
+		if(ret.isInSparseFormat())
 			ret.sortSparseRows();
 
-		if (DMLScript.STATISTICS || LOG.isDebugEnabled()) {
+		if(DMLScript.STATISTICS || LOG.isDebugEnabled()) {
 			double t = time.stop();
 			LOG.debug("decompressed block w/ k=" + 1 + " in " + t + "ms.");
 			DMLCompressionStatistics.addDecompressTime(t, 1);
@@ -252,7 +250,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	 */
 	public MatrixBlock decompress(int k) {
 
-		if (k <= 1)
+		if(k <= 1)
 			return decompress();
 
 		Timing time = new Timing(true);
@@ -268,26 +266,28 @@ public class CompressedMatrixBlock extends MatrixBlock {
 			int blklen = (int) Math.ceil((double) rlen / k);
 			blklen += (blklen % blkz != 0) ? blkz - blklen % blkz : 0;
 			ArrayList<DecompressTask> tasks = new ArrayList<>();
-			for (int i = 0; i < k & i * blklen < getNumRows(); i++)
+			for(int i = 0; i < k & i * blklen < getNumRows(); i++)
 				tasks.add(
-						new DecompressTask(_colGroups, ret, i * blklen, Math.min((i + 1) * blklen, rlen), overlapping));
+					new DecompressTask(_colGroups, ret, i * blklen, Math.min((i + 1) * blklen, rlen), overlapping));
 			List<Future<Long>> rtasks = pool.invokeAll(tasks);
 			pool.shutdown();
-			for (Future<Long> rt : rtasks)
+			for(Future<Long> rt : rtasks)
 				nonZeros += rt.get(); // error handling
-		} catch (InterruptedException | ExecutionException ex) {
+		}
+		catch(InterruptedException | ExecutionException ex) {
 			LOG.error("Parallel decompression failed defaulting to non parallel implementation " + ex.getMessage());
 			nonZeros = -1;
 			ex.printStackTrace();
 			return decompress();
 		}
-		if (overlapping) {
+		if(overlapping) {
 			ret.recomputeNonZeros();
-		} else {
+		}
+		else {
 			ret.setNonZeros(nonZeros);
 		}
 
-		if (DMLScript.STATISTICS || LOG.isDebugEnabled()) {
+		if(DMLScript.STATISTICS || LOG.isDebugEnabled()) {
 			double t = time.stop();
 			LOG.debug("decompressed block w/ k=" + k + " in " + time.stop() + "ms.");
 			DMLCompressionStatistics.addDecompressTime(t, k);
@@ -302,13 +302,12 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	/**
 	 * Obtain an upper bound on the memory used to store the compressed block.
 	 * 
-	 * @return an upper bound on the memory used to store this compressed block
-	 *         considering class overhead.
+	 * @return an upper bound on the memory used to store this compressed block considering class overhead.
 	 */
 	public long estimateCompressedSizeInMemory() {
 		long total = baseSizeInMemory();
 
-		for (AColGroup grp : _colGroups)
+		for(AColGroup grp : _colGroups)
 			total += grp.estimateInMemorySize();
 
 		return total;
@@ -330,15 +329,16 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 		// TODO Optimize Quick Get Value, to located the correct column group without
 		// having to search for it
-		if (isOverlapping()) {
+		if(isOverlapping()) {
 			double v = 0.0;
-			for (AColGroup group : _colGroups)
-				if (Arrays.binarySearch(group.getColIndices(), c) >= 0)
+			for(AColGroup group : _colGroups)
+				if(Arrays.binarySearch(group.getColIndices(), c) >= 0)
 					v += group.get(r, c);
 			return v;
-		} else {
-			for (AColGroup group : _colGroups)
-				if (Arrays.binarySearch(group.getColIndices(), c) >= 0)
+		}
+		else {
+			for(AColGroup group : _colGroups)
+				if(Arrays.binarySearch(group.getColIndices(), c) >= 0)
 					return group.get(r, c);
 			return 0;
 		}
@@ -352,7 +352,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public long getExactSizeOnDisk() {
 		// header information
 		long ret = 20;
-		for (AColGroup grp : _colGroups) {
+		for(AColGroup grp : _colGroups) {
 			ret += 1; // type info
 			ret += grp.getExactSizeOnDisk();
 		}
@@ -380,8 +380,8 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	/**
-	 * Redirects the default java serialization via externalizable to our default
-	 * hadoop writable serialization for efficient broadcast/rdd de-serialization.
+	 * Redirects the default java serialization via externalizable to our default hadoop writable serialization for
+	 * efficient broadcast/rdd de-serialization.
 	 * 
 	 * @param is object input
 	 * @throws IOException if IOException occurs
@@ -392,8 +392,8 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	/**
-	 * Redirects the default java serialization via externalizable to our default
-	 * hadoop writable serialization for efficient broadcast/rdd serialization.
+	 * Redirects the default java serialization via externalizable to our default hadoop writable serialization for
+	 * efficient broadcast/rdd serialization.
 	 * 
 	 * @param os object output
 	 * @throws IOException if IOException occurs
@@ -425,7 +425,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock append(MatrixBlock that, MatrixBlock ret, boolean cbind) {
-		if (cbind) // use supported operation
+		if(cbind) // use supported operation
 			return append(that, ret);
 		printDecompressWarning("append-rbind", that);
 		MatrixBlock left = getUncompressed();
@@ -435,13 +435,12 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void append(MatrixValue v2, ArrayList<IndexedMatrixValue> outlist, int blen, boolean cbind, boolean m2IsLast,
-			int nextNCol) {
+		int nextNCol) {
 		printDecompressWarning("append", (MatrixBlock) v2);
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(v2);
 		left.append(right, outlist, blen, cbind, m2IsLast, nextNCol);
 	}
-
 
 	@Override
 	public MatrixBlock chainMatrixMultOperations(MatrixBlock v, MatrixBlock w, MatrixBlock out, ChainType ctype) {
@@ -450,33 +449,33 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock chainMatrixMultOperations(MatrixBlock v, MatrixBlock w, MatrixBlock out, ChainType ctype,
-			int k) {
+		int k) {
 
-		if (this.getNumColumns() != v.getNumRows())
-			throw new DMLRuntimeException("Dimensions mismatch on mmchain operation (" + this.getNumColumns() + " != "
-					+ v.getNumRows() + ")");
-		if (v.getNumColumns() != 1)
+		if(this.getNumColumns() != v.getNumRows())
 			throw new DMLRuntimeException(
-					"Invalid input vector (column vector expected, but ncol=" + v.getNumColumns() + ")");
-		if (w != null && w.getNumColumns() != 1)
+				"Dimensions mismatch on mmchain operation (" + this.getNumColumns() + " != " + v.getNumRows() + ")");
+		if(v.getNumColumns() != 1)
 			throw new DMLRuntimeException(
-					"Invalid weight vector (column vector expected, but ncol=" + w.getNumColumns() + ")");
+				"Invalid input vector (column vector expected, but ncol=" + v.getNumColumns() + ")");
+		if(w != null && w.getNumColumns() != 1)
+			throw new DMLRuntimeException(
+				"Invalid weight vector (column vector expected, but ncol=" + w.getNumColumns() + ")");
 
 		// multi-threaded MMChain of single uncompressed ColGroup
-		if (isSingleUncompressedGroup()) {
+		if(isSingleUncompressedGroup()) {
 			return ((ColGroupUncompressed) _colGroups.get(0)).getData().chainMatrixMultOperations(v, w, out, ctype, k);
 		}
 
 		// Timing time = LOG.isDebugEnabled() ? new Timing(true) : null;
 
 		// prepare result
-		if (out != null)
+		if(out != null)
 			out.reset(clen, 1, false);
 		else
 			out = new MatrixBlock(clen, 1, false);
 
 		// empty block handling
-		if (isEmptyBlock(false))
+		if(isEmptyBlock(false))
 			return out;
 
 		BinaryOperator bop = new BinaryOperator(Multiply.getMultiplyFnObject());
@@ -486,14 +485,15 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		boolean tryOverlapOutput = v.getNumColumns() > _colGroups.size() && w != null && w.getNumRows() > 1;
 		MatrixBlock tmp = CLALibRightMultBy.rightMultByMatrix(this, v, null, k, tryOverlapOutput);
 
-		if (tmp instanceof CompressedMatrixBlock) {
+		if(tmp instanceof CompressedMatrixBlock) {
 			CompressedMatrixBlock tmpC = (CompressedMatrixBlock) tmp;
-			if (ctype == ChainType.XtwXv)
+			if(ctype == ChainType.XtwXv)
 				tmpC = (CompressedMatrixBlock) CLALibBinaryCellOp.binaryOperations(bop, tmpC, w, null);
 			tmp = tmpC.decompress(k);
-		} else if (ctype == ChainType.XtwXv)
-				LibMatrixBincell.bincellOpInPlace(tmp, w, bop);
-		
+		}
+		else if(ctype == ChainType.XtwXv)
+			LibMatrixBincell.bincellOpInPlace(tmp, w, bop);
+
 		CLALibLeftMultBy.leftMultByMatrixTransposed(this, tmp, out, k);
 		out = LibMatrixReorg.transposeInPlace(out, k);
 
@@ -502,22 +502,26 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock aggregateBinaryOperations(MatrixBlock m1, MatrixBlock m2, MatrixBlock ret,
-			AggregateBinaryOperator op) {
+		AggregateBinaryOperator op) {
 		return aggregateBinaryOperations(m1, m2, ret, op, false, false);
 	}
 
 	public MatrixBlock aggregateBinaryOperations(MatrixBlock m1, MatrixBlock m2, MatrixBlock ret,
-			AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
-		if (m1 instanceof CompressedMatrixBlock && m2 instanceof CompressedMatrixBlock) {
-			return doubleCompressedAggregateBinaryOperations((CompressedMatrixBlock) m1, (CompressedMatrixBlock) m2,
-					ret, op, transposeLeft, transposeRight);
+		AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
+		if(m1 instanceof CompressedMatrixBlock && m2 instanceof CompressedMatrixBlock) {
+			return doubleCompressedAggregateBinaryOperations((CompressedMatrixBlock) m1,
+				(CompressedMatrixBlock) m2,
+				ret,
+				op,
+				transposeLeft,
+				transposeRight);
 		}
 		boolean transposeOutput = false;
-		if (transposeLeft || transposeRight) {
+		if(transposeLeft || transposeRight) {
 			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
 
-			if ((m1 instanceof CompressedMatrixBlock && transposeLeft)
-					|| (m2 instanceof CompressedMatrixBlock && transposeRight)) {
+			if((m1 instanceof CompressedMatrixBlock && transposeLeft) ||
+				(m2 instanceof CompressedMatrixBlock && transposeRight)) {
 				// change operation from m1 %*% m2 -> t( t(m2) %*% t(m1) )
 				transposeOutput = true;
 				MatrixBlock tmp = m1;
@@ -529,10 +533,11 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 			}
 
-			if (!(m1 instanceof CompressedMatrixBlock) && transposeLeft) {
+			if(!(m1 instanceof CompressedMatrixBlock) && transposeLeft) {
 				m1 = new MatrixBlock().copyShallow(m1).reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
 				transposeLeft = false;
-			} else if (!(m2 instanceof CompressedMatrixBlock) && transposeRight) {
+			}
+			else if(!(m2 instanceof CompressedMatrixBlock) && transposeRight) {
 				m2 = new MatrixBlock().copyShallow(m2).reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
 				transposeRight = false;
 			}
@@ -541,49 +546,55 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		// setup meta data (dimensions, sparsity)
 		boolean right = (m1 == this);
 		MatrixBlock that = right ? m2 : m1;
-		if (!right && m2 != this) {
+		if(!right && m2 != this) {
 			throw new DMLRuntimeException(
-					"Invalid inputs for aggregate Binary Operation which expect either m1 or m2 to be equal to the object calling");
+				"Invalid inputs for aggregate Binary Operation which expect either m1 or m2 to be equal to the object calling");
 		}
 
 		// create output matrix block
-		if (right) {
+		if(right) {
 			boolean allowOverlap = ConfigurationManager.getDMLConfig()
-					.getBooleanValue(DMLConfig.COMPRESSED_OVERLAPPING);
+				.getBooleanValue(DMLConfig.COMPRESSED_OVERLAPPING);
 			ret = CLALibRightMultBy.rightMultByMatrix(this, that, ret, op.getNumThreads(), allowOverlap);
-		} else {
+		}
+		else {
 			ret = CLALibLeftMultBy.leftMultByMatrix(this, that, ret, op.getNumThreads());
 		}
 
-		if (transposeOutput) {
+		if(transposeOutput) {
 			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
 			return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
-		} else
+		}
+		else
 			return ret;
 
 	}
 
 	private MatrixBlock doubleCompressedAggregateBinaryOperations(CompressedMatrixBlock m1, CompressedMatrixBlock m2,
-			MatrixBlock ret, AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
-		if (!transposeLeft && !transposeRight) {
+		MatrixBlock ret, AggregateBinaryOperator op, boolean transposeLeft, boolean transposeRight) {
+		if(!transposeLeft && !transposeRight) {
 			// If both are not transposed, decompress the right hand side. to enable
 			// compressed overlapping output.
 			LOG.warn("Matrix decompression from multiplying two compressed matrices.");
 			return aggregateBinaryOperations(m1, getUncompressed(m2), ret, op, transposeLeft, transposeRight);
-		} else if (transposeLeft && !transposeRight) {
+		}
+		else if(transposeLeft && !transposeRight) {
 			// Select witch compressed matrix to decompress.
-			if (m1.getNumColumns() > m2.getNumColumns()) {
+			if(m1.getNumColumns() > m2.getNumColumns()) {
 				ret = CLALibLeftMultBy.leftMultByMatrixTransposed(m1, m2, ret, op.getNumThreads());
 				ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
 				return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
-			} else
+			}
+			else
 				return CLALibLeftMultBy.leftMultByMatrixTransposed(m2, m1, ret, op.getNumThreads());
 
-		} else if (!transposeLeft && transposeRight) {
+		}
+		else if(!transposeLeft && transposeRight) {
 			throw new DMLCompressionException("Not Implemented compressed Matrix Mult, to produce larger matrix");
 			// worst situation since it blows up the result matrix in number of rows in
 			// either compressed matrix.
-		} else {
+		}
+		else {
 			ret = aggregateBinaryOperations(m2, m1, ret, op);
 			ReorgOperator r_op = new ReorgOperator(SwapIndex.getSwapIndexFnObject(), op.getNumThreads());
 			return ret.reorgOperations(r_op, new MatrixBlock(), 0, 0, 0);
@@ -592,48 +603,48 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock aggregateUnaryOperations(AggregateUnaryOperator op, MatrixValue result, int blen,
-			MatrixIndexes indexesIn) {
+		MatrixIndexes indexesIn) {
 		return aggregateUnaryOperations(op, result, blen, indexesIn, false);
 	}
 
 	@Override
 	public MatrixBlock aggregateUnaryOperations(AggregateUnaryOperator op, MatrixValue result, int blen,
-			MatrixIndexes indexesIn, boolean inCP) {
+		MatrixIndexes indexesIn, boolean inCP) {
 
 		// check for supported operations
-		if (!(op.aggOp.increOp.fn instanceof KahanPlus || op.aggOp.increOp.fn instanceof KahanPlusSq
-				|| op.aggOp.increOp.fn instanceof Mean
-				|| (op.aggOp.increOp.fn instanceof Builtin
-						&& (((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN
-								|| ((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX)))) {
+		if(!(op.aggOp.increOp.fn instanceof KahanPlus || op.aggOp.increOp.fn instanceof KahanPlusSq ||
+			op.aggOp.increOp.fn instanceof Mean ||
+			(op.aggOp.increOp.fn instanceof Builtin &&
+				(((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN ||
+					((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX)))) {
 			throw new NotImplementedException("Unary aggregate " + op.aggOp.increOp.fn + " not supported yet.");
 		}
 
 		// prepare output dimensions
 		CellIndex tempCellIndex = new CellIndex(-1, -1);
 		op.indexFn.computeDimension(rlen, clen, tempCellIndex);
-		// Correction no long exists
-		if (op.aggOp.existsCorrection()) {
-			switch (op.aggOp.correction) {
-			case LASTROW:
-				tempCellIndex.row++;
-				break;
-			case LASTCOLUMN:
-				tempCellIndex.column++;
-				break;
-			case LASTTWOROWS:
-				tempCellIndex.row += 2;
-				break;
-			case LASTTWOCOLUMNS:
-				tempCellIndex.column += 2;
-				break;
-			default:
-				throw new DMLRuntimeException("unrecognized correctionLocation: " + op.aggOp.correction);
-			}
-		}
+
+		// if(op.aggOp.existsCorrection()) {
+		// 	switch(op.aggOp.correction) {
+		// 		case LASTROW:
+		// 			// tempCellIndex.row++;
+		// 			break;
+		// 		case LASTCOLUMN:
+		// 			// tempCellIndex.column++;
+		// 			break;
+		// 		case LASTTWOROWS:
+		// 			tempCellIndex.row += 1;
+		// 			break;
+		// 		case LASTTWOCOLUMNS:
+		// 			tempCellIndex.column += 1;
+		// 			break;
+		// 		default:
+		// 			throw new DMLRuntimeException("unrecognized correctionLocation: " + op.aggOp.correction);
+		// 	}
+		// }
 
 		// initialize and allocate the result
-		if (result == null)
+		if(result == null)
 			result = new MatrixBlock(tempCellIndex.row, tempCellIndex.column, false);
 		else
 			result.reset(tempCellIndex.row, tempCellIndex.column, false);
@@ -651,20 +662,20 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	@Override
 	public MatrixBlock transposeSelfMatrixMultOperations(MatrixBlock out, MMTSJType tstype, int k) {
 		// check for transpose type
-		if (tstype != MMTSJType.LEFT) // right not supported yet
+		if(tstype != MMTSJType.LEFT) // right not supported yet
 			throw new DMLRuntimeException("Invalid MMTSJ type '" + tstype.toString() + "'.");
 
 		// create output matrix block
-		if (out == null)
+		if(out == null)
 			out = new MatrixBlock(clen, clen, false);
 		else
 			out.reset(clen, clen, false);
 		out.allocateDenseBlock();
 
-		if (!isEmptyBlock(false)) {
+		if(!isEmptyBlock(false)) {
 			// compute matrix mult
-			CLALibLeftMultBy.leftMultByTransposeSelf(_colGroups, out, k, getNumColumns(), getMaxNumValues(),
-					isOverlapping());
+			CLALibLeftMultBy
+				.leftMultByTransposeSelf(_colGroups, out, k, getNumColumns(), getMaxNumValues(), isOverlapping());
 			// post-processing
 			out.setNonZeros(LinearAlgebraUtils.copyUpperToLowerTriangle(out));
 		}
@@ -688,29 +699,31 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	public ColGroupUncompressed getUncompressedColGroup() {
-		for (AColGroup grp : _colGroups)
-			if (grp instanceof ColGroupUncompressed)
+		for(AColGroup grp : _colGroups)
+			if(grp instanceof ColGroupUncompressed)
 				return (ColGroupUncompressed) grp;
 		return null;
 	}
 
 	public Pair<Integer, int[]> getMaxNumValues() {
-		if (v == null) {
+		if(v == null) {
 
 			int numVals = 1;
 			int[] numValues = new int[_colGroups.size()];
 			int nr;
-			for (int i = 0; i < _colGroups.size(); i++)
-				if (_colGroups.get(i) instanceof ColGroupValue) {
+			for(int i = 0; i < _colGroups.size(); i++)
+				if(_colGroups.get(i) instanceof ColGroupValue) {
 					nr = ((ColGroupValue) _colGroups.get(i)).getNumValues();
 					numValues[i] = nr;
 					numVals = Math.max(numVals, nr);
-				} else {
+				}
+				else {
 					numValues[i] = -1;
 				}
 			v = new ImmutablePair<>(numVals, numValues);
 			return v;
-		} else {
+		}
+		else {
 			return v;
 		}
 	}
@@ -734,21 +747,21 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		public Long call() {
 
 			// preallocate sparse rows to avoid repeated alloc
-			if (!_overlapping && _ret.isInSparseFormat()) {
+			if(!_overlapping && _ret.isInSparseFormat()) {
 				int[] rnnz = new int[_ru - _rl];
-				for (AColGroup grp : _colGroups)
+				for(AColGroup grp : _colGroups)
 					grp.countNonZerosPerRow(rnnz, _rl, _ru);
 				SparseBlock rows = _ret.getSparseBlock();
-				for (int i = _rl; i < _ru; i++)
+				for(int i = _rl; i < _ru; i++)
 					rows.allocate(i, rnnz[i - _rl]);
 			}
 
 			// decompress row partition
-			for (AColGroup grp : _colGroups)
+			for(AColGroup grp : _colGroups)
 				grp.decompressToBlock(_ret, _rl, _ru, grp.getValues(), false);
 
 			// post processing (sort due to append)
-			if (_ret.isInSparseFormat())
+			if(_ret.isInSparseFormat())
 				_ret.sortSparseRows(_rl, _ru);
 
 			return _overlapping ? 0 : _ret.recomputeNonZeros(_rl, _ru - 1);
@@ -760,8 +773,8 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		StringBuilder sb = new StringBuilder();
 		sb.append("\nCompressed Matrix:");
 		sb.append("\nCols:" + getNumColumns() + " Rows:" + getNumRows());
-		if (_colGroups != null)
-			for (AColGroup cg : _colGroups) {
+		if(_colGroups != null)
+			for(AColGroup cg : _colGroups) {
 				sb.append("\n" + cg);
 			}
 		else
@@ -781,24 +794,27 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep, CacheBlock ret) {
 		validateSliceArgument(rl, ru, cl, cu);
 		MatrixBlock tmp;
-		if (rl == ru && cl == cu) {
+		if(rl == ru && cl == cu) {
 			// get a single index, and return in a matrixBlock
 			tmp = new MatrixBlock(1, 1, 0);
 			tmp.appendValue(0, 0, getValue(rl, cl));
 			return tmp;
-		} else if (rl == 0 && ru == getNumRows() - 1) {
+		}
+		else if(rl == 0 && ru == getNumRows() - 1) {
 			tmp = sliceColumns(cl, cu);
-		} else if (cl == 0 && cu == getNumColumns() - 1) {
+		}
+		else if(cl == 0 && cu == getNumColumns() - 1) {
 			// Row Slice. Potential optimization if the slice contains enough rows.
 			// +1 since the implementation arguments for slice is inclusive values for ru
 			// and cu.
 			// and it is not inclusive in decompression, and construction of MatrixBlock.
 			tmp = new MatrixBlock(ru + 1 - rl, getNumColumns(), false).allocateDenseBlock();
-			for (AColGroup g : getColGroups())
+			for(AColGroup g : getColGroups())
 				g.decompressToBlock(tmp, rl, ru + 1, 0);
 
 			return tmp;
-		} else {
+		}
+		else {
 			// In the case where an internal matrix is sliced out, then first slice out the
 			// columns
 			// to an compressed intermediate.
@@ -817,9 +833,9 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		CompressedMatrixBlock ret = new CompressedMatrixBlock(this.getNumRows(), cu + 1 - cl);
 
 		List<AColGroup> newColGroups = new ArrayList<>();
-		for (AColGroup grp : getColGroups()) {
+		for(AColGroup grp : getColGroups()) {
 			AColGroup slice = grp.sliceColumns(cl, cu + 1);
-			if (slice != null)
+			if(slice != null)
 				newColGroups.add(slice);
 		}
 		ret.allocateColGroupList(newColGroups);
@@ -829,9 +845,9 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void slice(ArrayList<IndexedMatrixValue> outlist, IndexRange range, int rowCut, int colCut, int blen,
-			int boundaryRlen, int boundaryClen) {
+		int boundaryRlen, int boundaryClen) {
 		printDecompressWarning(
-				"slice for distribution to spark. (Could be implemented such that it does not decompress)");
+			"slice for distribution to spark. (Could be implemented such that it does not decompress)");
 		MatrixBlock tmp = getUncompressed();
 		tmp.slice(outlist, range, rowCut, colCut, blen, boundaryRlen, boundaryClen);
 	}
@@ -869,18 +885,19 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock rexpandOperations(MatrixBlock ret, double max, boolean rows, boolean cast, boolean ignore,
-			int k) {
-		if (rows) {
+		int k) {
+		if(rows) {
 			printDecompressWarning("rexpandOperations");
 			MatrixBlock tmp = getUncompressed();
 			return tmp.rexpandOperations(ret, max, rows, cast, ignore, k);
-		} else
+		}
+		else
 			return CLALibReExpand.reExpand(this, ret, max, cast, ignore, k);
 	}
 
 	@Override
 	public boolean isEmptyBlock(boolean safe) {
-		return (_colGroups == null || getNonZeros() == 0);
+		return(_colGroups == null || getNonZeros() == 0);
 	}
 
 	public static long estimateOriginalSizeInMemory(int nrows, int ncols, double sparsity) {
@@ -898,7 +915,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		size += 8; // Object reference Sparse Block
 		size += 4; // estimated NNzs Per Row
 
-		if (size % 8 != 0)
+		if(size % 8 != 0)
 			size += 8 - size % 8; // Add padding
 
 		return size;
@@ -915,7 +932,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void incrementalAggregate(AggregateOperator aggOp, MatrixValue correction, MatrixValue newWithCorrection,
-			boolean deep) {
+		boolean deep) {
 		throw new DMLRuntimeException("CompressedMatrixBlock: incrementalAggregate not supported.");
 	}
 
@@ -923,7 +940,6 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public void incrementalAggregate(AggregateOperator aggOp, MatrixValue newWithCorrection) {
 		throw new DMLRuntimeException("CompressedMatrixBlock: incrementalAggregate not supported.");
 	}
-
 
 	@Override
 	public void permutationMatrixMultOperations(MatrixValue m2Val, MatrixValue out1Val, MatrixValue out2Val) {
@@ -940,7 +956,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock leftIndexingOperations(MatrixBlock rhsMatrix, int rl, int ru, int cl, int cu, MatrixBlock ret,
-			UpdateType update) {
+		UpdateType update) {
 		printDecompressWarning("leftIndexingOperations");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(rhsMatrix);
@@ -964,27 +980,29 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	@Override
 	public CM_COV_Object cmOperations(CMOperator op) {
 		printDecompressWarning("cmOperations");
-		if (isEmptyBlock())
+		if(isEmptyBlock())
 			return super.cmOperations(op);
 		AColGroup grp = _colGroups.get(0);
 		MatrixBlock vals = grp.getValuesAsBlock();
-		if (grp instanceof ColGroupValue) {
+		if(grp instanceof ColGroupValue) {
 			MatrixBlock counts = getCountsAsBlock(((ColGroupValue) grp).getCounts());
-			if (counts.isEmpty())
+			if(counts.isEmpty())
 				return vals.cmOperations(op);
 			return vals.cmOperations(op, counts);
-		} else {
+		}
+		else {
 			return vals.cmOperations(op);
 		}
 	}
 
 	private static MatrixBlock getCountsAsBlock(int[] counts) {
-		if (counts != null) {
+		if(counts != null) {
 			MatrixBlock ret = new MatrixBlock(counts.length, 1, false);
-			for (int i = 0; i < counts.length; i++)
+			for(int i = 0; i < counts.length; i++)
 				ret.quickSetValue(i, 0, counts[i]);
 			return ret;
-		} else
+		}
+		else
 			return new MatrixBlock(1, 1, false);
 	}
 
@@ -992,10 +1010,10 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public CM_COV_Object cmOperations(CMOperator op, MatrixBlock weights) {
 		printDecompressWarning("cmOperations");
 		MatrixBlock right = getUncompressed(weights);
-		if (isEmptyBlock())
+		if(isEmptyBlock())
 			return super.cmOperations(op, right);
 		AColGroup grp = _colGroups.get(0);
-		if (grp instanceof ColGroupUncompressed)
+		if(grp instanceof ColGroupUncompressed)
 			return ((ColGroupUncompressed) grp).getData().cmOperations(op);
 		return getUncompressed().cmOperations(op, right);
 	}
@@ -1022,25 +1040,26 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		printDecompressWarning("sortOperations");
 		MatrixBlock right = getUncompressed(weights);
 		AColGroup grp = _colGroups.get(0);
-		if (grp.getIfCountsType() != true)
+		if(grp.getIfCountsType() != true)
 			return grp.getValuesAsBlock().sortOperations(right, result);
 
-		if (right == null && grp instanceof ColGroupValue) {
+		if(right == null && grp instanceof ColGroupValue) {
 			MatrixBlock vals = grp.getValuesAsBlock();
 			int[] counts = ((ColGroupValue) grp).getCounts();
 			double[] data = (vals.getDenseBlock() != null) ? vals.getDenseBlockValues() : null;
 			SortUtils.sortByValue(0, vals.getNumRows(), data, counts);
 			MatrixBlock counts2 = getCountsAsBlock(counts);
-			if (counts2.isEmpty())
+			if(counts2.isEmpty())
 				return vals;
 			return vals.sortOperations(counts2, result);
-		} else
+		}
+		else
 			return getUncompressed().sortOperations(right, result);
 	}
 
 	@Override
 	public MatrixBlock aggregateBinaryOperations(MatrixIndexes m1Index, MatrixBlock m1Value, MatrixIndexes m2Index,
-			MatrixBlock m2Value, MatrixBlock result, AggregateBinaryOperator op) {
+		MatrixBlock m2Value, MatrixBlock result, AggregateBinaryOperator op) {
 		printDecompressWarning("aggregateBinaryOperations");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(m2Value);
@@ -1049,13 +1068,13 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock aggregateTernaryOperations(MatrixBlock m1, MatrixBlock m2, MatrixBlock m3, MatrixBlock ret,
-			AggregateTernaryOperator op, boolean inCP) {
+		AggregateTernaryOperator op, boolean inCP) {
 		boolean m1C = m1 instanceof CompressedMatrixBlock;
 		boolean m2C = m2 instanceof CompressedMatrixBlock;
 		boolean m3C = m3 instanceof CompressedMatrixBlock;
 		printDecompressWarning("aggregateTernaryOperations " + op.aggOp.getClass().getSimpleName() + " "
-				+ op.indexFn.getClass().getSimpleName() + "  " + op.aggOp.increOp.fn.getClass().getSimpleName() + " "
-				+ op.binaryFn.getClass().getSimpleName() + "m1,m2,m3" + m1C + " " + m2C + " " + m3C);
+			+ op.indexFn.getClass().getSimpleName() + "  " + op.aggOp.increOp.fn.getClass().getSimpleName() + " "
+			+ op.binaryFn.getClass().getSimpleName() + "m1,m2,m3" + m1C + " " + m2C + " " + m3C);
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right1 = getUncompressed(m2);
 		MatrixBlock right2 = getUncompressed(m3);
@@ -1064,7 +1083,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock uaggouterchainOperations(MatrixBlock mbLeft, MatrixBlock mbRight, MatrixBlock mbOut,
-			BinaryOperator bOp, AggregateUnaryOperator uaggOp) {
+		BinaryOperator bOp, AggregateUnaryOperator uaggOp) {
 		printDecompressWarning("uaggouterchainOperations");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(mbRight);
@@ -1073,13 +1092,13 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock groupedAggOperations(MatrixValue tgt, MatrixValue wghts, MatrixValue ret, int ngroups,
-			Operator op) {
+		Operator op) {
 		return groupedAggOperations(tgt, wghts, ret, ngroups, op, 1);
 	}
 
 	@Override
 	public MatrixBlock groupedAggOperations(MatrixValue tgt, MatrixValue wghts, MatrixValue ret, int ngroups,
-			Operator op, int k) {
+		Operator op, int k) {
 		printDecompressWarning("groupedAggOperations");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(wghts);
@@ -1102,7 +1121,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void ctableOperations(Operator op, double scalar, MatrixValue that, CTableMap resultMap,
-			MatrixBlock resultBlock) {
+		MatrixBlock resultBlock) {
 		printDecompressWarning("ctableOperations Var 1");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(that);
@@ -1111,7 +1130,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void ctableOperations(Operator op, double scalar, double scalar2, CTableMap resultMap,
-			MatrixBlock resultBlock) {
+		MatrixBlock resultBlock) {
 		printDecompressWarning("ctableOperations Var 2");
 		MatrixBlock tmp = getUncompressed();
 		tmp.ctableOperations(op, scalar, scalar2, resultMap, resultBlock);
@@ -1119,7 +1138,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void ctableOperations(Operator op, MatrixIndexes ix1, double scalar, boolean left, int brlen,
-			CTableMap resultMap, MatrixBlock resultBlock) {
+		CTableMap resultMap, MatrixBlock resultBlock) {
 		printDecompressWarning("ctableOperations Var 3");
 		MatrixBlock tmp = getUncompressed();
 		tmp.ctableOperations(op, ix1, scalar, left, brlen, resultMap, resultBlock);
@@ -1127,7 +1146,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void ctableOperations(Operator op, MatrixValue that, double scalar, boolean ignoreZeros, CTableMap resultMap,
-			MatrixBlock resultBlock) {
+		MatrixBlock resultBlock) {
 		printDecompressWarning("ctableOperations Var 4");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right = getUncompressed(that);
@@ -1153,7 +1172,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public void ctableOperations(Operator op, MatrixValue that, MatrixValue that2, CTableMap resultMap,
-			MatrixBlock resultBlock) {
+		MatrixBlock resultBlock) {
 		printDecompressWarning("ctableOperations Var 7");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right1 = getUncompressed(that);
@@ -1172,13 +1191,13 @@ public class CompressedMatrixBlock extends MatrixBlock {
 
 	@Override
 	public MatrixBlock quaternaryOperations(QuaternaryOperator qop, MatrixBlock um, MatrixBlock vm, MatrixBlock wm,
-			MatrixBlock out) {
+		MatrixBlock out) {
 		return quaternaryOperations(qop, um, vm, wm, out, 1);
 	}
 
 	@Override
 	public MatrixBlock quaternaryOperations(QuaternaryOperator qop, MatrixBlock um, MatrixBlock vm, MatrixBlock wm,
-			MatrixBlock out, int k) {
+		MatrixBlock out, int k) {
 		printDecompressWarning("quaternaryOperations");
 		MatrixBlock left = getUncompressed();
 		MatrixBlock right1 = getUncompressed(um);
@@ -1204,19 +1223,17 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	private static boolean isCompressed(MatrixBlock mb) {
-		return (mb instanceof CompressedMatrixBlock);
+		return(mb instanceof CompressedMatrixBlock);
 	}
 
 	public static MatrixBlock getUncompressed(MatrixValue mVal) {
-		return isCompressed((MatrixBlock) mVal)
-				? ((CompressedMatrixBlock) mVal).decompress(OptimizerUtils.getConstrainedNumThreads(-1))
-				: (MatrixBlock) mVal;
+		return isCompressed((MatrixBlock) mVal) ? ((CompressedMatrixBlock) mVal)
+			.decompress(OptimizerUtils.getConstrainedNumThreads(-1)) : (MatrixBlock) mVal;
 	}
 
 	public MatrixBlock getUncompressed() {
-		return isCompressed((MatrixBlock) this)
-				? ((CompressedMatrixBlock) this).decompress(OptimizerUtils.getConstrainedNumThreads(-1))
-				: (MatrixBlock) this;
+		return isCompressed((MatrixBlock) this) ? ((CompressedMatrixBlock) this)
+			.decompress(OptimizerUtils.getConstrainedNumThreads(-1)) : (MatrixBlock) this;
 	}
 
 	protected void printDecompressWarning(String operation) {
@@ -1224,7 +1241,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	protected void printDecompressWarning(String operation, MatrixBlock m2) {
-		if (isCompressed(m2))
+		if(isCompressed(m2))
 			LOG.warn("Operation '" + operation + "' not supported yet - decompressing for ULA operations.");
 		else
 			LOG.warn("Operation '" + operation + "' not supported yet - decompressing'");
@@ -1248,13 +1265,13 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	@Override
 	public void copy(MatrixValue thatValue) {
 		CompressedMatrixBlock that = checkType(thatValue);
-		if (this == that) // prevent data loss (e.g., on sparse-dense conversion)
+		if(this == that) // prevent data loss (e.g., on sparse-dense conversion)
 			throw new RuntimeException("Copy must not overwrite itself!");
 
 	}
 
 	private CompressedMatrixBlock checkType(MatrixValue thatValue) {
-		if (thatValue == null || !(thatValue instanceof CompressedMatrixBlock)) {
+		if(thatValue == null || !(thatValue instanceof CompressedMatrixBlock)) {
 			throw new DMLRuntimeException("Invalid call to copy, requre a compressed MatrixBlock to copy to");
 		}
 		return (CompressedMatrixBlock) thatValue;
@@ -1268,14 +1285,14 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	private void copyCompressedMatrix(CompressedMatrixBlock that) {
-		if (this == that) // prevent data loss (e.g., on sparse-dense conversion)
+		if(this == that) // prevent data loss (e.g., on sparse-dense conversion)
 			throw new RuntimeException("Copy must not overwrite itself!");
 		this.rlen = that.rlen;
 		this.clen = that.clen;
 
 		this.nonZeros = that.getNonZeros();
 		this._colGroups = new ArrayList<>();
-		for (AColGroup cg : that._colGroups)
+		for(AColGroup cg : that._colGroups)
 			_colGroups.add(cg.copy());
 
 		overlappingColGroups = that.overlappingColGroups;

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -102,14 +102,14 @@ public class CompressedMatrixBlockFactory {
 		return cmbf.compressMatrix();
 	}
 
-	public static CompressedMatrixBlock createConstant(int numRows, int numCols, double value){
+	public static CompressedMatrixBlock createConstant(int numRows, int numCols, double value) {
 		CompressedMatrixBlock block = new CompressedMatrixBlock(numRows, numCols);
 		ColGroupConst cg = ColGroupConst.genColGroupConst(numRows, numCols, value);
 		block.allocateColGroup(cg);
 		block.setNonZeros(value == 0.0 ? 0 : numRows * numCols);
 		return block;
 	}
-	
+
 	private Pair<MatrixBlock, CompressionStatistics> compressMatrix() {
 		// Check for redundant compression
 		if(mb instanceof CompressedMatrixBlock) {
@@ -232,8 +232,8 @@ public class CompressedMatrixBlockFactory {
 					DblArrayIntListHashMap.hashMissCount = 0;
 					break;
 				// case 4:
-				// 	LOG.debug("--compression phase " + phase++ + " Share     : " + _stats.getLastTimePhase());
-				// 	break;
+				// LOG.debug("--compression phase " + phase++ + " Share : " + _stats.getLastTimePhase());
+				// break;
 				case 4:
 					LOG.debug("--num col groups: " + res.getColGroups().size());
 					LOG.debug("--compression phase " + phase + " Cleanup   : " + _stats.getLastTimePhase());
@@ -289,6 +289,5 @@ public class CompressedMatrixBlockFactory {
 			ret.add(i);
 		return ret;
 	}
-
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressionSettings.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressionSettings.java
@@ -30,10 +30,10 @@ import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
  */
 public class CompressionSettings {
 
-	/** Size of the blocks used in a blocked bitmap representation. 
-	 * Note it is exactly Character.MAX_VALUE. 
-	 * This is not Character max value + 1 because it breaks the offsets in cases with fully
-	 * dense values.*/
+	/**
+	 * Size of the blocks used in a blocked bitmap representation. Note it is exactly Character.MAX_VALUE. This is not
+	 * Character max value + 1 because it breaks the offsets in cases with fully dense values.
+	 */
 	public static final int BITMAP_BLOCK_SZ = Character.MAX_VALUE;
 
 	/**
@@ -56,8 +56,8 @@ public class CompressionSettings {
 	public final String transposeInput;
 
 	/**
-	 * Transpose input matrix, to optimize access when extracting bitmaps.
-	 * This setting is changed inside the script based on the transposeInput setting.
+	 * Transpose input matrix, to optimize access when extracting bitmaps. This setting is changed inside the script
+	 * based on the transposeInput setting.
 	 */
 	public boolean transposed = false;
 

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressionSettingsBuilder.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressionSettingsBuilder.java
@@ -123,11 +123,12 @@ public class CompressionSettingsBuilder {
 	 * Specify if the input matrix should be transposed before compression. This improves cache efficiency while
 	 * compression the input matrix
 	 * 
-	 * @param transposeInput string specifying if the input should be transposed before compression, should be one of "auto", "true" or "false"
+	 * @param transposeInput string specifying if the input should be transposed before compression, should be one of
+	 *                       "auto", "true" or "false"
 	 * @return The CompressionSettingsBuilder
 	 */
 	public CompressionSettingsBuilder setTransposeInput(String transposeInput) {
-		switch(transposeInput){
+		switch(transposeInput) {
 			case "auto":
 			case "true":
 			case "false":

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -520,7 +520,7 @@ public abstract class AColGroup implements Serializable {
 	 */
 	public abstract void leftMultByRowVector(double[] vector, double[] result, int numVals, double[] values, int offT);
 
-	public abstract void leftMultBySelfDiagonalColGroup(double[] result, int numColumns );
+	public abstract void leftMultBySelfDiagonalColGroup(double[] result, int numColumns);
 
 	/**
 	 * Multiply with a matrix on the left.
@@ -578,7 +578,7 @@ public abstract class AColGroup implements Serializable {
 	 * @param op The operator used
 	 * @param c  Rhe output matrix block.
 	 */
-	public abstract void unaryAggregateOperations(AggregateUnaryOperator op, MatrixBlock c);
+	public abstract void unaryAggregateOperations(AggregateUnaryOperator op, double[] c);
 
 	/**
 	 * Unary Aggregate operator, since aggregate operators require new object output, the output becomes an uncompressed
@@ -589,7 +589,7 @@ public abstract class AColGroup implements Serializable {
 	 * @param rl The Starting Row to do aggregation from
 	 * @param ru The last Row to do aggregation to (not included)
 	 */
-	public abstract void unaryAggregateOperations(AggregateUnaryOperator op, MatrixBlock c, int rl, int ru);
+	public abstract void unaryAggregateOperations(AggregateUnaryOperator op, double[] c, int rl, int ru);
 
 	/**
 	 * Count the number of non-zeros per row

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ADictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ADictionary.java
@@ -54,10 +54,10 @@ public abstract class ADictionary {
 	 * Determines if the content has a zero tuple. meaning all values at a specific row are zero value. This is useful
 	 * information to find out if the dictionary is used in a dense context. To improve some specific operations.
 	 * 
-	 * @param ncol The number of columns in the dictionary.
+	 * @param nCol The number of columns in the dictionary.
 	 * @return The index at which the zero tuple is located.
 	 */
-	public abstract int hasZeroTuple(int ncol);
+	public abstract int hasZeroTuple(int nCol);
 
 	/**
 	 * Returns the memory usage of the dictionary.
@@ -75,6 +75,15 @@ public abstract class ADictionary {
 	 * @return The aggregated value as a double.
 	 */
 	public abstract double aggregate(double init, Builtin fn);
+
+	/**
+	 * Aggregate all entries in the rows.
+	 * 
+	 * @param fn The aggregate function
+	 * @param nCol The number of columns contained in the dictionary.
+	 * @return Aggregates for this dictionary tuples.
+	 */
+	public abstract double[] aggregateTuples(Builtin fn, int nCol);
 
 	/**
 	 * returns the count of values contained in the dictionary.

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.colgroup.pre.ArrPreAggregate;
 import org.apache.sysds.runtime.compress.colgroup.pre.IPreAggregate;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -287,6 +288,11 @@ public class ColGroupConst extends ColGroupValue {
 	@Override
 	public boolean sameIndexStructure(ColGroupValue that) {
 		return that instanceof ColGroupConst;
+	}
+
+	@Override
+	public int getIndexStructureHash(){
+		throw new NotImplementedException("This function should not be called");
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConverter.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConverter.java
@@ -28,44 +28,6 @@ import org.apache.sysds.runtime.util.DataConverter;
  * Utility functions for ColGroup to convert ColGroups or MatrixBlocks. to other representations.
  */
 public class ColGroupConverter {
-	/**
-	 * Copy col group instance with deep copy of column indices but shallow copy of actual contents;
-	 * 
-	 * @param group column group
-	 * @return column group (deep copy of indices but shallow copy of contents)
-	 */
-	// public static AColGroup copyColGroup(AColGroup group) {
-	// 	AColGroup ret = null;
-
-	// 	// deep copy col indices
-	// 	int[] colIndices = Arrays.copyOf(group.getColIndices(), group.getNumCols());
-
-	// 	// create copy of column group
-	// 	if(group instanceof ColGroupUncompressed) {
-	// 		ColGroupUncompressed in = (ColGroupUncompressed) group;
-	// 		ret = new ColGroupUncompressed(colIndices, in._numRows, in.getData());
-	// 	}
-	// 	else if(group instanceof ColGroupRLE) {
-	// 		ColGroupRLE in = (ColGroupRLE) group;
-	// 		ret = new ColGroupRLE(colIndices, in._numRows, in.hasZeros(), in._dict, in.getBitmaps(),
-	// 			in.getBitmapOffsets(), null);
-	// 	}
-	// 	else if(group instanceof ColGroupOLE) {
-	// 		ColGroupOLE in = (ColGroupOLE) group;
-	// 		ret = new ColGroupOLE(colIndices, in._numRows, in.hasZeros(), in._dict, in.getBitmaps(),
-	// 			in.getBitmapOffsets(), null);
-	// 	}
-	// 	else if(group instanceof ColGroupDDC1) {
-	// 		ColGroupDDC1 in = (ColGroupDDC1) group;
-	// 		ret = new ColGroupDDC1(colIndices, in._numRows, in._dict, in.getData(), in._zeros, null);
-	// 	}
-	// 	else if(group instanceof ColGroupConst)
-	// 		ret = new ColGroupConst(colIndices, group.getNumRows(), ((ColGroupValue)group)._dict);
-	// 	else 
-	// 		throw new RuntimeException("Using '" + group.getClass() + "' instance of ColGroup not fully supported");
-		
-	// 	return ret;
-	// }
 
 	/**
 	 * Extract the double array primitive from a Matrix Block that is an vector.

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -546,6 +546,11 @@ public class ColGroupDDC extends ColGroupValue {
 	}
 
 	@Override
+	public int getIndexStructureHash(){
+		return _data.hashCode();
+	}
+
+	@Override
 	public ColGroupType getColGroupType() {
 		return ColGroupType.DDC;
 		// if(_data instanceof MapToBit)

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -72,11 +72,10 @@ public class ColGroupEmpty extends ColGroupValue {
 	}
 
 	@Override
-	protected void computeRowMxx(MatrixBlock target, Builtin builtin, int rl, int ru) {
-		double[] c = target.getDenseBlockValues();
-		for(int i = rl; i < ru; i++) {
+	protected void computeRowMxx(double[] c, Builtin builtin, int rl, int ru) {
+		for(int i = rl; i < ru; i++)
 			c[i] = builtin.execute(c[i], 0);
-		}
+		
 	}
 
 	@Override
@@ -205,7 +204,7 @@ public class ColGroupEmpty extends ColGroupValue {
 	}
 
 	@Override
-	public int getIndexStructureHash(){
+	public int getIndexStructureHash() {
 		throw new NotImplementedException("This function should not be called");
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.colgroup.pre.IPreAggregate;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -201,6 +202,11 @@ public class ColGroupEmpty extends ColGroupValue {
 	@Override
 	public boolean sameIndexStructure(ColGroupValue that) {
 		return false;
+	}
+
+	@Override
+	public int getIndexStructureHash(){
+		throw new NotImplementedException("This function should not be called");
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupFactory.java
@@ -277,14 +277,14 @@ public class ColGroupFactory {
 		AColGroup cg;
 		ADictionary dict = new Dictionary(((Bitmap) ubm).getValues());
 		if(numZeros >= largestOffset && ubm.getOffsetList().length == 1)
-			cg =  new ColGroupSDCSingleZeros(colIndexes, rlen, dict, ubm.getOffsetList()[0].extractValues(true), null);
+			cg = new ColGroupSDCSingleZeros(colIndexes, rlen, dict, ubm.getOffsetList()[0].extractValues(true), null);
 		else if(numZeros >= largestOffset)
-			cg =  setupMultiValueZeroColGroup(colIndexes, ubm, rlen, dict);
+			cg = setupMultiValueZeroColGroup(colIndexes, ubm, rlen, dict);
 		else if(ubm.getOffsetList().length == 1 && ubm.getOffsetsList(0).size() == rlen)
-			cg =  new ColGroupConst(colIndexes, rlen, dict);
+			cg = new ColGroupConst(colIndexes, rlen, dict);
 		else {
 			dict = moveFrequentToLastDictionaryEntry(dict, ubm, rlen, largestIndex);
-			cg =  setupMultiValueColGroup(colIndexes, numZeros, largestOffset, ubm, rlen, largestIndex, dict);
+			cg = setupMultiValueColGroup(colIndexes, numZeros, largestOffset, ubm, rlen, largestIndex, dict);
 			// return new ColGroupEmpty(colIndexes, rlen);
 		}
 		return cg;
@@ -307,7 +307,7 @@ public class ColGroupFactory {
 		IntArrayList[] offsets = ubm.getOffsetList();
 
 		AInsertionSorter s = InsertionSorterFactory.create(numRows - largestOffset, offsets.length, numRows);
-		
+
 		s.insert(offsets, largestIndex);
 		int[] _indexes = s.getIndexes();
 		IMapToData _data = s.getData();
@@ -357,7 +357,7 @@ public class ColGroupFactory {
 		if(ubm instanceof BitmapLossy)
 			dict = new QDictionary((BitmapLossy) ubm).makeDoubleDictionary();
 		else
-			dict = new Dictionary( ((Bitmap) ubm).getValues());
+			dict = new Dictionary(((Bitmap) ubm).getValues());
 		double[] values = dict.getValues();
 		if(_zeros) {
 			double[] appendedZero = new double[values.length + colIndexes.length];

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -1016,6 +1016,11 @@ public class ColGroupOLE extends ColGroupOffset {
 		return that instanceof ColGroupOLE && ((ColGroupOLE) that)._data == _data;
 	}
 
+	@Override
+	public int getIndexStructureHash(){
+		return _data.hashCode();
+	}
+
 	/**
 	 * Encodes the bitmap in blocks of offsets. Within each block, the bits are stored as absolute offsets from the
 	 * start of the block.

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -729,7 +729,6 @@ public class ColGroupOLE extends ColGroupOffset {
 		final int blksz = CompressionSettings.BITMAP_BLOCK_SZ;
 		final int numVals = getNumValues();
 
-		final int mult = (2 + (mean ? 1 : 0));
 		if(numVals > 1 && _numRows > blksz) {
 			final int blksz2 = CompressionSettings.BITMAP_BLOCK_SZ;
 
@@ -757,7 +756,7 @@ public class ColGroupOLE extends ColGroupOffset {
 							int rix = ii + _data[boff + bix + i];
 							if(rix >= getNumRows())
 								throw new DMLCompressionException("Invalid row " + rix);
-							setandExecute(c, false, val, rix * mult);
+							c[rix] += val;
 						}
 						bix += len + 1;
 					}
@@ -782,7 +781,7 @@ public class ColGroupOLE extends ColGroupOffset {
 						slen = _data[boff + bix];
 						for(int i = 1; i <= slen; i++) {
 							int rix = off + _data[boff + bix + i];
-							setandExecute(c, false, val, rix * mult);
+							c[rix] += val;
 						}
 					}
 				}
@@ -791,7 +790,7 @@ public class ColGroupOLE extends ColGroupOffset {
 	}
 
 	@Override
-	protected final void computeRowMxx(MatrixBlock c, Builtin builtin, int rl, int ru) {
+	protected final void computeRowMxx(double[] c, Builtin builtin, int rl, int ru) {
 		// NOTE: zeros handled once for all column groups outside
 		final int blksz = CompressionSettings.BITMAP_BLOCK_SZ;
 		final int numVals = getNumValues();
@@ -812,7 +811,7 @@ public class ColGroupOLE extends ColGroupOffset {
 				slen = _data[boff + bix];
 				for(int i = 1; i <= slen; i++) {
 					int rix = off + _data[boff + bix + i];
-					c.quickSetValue(rix, 0, builtin.execute(c.quickGetValue(rix, 0), val));
+					c[rix] = builtin.execute(c[rix], val);
 				}
 			}
 		}
@@ -1017,7 +1016,7 @@ public class ColGroupOLE extends ColGroupOffset {
 	}
 
 	@Override
-	public int getIndexStructureHash(){
+	public int getIndexStructureHash() {
 		return _data.hashCode();
 	}
 
@@ -1115,14 +1114,14 @@ public class ColGroupOLE extends ColGroupOffset {
 			final int krOff = kr * NVL;
 			for(int bixR = 0, offR = 0, sLenR = 0; bixR < bLenR; bixR += sLenR + 1, offR += blksz) {
 				sLenR = this._data[bOffR + bixR];
-				for(int j = 1; j <= sLenR; j++){
+				for(int j = 1; j <= sLenR; j++) {
 					final int row = offR + this._data[bOffR + bixR + j];
-					while(offL < l.length && l[offL] < row )
+					while(offL < l.length && l[offL] < row)
 						offL++;
 					if(offL < l.length && l[offL] == row)
 						ag.increment(lhs.getIndex(offL++) + krOff);
 					else
-						ag.increment(defL+krOff);
+						ag.increment(defL + krOff);
 				}
 			}
 		}
@@ -1150,11 +1149,11 @@ public class ColGroupOLE extends ColGroupOffset {
 			final int bOffR = this._ptr[kr];
 			final int bLenR = this.len(kr);
 			final int krOff = kr * NVL;
-			for(int bixR = 0, offR = 0, sLenR = 0;offL < l.length && bixR < bLenR; bixR += sLenR + 1, offR += blksz) {
+			for(int bixR = 0, offR = 0, sLenR = 0; offL < l.length && bixR < bLenR; bixR += sLenR + 1, offR += blksz) {
 				sLenR = this._data[bOffR + bixR];
-				for(int j = 1; offL < l.length&& j <= sLenR; j++){
+				for(int j = 1; offL < l.length && j <= sLenR; j++) {
 					final int row = offR + this._data[bOffR + bixR + j];
-					while(offL < l.length && l[offL] < row )
+					while(offL < l.length && l[offL] < row)
 						offL++;
 					if(offL < l.length && l[offL] == row)
 						ag.increment(lhs.getIndex(offL++) + krOff);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOffset.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOffset.java
@@ -28,7 +28,6 @@ import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.utils.ABitmap;
 import org.apache.sysds.runtime.compress.utils.LinearAlgebraUtils;
 import org.apache.sysds.runtime.functionobjects.Builtin;
-import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 
 /**
  * Base class for column groups encoded with various types of bitmap encoding.
@@ -94,7 +93,6 @@ public abstract class ColGroupOffset extends ColGroupValue {
 
 	}
 
-
 	protected final void sumAllValues(double[] b, double[] c) {
 		final int numVals = getNumValues();
 		final int numCols = getNumCols();
@@ -109,9 +107,8 @@ public abstract class ColGroupOffset extends ColGroupValue {
 	protected final double mxxValues(int bitmapIx, Builtin builtin, double[] values) {
 		final int numCols = getNumCols();
 		final int valOff = bitmapIx * numCols;
-		double val = (builtin
-			.getBuiltinCode() == BuiltinCode.MAX) ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-		for(int i = 0; i < numCols; i++)
+		double val = values[valOff];
+		for(int i = 1; i < numCols; i++)
 			val = builtin.execute(val, values[valOff + i]);
 
 		return val;
@@ -204,7 +201,7 @@ public abstract class ColGroupOffset extends ColGroupValue {
 		return sb.toString();
 	}
 
-	protected static String charsToString(char[] data){
+	protected static String charsToString(char[] data) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("[");
 		for(int x = 0; x < data.length; x++) {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -976,6 +976,11 @@ public class ColGroupRLE extends ColGroupOffset {
 		return that instanceof ColGroupRLE && ((ColGroupRLE) that)._data == _data;
 	}
 
+	@Override
+	public int getIndexStructureHash(){
+		return _data.hashCode();
+	}
+
 	/**
 	 * Encodes the bitmap as a series of run lengths and offsets.
 	 * 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -685,7 +685,6 @@ public class ColGroupRLE extends ColGroupOffset {
 
 		final int numVals = getNumValues();
 
-		final int mult = (2 + (mean ? 1 : 0));
 		if(numVals > 1 && _numRows > CompressionSettings.BITMAP_BLOCK_SZ) {
 			final int blksz = CompressionSettings.BITMAP_BLOCK_SZ;
 
@@ -714,9 +713,9 @@ public class ColGroupRLE extends ColGroupOffset {
 						int llen = _data[boff + bix + 1];
 						int from = Math.max(bi, start + lstart);
 						int to = Math.min(start + lstart + llen, bimax);
-						for(int rix = from; rix < to; rix++) {
-							setandExecute(c, false, val, rix * mult);
-						}
+						for(int rix = from; rix < to; rix++) 
+							c[rix] += val;
+						
 						if(start + lstart + llen >= bimax)
 							break;
 						start += lstart + llen;
@@ -742,9 +741,9 @@ public class ColGroupRLE extends ColGroupOffset {
 					for(; bix < blen && curRunEnd < ru; bix += 2) {
 						curRunStartOff = curRunEnd + _data[boff + bix];
 						curRunEnd = curRunStartOff + _data[boff + bix + 1];
-						for(int rix = curRunStartOff; rix < curRunEnd && rix < ru; rix++) {
-							setandExecute(c, false, val, rix * mult);
-						}
+						for(int rix = curRunStartOff; rix < curRunEnd && rix < ru; rix++) 
+							c[rix] += val;
+						
 					}
 				}
 			}
@@ -752,7 +751,7 @@ public class ColGroupRLE extends ColGroupOffset {
 	}
 
 	@Override
-	protected final void computeRowMxx(MatrixBlock c, Builtin builtin, int rl, int ru) {
+	protected final void computeRowMxx(double[] c, Builtin builtin, int rl, int ru) {
 		// NOTE: zeros handled once for all column groups outside
 		final int numVals = getNumValues();
 		// double[] c = result.getDenseBlockValues();
@@ -771,7 +770,7 @@ public class ColGroupRLE extends ColGroupOffset {
 				curRunStartOff = curRunEnd + _data[boff + bix];
 				curRunEnd = curRunStartOff + _data[boff + bix + 1];
 				for(int rix = curRunStartOff; rix < curRunEnd && rix < ru; rix++)
-					c.quickSetValue(rix, 0, builtin.execute(c.quickGetValue(rix, 0), val));
+					c[rix] =  builtin.execute(c[rix], val);
 			}
 		}
 	}
@@ -977,7 +976,7 @@ public class ColGroupRLE extends ColGroupOffset {
 	}
 
 	@Override
-	public int getIndexStructureHash(){
+	public int getIndexStructureHash() {
 		return _data.hashCode();
 	}
 
@@ -1076,7 +1075,6 @@ public class ColGroupRLE extends ColGroupOffset {
 		for(int i = 0; i < buf.size(); i++)
 			ret[i] = buf.get(i);
 
-
 		return ret;
 	}
 
@@ -1097,7 +1095,7 @@ public class ColGroupRLE extends ColGroupOffset {
 				final int endL = startL + lenL;
 				for(int i = startL; i < endL; i++)
 					ag.increment(lhs.getIndex(i) + offKr);
-				
+
 			}
 		}
 		return ag;
@@ -1155,11 +1153,11 @@ public class ColGroupRLE extends ColGroupOffset {
 						startR += _data[boffR + bixR];
 						lenR = _data[boffR + bixR + 1];
 						final int endR = startR + lenR;
-						if(startL < endR && startR < endL){
+						if(startL < endR && startR < endL) {
 							final int endOverlap = Math.min(endR, endL);
 							final int startOverlap = Math.max(startL, startR);
-							final int lenOverlap = endOverlap - startOverlap ;
-							ag.increment(kl + krOff, lenOverlap );
+							final int lenOverlap = endOverlap - startOverlap;
+							ag.increment(kl + krOff, lenOverlap);
 						}
 					}
 				}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -435,7 +435,13 @@ public class ColGroupSDC extends ColGroupValue {
 
 	@Override
 	public boolean sameIndexStructure(ColGroupValue that) {
-		return that instanceof ColGroupSDC && ((ColGroupSDC) that)._data == _data;
+		// TODO add such that if the column group switched from Zeros type it also matches.
+		return that instanceof ColGroupSDC && ((ColGroupSDC) that)._indexes == _indexes && ((ColGroupSDC) that)._data == _data;
+	}
+
+	@Override
+	public int getIndexStructureHash(){
+		return _data.hashCode() + _indexes.hashCode();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -385,6 +385,11 @@ public class ColGroupSDCSingle extends ColGroupValue {
 	}
 
 	@Override
+	public int getIndexStructureHash(){
+		return _indexes.hashCode();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -348,6 +348,11 @@ public class ColGroupSDCSingleZeros extends ColGroupValue {
 	}
 
 	@Override
+	public int getIndexStructureHash(){
+		return _indexes.hashCode();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -159,31 +159,27 @@ public class ColGroupSDCSingleZeros extends ColGroupValue {
 
 	@Override
 	protected void computeRowSums(double[] c, boolean square, int rl, int ru, boolean mean) {
-		double[] vals = _dict.sumAllRowsToDouble(square, _colIndexes.length);
+		double val = _dict.sumAllRowsToDouble(square, _colIndexes.length)[0];
 		int i = 0;
-		// TODO remove error correction from kahn.
-		final int mult = (2 + (mean ? 1 : 0));
-		while(_indexes[i] < rl) {
+
+		while(_indexes[i] < rl)
 			i++;
-		}
-		for(; i < _indexes.length && _indexes[i] < ru; i++) {
-			c[_indexes[i] * mult] += vals[0];
-		}
+		
+		for(; i < _indexes.length && _indexes[i] < ru; i++)
+			c[_indexes[i] ] += val;
+		
 	}
 
 	@Override
-	protected void computeRowMxx(MatrixBlock target, Builtin builtin, int rl, int ru) {
-		double[] c = target.getDenseBlockValues();
-		double[] vals = getValues();
-		int ncol = getNumCols();
+	protected void computeRowMxx(double[] c, Builtin builtin, int rl, int ru) {
+		double val = _dict.aggregateTuples(builtin, _colIndexes.length)[0];
 		int i = 0;
-		while(_indexes[i] < rl) {
+		while(_indexes[i] < rl)
 			i++;
-		}
+		
 		for(; i < _indexes.length && _indexes[i] < ru; i++) {
 			int idx = _indexes[i];
-			for(int j = 0; j < ncol; j++)
-				c[idx] = builtin.execute(c[idx], vals[j]);
+			c[idx] = builtin.execute(c[idx], val);
 		}
 	}
 
@@ -348,7 +344,7 @@ public class ColGroupSDCSingleZeros extends ColGroupValue {
 	}
 
 	@Override
-	public int getIndexStructureHash(){
+	public int getIndexStructureHash() {
 		return _indexes.hashCode();
 	}
 
@@ -364,7 +360,7 @@ public class ColGroupSDCSingleZeros extends ColGroupValue {
 	@Override
 	public IPreAggregate preAggregateDDC(ColGroupDDC lhs) {
 		IPreAggregate ag = PreAggregateFactory.ag(lhs.getNumValues());
-		for(int i = 0; i < _indexes.length; i++) 
+		for(int i = 0; i < _indexes.length; i++)
 			ag.increment(lhs.getIndex(_indexes[i]));
 		return ag;
 	}
@@ -393,7 +389,7 @@ public class ColGroupSDCSingleZeros extends ColGroupValue {
 		final int[] l = lhs._indexes;
 		final int[] r = this._indexes;
 		while(offL < l.length && offR < r.length)
-			if(l[offL] == r[offR]){
+			if(l[offL] == r[offR]) {
 				ag.increment(lhs.getIndex(offL++));
 				offR++;
 			}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -365,8 +365,14 @@ public class ColGroupSDCZeros extends ColGroupValue {
 
 	@Override
 	public boolean sameIndexStructure(ColGroupValue that) {
-		return that instanceof ColGroupSDCZeros && ((ColGroupSDCZeros) that)._indexes == _indexes;
+		return that instanceof ColGroupSDCZeros && ((ColGroupSDCZeros) that)._indexes == _indexes && ((ColGroupSDCZeros) that)._data == _data;
 	}
+
+	@Override
+	public int getIndexStructureHash(){
+		return _indexes.hashCode() + _data.hashCode();
+	}
+
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSizes.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSizes.java
@@ -43,11 +43,11 @@ public class ColGroupSizes {
 	public static long estimateInMemorySizeGroupValue(int nrColumns, int nrValues, boolean lossy) {
 		long size = estimateInMemorySizeGroup(nrColumns);
 		size += 8; // Dictionary Reference.
-		if(lossy) 
+		if(lossy)
 			size += QDictionary.getInMemorySize(nrValues);
-		else 
+		else
 			size += Dictionary.getInMemorySize(nrValues);
-		
+
 		return size;
 	}
 
@@ -88,18 +88,19 @@ public class ColGroupSizes {
 		return size;
 	}
 
-	public static long estimateInMemorySizeSDC(int nrColumns, int nrValues, int nrRows, int largestOff, boolean lossy){
+	public static long estimateInMemorySizeSDC(int nrColumns, int nrValues, int nrRows, int largestOff, boolean lossy) {
 		long size = estimateInMemorySizeGroupValue(nrColumns, nrValues, lossy);
-		size += MemoryEstimates.intArrayCost(nrRows- largestOff);
+		size += MemoryEstimates.intArrayCost(nrRows - largestOff);
 		// size += MemoryEstimates.byteArrayCost(nrRows- largestOff);
 		size += MapToFactory.estimateInMemorySize(nrRows - largestOff, nrValues);
 		return size;
 	}
 
-	public static long estimateInMemorySizeSDCSingle(int nrColumns, int nrValues, int nrRows, int largestOff, boolean lossy){
+	public static long estimateInMemorySizeSDCSingle(int nrColumns, int nrValues, int nrRows, int largestOff,
+		boolean lossy) {
 		long size = estimateInMemorySizeGroupValue(nrColumns, nrValues, lossy);
 		// size += MemoryEstimates.intArrayCost(nrRows - largestOff);
-		size += MemoryEstimates.byteArrayCost(nrRows- largestOff);
+		size += MemoryEstimates.byteArrayCost(nrRows - largestOff);
 		return size;
 	}
 
@@ -108,7 +109,7 @@ public class ColGroupSizes {
 		return size;
 	}
 
-	public static long estimateInMemorySizeEMPTY(int nrColumns){
+	public static long estimateInMemorySizeEMPTY(int nrColumns) {
 		long size = estimateInMemorySizeGroup(nrColumns);
 		size += 8; // null pointer to _dict
 		return size;

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSizes.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSizes.java
@@ -90,8 +90,8 @@ public class ColGroupSizes {
 
 	public static long estimateInMemorySizeSDC(int nrColumns, int nrValues, int nrRows, int largestOff, boolean lossy){
 		long size = estimateInMemorySizeGroupValue(nrColumns, nrValues, lossy);
-		// size += MemoryEstimates.intArrayCost(nrRows- largestOff);
-		size += MemoryEstimates.byteArrayCost(nrRows- largestOff);
+		size += MemoryEstimates.intArrayCost(nrRows- largestOff);
+		// size += MemoryEstimates.byteArrayCost(nrRows- largestOff);
 		size += MapToFactory.estimateInMemorySize(nrRows - largestOff, nrValues);
 		return size;
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -279,7 +279,6 @@ public class ColGroupUncompressed extends AColGroup {
 		}
 	}
 
-
 	@Override
 	public void decompressColumnToBlock(double[] target, int colpos, int rl, int ru) {
 		// empty block, nothing to add to output
@@ -290,10 +289,9 @@ public class ColGroupUncompressed extends AColGroup {
 		for(int row = rl; row < ru; row++) {
 			double cellVal = _data.quickGetValue(row, colpos);
 			// Apparently rows are cols here.
-			target[row] +=  cellVal;
+			target[row] += cellVal;
 		}
 	}
-
 
 	@Override
 	public double get(int r, int c) {
@@ -429,7 +427,7 @@ public class ColGroupUncompressed extends AColGroup {
 	}
 
 	@Override
-	public void unaryAggregateOperations(AggregateUnaryOperator op, MatrixBlock result, int rl, int ru) {
+	public void unaryAggregateOperations(AggregateUnaryOperator op, double[] result, int rl, int ru) {
 		throw new NotImplementedException("Unimplemented Specific Sub ColGroup Aggregation Operation");
 	}
 
@@ -508,17 +506,15 @@ public class ColGroupUncompressed extends AColGroup {
 	}
 
 	@Override
-	public AColGroup sliceColumns(int cl, int cu){
+	public AColGroup sliceColumns(int cl, int cu) {
 		throw new NotImplementedException("Not implemented slice columns");
 	}
 
-
-	public double getMin(){
+	public double getMin() {
 		return _data.min();
 	}
 
-
-	public double getMax(){
+	public double getMax() {
 		return _data.max();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupValue.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupValue.java
@@ -53,8 +53,7 @@ import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 
 /**
- * Base class for column groups encoded with value dictionary. This include
- * column groups such as DDC OLE and RLE.
+ * Base class for column groups encoded with value dictionary. This include column groups such as DDC OLE and RLE.
  * 
  */
 public abstract class ColGroupValue extends AColGroup implements Cloneable {
@@ -77,11 +76,10 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Main constructor for the ColGroupValues. Used to contain the dictionaries
-	 * used for the different types of ColGroup.
+	 * Main constructor for the ColGroupValues. Used to contain the dictionaries used for the different types of
+	 * ColGroup.
 	 * 
-	 * @param colIndices indices (within the block) of the columns included in this
-	 *                   column
+	 * @param colIndices indices (within the block) of the columns included in this column
 	 * @param numRows    total number of rows in the parent block
 	 * @param ubm        Uncompressed bitmap representation of the block
 	 * @param cs         The Compression settings used for compression
@@ -91,17 +89,17 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 
 		_zeros = ubm.getNumOffsets() < (long) numRows;
 		// sort values by frequency, if requested
-		if (cs.sortValuesByLength && numRows > CompressionSettings.BITMAP_BLOCK_SZ)
+		if(cs.sortValuesByLength && numRows > CompressionSettings.BITMAP_BLOCK_SZ)
 			ubm.sortValuesByFrequency();
 
-		switch (ubm.getType()) {
-		case Full:
-			_dict = new Dictionary(((Bitmap) ubm).getValues());
-			break;
-		case Lossy:
-			_dict = new QDictionary((BitmapLossy) ubm).makeDoubleDictionary();
-			// _lossy = true;
-			break;
+		switch(ubm.getType()) {
+			case Full:
+				_dict = new Dictionary(((Bitmap) ubm).getValues());
+				break;
+			case Lossy:
+				_dict = new QDictionary((BitmapLossy) ubm).makeDoubleDictionary();
+				// _lossy = true;
+				break;
 		}
 	}
 
@@ -122,11 +120,9 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Obtain number of distinct sets of values associated with the bitmaps in this
-	 * column group.
+	 * Obtain number of distinct sets of values associated with the bitmaps in this column group.
 	 * 
-	 * @return the number of distinct sets of values associated with the bitmaps in
-	 *         this column group
+	 * @return the number of distinct sets of values associated with the bitmaps in this column group
 	 */
 	public int getNumValues() {
 		return _dict.getNumberOfValues(_colIndexes.length);
@@ -152,13 +148,13 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	@Override
 	public MatrixBlock getValuesAsBlock() {
 		final double[] values = getValues();
-		if (values != null) {
+		if(values != null) {
 
 			int vlen = values.length;
 
 			int rlen = _zeros ? vlen + 1 : vlen;
 			MatrixBlock ret = new MatrixBlock(rlen, 1, false);
-			for (int i = 0; i < vlen; i++)
+			for(int i = 0; i < vlen; i++)
 				ret.quickSetValue(i, 0, values[i]);
 			return ret;
 		}
@@ -166,22 +162,22 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Returns the counts of values inside the dictionary. If already calculated it
-	 * will return the previous counts. This produce an overhead in cases where the
-	 * count is calculated, but the overhead will be limited to number of distinct
-	 * tuples in the dictionary.
+	 * Returns the counts of values inside the dictionary. If already calculated it will return the previous counts.
+	 * This produce an overhead in cases where the count is calculated, but the overhead will be limited to number of
+	 * distinct tuples in the dictionary.
 	 * 
-	 * The returned counts always contains the number of zeros as well if there are
-	 * some contained, even if they are not materialized.
+	 * The returned counts always contains the number of zeros as well if there are some contained, even if they are not
+	 * materialized.
 	 *
 	 * @return the count of each value in the MatrixBlock.
 	 */
 	public final int[] getCounts() {
 
-		if (counts == null && _dict != null) {
+		if(counts == null && _dict != null) {
 			counts = getCounts(new int[getNumValues() + (_zeros ? 1 : 0)]);
 			return counts;
-		} else
+		}
+		else
 			return counts;
 
 	}
@@ -191,11 +187,11 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Returns the counts of values inside the MatrixBlock returned in
-	 * getValuesAsBlock Throws an exception if the getIfCountsType is false.
+	 * Returns the counts of values inside the MatrixBlock returned in getValuesAsBlock Throws an exception if the
+	 * getIfCountsType is false.
 	 * 
-	 * The returned counts always contains the number of zeros as well if there are
-	 * some contained, even if they are not materialized.
+	 * The returned counts always contains the number of zeros as well if there are some contained, even if they are not
+	 * materialized.
 	 *
 	 * @param rl the lower index of the interval of rows queried
 	 * @param ru the the upper boundary of the interval of rows queried
@@ -203,9 +199,10 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	 */
 	public final int[] getCounts(int rl, int ru) {
 		int[] tmp;
-		if (_zeros) {
+		if(_zeros) {
 			tmp = allocIVector(getNumValues() + 1, true);
-		} else {
+		}
+		else {
 			tmp = allocIVector(getNumValues(), true);
 		}
 		return getCounts(rl, ru, tmp);
@@ -223,7 +220,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		final int numCols = getNumCols();
 		final int valOff = valIx * numCols;
 		double val = 0;
-		for (int i = 0; i < numCols; i++)
+		for(int i = 0; i < numCols; i++)
 			val += dictVals[valOff + i] * b[_colIndexes[i]];
 		return val;
 	}
@@ -232,7 +229,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		final int numCols = getNumCols();
 		final int valOff = valIx * numCols;
 		double val = 0;
-		for (int i = 0; i < numCols; i++)
+		for(int i = 0; i < numCols; i++)
 			val += dictVals[valOff + i] * b[_colIndexes[i] + off];
 		return val;
 	}
@@ -250,11 +247,12 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		// the arrays index.
 		double[] ret = allocNew ? new double[numVals + 1] : allocDVector(numVals + 1, true);
 
-		if (_colIndexes.length == 1) {
-			for (int k = 0; k < numVals; k++)
+		if(_colIndexes.length == 1) {
+			for(int k = 0; k < numVals; k++)
 				ret[k] = dictVals[k] * b[_colIndexes[0] + off];
-		} else {
-			for (int k = 0; k < numVals; k++)
+		}
+		else {
+			for(int k = 0; k < numVals; k++)
 				ret[k] = sumValues(k, b, dictVals, off);
 		}
 
@@ -264,15 +262,15 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	private int[] getAggregateColumnsSetDense(double[] b, int cl, int cu, int cut) {
 		Set<Integer> aggregateColumnsSet = new HashSet<>();
 		final int retCols = (cu - cl);
-		for (int k = 0; k < _colIndexes.length; k++) {
+		for(int k = 0; k < _colIndexes.length; k++) {
 			int rowIdxOffset = _colIndexes[k] * cut;
-			for (int h = cl; h < cu; h++) {
+			for(int h = cl; h < cu; h++) {
 				double v = b[rowIdxOffset + h];
-				if (v != 0.0) {
+				if(v != 0.0) {
 					aggregateColumnsSet.add(h);
 				}
 			}
-			if (aggregateColumnsSet.size() == retCols)
+			if(aggregateColumnsSet.size() == retCols)
 				break;
 		}
 
@@ -282,17 +280,18 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	private Pair<int[], double[]> preaggValuesFromDense(final int numVals, final double[] b, double[] dictVals,
-			final int cl, final int cu, final int cut) {
+		final int cl, final int cu, final int cut) {
 
 		int[] aggregateColumns = getAggregateColumnsSetDense(b, cl, cu, cut);
 		double[] ret = new double[numVals * aggregateColumns.length];
 
-		for (int k = 0,
-				off = 0; k < numVals * _colIndexes.length; k += _colIndexes.length, off += aggregateColumns.length) {
-			for (int h = 0; h < _colIndexes.length; h++) {
+		for(int k = 0, off = 0;
+			k < numVals * _colIndexes.length;
+			k += _colIndexes.length, off += aggregateColumns.length) {
+			for(int h = 0; h < _colIndexes.length; h++) {
 				int idb = _colIndexes[h] * cut;
 				double v = dictVals[k + h];
-				for (int i = 0; i < aggregateColumns.length; i++) {
+				for(int i = 0; i < aggregateColumns.length; i++) {
 					ret[off + i] += v * b[idb + aggregateColumns[i]];
 				}
 
@@ -305,11 +304,11 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	private int[] getAggregateColumnsSetSparse(SparseBlock b) {
 		Set<Integer> aggregateColumnsSet = new HashSet<>();
 
-		for (int h = 0; h < _colIndexes.length; h++) {
+		for(int h = 0; h < _colIndexes.length; h++) {
 			int colIdx = _colIndexes[h];
-			if (!b.isEmpty(colIdx)) {
+			if(!b.isEmpty(colIdx)) {
 				int[] sIndexes = b.indexes(colIdx);
-				for (int i = b.pos(colIdx); i < b.size(colIdx) + b.pos(colIdx); i++) {
+				for(int i = b.pos(colIdx); i < b.size(colIdx) + b.pos(colIdx); i++) {
 					aggregateColumnsSet.add(sIndexes[i]);
 				}
 			}
@@ -321,24 +320,25 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	private Pair<int[], double[]> preaggValuesFromSparse(int numVals, SparseBlock b, double[] dictVals, int cl, int cu,
-			int cut) {
+		int cut) {
 
 		int[] aggregateColumns = getAggregateColumnsSetSparse(b);
 
 		double[] ret = new double[numVals * aggregateColumns.length];
 
-		for (int h = 0; h < _colIndexes.length; h++) {
+		for(int h = 0; h < _colIndexes.length; h++) {
 			int colIdx = _colIndexes[h];
-			if (!b.isEmpty(colIdx)) {
+			if(!b.isEmpty(colIdx)) {
 				double[] sValues = b.values(colIdx);
 				int[] sIndexes = b.indexes(colIdx);
 				int retIdx = 0;
-				for (int i = b.pos(colIdx); i < b.size(colIdx) + b.pos(colIdx); i++) {
-					while (aggregateColumns[retIdx] < sIndexes[i])
+				for(int i = b.pos(colIdx); i < b.size(colIdx) + b.pos(colIdx); i++) {
+					while(aggregateColumns[retIdx] < sIndexes[i])
 						retIdx++;
-					if (sIndexes[i] == aggregateColumns[retIdx])
-						for (int j = 0, offOrg = h; j < numVals
-								* aggregateColumns.length; j += aggregateColumns.length, offOrg += _colIndexes.length) {
+					if(sIndexes[i] == aggregateColumns[retIdx])
+						for(int j = 0, offOrg = h;
+							j < numVals * aggregateColumns.length;
+							j += aggregateColumns.length, offOrg += _colIndexes.length) {
 							ret[j + retIdx] += dictVals[offOrg] * sValues[i];
 						}
 				}
@@ -348,14 +348,18 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	public Pair<int[], double[]> preaggValues(int numVals, MatrixBlock b, double[] dictVals, int cl, int cu, int cut) {
-		return b.isInSparseFormat() ? preaggValuesFromSparse(numVals, b.getSparseBlock(), dictVals, cl, cu, cut)
-				: preaggValuesFromDense(numVals, b.getDenseBlockValues(), dictVals, cl, cu, cut);
+		return b.isInSparseFormat() ? preaggValuesFromSparse(numVals,
+			b.getSparseBlock(),
+			dictVals,
+			cl,
+			cu,
+			cut) : preaggValuesFromDense(numVals, b.getDenseBlockValues(), dictVals, cl, cu, cut);
 	}
 
 	protected static double[] sparsePreaggValues(int numVals, double v, boolean allocNew, double[] dictVals) {
 		double[] ret = allocNew ? new double[numVals + 1] : allocDVector(numVals + 1, true);
 
-		for (int k = 0; k < numVals; k++)
+		for(int k = 0; k < numVals; k++)
 			ret[k] = dictVals[k] * v;
 		return ret;
 	}
@@ -369,26 +373,25 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	protected double computeMxx(double c, Builtin builtin) {
-		if (_zeros)
+		if(_zeros)
 			c = builtin.execute(c, 0);
-		if (_dict != null)
+		if(_dict != null)
 			return _dict.aggregate(c, builtin);
 		else
 			return c;
 	}
 
 	protected void computeColMxx(double[] c, Builtin builtin) {
-		if (_zeros) {
-			for (int x = 0; x < _colIndexes.length; x++)
+		if(_zeros) {
+			for(int x = 0; x < _colIndexes.length; x++)
 				c[_colIndexes[x]] = builtin.execute(c[_colIndexes[x]], 0);
 		}
-		if (_dict != null)
+		if(_dict != null)
 			_dict.aggregateCols(c, builtin, _colIndexes);
 	}
 
 	/**
-	 * Method for use by subclasses. Applies a scalar operation to the value
-	 * metadata stored in the dictionary.
+	 * Method for use by subclasses. Applies a scalar operation to the value metadata stored in the dictionary.
 	 * 
 	 * @param op scalar operation to perform
 	 * @return transformed copy of value metadata for this column group
@@ -398,17 +401,15 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Method for use by subclasses. Applies a scalar operation to the value
-	 * metadata stored in the dictionary. This specific method is used in cases
-	 * where an new entry is to be added in the dictionary.
+	 * Method for use by subclasses. Applies a scalar operation to the value metadata stored in the dictionary. This
+	 * specific method is used in cases where an new entry is to be added in the dictionary.
 	 * 
-	 * Method should only be called if the newVal is not 0! Also the newVal should
-	 * already have the operator applied.
+	 * Method should only be called if the newVal is not 0! Also the newVal should already have the operator applied.
 	 * 
 	 * @param op      The Operator to apply to the underlying data.
 	 * @param newVal  The new Value to append to the underlying data.
-	 * @param numCols The number of columns in the ColGroup, to specify how many
-	 *                copies of the newVal should be appended.
+	 * @param numCols The number of columns in the ColGroup, to specify how many copies of the newVal should be
+	 *                appended.
 	 * @return The new Dictionary containing the values.
 	 */
 	protected ADictionary applyScalarOp(ScalarOperator op, double newVal, int numCols) {
@@ -416,68 +417,67 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	}
 
 	/**
-	 * Apply the binary row-wise operator to the dictionary, and copy it
-	 * appropriately if needed.
+	 * Apply the binary row-wise operator to the dictionary, and copy it appropriately if needed.
 	 * 
 	 * @param fn         The function to apply.
 	 * @param v          The vector to apply on each tuple of the dictionary.
-	 * @param sparseSafe Specify if the operation is sparseSafe. if false then
-	 *                   allocate a new tuple.
+	 * @param sparseSafe Specify if the operation is sparseSafe. if false then allocate a new tuple.
 	 * @param left       Specify which side the operation is executed on.
 	 * @return The new Dictionary with values.
 	 */
 	public ADictionary applyBinaryRowOp(ValueFunction fn, double[] v, boolean sparseSafe, boolean left) {
-		return sparseSafe ? _dict.clone().applyBinaryRowOp(fn, v, sparseSafe, _colIndexes, left)
-				: _dict.applyBinaryRowOp(fn, v, sparseSafe, _colIndexes, left);
+		return sparseSafe ? _dict.clone().applyBinaryRowOp(fn, v, sparseSafe, _colIndexes, left) : _dict
+			.applyBinaryRowOp(fn, v, sparseSafe, _colIndexes, left);
 	}
 
 	@Override
-	public void unaryAggregateOperations(AggregateUnaryOperator op, MatrixBlock c) {
+	public void unaryAggregateOperations(AggregateUnaryOperator op, double[] c) {
 		unaryAggregateOperations(op, c, 0, _numRows);
 	}
 
 	@Override
-	public void unaryAggregateOperations(AggregateUnaryOperator op, MatrixBlock c, int rl, int ru) {
+	public void unaryAggregateOperations(AggregateUnaryOperator op, double[] c, int rl, int ru) {
 		// sum and sumsq (reduceall/reducerow over tuples and counts)
-		if (op.aggOp.increOp.fn instanceof KahanPlus || op.aggOp.increOp.fn instanceof KahanPlusSq
-				|| op.aggOp.increOp.fn instanceof Mean) {
-			KahanFunction kplus = (op.aggOp.increOp.fn instanceof KahanPlus || op.aggOp.increOp.fn instanceof Mean)
-					? KahanPlus.getKahanPlusFnObject()
-					: KahanPlusSq.getKahanPlusSqFnObject();
+		if(op.aggOp.increOp.fn instanceof KahanPlus || op.aggOp.increOp.fn instanceof KahanPlusSq ||
+			op.aggOp.increOp.fn instanceof Mean) {
+			KahanFunction kplus = (op.aggOp.increOp.fn instanceof KahanPlus ||
+				op.aggOp.increOp.fn instanceof Mean) ? KahanPlus
+					.getKahanPlusFnObject() : KahanPlusSq.getKahanPlusSqFnObject();
 			boolean mean = op.aggOp.increOp.fn instanceof Mean;
-			if (op.indexFn instanceof ReduceAll)
-				computeSum(c.getDenseBlockValues(), kplus instanceof KahanPlusSq);
-			else if (op.indexFn instanceof ReduceCol)
-				computeRowSums(c.getDenseBlockValues(), kplus instanceof KahanPlusSq, rl, ru, mean);
-			else if (op.indexFn instanceof ReduceRow)
-				computeColSums(c.getDenseBlockValues(), kplus instanceof KahanPlusSq);
+			if(op.indexFn instanceof ReduceAll)
+				computeSum(c, kplus instanceof KahanPlusSq);
+			else if(op.indexFn instanceof ReduceCol)
+				computeRowSums(c, kplus instanceof KahanPlusSq, rl, ru, mean);
+			else if(op.indexFn instanceof ReduceRow)
+				computeColSums(c, kplus instanceof KahanPlusSq);
 		}
 		// min and max (reduceall/reducerow over tuples only)
-		else if (op.aggOp.increOp.fn instanceof Builtin
-				&& (((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX
-						|| ((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN)) {
+		else if(op.aggOp.increOp.fn instanceof Builtin &&
+			(((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MAX ||
+				((Builtin) op.aggOp.increOp.fn).getBuiltinCode() == BuiltinCode.MIN)) {
 			Builtin builtin = (Builtin) op.aggOp.increOp.fn;
 
-			if (op.indexFn instanceof ReduceAll)
-				c.getDenseBlockValues()[0] = computeMxx(c.getDenseBlockValues()[0], builtin);
-			else if (op.indexFn instanceof ReduceCol)
+			if(op.indexFn instanceof ReduceAll)
+				c[0] = computeMxx(c[0], builtin);
+			else if(op.indexFn instanceof ReduceCol)
 				computeRowMxx(c, builtin, rl, ru);
-			else if (op.indexFn instanceof ReduceRow)
-				computeColMxx(c.getDenseBlockValues(), builtin);
-		} else {
+			else if(op.indexFn instanceof ReduceRow)
+				computeColMxx(c, builtin);
+		}
+		else {
 			throw new DMLScriptException("Unknown UnaryAggregate operator on CompressedMatrixBlock");
 		}
 	}
 
 	protected void setandExecute(double[] c, boolean square, double val, int rix) {
-		if (square)
+		if(square)
 			c[rix] += val * val;
 		else
 			c[rix] += val;
 	}
 
 	public static void setupThreadLocalMemory(int len) {
-		if (memPool.get() == null || memPool.get().getLeft().length < len) {
+		if(memPool.get() == null || memPool.get().getLeft().length < len) {
 			Pair<int[], double[]> p = new ImmutablePair<>(new int[len], new double[len]);
 			memPool.set(p);
 		}
@@ -491,18 +491,18 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		Pair<int[], double[]> p = memPool.get();
 
 		// sanity check for missing setup
-		if (p == null) {
+		if(p == null) {
 			return new double[len];
 		}
 
-		if (p.getValue().length < len) {
+		if(p.getValue().length < len) {
 			setupThreadLocalMemory(len);
 			return p.getValue();
 		}
 
 		// get and reset if necessary
 		double[] tmp = p.getValue();
-		if (reset)
+		if(reset)
 			Arrays.fill(tmp, 0, len, 0);
 		return tmp;
 	}
@@ -511,16 +511,16 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		Pair<int[], double[]> p = memPool.get();
 
 		// sanity check for missing setup
-		if (p == null)
+		if(p == null)
 			return new int[len + 1];
 
-		if (p.getKey().length < len) {
+		if(p.getKey().length < len) {
 			setupThreadLocalMemory(len);
 			return p.getKey();
 		}
 
 		int[] tmp = p.getKey();
-		if (reset)
+		if(reset)
 			Arrays.fill(tmp, 0, len, 0);
 		return tmp;
 	}
@@ -531,7 +531,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		sb.append(super.toString());
 		sb.append(String.format("\n%15s%5d ", "Columns:", _colIndexes.length));
 		sb.append(Arrays.toString(_colIndexes));
-		if (_dict != null) {
+		if(_dict != null) {
 			sb.append(String.format("\n%15s%5d ", "Values:", _dict.getValues().length));
 			_dict.getString(sb, _colIndexes.length);
 		}
@@ -551,10 +551,10 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		_lossy = in.readBoolean();
 		// read col indices
 		_colIndexes = new int[numCols];
-		for (int i = 0; i < numCols; i++)
+		for(int i = 0; i < numCols; i++)
 			_colIndexes[i] = in.readInt();
 
-		if (in.readBoolean())
+		if(in.readBoolean())
 			_dict = ADictionary.read(in, _lossy);
 	}
 
@@ -566,13 +566,14 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		out.writeBoolean(_lossy);
 
 		// write col indices
-		for (int i = 0; i < _colIndexes.length; i++)
+		for(int i = 0; i < _colIndexes.length; i++)
 			out.writeInt(_colIndexes[i]);
 
-		if (_dict != null) {
+		if(_dict != null) {
 			out.writeBoolean(true);
 			_dict.write(out);
-		} else
+		}
+		else
 			out.writeBoolean(false);
 	}
 
@@ -587,7 +588,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		ret += 4 * _colIndexes.length;
 		// distinct values (groups of values)
 		ret += 1; // Dict exists boolean
-		if (_dict != null)
+		if(_dict != null)
 			ret += _dict.getExactSizeOnDisk();
 
 		return ret;
@@ -598,8 +599,8 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	public abstract int[] getCounts(int rl, int ru, int[] out);
 
 	protected void computeSum(double[] c, boolean square) {
-		if (_dict != null)
-			if (square)
+		if(_dict != null)
+			if(square)
 				c[0] += _dict.sumsq(getCounts(), _colIndexes.length);
 			else
 				c[0] += _dict.sum(getCounts(), _colIndexes.length);
@@ -611,7 +612,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		_dict.colSum(c, getCounts(), _colIndexes, square);
 	}
 
-	protected abstract void computeRowMxx(MatrixBlock c, Builtin builtin, int rl, int ru);
+	protected abstract void computeRowMxx(double[] c, Builtin builtin, int rl, int ru);
 
 	protected Object clone() throws CloneNotSupportedException {
 		return super.clone();
@@ -623,7 +624,8 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 			clone.setDictionary(new Dictionary(newDictionary));
 			clone.setColIndices(colIndexes);
 			return clone;
-		} catch (CloneNotSupportedException e) {
+		}
+		catch(CloneNotSupportedException e) {
 			e.printStackTrace();
 		}
 		return null;
@@ -635,7 +637,8 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 			clone.setDictionary(newDictionary);
 			clone.setColIndices(colIndexes);
 			return clone;
-		} catch (CloneNotSupportedException e) {
+		}
+		catch(CloneNotSupportedException e) {
 			e.printStackTrace();
 		}
 		return null;
@@ -646,7 +649,8 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		try {
 			ColGroupValue clone = (ColGroupValue) this.clone();
 			return clone;
-		} catch (CloneNotSupportedException e) {
+		}
+		catch(CloneNotSupportedException e) {
 			e.printStackTrace();
 		}
 		return null;
@@ -680,7 +684,7 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 
 	@Override
 	public AColGroup sliceColumns(int cl, int cu) {
-		if (cu - cl == 1)
+		if(cu - cl == 1)
 			return sliceSingleColumn(cl);
 		else
 			return sliceMultiColumns(cl, cu);
@@ -692,17 +696,18 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		int idx = Arrays.binarySearch(_colIndexes, col);
 		// Binary search returns negative value if the column is not found.
 		// Therefore return null, if the column is not inside this colGroup.
-		if (idx >= 0) {
+		if(idx >= 0) {
 			ret._colIndexes = new int[1];
 			ret._colIndexes[0] = _colIndexes[idx] - col;
-			if (ret._dict != null)
-				if (_colIndexes.length == 1)
+			if(ret._dict != null)
+				if(_colIndexes.length == 1)
 					ret._dict = ret._dict.clone();
 				else
 					ret._dict = ret._dict.sliceOutColumnRange(idx, idx + 1, _colIndexes.length);
 
 			return ret;
-		} else
+		}
+		else
 			return null;
 	}
 
@@ -710,24 +715,25 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		ColGroupValue ret = (ColGroupValue) copy();
 		int idStart = 0;
 		int idEnd = 0;
-		for (int i = 0; i < _colIndexes.length; i++) {
-			if (_colIndexes[i] < cl)
+		for(int i = 0; i < _colIndexes.length; i++) {
+			if(_colIndexes[i] < cl)
 				idStart++;
-			if (_colIndexes[i] < cu)
+			if(_colIndexes[i] < cu)
 				idEnd++;
 		}
 		int numberOfOutputColumns = idEnd - idStart;
-		if (numberOfOutputColumns > 0) {
+		if(numberOfOutputColumns > 0) {
 			ret._dict = ret._dict != null ? ret._dict.sliceOutColumnRange(idStart, idEnd, _colIndexes.length) : null;
 
 			ret._colIndexes = new int[numberOfOutputColumns];
 			// Incrementing idStart here so make sure that the dictionary is extracted
 			// before
-			for (int i = 0; i < numberOfOutputColumns; i++) {
+			for(int i = 0; i < numberOfOutputColumns; i++) {
 				ret._colIndexes[i] = _colIndexes[idStart++] - cl;
 			}
 			return ret;
-		} else
+		}
+		else
 			return null;
 	}
 
@@ -757,9 +763,9 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		final int ncol = getNumCols();
 		int valOff = 0;
 
-		for (int k = 0; k < numVals; k++) {
+		for(int k = 0; k < numVals; k++) {
 			double aval = vals[k];
-			for (int j = 0; j < ncol; j++) {
+			for(int j = 0; j < ncol; j++) {
 				int colIx = _colIndexes[j] + row * totalCols;
 				c[colIx] += aval * dictValues[valOff++];
 			}
@@ -775,17 +781,17 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 	 * @param numVals    The number of values contained in the dictionary.
 	 * @param row        The row index in the output c to assign the result to.
 	 * @param totalCols  The total number of columns in c.
-	 * @param offT       The offset into C to assign the values from usefull in case
-	 *                   the c output is a smaller temporary array.
+	 * @param offT       The offset into C to assign the values from usefull in case the c output is a smaller temporary
+	 *                   array.
 	 */
 	protected void postScaling(double[] dictValues, double[] vals, double[] c, int numVals, int row, int totalCols,
-			int offT) {
+		int offT) {
 		final int ncol = getNumCols();
 		int valOff = 0;
 
-		for (int k = 0; k < numVals; k++) {
+		for(int k = 0; k < numVals; k++) {
 			double aval = vals[k];
-			for (int j = 0; j < ncol; j++) {
+			for(int j = 0; j < ncol; j++) {
 				int colIx = _colIndexes[j] + row * totalCols;
 				c[offT + colIx] += aval * dictValues[valOff++];
 			}
@@ -872,27 +878,27 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		// + Arrays.toString(lhs.getColIndices()) + " " +
 		// Arrays.toString(this.getColIndices()));
 
-		if (lhs instanceof ColGroupDDC)
+		if(lhs instanceof ColGroupDDC)
 			return preAggregateDDC((ColGroupDDC) lhs);
-		else if (lhs instanceof ColGroupSDC)
+		else if(lhs instanceof ColGroupSDC)
 			return preAggregateSDC((ColGroupSDC) lhs);
-		else if (lhs instanceof ColGroupSDCSingle)
+		else if(lhs instanceof ColGroupSDCSingle)
 			return preAggregateSDCSingle((ColGroupSDCSingle) lhs);
-		else if (lhs instanceof ColGroupSDCZeros)
+		else if(lhs instanceof ColGroupSDCZeros)
 			return preAggregateSDCZeros((ColGroupSDCZeros) lhs);
-		else if (lhs instanceof ColGroupSDCSingleZeros)
+		else if(lhs instanceof ColGroupSDCSingleZeros)
 			return preAggregateSDCSingleZeros((ColGroupSDCSingleZeros) lhs);
-		else if (lhs instanceof ColGroupOLE)
+		else if(lhs instanceof ColGroupOLE)
 			return preAggregateOLE((ColGroupOLE) lhs);
-		else if (lhs instanceof ColGroupRLE)
+		else if(lhs instanceof ColGroupRLE)
 			return preAggregateRLE((ColGroupRLE) lhs);
-		else if (lhs instanceof ColGroupConst)
+		else if(lhs instanceof ColGroupConst)
 			return preAggregateCONST((ColGroupConst) lhs);
-		else if (lhs instanceof ColGroupEmpty)
+		else if(lhs instanceof ColGroupEmpty)
 			return null;
 
 		throw new NotImplementedException("Not supported pre aggregate of :" + lhs.getClass().getSimpleName() + " in "
-				+ this.getClass().getSimpleName());
+			+ this.getClass().getSimpleName());
 	}
 
 	public IPreAggregate preAggregateCONST(ColGroupConst lhs) {
@@ -931,52 +937,68 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		final int lCol = lhs._colIndexes.length;
 		final int rCol = this._colIndexes.length;
 
-		if (sameIndexStructure(lhs)) {
+		if(sameIndexStructure(lhs)) {
 			int[] agI = getCounts();
-			for (int a = 0, off = 0; a < nvL; a++, off += nvL + 1)
+			for(int a = 0, off = 0; a < nvL; a++, off += nvL + 1)
 				leftMultDictEntry(agI[a], off, nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, result);
-		} else {
+		}
+		else {
 			// LOG.error(lCol +" "+ nvL);
 			// LOG.error(rCol +" "+ nvR);
 			IPreAggregate ag = preAggregate(lhs);
-			if (ag == null)
+			if(ag == null)
 				return;
-			else if (ag instanceof MapPreAggregate)
-				leftMultMapPreAggregate(nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, result,
-						(MapPreAggregate) ag);
+			else if(ag instanceof MapPreAggregate)
+				leftMultMapPreAggregate(nvL,
+					lCol,
+					rCol,
+					lhs,
+					numCols,
+					lhValues,
+					rhValues,
+					result,
+					(MapPreAggregate) ag);
 			else
-				leftMultArrayPreAggregate(nvL, nvR, lCol, rCol, lhs, numCols, lhValues, rhValues, result,
-						((ArrPreAggregate) ag).getArr());
+				leftMultArrayPreAggregate(nvL,
+					nvR,
+					lCol,
+					rCol,
+					lhs,
+					numCols,
+					lhValues,
+					rhValues,
+					result,
+					((ArrPreAggregate) ag).getArr());
 		}
 	}
 
 	private void leftMultMapPreAggregate(final int nvL, final int lCol, final int rCol, final ColGroupValue lhs,
-			final int numCols, double[] lhValues, double[] rhValues, double[] c, MapPreAggregate agM) {
+		final int numCols, double[] lhValues, double[] rhValues, double[] c, MapPreAggregate agM) {
 		final int[] map = agM.getMap();
 		final int aggSize = agM.getSize();
-		for (int k = 0; k < aggSize; k += 2)
+		for(int k = 0; k < aggSize; k += 2)
 			leftMultDictEntry(map[k + 1], map[k], nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, c);
 		leftMultDictEntry(agM.getMapFreeValue(), 0, nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, c);
 	}
 
 	private void leftMultArrayPreAggregate(final int nvL, final int nvR, final int lCol, final int rCol,
-			final ColGroupValue lhs, final int numCols, double[] lhValues, double[] rhValues, double[] c, int[] arr) {
-		for (int a = 0; a < nvL * nvR; a++)
+		final ColGroupValue lhs, final int numCols, double[] lhValues, double[] rhValues, double[] c, int[] arr) {
+		for(int a = 0; a < nvL * nvR; a++)
 			leftMultDictEntry(arr[a], a, nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, c);
 	}
 
 	private void leftMultDictEntry(final int m, final int a, final int nvL, final int lCol, final int rCol,
-			final ColGroupValue lhs, final int numCols, double[] lhValues, double[] rhValues, double[] c) {
+		final ColGroupValue lhs, final int numCols, double[] lhValues, double[] rhValues, double[] c) {
 
-		if (m > 0) {
+		if(m > 0) {
 			final int lhsRowOffset = (a % nvL) * lCol;
 			final int rhsRowOffset = (a / nvL) * rCol;
 
-			for (int j = 0; j < lCol; j++) {
+			for(int j = 0; j < lCol; j++) {
 				final int resultOff = lhs._colIndexes[j] * numCols;
 				final double lh = lhValues[lhsRowOffset + j] * m;
-				if (lh != 0)
-					for (int i = 0; i < rCol; i++) {
+				if(lh != 0)
+					for(int i = 0; i < rCol; i++) {
 						double rh = rhValues[rhsRowOffset + i];
 						c[resultOff + _colIndexes[i]] += lh * rh;
 					}
@@ -989,13 +1011,13 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 		int[] counts = getCounts();
 		double[] values = getValues();
 		int[] columns = getColIndices();
-		if (values == null)
+		if(values == null)
 			return;
-		for (int i = 0; i < columns.length; i++) {
+		for(int i = 0; i < columns.length; i++) {
 			final int y = columns[i] * numColumns;
-			for (int j = 0; j < columns.length; j++) {
+			for(int j = 0; j < columns.length; j++) {
 				final int x = columns[j];
-				for (int h = 0; h < values.length / columns.length; h++) {
+				for(int h = 0; h < values.length / columns.length; h++) {
 					double a = values[h * columns.length + i];
 					double b = values[h * columns.length + j];
 					result[x + y] += a * b * counts[h];

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupValue.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupValue.java
@@ -23,9 +23,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.NotImplementedException;
@@ -836,32 +834,32 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 
 	public abstract int getIndexStructureHash();
 
-
 	// try to make a memo table.
 	// private static Map<Integer,Map<Integer,Memo>> memorizer = new HashMap<>();
 
 	// private class Memo {
-	// 	ColGroupValue lhs;
-	// 	ColGroupValue rhs;
-	// 	IPreAggregate agg;
+	// ColGroupValue lhs;
+	// ColGroupValue rhs;
+	// IPreAggregate agg;
 
-	// 	private Memo(ColGroupValue lhs, ColGroupValue rhs, IPreAggregate agg) {
-	// 		this.lhs = lhs;
-	// 		this.rhs = rhs;
-	// 		this.agg = agg;
-	// 	}
+	// private Memo(ColGroupValue lhs, ColGroupValue rhs, IPreAggregate agg) {
+	// this.lhs = lhs;
+	// this.rhs = rhs;
+	// this.agg = agg;
+	// }
 	// }
 
 	public IPreAggregate preAggregate(ColGroupValue lhs) {
 		// int lhsH = lhs.getIndexStructureHash();
 		// int rhsH = this.getIndexStructureHash();
 		// if(memorizer.get(lhsH) == null){
-		// 	memorizer.put(lhsH, new HashMap<>()); 
+		// memorizer.put(lhsH, new HashMap<>());
 		// }
 		// Memo m = memorizer.get(lhsH).get(rhsH);
-		// if(m != null && lhs.sameIndexStructure(m.lhs) && this.sameIndexStructure(m.rhs))
-		// 	return m.agg;
-		
+		// if(m != null && lhs.sameIndexStructure(m.lhs) &&
+		// this.sameIndexStructure(m.rhs))
+		// return m.agg;
+
 		IPreAggregate r = preCallAggregate(lhs);
 		// Map<Integer,Memo> l = memorizer.get(lhsH);
 		// l.put(rhsH, new Memo(lhs, this, r));
@@ -938,8 +936,8 @@ public abstract class ColGroupValue extends AColGroup implements Cloneable {
 			for (int a = 0, off = 0; a < nvL; a++, off += nvL + 1)
 				leftMultDictEntry(agI[a], off, nvL, lCol, rCol, lhs, numCols, lhValues, rhValues, result);
 		} else {
-			// LOG.error(lCol +"  "+ nvL);
-			// LOG.error(rCol +"  "+ nvR);
+			// LOG.error(lCol +" "+ nvL);
+			// LOG.error(rCol +" "+ nvR);
 			IPreAggregate ag = preAggregate(lhs);
 			if (ag == null)
 				return;

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/QDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/QDictionary.java
@@ -122,6 +122,22 @@ public class QDictionary extends ADictionary {
 		return ret;
 	}
 
+
+	@Override
+	public double[] aggregateTuples(Builtin fn, final int nCol){
+		if(nCol == 1)
+			return getValues();
+		final int nRows = _values.length / nCol;
+		double[] res = new double[nRows];
+		for(int i = 0; i < nRows; i++){
+			final int off = i * nCol;
+			res[i] = _values[off];
+			for(int j = off + 1; j < off + nCol; j++)
+				res[i] = fn.execute(res[i], _values[j] * _scale);
+		}
+		return res;
+	}
+
 	@Override
 	public QDictionary apply(ScalarOperator op) {
 		if(_values == null)
@@ -226,7 +242,6 @@ public class QDictionary extends ADictionary {
 	public QDictionary applyBinaryRowOpLeft(ValueFunction fn, double[] v, boolean sparseSafe, int[] colIndexes) {
 		throw new NotImplementedException("Not Implemented yet");
 	}
-	
 
 	@Override
 	public int size() {
@@ -309,34 +324,34 @@ public class QDictionary extends ADictionary {
 	}
 
 	@Override
-	protected void colSum(double[] c, int[] counts, int[] colIndexes,  boolean square) {
+	protected void colSum(double[] c, int[] counts, int[] colIndexes, boolean square) {
 		throw new NotImplementedException("Not Implemented");
 		// final int rows = c.length / 2;
 		// if(!(kplus instanceof KahanPlusSq)) {
-		// 	int[] sum = new int[colIndexes.length];
-		// 	int valOff = 0;
-		// 	for(int k = 0; k < getNumberOfValues(colIndexes.length); k++) {
-		// 		int cntk = counts[k];
-		// 		for(int j = 0; j < colIndexes.length; j++) {
-		// 			sum[j] += cntk * getValueByte(valOff++);
-		// 		}
-		// 	}
-		// 	for(int j = 0; j < colIndexes.length; j++) {
-		// 		c[colIndexes[j]] = c[colIndexes[j]] + sum[j] * _scale;
-		// 	}
+		// int[] sum = new int[colIndexes.length];
+		// int valOff = 0;
+		// for(int k = 0; k < getNumberOfValues(colIndexes.length); k++) {
+		// int cntk = counts[k];
+		// for(int j = 0; j < colIndexes.length; j++) {
+		// sum[j] += cntk * getValueByte(valOff++);
+		// }
+		// }
+		// for(int j = 0; j < colIndexes.length; j++) {
+		// c[colIndexes[j]] = c[colIndexes[j]] + sum[j] * _scale;
+		// }
 		// }
 		// else {
-		// 	KahanObject kbuff = new KahanObject(0, 0);
-		// 	int valOff = 0;
-		// 	for(int k = 0; k < getNumberOfValues(colIndexes.length); k++) {
-		// 		int cntk = counts[k];
-		// 		for(int j = 0; j < colIndexes.length; j++) {
-		// 			kbuff.set(c[colIndexes[j]], c[colIndexes[j] + rows]);
-		// 			kplus.execute3(kbuff, getValue(valOff++), cntk);
-		// 			c[colIndexes[j]] = kbuff._sum;
-		// 			c[colIndexes[j] + rows] = kbuff._correction;
-		// 		}
-		// 	}
+		// KahanObject kbuff = new KahanObject(0, 0);
+		// int valOff = 0;
+		// for(int k = 0; k < getNumberOfValues(colIndexes.length); k++) {
+		// int cntk = counts[k];
+		// for(int j = 0; j < colIndexes.length; j++) {
+		// kbuff.set(c[colIndexes[j]], c[colIndexes[j] + rows]);
+		// kplus.execute3(kbuff, getValue(valOff++), cntk);
+		// c[colIndexes[j]] = kbuff._sum;
+		// c[colIndexes[j] + rows] = kbuff._correction;
+		// }
+		// }
 		// }
 	}
 
@@ -420,11 +435,11 @@ public class QDictionary extends ADictionary {
 		return new QDictionary(newDictValues, _scale);
 	}
 
-	public ADictionary reExpandColumns(int max){
+	public ADictionary reExpandColumns(int max) {
 		byte[] newDictValues = new byte[_values.length * max];
 
-		for(int i = 0, offset = 0; i< _values.length; i++, offset += max){
-			int val = _values[i]-1;
+		for(int i = 0, offset = 0; i < _values.length; i++, offset += max) {
+			int val = _values[i] - 1;
 			newDictValues[offset + val] = 1;
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/AInsertionSorter.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/AInsertionSorter.java
@@ -26,53 +26,70 @@ import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.compress.utils.IntArrayList;
 
 /**
- * This abstract class is for sorting the IntArrayList entries efficiently for SDC Column Groups construction.
+ * This abstract class is for sorting the IntArrayList entries efficiently for
+ * SDC Column Groups construction.
  * 
- * The idea is to construct an insertion tree, where the array is inserted along with a label, and the values are sorted
- * at insertion time.
+ * The idea is to construct an insertion tree, where the array is inserted along
+ * with a label, and the values are sorted at insertion time.
  * 
- * Any implementations is guaranteed that calls to getIndexes is first done once all _indexes are assigned.
+ * Any implementations is guaranteed that calls to getIndexes is first done once
+ * all _indexes are assigned.
  * 
  */
 public abstract class AInsertionSorter {
 	protected static final Log LOG = LogFactory.getLog(AInsertionSorter.class.getName());
 
-    protected final int[] _indexes;
-    protected final IMapToData _labels;
+	protected final int[] _indexes;
+	protected final IMapToData _labels;
 
-    protected final int _knownMax;
+	protected final int _numLabels;
+	protected final int _knownMax;
 
-    public AInsertionSorter(int endLength, int uniqueLabels, int knownMax) {
-        _indexes = new int[endLength];
-        _labels = MapToFactory.create(endLength, uniqueLabels);
-        _knownMax = knownMax;
-    }
+	public AInsertionSorter(int endLength, int uniqueLabels, int knownMax) {
+		_indexes = new int[endLength];
+		_labels = MapToFactory.create(endLength, uniqueLabels);
+		_numLabels = uniqueLabels;
+		_knownMax = knownMax;
+	}
 
-    public void insert(IntArrayList[] offsets, int negativeIndex){
-		for(int i = 0; i < offsets.length; i ++){
-			if( i < negativeIndex)
-				insert(offsets[i], i);
-			else if( i > negativeIndex)
-				insert(offsets[i], i -1);
+	public void insert(IntArrayList[] offsets) {
+		for (int i = 0; i < offsets.length; i++) {
+			insert(offsets[i], i);
 		}
-		negativeInsert(offsets[negativeIndex]);
-    }
+	}
 
-    protected abstract void insert(IntArrayList array, int label);
+	public void insert(IntArrayList[] offsets, int negativeIndex) {
+		for (int i = 0; i < offsets.length; i++) {
+			if (i < negativeIndex)
+				insert(offsets[i], i);
+			else if (i > negativeIndex)
+				insert(offsets[i], i - 1);
+		}
+		if (offsets[negativeIndex].size() > 0)
+			negativeInsert(offsets[negativeIndex]);
+	}
 
-    /**
-     * This method is to insert the remaining entries that are missing.
-     * But the trick is that the array provided is the entries that are not to be assigned.
-     * But instead any positions that are missing in the current _indexes and not present in the provided array.
-     * 
-     * This method should only be called after all other arrays are inserted.
-     * 
-     * @param array The provided array that should not be inserted, but instead the "negative imprint" of it should.
-     */
-    protected abstract void negativeInsert(IntArrayList array);
+	protected abstract void insert(IntArrayList array, int label);
 
-    public abstract int[] getIndexes();
+	/**
+	 * This method is to insert the remaining entries that are missing. But the
+	 * trick is that the array provided is the entries that are not to be assigned.
+	 * But instead any positions that are missing in the current _indexes and not
+	 * present in the provided array.
+	 * 
+	 * This method should only be called after all other arrays are inserted.
+	 * 
+	 * @param array The provided array that should not be inserted, but instead the
+	 *              "negative imprint" of it should.
+	 */
+	protected abstract void negativeInsert(IntArrayList array);
 
-    public abstract IMapToData getData();
+	public abstract int[] getIndexes();
 
+	public abstract IMapToData getData();
+
+	protected void set(int index, int value, int label) {
+		_indexes[index] = value;
+		_labels.set(index, label);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/BTree.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/BTree.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.tree;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.runtime.compress.colgroup.mapping.IMapToData;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+
+public class BTree extends AInsertionSorter {
+
+	public BTree(int endLength, int uniqueLabels, int knownMax) {
+		super(endLength, uniqueLabels, knownMax);
+	}
+
+	@Override
+	protected void insert(IntArrayList array, int label) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	protected void negativeInsert(IntArrayList array) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int[] getIndexes() {
+		return _indexes;
+	}
+
+	@Override
+	public IMapToData getData() {
+		return _labels;
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/InsertionSorterFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/InsertionSorterFactory.java
@@ -19,34 +19,15 @@
 
 package org.apache.sysds.runtime.compress.colgroup.tree;
 
-import org.apache.commons.lang.NotImplementedException;
-import org.apache.sysds.runtime.compress.colgroup.mapping.IMapToData;
-import org.apache.sysds.runtime.compress.utils.IntArrayList;
+public class InsertionSorterFactory {
+	public static AInsertionSorter create(int endLength, int uniqueLabels, int knownMax) {
 
-public class BTree extends AInsertionSorter {
+		// if ((double) endLength / (double) knownMax > 0.5)
+		return new MaterializeSort(endLength, uniqueLabels, knownMax);
+		// if (uniqueLabels < 10)
+		// return new MergeSort(endLength, uniqueLabels, knownMax);
+		// else
+		// return new Naive(endLength, uniqueLabels, knownMax);
 
-	public BTree(int endLength, int uniqueLabels, int knownMax) {
-		super(endLength, uniqueLabels, knownMax);
 	}
-
-	@Override
-	protected void insert(IntArrayList array, int label) {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	protected void negativeInsert(IntArrayList array) {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public int[] getIndexes() {
-		return _indexes;
-	}
-
-	@Override
-	public IMapToData getData() {
-		return _labels;
-	}
-
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/MaterializeSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/MaterializeSort.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.tree;
+
+import org.apache.sysds.runtime.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.mapping.IMapToData;
+import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+
+public class MaterializeSort extends AInsertionSorter {
+
+	public MaterializeSort(int endLength, int uniqueLabels, int knownMax) {
+		super(endLength, uniqueLabels, knownMax);
+	}
+
+	@Override
+	public void insert(final IntArrayList[] offsets) {
+		IMapToData md = MapToFactory.create(_knownMax, _numLabels);
+		md.fill(_numLabels);
+
+		for (int i = 0; i < offsets.length; i++) {
+			IntArrayList of = offsets[i];
+			for (int k = 0; k < of.size(); k++)
+				md.set(of.get(k), i);
+		}
+
+		int off = 0;
+		for (int i = 0; i < _knownMax; i++) {
+			int idx = md.getIndex(i);
+			if(idx != _numLabels)
+				set(off++, i, idx);
+		}
+
+	}
+
+
+	@Override
+	public void insert(final IntArrayList[] offsets, final int negativeIndex) {
+		IMapToData md = MapToFactory.create(_knownMax, _numLabels);
+		md.fill(_numLabels);
+		
+		for (int i = 0; i < offsets.length; i++) {
+			IntArrayList of = offsets[i];
+			for (int k = 0; k < of.size(); k++)
+				md.set(of.get(k), i);
+		}
+		int off = 0;
+		for (int i = 0; i < _knownMax; i++) {
+			int idx = md.getIndex(i);
+			if (idx < negativeIndex) 
+				set(off++, i, idx);
+			else if (idx > negativeIndex) 
+				set(off++, i, idx - 1);
+		}
+	}
+
+	@Override
+	protected void insert(IntArrayList array, int label) {
+		throw new DMLCompressionException("This class does not use this method");
+	}
+
+	@Override
+	protected void negativeInsert(IntArrayList array) {
+		throw new DMLCompressionException("This class does not use this method");
+	}
+
+	@Override
+	public int[] getIndexes() {
+		return _indexes;
+	}
+
+	@Override
+	public IMapToData getData() {
+		return _labels;
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/MergeSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/MergeSort.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.tree;
+
+import org.apache.sysds.runtime.compress.colgroup.mapping.IMapToData;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+
+public class MergeSort extends AInsertionSorter {
+
+	private int currentFill = 0;
+
+	public MergeSort(int endLength, int uniqueLabels, int knownMax) {
+		super(endLength, uniqueLabels, knownMax);
+	}
+
+	@Override
+	protected void insert(IntArrayList array, int label) {
+
+		if (currentFill == 0) {
+			currentFill = array.size();
+			for (int i = 0; i < currentFill; i++)
+				set(i, array.get(i), label);
+		} else
+			merge(array, label);
+
+	}
+
+	private void merge(IntArrayList a, int label) {
+		int pA = a.size(); // Pointer A
+		int pP = currentFill; // Pointer Previous
+		currentFill = pA + pP;
+		int pN = currentFill - 1; // Pointer new
+		pA--; // last element
+		pP--; // last element
+		int vA, vP;
+
+		while (pP >= 0 && pA >= 0) {
+			vA = a.get(pA);
+			vP = _indexes[pP];
+			if (vP > vA) {
+				set(pN--, vP, _labels.getIndex(pP--));
+			} else {
+				set(pN--, vA, label);
+				pA--;
+			}
+		}
+		while (pA >= 0)
+			set(pN--, a.get(pA--), label);
+
+	}
+
+
+	@Override
+	protected void negativeInsert(IntArrayList a) {
+		if (currentFill == _indexes.length)
+			return;
+		final int label = _numLabels - 1;
+		int pA = a.size() - 1; // Pointer A
+		int pP = currentFill - 1; // Pointer Previous
+		// From here on currentFill is no longer needed.
+		int pN = _indexes.length - 1; // Pointer new
+		int vA = a.get(pA);
+		int vP;
+		int vM = _knownMax;
+		while (pP > 0 && pA >= 0 && pN >= 0) {
+			vP = _indexes[pP];
+			vA = a.get(pA);
+			if (vP == vM)
+				set(pN--, vM, _labels.getIndex(pP--));
+			else if (vA == vM)
+				pA--;
+			else
+				set(pN--, vM, label);
+			vM--;
+		}
+
+		while (pN >= 0 && pA >= 0) {
+			vA = a.get(pA);
+			if (vA < vM)
+				set(pN--, vM, label);
+			else if (vA == vM)
+				pA--;
+
+			vM--;
+
+		}
+
+		while (pN >= 0 && vM > 0)
+			set(pN--, vM--, label);
+
+	}
+
+	@Override
+	public int[] getIndexes() {
+		return _indexes;
+	}
+
+	@Override
+	public IMapToData getData() {
+		return _labels;
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/Naive.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/tree/Naive.java
@@ -32,6 +32,46 @@ public class Naive extends AInsertionSorter {
 	}
 
 	@Override
+	public void insert(final IntArrayList[] offsets) {
+		
+
+		int[] offsetsRowIndex = new int[offsets.length];
+
+		int lastIndex = -1;
+
+		for(int i = 0; i < _indexes.length; i++) {
+			lastIndex++;
+			int start = Integer.MAX_VALUE;
+			int groupId = Integer.MAX_VALUE;
+			for(int j = 0; j < offsets.length; j++) {
+				final int off = offsetsRowIndex[j];
+				if(off < offsets[j].size()) {
+					final int v = offsets[j].get(off);
+					if(v == lastIndex) {
+						start = lastIndex;
+						groupId = j;
+						break;
+					}
+					else if(v < start) {
+						start = v;
+						groupId = j;
+					}
+				}
+			}
+			offsetsRowIndex[groupId]++;
+			_labels.set(i, groupId);
+			_indexes[i] = start;
+			lastIndex = start;
+		}
+
+		if(_indexes[_indexes.length-1] == 0 )
+			throw new DMLCompressionException("Invalid Index Structure" + Arrays.toString(_indexes));
+
+
+	}
+
+
+	@Override
 	public void insert(final IntArrayList[] offsets, final int negativeIndex) {
 		
 		final int[] offsetsRowIndex = new int[offsets.length];

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibAppend.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibAppend.java
@@ -36,10 +36,10 @@ public class CLALibAppend {
 
 	public static MatrixBlock append(MatrixBlock left, MatrixBlock right) {
 		
-		if(left.isEmpty())
-			return right;
-		else if(right.isEmpty())
-			return left;
+		// if(left.isEmpty())
+		// 	return right;
+		// else if(right.isEmpty())
+		// 	return left;
 		final int m = left.getNumRows();
 		final int n = left.getNumColumns() + right.getNumColumns();
 		long nnz = left.getNonZeros() + right.getNonZeros();
@@ -63,7 +63,7 @@ public class CLALibAppend {
 
 		// if compression failed then use default append method.
 		if(!(left instanceof CompressedMatrixBlock && right instanceof CompressedMatrixBlock))
-			return uc(left).append(uc(right), new MatrixBlock());
+			return uc(left).append(uc(right), null);
 
 		CompressedMatrixBlock leftC = (CompressedMatrixBlock) left;
 		CompressedMatrixBlock rightC = (CompressedMatrixBlock) right;
@@ -72,12 +72,13 @@ public class CLALibAppend {
 		CompressedMatrixBlock ret = new CompressedMatrixBlock(m, n);
 
 		// shallow copy of lhs column groups
-		ret.allocateColGroupList(new ArrayList<AColGroup>());
+		ret.allocateColGroupList(new ArrayList<AColGroup>(leftC.getColGroups().size() + rightC.getColGroups().size()));
 
 		for(AColGroup group : leftC.getColGroups()){
 			AColGroup tmp = group.copy();
 			ret.getColGroups().add(tmp);
 		}
+
 		for(AColGroup group : rightC.getColGroups()) {
 			AColGroup tmp = group.copy();
 			tmp.shiftColIndices(left.getNumColumns());

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
@@ -67,6 +67,7 @@ public class CLALibBinaryCellOp {
 		MatrixBlock that = CompressedMatrixBlock.getUncompressed(thatValue);
 		LibMatrixBincell.isValidDimensionsBinary(m1, that);
 		BinaryAccessType atype = LibMatrixBincell.getBinaryAccessType(m1, that);
+		LOG.error(atype);
 		return selectProcessingBasedOnAccessType(op, m1, that, thatValue, result, atype, false);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
@@ -67,7 +67,6 @@ public class CLALibBinaryCellOp {
 		MatrixBlock that = CompressedMatrixBlock.getUncompressed(thatValue);
 		LibMatrixBincell.isValidDimensionsBinary(m1, that);
 		BinaryAccessType atype = LibMatrixBincell.getBinaryAccessType(m1, that);
-		LOG.error(atype);
 		return selectProcessingBasedOnAccessType(op, m1, that, thatValue, result, atype, false);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReExpand.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReExpand.java
@@ -22,8 +22,6 @@ package org.apache.sysds.runtime.compress.lib;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
@@ -34,7 +32,7 @@ import org.apache.sysds.runtime.util.UtilFunctions;
 
 public class CLALibReExpand {
 
-	private static final Log LOG = LogFactory.getLog(CLALibReExpand.class.getName());
+	// private static final Log LOG = LogFactory.getLog(CLALibReExpand.class.getName());
 
 	public static MatrixBlock reExpand(CompressedMatrixBlock in, MatrixBlock ret, double max, boolean cast,
 			boolean ignore, int k) {
@@ -72,7 +70,6 @@ public class CLALibReExpand {
 		ret.setOverlapping(true);
 		ret.setNonZeros(-1);
 
-		// LOG.error(ret);
 		return ret;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibRightMultBy.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibRightMultBy.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLCompressionException;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
-import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupValue;
@@ -94,20 +93,20 @@ public class CLALibRightMultBy {
 
 	}
 
-	private static MatrixBlock rightMultByMatrixNonOverlapping(List<AColGroup> colGroups, MatrixBlock that,
-		MatrixBlock ret, int k, Pair<Integer, int[]> v) {
+	// private static MatrixBlock rightMultByMatrixNonOverlapping(List<AColGroup> colGroups, MatrixBlock that,
+	// 	MatrixBlock ret, int k, Pair<Integer, int[]> v) {
 
-		int rl = colGroups.get(0).getNumRows();
-		int cl = that.getNumColumns();
-		if(ret == null)
-			ret = new MatrixBlock(rl, cl, false, rl * cl);
-		else if(!(ret.getNumColumns() == cl && ret.getNumRows() == rl && ret.isAllocated()))
-			ret.reset(rl, cl, false, rl * cl);
-		ret.allocateDenseBlock();
-		ret = rightMultByMatrix(colGroups, that, ret, k, v);
-		ret.setNonZeros(ret.getNumColumns() * ret.getNumRows());
-		return ret;
-	}
+	// 	int rl = colGroups.get(0).getNumRows();
+	// 	int cl = that.getNumColumns();
+	// 	if(ret == null)
+	// 		ret = new MatrixBlock(rl, cl, false, rl * cl);
+	// 	else if(!(ret.getNumColumns() == cl && ret.getNumRows() == rl && ret.isAllocated()))
+	// 		ret.reset(rl, cl, false, rl * cl);
+	// 	ret.allocateDenseBlock();
+	// 	ret = rightMultByMatrix(colGroups, that, ret, k, v);
+	// 	ret.setNonZeros(ret.getNumColumns() * ret.getNumRows());
+	// 	return ret;
+	// }
 
 	private static MatrixBlock rightMultByMatrixOverlapping(List<AColGroup> colGroups, MatrixBlock that, MatrixBlock ret,
 		int k, Pair<Integer, int[]> v) {
@@ -193,69 +192,69 @@ public class CLALibRightMultBy {
 	// 	result.recomputeNonZeros();
 	// }
 
-	private static MatrixBlock rightMultByMatrix(List<AColGroup> colGroups, MatrixBlock that, MatrixBlock ret, int k,
-		Pair<Integer, int[]> v) {
+	// private static MatrixBlock rightMultByMatrix(List<AColGroup> colGroups, MatrixBlock that, MatrixBlock ret, int k,
+	// 	Pair<Integer, int[]> v) {
 
-		double[] retV = ret.getDenseBlockValues();
+	// 	double[] retV = ret.getDenseBlockValues();
 
-		for(AColGroup grp : colGroups) {
-			if(grp instanceof ColGroupUncompressed) {
-				((ColGroupUncompressed) grp).rightMultByMatrix(that, ret, 0, ret.getNumRows());
-			}
-		}
+	// 	for(AColGroup grp : colGroups) {
+	// 		if(grp instanceof ColGroupUncompressed) {
+	// 			((ColGroupUncompressed) grp).rightMultByMatrix(that, ret, 0, ret.getNumRows());
+	// 		}
+	// 	}
 
-		if(k == 1) {
-			for(int j = 0; j < colGroups.size(); j++) {
-				if(colGroups.get(j) instanceof ColGroupValue) {
-					Pair<int[], double[]> preAggregatedB = ((ColGroupValue) colGroups.get(j)).preaggValues(
-						v.getRight()[j],
-						that,
-						colGroups.get(j).getValues(),
-						0,
-						that.getNumColumns(),
-						that.getNumColumns());
-					int blklenRows = CompressionSettings.BITMAP_BLOCK_SZ;
-					for(int n = 0; n * blklenRows < ret.getNumRows(); n++) {
-						colGroups.get(j).rightMultByMatrix(preAggregatedB.getLeft(),
-							preAggregatedB.getRight(),
-							retV,
-							that.getNumColumns(),
-							n * blklenRows,
-							Math.min((n + 1) * blklenRows, ret.getNumRows()));
-					}
-				}
+	// 	if(k == 1) {
+	// 		for(int j = 0; j < colGroups.size(); j++) {
+	// 			if(colGroups.get(j) instanceof ColGroupValue) {
+	// 				Pair<int[], double[]> preAggregatedB = ((ColGroupValue) colGroups.get(j)).preaggValues(
+	// 					v.getRight()[j],
+	// 					that,
+	// 					colGroups.get(j).getValues(),
+	// 					0,
+	// 					that.getNumColumns(),
+	// 					that.getNumColumns());
+	// 				int blklenRows = CompressionSettings.BITMAP_BLOCK_SZ;
+	// 				for(int n = 0; n * blklenRows < ret.getNumRows(); n++) {
+	// 					colGroups.get(j).rightMultByMatrix(preAggregatedB.getLeft(),
+	// 						preAggregatedB.getRight(),
+	// 						retV,
+	// 						that.getNumColumns(),
+	// 						n * blklenRows,
+	// 						Math.min((n + 1) * blklenRows, ret.getNumRows()));
+	// 				}
+	// 			}
 
-			}
+	// 		}
 
-		}
-		else {
-			ExecutorService pool = CommonThreadPool.get(k);
-			ArrayList<RightMatrixMultTask> tasks = new ArrayList<>();
+	// 	}
+	// 	else {
+	// 		ExecutorService pool = CommonThreadPool.get(k);
+	// 		ArrayList<RightMatrixMultTask> tasks = new ArrayList<>();
 
-			final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
-			// int blklenRows = blkz * 8 / ret.getNumColumns();
-			int blklenRows = Math.max(blkz,  ret.getNumColumns() / k);
+	// 		final int blkz = CompressionSettings.BITMAP_BLOCK_SZ;
+	// 		// int blklenRows = blkz * 8 / ret.getNumColumns();
+	// 		int blklenRows = Math.max(blkz,  ret.getNumColumns() / k);
 
-			try {
-				List<Future<Pair<int[], double[]>>> ag = pool.invokeAll(preAggregate(colGroups, that, that, v));
+	// 		try {
+	// 			List<Future<Pair<int[], double[]>>> ag = pool.invokeAll(preAggregate(colGroups, that, that, v));
 			
-				for(int j = 0; j * blklenRows < ret.getNumRows(); j++) {
-					RightMatrixMultTask rmmt = new RightMatrixMultTask(colGroups, retV, ag, v, that.getNumColumns(),
-						j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()));
-					tasks.add(rmmt);
-				}
+	// 			for(int j = 0; j * blklenRows < ret.getNumRows(); j++) {
+	// 				RightMatrixMultTask rmmt = new RightMatrixMultTask(colGroups, retV, ag, v, that.getNumColumns(),
+	// 					j * blklenRows, Math.min((j + 1) * blklenRows, ret.getNumRows()));
+	// 				tasks.add(rmmt);
+	// 			}
 
-				for(Future<Object> future : pool.invokeAll(tasks))
-					future.get();
-				pool.shutdown();
-			}
-			catch(InterruptedException | ExecutionException e) {
-				throw new DMLRuntimeException(e);
-			}
-		}
+	// 			for(Future<Object> future : pool.invokeAll(tasks))
+	// 				future.get();
+	// 			pool.shutdown();
+	// 		}
+	// 		catch(InterruptedException | ExecutionException e) {
+	// 			throw new DMLRuntimeException(e);
+	// 		}
+	// 	}
 
-		return ret;
-	}
+	// 	return ret;
+	// }
 
 	private static MatrixBlock rightMultByMatrixCompressed(List<AColGroup> colGroups, MatrixBlock that,
 		CompressedMatrixBlock ret, int k, Pair<Integer, int[]> v) {
@@ -351,43 +350,43 @@ public class CLALibRightMultBy {
 
 	// }
 
-	private static class RightMatrixMultTask implements Callable<Object> {
-		private final List<AColGroup> _colGroups;
-		private final double[] _retV;
-		private final List<Future<Pair<int[], double[]>>> _aggB;
-		private final Pair<Integer, int[]> _v;
-		private final int _numColumns;
+	// private static class RightMatrixMultTask implements Callable<Object> {
+	// 	private final List<AColGroup> _colGroups;
+	// 	private final double[] _retV;
+	// 	private final List<Future<Pair<int[], double[]>>> _aggB;
+	// 	private final Pair<Integer, int[]> _v;
+	// 	private final int _numColumns;
 
-		private final int _rl;
-		private final int _ru;
+	// 	private final int _rl;
+	// 	private final int _ru;
 
-		protected RightMatrixMultTask(List<AColGroup> groups, double[] retV, List<Future<Pair<int[], double[]>>> aggB,
-			Pair<Integer, int[]> v, int numColumns, int rl, int ru) {
-			_colGroups = groups;
-			_retV = retV;
-			_aggB = aggB;
-			_v = v;
-			_numColumns = numColumns;
-			_rl = rl;
-			_ru = ru;
-		}
+	// 	protected RightMatrixMultTask(List<AColGroup> groups, double[] retV, List<Future<Pair<int[], double[]>>> aggB,
+	// 		Pair<Integer, int[]> v, int numColumns, int rl, int ru) {
+	// 		_colGroups = groups;
+	// 		_retV = retV;
+	// 		_aggB = aggB;
+	// 		_v = v;
+	// 		_numColumns = numColumns;
+	// 		_rl = rl;
+	// 		_ru = ru;
+	// 	}
 
-		@Override
-		public Object call() {
-			try {
-				ColGroupValue.setupThreadLocalMemory((_v.getLeft() + 1));
-				for(int j = 0; j < _colGroups.size(); j++) {
-					Pair<int[], double[]> aggb = _aggB.get(j).get();
-					_colGroups.get(j).rightMultByMatrix(aggb.getLeft(), aggb.getRight(), _retV, _numColumns, _rl, _ru);
-				}
-				return null;
-			}
-			catch(Exception e) {
-				e.printStackTrace();
-				throw new DMLRuntimeException(e);
-			}
-		}
-	}
+	// 	@Override
+	// 	public Object call() {
+	// 		try {
+	// 			ColGroupValue.setupThreadLocalMemory((_v.getLeft() + 1));
+	// 			for(int j = 0; j < _colGroups.size(); j++) {
+	// 				Pair<int[], double[]> aggb = _aggB.get(j).get();
+	// 				_colGroups.get(j).rightMultByMatrix(aggb.getLeft(), aggb.getRight(), _retV, _numColumns, _rl, _ru);
+	// 			}
+	// 			return null;
+	// 		}
+	// 		catch(Exception e) {
+	// 			e.printStackTrace();
+	// 			throw new DMLRuntimeException(e);
+	// 		}
+	// 	}
+	// }
 
 	private static class RightMatrixPreAggregateTask implements Callable<Pair<int[], double[]>> {
 		private final ColGroupValue _colGroup;

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSquash.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSquash.java
@@ -67,7 +67,7 @@ public class CLALibSquash {
 	}
 
 	private static double[] extractMinMaxes(CompressedMatrixBlock m) {
-		double[] ret = new double[m.getNumColumns()*2];
+		double[] ret = new double[m.getNumColumns() * 2];
 		for(AColGroup g : m.getColGroups())
 			if(g instanceof ColGroupValue)
 				((ColGroupValue) g).addMinMax(ret);

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/ABitmap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/ABitmap.java
@@ -91,9 +91,9 @@ public abstract class ABitmap {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(super.toString());
-		sb.append("\nzeros:  " + _numZeros);
-		sb.append("\ncolumns:" + _numCols);
+		sb.append(this.getClass().getSimpleName());
+		sb.append("  zeros:  " + _numZeros);
+		sb.append("  columns:" + _numCols);
 		sb.append("\nOffsets:" + Arrays.toString(_offsetsLists));
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateTernaryCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateTernaryCPInstruction.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.runtime.instructions.cp;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.functionobjects.KahanPlus;
@@ -29,6 +31,8 @@ import org.apache.sysds.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
 public class AggregateTernaryCPInstruction extends ComputationCPInstruction {
+
+	private static final Log LOG = LogFactory.getLog(AggregateTernaryCPInstruction.class.getName());
 
 	private AggregateTernaryCPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
 		String opcode, String istr) {
@@ -88,9 +92,15 @@ public class AggregateTernaryCPInstruction extends ComputationCPInstruction {
 		int m2c = m2.getNumColumns();
 		int m3c = m3 == null ? m2c : m3.getNumColumns();
 
-		if(m1r != m2r || m1c != m2c || m2r != m3r || m2c != m3c)
+		if(m1r != m2r || m1c != m2c || m2r != m3r || m2c != m3c){
+			if(LOG.isTraceEnabled()){
+				LOG.trace("matBlock1:" + m1);
+				LOG.trace("matBlock2:" + m2);
+				LOG.trace("matBlock3:" + m3);
+			}
 			throw new DMLRuntimeException("Invalid dimensions for aggregate ternary (" + m1r + "x" + m1c + ", "
 				+ m2r + "x" + m2c + ", " + m3r + "x" + m3c + ").");
+		}
 				
 		if(!(op.aggOp.increOp.fn instanceof KahanPlus && op.binaryFn instanceof Multiply))
 			throw new DMLRuntimeException("Unsupported operator for aggregate ternary operations.");

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixReorg.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixReorg.java
@@ -1022,25 +1022,32 @@ public class LibMatrixReorg {
 		DenseBlock values = in.getDenseBlock();
 		if(values.numBlocks()>1)
 			throw new NotImplementedException("Not Implemented in place transpose with more than one block");
-		int cols = in.getNumRows();
-		int rows = in.getNumColumns();
-
-	
+		
+		// Swap rows and cols
+		final int cols = in.getNumRows();
+		final int rows = in.getNumColumns();
+		
 		if(cols == 1 || rows == 1){
-			// do nothing
+			values.setDims(new int[] {rows, cols});
+			in.setNumColumns(cols);
+			in.setNumRows(rows);
+			// swap rows and column numbers;
 		}
 		else if(cols == rows){
 			// If the number of rows equals the number of columns simply swap each element along the diagonal.
 			// This only results in half - number of diagonal elements swaps.
 			transposeInPlaceTrivial(in.getDenseBlockValues(), cols, k);
-		}else{
+		}
+		else {
 			if(cols<rows){
+				// important to set dims after
 				c2r(in, k);
 				values.setDims(new int[]{rows,cols});
 				in.setNumColumns(cols);
 				in.setNumRows(rows);
 			}
 			else{
+				// important to set dims before
 				values.setDims(new int[]{rows,cols});
 				in.setNumColumns(cols);
 				in.setNumRows(rows);

--- a/src/test/java/org/apache/sysds/test/component/compress/AbstractCompressedUnaryTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/AbstractCompressedUnaryTests.java
@@ -180,6 +180,8 @@ public abstract class AbstractCompressedUnaryTests extends CompressedTestBase {
 			int dim2 = (aggType == AggType.COLSUMS || aggType == AggType.COLSUMSSQ || aggType == AggType.COLMAXS ||
 				aggType == AggType.COLMINS || aggType == AggType.COLMEAN) ? cols : 1;
 
+			// LOG.error(ret1);
+			// LOG.error(ret2);
 			assertTrue("dim 1 is not equal in non compressed res  is: " + d1.length + "  Should be: " + dim1,
 				d1.length == dim1);
 			assertTrue("dim 1 is not equal in compressed res      is: " + d2.length + "  Should be: " + dim1,

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
@@ -1058,4 +1058,7 @@ public abstract class CompressedTestBase extends TestBase {
 		double[][] d2 = DataConverter.convertToDoubleMatrix(ret2);
 		compareResultMatrices(d1, d2, toleranceMultiplier);
 	}
+
+
+
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
@@ -300,13 +300,11 @@ public abstract class CompressedTestBase extends TestBase {
 	}
 
 	@Test
-	@Ignore
 	public void testMatrixMultChainXtXv() {
 		testMatrixMultChain(ChainType.XtXv);
 	}
 
 	@Test
-	@Ignore
 	public void testMatrixMultChainXtwXv() {
 		testMatrixMultChain(ChainType.XtwXv);
 	}
@@ -334,8 +332,11 @@ public abstract class CompressedTestBase extends TestBase {
 			// matrix-vector compressed
 			MatrixBlock ret2 = cmb.chainMatrixMultOperations(vector1, vector2, new MatrixBlock(), ctype, _k);
 
+			// LOG.error(ret1);
+			// LOG.error(ret2);
 			// compare result with input
-			compareResultMatrices(ret1, ret2, 200);
+			TestUtils.compareMatricesPercentageDistance(DataConverter.convertToDoubleMatrix(
+					ret1), DataConverter.convertToDoubleMatrix(ret2), 0.9, 0.9, this.toString());
 
 		}
 		catch(Exception e) {

--- a/src/test/java/org/apache/sysds/test/component/compress/insertionsorter/MergeSortTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/insertionsorter/MergeSortTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.insertionsorter;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sysds.runtime.compress.colgroup.mapping.IMapToData;
+import org.apache.sysds.runtime.compress.colgroup.tree.AInsertionSorter;
+import org.apache.sysds.runtime.compress.colgroup.tree.MergeSort;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+import org.junit.Test;
+
+public class MergeSortTest {
+    // private static final Log LOG = LogFactory.getLog(MergeSortTest.class.getName());
+
+    @Test
+    public void testInsertionSingleValue_01() {
+        AInsertionSorter t = new MergeSort(1, 1, 1);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 0 });
+        t.insert(array);
+        int[] resIndexes = t.getIndexes();
+        assertEquals(0, resIndexes[0]);
+    }
+
+    @Test
+    public void testInsertionSingleValue_02() {
+        AInsertionSorter t = new MergeSort(1, 1, 1);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 1 });
+        t.insert(array);
+        int[] resIndexes = t.getIndexes();
+        assertEquals(1, resIndexes[0]);
+    }
+
+    @Test
+    public void testInsertionTwoValues_01() {
+        AInsertionSorter t = new MergeSort(2, 1, 10);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 1, 3 });
+        t.insert(array);
+        int[] resIndexes = t.getIndexes();
+        assertEquals(1, resIndexes[0]);
+        assertEquals(3, resIndexes[1]);
+        assertEquals(2, resIndexes.length);
+    }
+
+    @Test
+    public void testInsertionMore_01() {
+        AInsertionSorter t = new MergeSort(9, 1, 20);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5, 6, 7, 9, 10, 11, 12 });
+        t.insert(array);
+        int[] resIndexes = t.getIndexes();
+        assertEquals(1, resIndexes[0]);
+        assertEquals(3, resIndexes[1]);
+        assertEquals(12, resIndexes[8]);
+        assertEquals(9, resIndexes.length);
+    }
+
+    @Test
+    public void testInsertionTwoUnique_01() {
+        AInsertionSorter t = new MergeSort(9, 2, 20);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5, 6, 7, 9 });
+        array[1] = new IntArrayList(new int[] { 10, 11, 12 });
+
+        try {
+            t.insert(array);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        IMapToData data = t.getData();
+        assertEquals(1, resIndexes[0]);
+        assertEquals(0, data.getIndex(0));
+        assertEquals(3, resIndexes[1]);
+        assertEquals(12, resIndexes[8]);
+        assertEquals(1, data.getIndex(8));
+        assertEquals(9, resIndexes.length);
+    }
+
+    @Test
+    public void testInsertionTwoUnique_02() {
+        AInsertionSorter t = new MergeSort(5, 2, 20);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5 });
+        array[1] = new IntArrayList(new int[] { 2, 4, });
+
+        try {
+            t.insert(array);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        IMapToData data = t.getData();
+        assertArrayEquals(new int[] { 1, 2, 3, 4, 5 }, resIndexes);
+        assertEquals(0, data.getIndex(0));
+        assertEquals(1, data.getIndex(1));
+    }
+
+    @Test
+    public void testInsertionTwoUnique_03() {
+        AInsertionSorter t = new MergeSort(5, 2, 20);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5 });
+        array[1] = new IntArrayList(new int[] { 0, 4, });
+
+        try {
+            t.insert(array);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        IMapToData data = t.getData();
+        assertArrayEquals(new int[] { 0, 1, 3, 4, 5 }, resIndexes);
+        assertEquals(1, data.getIndex(0));
+        assertEquals(0, data.getIndex(1));
+    }
+
+    @Test
+    public void testInsertionNegative_01() {
+        AInsertionSorter t = new MergeSort(3, 1, 5);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 0, 2, 4 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_02() {
+        AInsertionSorter t = new MergeSort(2, 1, 5);
+        IntArrayList[] array = new IntArrayList[1];
+        array[0] = new IntArrayList(new int[] { 0, 1, 3, 5 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 2, 4 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_03() {
+        AInsertionSorter t = new MergeSort(3, 2, 5);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 0, 1, 5 });
+        array[1] = new IntArrayList(new int[] { 3 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 2, 3, 4 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_04() {
+        AInsertionSorter t = new MergeSort(4, 2, 5);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 0, 5 });
+        array[1] = new IntArrayList(new int[] { 1, 3 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 1, 2, 3, 4 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_05() {
+        AInsertionSorter t = new MergeSort(4, 2, 10);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 0, 5, 6, 7, 8, 9, 10 });
+        array[1] = new IntArrayList(new int[] { 1, 3 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 1, 2, 3, 4 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_06() {
+        AInsertionSorter t = new MergeSort(4, 2, 10);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 0, 3, 5, 6, 7, 8, 9 });
+        array[1] = new IntArrayList(new int[] { 1, 10 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 1, 2, 4, 10 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertionNegative_07() {
+        AInsertionSorter t = new MergeSort(4, 2, 10);
+        IntArrayList[] array = new IntArrayList[2];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5, 6, 7, 8, 9 });
+        array[1] = new IntArrayList(new int[] { 0, 10 });
+
+        try {
+            t.insert(array, 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 0, 2, 4, 10 }, resIndexes);
+    }
+
+    @Test
+    public void testInsertion_01() {
+        AInsertionSorter t = new MergeSort(5, 3, 20);
+        IntArrayList[] array = new IntArrayList[3];
+        array[0] = new IntArrayList(new int[] { 1, 3, 5 });
+        array[1] = new IntArrayList(new int[] { 4, });
+        array[2] = new IntArrayList(new int[] { 0, });
+
+        try {
+            t.insert(array);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        int[] resIndexes = t.getIndexes();
+        assertArrayEquals(new int[] { 0, 1, 3, 4, 5 }, resIndexes);
+    }
+}


### PR DESCRIPTION
This commit modifies the code our MMChain operation in CLA to use the
matrix operations rather than the vector operations. furthermore if found
to be prudent the mmchain will now no longer decompress.

The right Matrix Multiplication is changed to include a decompression
from compressed overlapping, since the decompression operation is more
optimized than the decompression internal to the right matrix multiplication.
This also gives a clearer view of where we are using our time in the
statistics output of the execution.

The modifications made LmCG go from ~250 to ~90 sec
while ULA is at 200sec (unlike the paper this is with num cols iterations)