### PR TITLE
[SYSTEMDS-2893] Lineage tracing GPU instructions

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/AggregateBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/AggregateBinaryGPUInstruction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sysds.runtime.instructions.gpu;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -26,6 +27,9 @@ import org.apache.sysds.runtime.functionobjects.Plus;
 import org.apache.sysds.runtime.functionobjects.SwapIndex;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
+import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.runtime.matrix.data.LibMatrixCUDA;
 import org.apache.sysds.runtime.matrix.data.LibMatrixCuMatMult;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -34,7 +38,7 @@ import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.utils.GPUStatistics;
 
-public class AggregateBinaryGPUInstruction extends GPUInstruction {
+public class AggregateBinaryGPUInstruction extends GPUInstruction implements LineageTraceable {
 	private CPOperand _input1 = null;
 	private CPOperand _input2 = null;
 	private CPOperand _output = null;
@@ -96,5 +100,11 @@ public class AggregateBinaryGPUInstruction extends GPUInstruction {
 	private static boolean isSparse(ExecutionContext ec, String var) {
 		MatrixObject mo = ec.getMatrixObject(var);
 		return LibMatrixCUDA.isInSparseFormat(ec.getGPUContext(0), mo);
+	}
+
+	@Override
+	public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+		return Pair.of(_output.getName(), new LineageItem(getOpcode(),
+			LineageItemUtils.getLineage(ec, _input1, _input2)));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/ArithmeticBinaryGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/ArithmeticBinaryGPUInstruction.java
@@ -19,13 +19,18 @@
 
 package org.apache.sysds.runtime.instructions.gpu;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
+import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
-public abstract class ArithmeticBinaryGPUInstruction extends GPUInstruction {
+public abstract class ArithmeticBinaryGPUInstruction extends GPUInstruction implements LineageTraceable {
 	protected CPOperand _input1;
 	protected CPOperand _input2;
 	protected CPOperand _output;
@@ -64,5 +69,11 @@ public abstract class ArithmeticBinaryGPUInstruction extends GPUInstruction {
 		}
 		else
 			throw new DMLRuntimeException("Unsupported GPU ArithmeticInstruction.");
+	}
+
+	@Override
+	public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+		return Pair.of(_output.getName(), new LineageItem(getOpcode(),
+			LineageItemUtils.getLineage(ec, _input1, _input2)));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/MatrixMatrixBuiltinGPUInstruction.java
@@ -35,24 +35,25 @@ public class MatrixMatrixBuiltinGPUInstruction extends BuiltinBinaryGPUInstructi
 		_gputype = GPUINSTRUCTION_TYPE.BuiltinUnary;
 	}
 
-  @Override
-  public void processInstruction(ExecutionContext ec) {
-    GPUStatistics.incrementNoOfExecutedGPUInst();
+	@Override
+	public void processInstruction(ExecutionContext ec) {
+		GPUStatistics.incrementNoOfExecutedGPUInst();
 
-    String opcode = getOpcode();
-    MatrixObject mat1 = getMatrixInputForGPUInstruction(ec, input1.getName());
-    MatrixObject mat2 = getMatrixInputForGPUInstruction(ec, input2.getName());
+		String opcode = getOpcode();
+		MatrixObject mat1 = getMatrixInputForGPUInstruction(ec, input1.getName());
+		MatrixObject mat2 = getMatrixInputForGPUInstruction(ec, input2.getName());
 
-    if(opcode.equals("solve")) {
-      ec.setMetaData(output.getName(), mat1.getNumColumns(), 1);
-      LibMatrixCUDA.solve(ec, ec.getGPUContext(0), getExtendedOpcode(), mat1, mat2, output.getName());
+		if (opcode.equals("solve")) {
+			ec.setMetaData(output.getName(), mat1.getNumColumns(), 1);
+			LibMatrixCUDA.solve(ec, ec.getGPUContext(0), getExtendedOpcode(), mat1, mat2, output.getName());
 
-    } else {
-      throw new DMLRuntimeException("Unsupported GPU operator:" + opcode);
-    }
-    ec.releaseMatrixInputForGPUInstruction(input1.getName());
-    ec.releaseMatrixInputForGPUInstruction(input2.getName());
-    ec.releaseMatrixOutputForGPUInstruction(output.getName());
-  }
+		}
+		else {
+			throw new DMLRuntimeException("Unsupported GPU operator:" + opcode);
+		}
+		ec.releaseMatrixInputForGPUInstruction(input1.getName());
+		ec.releaseMatrixInputForGPUInstruction(input2.getName());
+		ec.releaseMatrixOutputForGPUInstruction(output.getName());
+	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/ReorgGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/ReorgGPUInstruction.java
@@ -19,18 +19,22 @@
 
 package org.apache.sysds.runtime.instructions.gpu;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.functionobjects.SwapIndex;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
+import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.runtime.matrix.data.LibMatrixCUDA;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.utils.GPUStatistics;
 
-public class ReorgGPUInstruction extends GPUInstruction {
+public class ReorgGPUInstruction extends GPUInstruction implements LineageTraceable {
 	private CPOperand _input;
 	private CPOperand _output;
 
@@ -79,5 +83,11 @@ public class ReorgGPUInstruction extends GPUInstruction {
 		//release inputs/outputs
 		ec.releaseMatrixInputForGPUInstruction(_input.getName());
 		ec.releaseMatrixOutputForGPUInstruction(_output.getName());
+	}
+
+	@Override
+	public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+		return Pair.of(_output.getName(), new LineageItem(getOpcode(),
+			LineageItemUtils.getLineage(ec, _input)));
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinCsplineTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinCsplineTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
  
-package org.apache.sysds.test.applications;
+package org.apache.sysds.test.functions.builtin;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,8 +43,8 @@ public class BuiltinCsplineTest extends AutomatedTestBase {
 	
 	protected int numRecords;
 	private final static int numDim = 1;
-    
-    public BuiltinCsplineTest(int rows, int cols) {
+
+	public BuiltinCsplineTest(int rows, int cols) {
 		numRecords = rows;
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageTraceGPUTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageTraceGPUTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.lineage;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.lineage.LineageRecomputeUtils;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+import jcuda.runtime.JCuda;
+import jcuda.runtime.cudaError;
+
+public class LineageTraceGPUTest extends AutomatedTestBase{
+	
+	protected static final String TEST_DIR = "functions/lineage/";
+	protected static final String TEST_NAME1 = "LineageTraceGPU1"; 
+	protected String TEST_CLASS_DIR = TEST_DIR + LineageTraceGPUTest.class.getSimpleName() + "/";
+	
+	protected static final int numRecords = 10;
+	protected static final int numFeatures = 5;
+	
+	
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration( TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}) );
+	}
+	
+	@Test
+	public void simpleHLM_gpu() {              //hyper-parameter tuning over LM (simple)
+		testLineageTraceExec(TEST_NAME1);
+	}
+	
+	private void testLineageTraceExec(String testname) {
+		System.out.println("------------ BEGIN " + testname + "------------");
+		
+		final int[] deviceCount = new int[1];
+		int status = JCuda.cudaGetDeviceCount(deviceCount);
+		getAndLoadTestConfiguration(testname);
+		List<String> proArgs = new ArrayList<>();
+		
+		proArgs.add("-stats");
+		if (status == cudaError.cudaSuccess && deviceCount.length > 0)
+			proArgs.add("-gpu");
+		proArgs.add("-lineage");
+		proArgs.add("-args");
+		proArgs.add(output("R"));
+		proArgs.add(String.valueOf(numRecords));
+		proArgs.add(String.valueOf(numFeatures));
+		programArgs = proArgs.toArray(new String[proArgs.size()]);
+		fullDMLScriptName = getScript();
+		
+		Lineage.resetInternalState();
+		//run the test
+		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+		
+		//get lineage and generate program
+		String Rtrace = readDMLLineageFromHDFS("R");
+		//NOTE: the generated program is CP-only.
+		Data ret = LineageRecomputeUtils.parseNComputeLineageTrace(Rtrace, null);
+		
+		HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("R");
+		MatrixBlock tmp = ((MatrixObject)ret).acquireReadAndRelease();
+		TestUtils.compareMatrices(dmlfile, tmp, 1e-6);
+	}
+}

--- a/src/test/scripts/functions/lineage/LineageTraceGPU1.dml
+++ b/src/test/scripts/functions/lineage/LineageTraceGPU1.dml
@@ -1,0 +1,49 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N)
+ return (Matrix[double] beta)
+{
+  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+}
+
+no_lamda = 10;
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+lim = 0.1;
+
+X = rand(rows=1000, cols=100, seed=42);
+y = rand(rows=1000, cols=1, seed=42);
+N = ncol(X);
+R = matrix(0, rows=N, cols=no_lamda+2);
+i = 1;
+
+while (lamda < lim)
+{
+  beta = SimlinRegDS(X, y, lamda, N);
+  R[,i] = beta;
+  lamda = lamda + stp;
+  i = i + 1;
+}
+write(R, $1);
+


### PR DESCRIPTION
This patch extends lineage tracing for GPU instructions.
This is the initial version and only a few operations
are supported at this moment.