### PR TITLE
[SYSTEMDS-???] Parameterserver aggregation optimization

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixValue.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixValue.java
@@ -96,7 +96,22 @@ public abstract class MatrixValue implements WritableComparable
 	public abstract void reset(int rl, int cl, boolean sp, long nnzs);
 	public abstract void reset(int rl, int cl, double v);
 
+	/**
+	 * Copy this MatrixValue into that MatrixValue.
+	 * 
+	 * If the MatrixValue is a MatrixBlock evaluate the sparsity of the original matrix,
+	 * and copy into either a sparse or a dense matrix.
+	 * 
+	 * @param that object to copy the values into.
+	 */
 	public abstract void copy(MatrixValue that);
+
+	/**
+	 * Copy this MatrixValue into that MatrixValue. But select sparse destination block depending on boolean parameter.
+	 * 
+	 * @param that object to copy the values into.
+	 * @param sp boolean specifying if output should be forced sparse or dense. (only applicable if the 'that' is a MatrixBlock)
+	 */
 	public abstract void copy(MatrixValue that, boolean sp);
 	
 	public abstract MatrixValue scalarOperations(ScalarOperator op, MatrixValue result);


### PR DESCRIPTION
This PR contains two small commits.

1. Remove incorrect warning of native error in MKL call. that print in case of 
2. AggregateFinalResults avoid Generic access by forcing dense if the format of both parts are different.

the second part make the execution of CNN ParameterServer with batch size 32 on MNIST go from 260 sec to 200 on my laptop, with minimal changes (10 lines), i don't think this have any bad side effects but would like confirmation.