### PR TITLE
[SYSTEMDS-2925] Federated left indexing

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
@@ -172,6 +172,22 @@ public class FederationMap {
 		return ret;
 	}
 
+	public FederatedRequest[] broadcastSliced(CacheableData<?> data, int[][] ix) {
+		if( _type == FType.FULL )
+			return new FederatedRequest[]{broadcast(data)};
+
+		// prepare broadcast id and pin input
+		long id = FederationUtils.getNextFedDataID();
+		CacheBlock cb = data.acquireReadAndRelease();
+
+		// multi-threaded block slicing and federation request creation
+		FederatedRequest[] ret = new FederatedRequest[ix.length];
+		Arrays.setAll(ret,
+			i -> new FederatedRequest(RequestType.PUT_VAR, id,
+				cb.slice(ix[i][0], ix[i][1], ix[i][2], ix[i][3], new MatrixBlock())));
+		return ret;
+	}
+
 	public boolean isAligned(FederationMap that, boolean transposed) {
 		// determines if the two federated data are aligned row/column partitions
 		// at the same federated site (which allows for purely federated operation)

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -437,8 +437,9 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 			
 		case CopyVariable:
 			// Value types are not given here
-			in1 = new CPOperand(parts[1], ValueType.UNKNOWN, DataType.UNKNOWN);
-			in2 = new CPOperand(parts[2], ValueType.UNKNOWN, DataType.UNKNOWN);
+			boolean withTypes = parts[1].split(VALUETYPE_PREFIX).length > 2 && parts[2].split(VALUETYPE_PREFIX).length > 2;
+			in1 = withTypes ? new CPOperand(parts[1]) : new CPOperand(parts[1], ValueType.UNKNOWN, DataType.UNKNOWN);
+			in2 = withTypes ? new CPOperand(parts[2]) : new CPOperand(parts[2], ValueType.UNKNOWN, DataType.UNKNOWN);
 			break;
 			
 		case MoveVariable:
@@ -906,7 +907,7 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 	 * @param ec execution context
 	 */
 	private void processCopyInstruction(ExecutionContext ec) {
-		// get source variable 
+		// get source variable
 		Data dd = ec.getVariable(getInput1().getName());
 		
 		if ( dd == null )

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
@@ -172,8 +172,7 @@ public class FEDInstructionUtils {
 		else if(inst instanceof IndexingCPInstruction) {
 			// matrix and frame indexing
 			IndexingCPInstruction minst = (IndexingCPInstruction) inst;
-			if(inst.getOpcode().equalsIgnoreCase("rightIndex")
-				&& (minst.input1.isMatrix() || minst.input1.isFrame())
+			if((minst.input1.isMatrix() || minst.input1.isFrame())
 				&& ec.getCacheableData(minst.input1).isFederated()) {
 				fedinst = IndexingFEDInstruction.parseInstruction(minst.getInstructionString());
 			}

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
@@ -41,6 +41,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.util.IndexRange;
 
 public final class IndexingFEDInstruction extends UnaryFEDInstruction {
@@ -162,11 +163,7 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 			long[] newIx = new long[]{rsn, ren, csn, cen};
 
 			// change 4 indices in instString
-			instStrings[i] = instString;
-			String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
-			for(int j = 3; j < 7; j++)
-				instParts[j] = InstructionUtils.createLiteralOperand(String.valueOf(newIx[j-3]+1), ValueType.INT64);
-			instStrings[i] = String.join(Lop.OPERAND_DELIMITOR, instParts);
+			instStrings[i] = modifyIndices(newIx, 3, 7);
 			
 			if(input1.isFrame()) {
 				//modify frame schema
@@ -221,7 +218,7 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 		FederatedRange[] ranges = new FederatedRange[fedMap.getSize()];
 
 		// replace old reshape values for each worker
-		int i = 0, prev = 0;
+		int i = 0, prev = 0, from = fedMap.getSize();
 		for(FederatedRange range : fedMap.getMap().keySet()) {
 			long rs = range.getBeginDims()[0], re = range.getEndDims()[0],
 				cs = range.getBeginDims()[1], ce = range.getEndDims()[1];
@@ -230,55 +227,49 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 			long csn = (ixrange.colStart >= cs) ? (ixrange.colStart - cs) : 0;
 			long cen = (ixrange.colEnd >= cs && ixrange.colEnd < ce) ? (ixrange.colEnd - cs) : (ce - cs - 1);
 
-			int[] newIx = new int[]{(int) rsn, (int) ren, (int) csn, (int) cen};
+			long[] newIx = new long[]{(int) rsn, (int) ren, (int) csn, (int) cen};
 
-			if(in1.isFederated(FederationMap.FType.ROW)) {
-				if((prev + ren - rsn) < in2.getNumRows() && ixrange.rowStart <= re) {
-					sliceIxs[i] = new int[] { prev, (int) (prev + ren - rsn), 0, (int) in2.getNumColumns()-1};
-					prev += ren - rsn + 1;
+			// find ranges where to apply  leftIndex
+			long to;
+			if(in1.isFederated(FederationMap.FType.ROW) && (to = (prev + ren - rsn)) >= 0 &&
+					to < in2.getNumRows() && ixrange.rowStart <= re) {
+					sliceIxs[i] = new int[] { prev, (int) to, 0, (int) in2.getNumColumns()-1};
+					prev = (int) (to + 1);
 
-					// change 4 indices in instString
-					instStrings[i] = instString;
-					String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
-					for(int j = 4; j < 8; j++)
-						instParts[j] = InstructionUtils.createLiteralOperand(String.valueOf(newIx[j-4]+1), ValueType.INT64);
-					instStrings[i] = String.join(Lop.OPERAND_DELIMITOR, instParts);
-
+					instStrings[i] = modifyIndices(newIx, 4, 8);
 					ranges[i] = range;
-				}
-			} else {
-				if((prev + cen - csn) < in2.getNumColumns() && ixrange.colStart <= ce) {
-					sliceIxs[i] = new int[] {0, (int) in2.getNumRows() - 1, prev, (int) (prev + cen - csn)};
-					prev += cen - csn + 1;
+					from = Math.min(i, from);
+			} else if(in1.isFederated(FederationMap.FType.COL) && (to = (prev + cen - csn)) >= 0 &&
+					to < in2.getNumColumns() && ixrange.colStart <= ce) {
+					sliceIxs[i] = new int[] {0, (int) in2.getNumRows() - 1, prev, (int) to};
+					prev = (int) (to + 1);
 
-					// change 4 indices in instString
-					instStrings[i] = instString;
-					String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
-					for(int j = 4; j < 8; j++)
-						instParts[j] = InstructionUtils.createLiteralOperand(String.valueOf(newIx[j-4]+1), ValueType.INT64);
-					instStrings[i] = String.join(Lop.OPERAND_DELIMITOR, instParts);
-
+					instStrings[i] = modifyIndices(newIx, 4, 8);
 					ranges[i] = range;
-				}
-			}
+					from = Math.min(i, from);
+			} else
+				instStrings[i] = createCopyInstString();
+
 			i++;
-//			// change 4 indices in instString
-//			instStrings[i] = instString;
-//			String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
-//			for(int j = 4; j < 8; j++)
-//				instParts[j] = InstructionUtils.createLiteralOperand(String.valueOf(newIx[j-4]+1), ValueType.INT64);
-//			instStrings[i++] = String.join(Lop.OPERAND_DELIMITOR, instParts);
 		}
 
 		sliceIxs = Arrays.stream(sliceIxs).filter(Objects::nonNull).toArray(int[][] :: new);
-		instStrings = Arrays.stream(instStrings).filter(Objects::nonNull).toArray(String[] :: new);
 
 		FederatedRequest[] fr1 = fedMap.broadcastSliced(in2, input2.isFrame(), sliceIxs);
 		FederatedRequest[] fr2 = FederationUtils.callInstruction(instStrings, output, new CPOperand[]{input1, input2},
 			new long[]{fedMap.getID(), fr1[0].getID()});
 		FederatedRequest fr3 = fedMap.cleanup(getTID(), fr1[0].getID());
+
 		//execute federated instruction and cleanup intermediates
-		fedMap.execute(getTID(), true, ranges, fr2, fr1, fr3);
+		if(sliceIxs.length == fedMap.getSize())
+			fedMap.execute(getTID(), true, fr2, fr1, fr3);
+		else {
+			// get index of cpvar request
+			for(i = 0; i < fr2.length; i++)
+				if(i < from || i >= from + sliceIxs.length)
+					break;
+			fedMap.execute(getTID(), true, ranges, (fr2[i]), Arrays.copyOfRange(fr2, from, from + sliceIxs.length), fr1, fr3);
+		}
 
 		if(input1.isFrame()) {
 			FrameObject out = ec.getFrameObject(output);
@@ -290,5 +281,18 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 			out.getDataCharacteristics().set(in1.getDataCharacteristics());;
 			out.setFedMapping(fedMap.copyWithNewID(fr2[0].getID()));
 		}
+	}
+
+	private String modifyIndices(long[] newIx, int from, int to) {
+		// change 4 indices in instString
+		String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
+		for(int j = from; j < to; j++)
+			instParts[j] = InstructionUtils.createLiteralOperand(String.valueOf(newIx[j-from]+1), ValueType.INT64);
+		return String.join(Lop.OPERAND_DELIMITOR, instParts);
+	}
+
+	private String createCopyInstString() {
+		String[] instParts = instString.split(Lop.OPERAND_DELIMITOR);
+		return VariableCPInstruction.prepareCopyInstruction(instParts[2], instParts[8]).toString();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
@@ -248,6 +248,7 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 					ranges[i] = range;
 					from = Math.min(i, from);
 			} else
+				// TODO shallow copy, add more advanced update in place for federated
 				instStrings[i] = createCopyInstString();
 
 			i++;

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
@@ -232,22 +232,24 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 			// find ranges where to apply  leftIndex
 			long to;
 			if(in1.isFederated(FederationMap.FType.ROW) && (to = (prev + ren - rsn)) >= 0 &&
-					to < in2.getNumRows() && ixrange.rowStart <= re) {
-					sliceIxs[i] = new int[] { prev, (int) to, 0, (int) in2.getNumColumns()-1};
-					prev = (int) (to + 1);
+				to < in2.getNumRows() && ixrange.rowStart <= re) {
+				sliceIxs[i] = new int[] { prev, (int) to, 0, (int) in2.getNumColumns()-1};
+				prev = (int) (to + 1);
 
-					instStrings[i] = modifyIndices(newIx, 4, 8);
-					ranges[i] = range;
-					from = Math.min(i, from);
-			} else if(in1.isFederated(FederationMap.FType.COL) && (to = (prev + cen - csn)) >= 0 &&
-					to < in2.getNumColumns() && ixrange.colStart <= ce) {
-					sliceIxs[i] = new int[] {0, (int) in2.getNumRows() - 1, prev, (int) to};
-					prev = (int) (to + 1);
+				instStrings[i] = modifyIndices(newIx, 4, 8);
+				ranges[i] = range;
+				from = Math.min(i, from);
+			}
+			else if(in1.isFederated(FederationMap.FType.COL) && (to = (prev + cen - csn)) >= 0 &&
+				to < in2.getNumColumns() && ixrange.colStart <= ce) {
+				sliceIxs[i] = new int[] {0, (int) in2.getNumRows() - 1, prev, (int) to};
+				prev = (int) (to + 1);
 
-					instStrings[i] = modifyIndices(newIx, 4, 8);
-					ranges[i] = range;
-					from = Math.min(i, from);
-			} else
+				instStrings[i] = modifyIndices(newIx, 4, 8);
+				ranges[i] = range;
+				from = Math.min(i, from);
+			}
+			else
 				// TODO shallow copy, add more advanced update in place for federated
 				instStrings[i] = createCopyInstString();
 

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedLeftIndexTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedLeftIndexTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.federated.primitives;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.runtime.util.HDFSTool;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(value = Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
+public class FederatedLeftIndexTest extends AutomatedTestBase {
+
+	private final static String TEST_NAME1 = "FederatedLeftIndexFullTest";
+	private final static String TEST_NAME2 = "FederatedLeftIndexFrameFullTest"; //TODO
+
+	private final static String TEST_DIR = "functions/federated/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + FederatedLeftIndexTest.class.getSimpleName() + "/";
+
+	private final static int blocksize = 1024;
+	@Parameterized.Parameter()
+	public int rows1;
+	@Parameterized.Parameter(1)
+	public int cols1;
+
+	@Parameterized.Parameter(2)
+	public int rows2;
+	@Parameterized.Parameter(3)
+	public int cols2;
+
+	@Parameterized.Parameter(4)
+	public int from;
+	@Parameterized.Parameter(5)
+	public int to;
+
+	@Parameterized.Parameter(6)
+	public int from2;
+	@Parameterized.Parameter(7)
+	public int to2;
+
+	@Parameterized.Parameter(8)
+	public boolean rowPartitioned;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			{24, 12, 20, 8, 3, 22, 1, 8, true},
+		});
+	}
+
+	private enum DataType {
+		MATRIX, FRAME
+	}
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"S"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"S"}));
+	}
+
+	@Test
+	public void testLeftIndexFullDenseMatrixCP() {
+		runAggregateOperationTest(DataType.MATRIX, ExecMode.SINGLE_NODE);
+	}
+
+	@Test
+	public void testLeftIndexFullDenseFrameCP() {
+		runAggregateOperationTest(DataType.FRAME, ExecMode.SINGLE_NODE);
+	}
+
+	private void runAggregateOperationTest(DataType dataType, ExecMode execMode) {
+		setExecMode(execMode);
+
+		String TEST_NAME = null;
+
+		if(dataType == DataType.MATRIX)
+			TEST_NAME = TEST_NAME1;
+		else
+			TEST_NAME = TEST_NAME2;
+
+
+		getAndLoadTestConfiguration(TEST_NAME);
+		String HOME = SCRIPT_DIR + TEST_DIR;
+
+		// write input matrices
+		int r1 = rows1;
+		int c1 = cols1 / 4;
+		if(rowPartitioned) {
+			r1 = rows1 / 4;
+			c1 = cols1;
+		}
+
+		double[][] X1 = getRandomMatrix(r1, c1, 1, 5, 1, 3);
+		double[][] X2 = getRandomMatrix(r1, c1, 1, 5, 1, 7);
+		double[][] X3 = getRandomMatrix(r1, c1,  1, 5, 1, 8);
+		double[][] X4 = getRandomMatrix(r1, c1, 1, 5, 1, 9);
+
+		MatrixCharacteristics mc = new MatrixCharacteristics(r1, c1,  blocksize, r1 * c1);
+		writeInputMatrixWithMTD("X1", X1, false, mc);
+		writeInputMatrixWithMTD("X2", X2, false, mc);
+		writeInputMatrixWithMTD("X3", X3, false, mc);
+		writeInputMatrixWithMTD("X4", X4, false, mc);
+
+		int r2 = rows2;
+		int c2 = cols2 / 4;
+		if(rowPartitioned) {
+			r2 = rows2 / 4;
+			c2 = cols2;
+		}
+
+		double[][] Y1 = getRandomMatrix(r2, c2, 1, 5, 1, 3);
+		double[][] Y2 = getRandomMatrix(r2, c2,1, 5, 1, 7);
+		double[][] Y3 = getRandomMatrix(r2, c2,1, 5, 1, 8);
+		double[][] Y4 = getRandomMatrix(r2, c2,1, 5, 1, 9);
+
+		MatrixCharacteristics mc2 = new MatrixCharacteristics(r2, c2, blocksize, r2 * c2);
+		writeInputMatrixWithMTD("Y1", Y1, false, mc2);
+		writeInputMatrixWithMTD("Y2", Y2, false, mc2);
+		writeInputMatrixWithMTD("Y3", Y3, false, mc2);
+		writeInputMatrixWithMTD("Y4", Y4, false, mc2);
+
+		// empty script name because we don't execute any script, just start the worker
+		fullDMLScriptName = "";
+		int port1 = getRandomAvailablePort();
+		int port2 = getRandomAvailablePort();
+		int port3 = getRandomAvailablePort();
+		int port4 = getRandomAvailablePort();
+		Thread t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+		Thread t2 = startLocalFedWorkerThread(port2, FED_WORKER_WAIT_S);
+		Thread t3 = startLocalFedWorkerThread(port3, FED_WORKER_WAIT_S);
+		Thread t4 = startLocalFedWorkerThread(port4);
+
+		int port5 = getRandomAvailablePort();
+		int port6 = getRandomAvailablePort();
+		int port7 = getRandomAvailablePort();
+		int port8 = getRandomAvailablePort();
+		Thread t5 = startLocalFedWorkerThread(port5, FED_WORKER_WAIT_S);
+		Thread t6 = startLocalFedWorkerThread(port6, FED_WORKER_WAIT_S);
+		Thread t7 = startLocalFedWorkerThread(port7, FED_WORKER_WAIT_S);
+		Thread t8 = startLocalFedWorkerThread(port8);
+
+		rtplatform = execMode;
+		if(rtplatform == ExecMode.SPARK) {
+			System.out.println(7);
+			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+		}
+		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
+		loadTestConfiguration(config);
+
+		if(from > to)
+			from = to;
+		if(from2 > to2)
+			from2 = to2;
+
+		// Run reference dml script with normal matrix
+		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+		programArgs = new String[] {"-args", input("X1"), input("X2"), input("X3"), input("X4"),
+			input("Y1"), input("Y2"), input("Y3"), input("Y4"),
+			String.valueOf(from), String.valueOf(to), String.valueOf(from2), String.valueOf(to2),
+			Boolean.toString(rowPartitioned).toUpperCase(), expected("S")};
+		runTest(null);
+		// Run actual dml script with federated matrix
+
+		fullDMLScriptName = HOME + TEST_NAME + ".dml";
+		programArgs = new String[] {"-stats", "100", "-nvargs",
+			"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
+			"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
+			"in_X4=" + TestUtils.federatedAddress(port4, input("X4")),
+			"in_Y1=" + TestUtils.federatedAddress(port5, input("Y1")),
+			"in_Y2=" + TestUtils.federatedAddress(port6, input("Y2")),
+			"in_Y3=" + TestUtils.federatedAddress(port7, input("Y3")),
+			"in_Y4=" + TestUtils.federatedAddress(port8, input("Y4")),
+			"rows=" + rows1, "cols=" + cols1, "rows2=" + rows2, "cols2=" + cols2,
+			"from=" + from, "to=" + to,"from2=" + from2, "to2=" + to2,
+			"rP=" + Boolean.toString(rowPartitioned).toUpperCase(), "out_S=" + output("S")};
+
+		runTest(null);
+
+		// compare via files
+		compareResults(1e-9);
+
+		Assert.assertTrue(heavyHittersContainsString("fed_leftIndex"));
+
+		// check that federated input files are still existing
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("X1")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("X2")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("X3")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("X4")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("Y1")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("Y2")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("Y3")));
+		Assert.assertTrue(HDFSTool.existsFileOnHDFS(input("Y4")));
+
+		TestUtils.shutdownThreads(t1, t2, t3, t4, t5, t6, t7, t8);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedLeftIndexTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedLeftIndexTest.java
@@ -73,8 +73,10 @@ public class FederatedLeftIndexTest extends AutomatedTestBase {
 		return Arrays.asList(new Object[][] {
 			{8, 2, 8, 1, 1, 8, 1, 1, true},
 			{24, 12, 20, 8, 3, 22, 1, 8, true},
+			{24, 12, 10, 8, 7, 16, 1, 8, true},
 			{24, 12, 20, 11, 3, 22, 1, 11, false},
-//			{24, 12, 20, 8, 3, 22, 1, 8, false}, //FIXME
+			{24, 12, 20, 8, 3, 22, 1, 8, false},
+			{24, 12, 20, 8, 3, 22, 5, 12, false},
 		});
 	}
 
@@ -163,7 +165,7 @@ public class FederatedLeftIndexTest extends AutomatedTestBase {
 
 		// Run reference dml script with normal matrix
 		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
-		programArgs = new String[] {"-args", input("X1"), input("X2"), input("X3"), input("X4"),
+		programArgs = new String[] {"-explain", "-args", input("X1"), input("X2"), input("X3"), input("X4"),
 			input("Y"), String.valueOf(from), String.valueOf(to),
 			String.valueOf(from2), String.valueOf(to2),
 			Boolean.toString(rowPartitioned).toUpperCase(), expected("S")};

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTest.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTest.dml
@@ -1,0 +1,50 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+from = $from;
+to = $to;
+from2 = $from2;
+to2 = $to2;
+
+if ($rP) {
+  A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
+    list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)));
+
+  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
+      ranges=list(list(0, 0), list($rows2/4, $cols2), list($rows2/4, 0), list(2*$rows2/4, $cols2),
+      list(2*$rows2/4, 0), list(3*$rows2/4, $cols2), list(3*$rows2/4, 0), list($rows2, $cols2)));
+} else {
+  A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols/4), list(0,$cols/4), list($rows, $cols/2),
+    list(0,$cols/2), list($rows, 3*($cols/4)), list(0, 3*($cols/4)), list($rows, $cols)));
+
+  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
+      ranges=list(list(0, 0), list($rows2, $cols2/4), list(0,$cols2/4), list($rows2, $cols2/2),
+      list(0,$cols2/2), list($rows2, 3*($cols2/4)), list(0, 3*($cols2/4)), list($rows2, $cols2)));
+}
+
+A = as.frame(A)
+
+A[from:to, from2:to2] = B;
+write(A, $out_S);
+
+print(toString(A))

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTest.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTest.dml
@@ -28,20 +28,15 @@ if ($rP) {
   A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
     list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)));
-
-  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
-      ranges=list(list(0, 0), list($rows2/4, $cols2), list($rows2/4, 0), list(2*$rows2/4, $cols2),
-      list(2*$rows2/4, 0), list(3*$rows2/4, $cols2), list(3*$rows2/4, 0), list($rows2, $cols2)));
 } else {
   A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list($rows, $cols/4), list(0,$cols/4), list($rows, $cols/2),
     list(0,$cols/2), list($rows, 3*($cols/4)), list(0, 3*($cols/4)), list($rows, $cols)));
-
-  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
-      ranges=list(list(0, 0), list($rows2, $cols2/4), list(0,$cols2/4), list($rows2, $cols2/2),
-      list(0,$cols2/2), list($rows2, 3*($cols2/4)), list(0, 3*($cols2/4)), list($rows2, $cols2)));
 }
 
+B = read($in_Y)
+
+B = as.frame(B)
 A = as.frame(A)
 
 A[from:to, from2:to2] = B;

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTestReference.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTestReference.dml
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+from = $9;
+to = $10;
+from2 = $11;
+to2 = $12;
+
+if($11) {
+  A = rbind(read($1), read($2), read($3), read($4));
+  B = rbind(read($5), read($6), read($7), read($8));
+}
+else {
+  A = cbind(read($1), read($2), read($3), read($4));
+  B = cbind(read($5), read($6), read($7), read($8));
+}
+
+A = as.frame(A)
+
+A[from:to, from2:to2] = B;
+write(A, $13);
+
+print(toString(A))

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTestReference.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFrameFullTestReference.dml
@@ -19,23 +19,23 @@
 #
 #-------------------------------------------------------------
 
-from = $9;
-to = $10;
-from2 = $11;
-to2 = $12;
-
-if($11) {
+from = $6;
+to = $7;
+from2 = $8;
+to2 = $9;
+if($10) {
   A = rbind(read($1), read($2), read($3), read($4));
-  B = rbind(read($5), read($6), read($7), read($8));
 }
 else {
   A = cbind(read($1), read($2), read($3), read($4));
-  B = cbind(read($5), read($6), read($7), read($8));
 }
 
+B = read($5)
+
+B = as.frame(B)
 A = as.frame(A)
 
 A[from:to, from2:to2] = B;
-write(A, $13);
+write(A, $11);
 
 print(toString(A))

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFullTest.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFullTest.dml
@@ -1,0 +1,48 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+from = $from;
+to = $to;
+from2 = $from2;
+to2 = $to2;
+
+if ($rP) {
+  A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
+    list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)));
+
+  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
+      ranges=list(list(0, 0), list($rows2/4, $cols2), list($rows2/4, 0), list(2*$rows2/4, $cols2),
+      list(2*$rows2/4, 0), list(3*$rows2/4, $cols2), list(3*$rows2/4, 0), list($rows2, $cols2)));
+} else {
+  A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
+    ranges=list(list(0, 0), list($rows, $cols/4), list(0,$cols/4), list($rows, $cols/2),
+    list(0,$cols/2), list($rows, 3*($cols/4)), list(0, 3*($cols/4)), list($rows, $cols)));
+
+  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
+      ranges=list(list(0, 0), list($rows2, $cols2/4), list(0,$cols2/4), list($rows2, $cols2/2),
+      list(0,$cols2/2), list($rows2, 3*($cols2/4)), list(0, 3*($cols2/4)), list($rows2, $cols2)));
+}
+
+A[from:to, from2:to2] = B;
+write(A, $out_S);
+
+print(toString(A))

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFullTest.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFullTest.dml
@@ -28,19 +28,13 @@ if ($rP) {
   A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list($rows/4, $cols), list($rows/4, 0), list(2*$rows/4, $cols),
     list(2*$rows/4, 0), list(3*$rows/4, $cols), list(3*$rows/4, 0), list($rows, $cols)));
-
-  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
-      ranges=list(list(0, 0), list($rows2/4, $cols2), list($rows2/4, 0), list(2*$rows2/4, $cols2),
-      list(2*$rows2/4, 0), list(3*$rows2/4, $cols2), list(3*$rows2/4, 0), list($rows2, $cols2)));
 } else {
   A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list($rows, $cols/4), list(0,$cols/4), list($rows, $cols/2),
     list(0,$cols/2), list($rows, 3*($cols/4)), list(0, 3*($cols/4)), list($rows, $cols)));
-
-  B = federated(addresses=list($in_Y1, $in_Y2, $in_Y3, $in_Y4),
-      ranges=list(list(0, 0), list($rows2, $cols2/4), list(0,$cols2/4), list($rows2, $cols2/2),
-      list(0,$cols2/2), list($rows2, 3*($cols2/4)), list(0, 3*($cols2/4)), list($rows2, $cols2)));
 }
+
+B = read($in_Y)
 
 A[from:to, from2:to2] = B;
 write(A, $out_S);

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFullTestReference.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFullTestReference.dml
@@ -19,20 +19,20 @@
 #
 #-------------------------------------------------------------
 
-from = $9;
-to = $10;
-from2 = $11;
-to2 = $12;
-if($11) {
+from = $6;
+to = $7;
+from2 = $8;
+to2 = $9;
+if($10) {
   A = rbind(read($1), read($2), read($3), read($4));
-  B = rbind(read($5), read($6), read($7), read($8));
 }
 else {
   A = cbind(read($1), read($2), read($3), read($4));
-  B = cbind(read($5), read($6), read($7), read($8));
 }
 
+B = read($5)
+
 A[from:to, from2:to2] = B;
-write(A, $13);
+write(A, $11);
 
 print(toString(A))

--- a/src/test/scripts/functions/federated/FederatedLeftIndexFullTestReference.dml
+++ b/src/test/scripts/functions/federated/FederatedLeftIndexFullTestReference.dml
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+from = $9;
+to = $10;
+from2 = $11;
+to2 = $12;
+if($11) {
+  A = rbind(read($1), read($2), read($3), read($4));
+  B = rbind(read($5), read($6), read($7), read($8));
+}
+else {
+  A = cbind(read($1), read($2), read($3), read($4));
+  B = cbind(read($5), read($6), read($7), read($8));
+}
+
+A[from:to, from2:to2] = B;
+write(A, $13);
+
+print(toString(A))


### PR DESCRIPTION
This PR adds federated left indexing, the simplest case when rhs matrix or frame is read and broadcast sliced (e.g. A[2:12, 3:4] = B).