### PR TITLE
[MINOR] Convert Component Test spark retry

### DIFF
--- a/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
+++ b/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
@@ -64,7 +64,7 @@ public class RDDConverterUtilsExtTest extends AutomatedTestBase {
 					.set("spark.driver.bindAddress", "127.0.0.1")
 					.set("SPARK_MASTER_PORT", "0")
 					.set("SPARK_WORKER_PORT", "0");
-					
+
 		if (sc == null)
 			sc = new JavaSparkContext(conf);
 	}

--- a/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
+++ b/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
@@ -59,7 +59,11 @@ public class RDDConverterUtilsExtTest extends AutomatedTestBase {
 	public static void setUpClass() {
 		if (conf == null)
 			conf = SparkExecutionContext.createSystemDSSparkConf().setAppName("RDDConverterUtilsExtTest")
-					.set("spark.port.maxRetries", "100").setMaster("local").set("spark.driver.bindAddress", "127.0.0.1");
+					.set("spark.port.maxRetries", "100")
+					.setMaster("local")
+					.set("spark.driver.bindAddress", "127.0.0.1")
+					.set("SPARK_MASTER_PORT", "0")
+					.set("SPARK_WORKER_PORT", "0");
 		if (sc == null)
 			sc = new JavaSparkContext(conf);
 	}

--- a/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
+++ b/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
@@ -64,6 +64,7 @@ public class RDDConverterUtilsExtTest extends AutomatedTestBase {
 					.set("spark.driver.bindAddress", "127.0.0.1")
 					.set("SPARK_MASTER_PORT", "0")
 					.set("SPARK_WORKER_PORT", "0");
+					
 		if (sc == null)
 			sc = new JavaSparkContext(conf);
 	}

--- a/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
+++ b/src/test/java/org/apache/sysds/test/component/convert/RDDConverterUtilsExtTest.java
@@ -59,7 +59,7 @@ public class RDDConverterUtilsExtTest extends AutomatedTestBase {
 	public static void setUpClass() {
 		if (conf == null)
 			conf = SparkExecutionContext.createSystemDSSparkConf().setAppName("RDDConverterUtilsExtTest")
-					.setMaster("local");
+					.set("spark.port.maxRetries", "100").setMaster("local").set("spark.driver.bindAddress", "127.0.0.1");
 		if (sc == null)
 			sc = new JavaSparkContext(conf);
 	}


### PR DESCRIPTION
This PR is to fix the unstable component.converter.RDDConverterUtilExtTest
I have a suspicion that the GitHub actions use the default ports from spark for something else.