### PR TITLE
[SYSTEMDS-2933] Imputation By Multi-valued Dependency

### DIFF
--- a/scripts/builtin/imputeByMVD.dml
+++ b/scripts/builtin/imputeByMVD.dml
@@ -1,0 +1,133 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Implements built-in for fixing erroneous values in the group.
+# for example, if two employees have the same rank, their values should fall into the same bucket 
+# the built-in identifies the values that do not follow the bin/range pattern and replace them
+# with the mix or the max value observed in the group.
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# X               Double    --       Matrix X 
+# source          Integer   --       source attribute to use for imputation and error correction
+# target          Integer   --       attribute to be fixed
+# replace         String    --       replace the error with min/max value of the group 
+# ---------------------------------------------------------------------------------------------
+
+
+#Output(s)
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# X               Double   ---        Matrix with possible imputations 
+
+m_imputeByMVD = function(Matrix[Double] X, Integer sourceAttribute, Integer targetAttribute, String replace = "min", Boolean verbose = FALSE)
+return(Matrix[Double] X)
+{
+  S = X[, sourceAttribute]
+  T =  X[, targetAttribute]
+
+  XY = cbind(S, T)
+  
+  # replace the NaN values with zero
+  XY = replace(target = XY, pattern=NaN, replacement=0)
+  missing_mask = (XY == 0)
+  
+  # map the missing values to an arbitrary number (i.e., Max values + 1)
+  XY = missing_mask * (colMaxs(XY)+1) + XY
+  
+  # create mapping between source and target
+  ctab = (table(XY[,1], XY[,2], 1) > 0)
+
+  # table contain the 0,1 so multiply it with seq to get the original value
+  values = ctab * t(seq(1, ncol(ctab)))
+  values = removeEmpty(target=values, margin="cols")
+  bins = matrix(0, rows=nrow(ctab), cols=2)
+  # take care of zero value while computing the min value
+  ctabNonZero = replace(target=values, pattern = 0, replacement= max(values))
+  rowMin = rowMins(ctabNonZero)
+  rowMax = rowMaxs(values)
+
+  # create the ordered ranges of values for each distinct value in source attribute
+  # each distinct value in source will map to a group of different values in target
+  # assumption is that the group is non-overlapping, like the salaries of employees associated
+  # with their ranks. So not two employees with same rank could have huge difference in salaries
+  ranges = order(target=cbind(rowMin, rowMax, seq(1, nrow(ctab))), by = 1, decreasing=FALSE, index.return=FALSE)
+  ranges = fixRanges(ranges)
+
+  ranges = order(target=ranges, by=3, decreasing=FALSE, index.return=FALSE)
+  # open the source/target matrix so that each distinct value in source has a new column having its all values as rows
+  openXY = matrix(0, nrow(XY), max(XY[, 1]))
+  openXY =  ((openXY + t(seq(1, max(XY[, 1])))) == XY[, 1])
+  openXY = openXY * XY[, 2]
+  # identify and fix invalid value ranges
+  identify = (openXY > 0 & openXY < t(ranges[, 1])) | openXY > t(ranges[, 2])
+  # replace the column values with max value in the group
+  validValues = openXY*(identify == 0) 
+  impute = as.matrix(0)
+  
+  if(replace == "max")
+    impute = colMaxs(validValues)
+  else if(replace == "min")
+  {
+    zeroReplacement = max(validValues) + 9999
+    # replace the zeros with arbitrary large number to avoid 0 to be imputed as min value
+    validValues = replace(target = validValues, pattern = 0, replacement = zeroReplacement)
+    impute = colMins(validValues)
+    # retrieve original validValues
+    validValues = replace(target = validValues, pattern = zeroReplacement, replacement = 0)
+  
+  }
+  else stop("imputeByMVD: invalid parameter value, replace expected \"min\" or \"max\" found: "+replace)
+  
+  fixed = validValues + (identify * impute)
+  fixed = rowSums(fixed)  
+  X[, targetAttribute] = fixed
+  
+  if(verbose)
+    print("fixed data \n"+toString(X))
+}
+
+# function to fix the value ranges and make them non-overlapping
+fixRanges = function(Matrix[Double] ranges)
+return(Matrix[Double] ranges)
+{
+  for(i in 1:nrow(ranges)-1)
+  {
+    valCurr = as.scalar(ranges[i, 2]) # value we are checking 
+    valPre =  as.scalar(ranges[i, 1]) # max range of previous item 
+    valNext = as.scalar(ranges[i+1, 1]) # min range of next item 
+    valNextNext = as.scalar(ranges[i+1, 2]) # min range of next item 
+    if(valNext <= valCurr)
+    {
+      # compute the bucket size
+      currentBucket = abs(valCurr - valPre)
+      nextBucket = abs(valNextNext - valNext)
+      if(currentBucket > nextBucket ) { 
+        ranges[i, 2] = valNext - 1
+      }
+      else {
+        ranges[i+1, 1] = valCurr + 1
+      }
+    }
+  }
+}

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -136,6 +136,7 @@ public enum Builtins {
 	IMPUTE_BY_MODE("imputeByMode", true),
 	IMG_CROP("img_crop", true),
 	IMPUTE_FD("imputeByFD", true),
+	IMPUTE_MVD("imputeByMVD", true),
 	INTERQUANTILE("interQuantile", false),
 	INTERSECT("intersect", true),
 	INVERSE("inv", "inverse", false),

--- a/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinImputeByMVDTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/BuiltinImputeByMVDTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.test.functions.builtin;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.lops.LopProperties;
+import org.apache.sysds.runtime.io.FrameWriter;
+import org.apache.sysds.runtime.io.FrameWriterFactory;
+import org.apache.sysds.runtime.matrix.data.FrameBlock;
+import org.apache.sysds.runtime.util.UtilFunctions;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class BuiltinImputeByMVDTest extends AutomatedTestBase {
+	private final static String TEST_NAME = "imputeByMVD";
+	private final static String TEST_DIR = "functions/builtin/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + BuiltinImputeFDTest.class.getSimpleName() + "/";
+	private final static int rows = 12;
+	private final static int cols = 4;
+	private final static double epsilon = 0.0000000001;
+
+	private final static Types.ValueType[] schema = {Types.ValueType.BOOLEAN, Types.ValueType.STRING,
+		Types.ValueType.STRING, Types.ValueType.FP64};
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"C"}));
+	}
+
+	@Test
+	public void test1() throws IOException {
+		runImpute_MVDTests(2,3, "max", 1,  LopProperties.ExecType.CP);
+	}
+
+	@Test
+	public void test2() throws IOException {
+		runImpute_MVDTests(2,3, "min", 2, LopProperties.ExecType.CP);
+	}
+
+	@Test
+	public void test3() throws IOException {
+		runImpute_MVDTests(2,3, "max", 1,  LopProperties.ExecType.SPARK);
+	}
+
+	@Test
+	public void test4() throws IOException {
+		runImpute_MVDTests(2,3, "min", 2, LopProperties.ExecType.SPARK);
+	}
+
+
+	private void runImpute_MVDTests(int source, int target, String replace, int test, LopProperties.ExecType instType)
+		throws IOException
+	{
+		Types.ExecMode platformOld = setExecMode(instType);
+		try {
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-args", input("A"), String.valueOf(source),String.valueOf(target),
+				String.valueOf(replace), output("B")};
+			//initialize the frame data.
+			FrameBlock frame1 = new FrameBlock(schema);
+			FrameWriter writer = FrameWriterFactory.createFrameWriter(Types.FileFormat.CSV);
+			double[][] A = getRandomMatrix(rows, cols, 0, 1, 0.7, -1);
+			initFrameDataString(frame1, A);
+			writer.writeFrameToHDFS(frame1.slice(0, rows - 1, 0, schema.length - 1, new FrameBlock()),
+				input("A"), rows, schema.length);
+
+			runTest(true, false, null, -1);
+			FrameBlock frameRead = readDMLFrameFromHDFS("B", Types.FileFormat.BINARY);
+			FrameBlock realFrame = tureOutput(A, test);
+			verifyFrameData(frameRead, realFrame, schema);
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+//	TODO add more test cases
+	private static void initFrameDataString(FrameBlock frame1, double[][] data) {
+		boolean[] b = new boolean[rows];
+		long[] l = new long[rows];
+		String[] s1 = null, s2 = null;
+		for (int i = 0; i < rows; i++) {
+			data[i][1] = (b[i] = (Boolean) UtilFunctions.doubleToObject(Types.ValueType.BOOLEAN, data[i][1], false)) ? 1 : 0;
+			l[i] = (Long) UtilFunctions.doubleToObject(Types.ValueType.INT64, data[i][2], false);
+		}
+
+		//				salary ranges:
+		//					Ph.D. = 11k - 15k
+		//					Master = 8k - 10k
+		//					Bachelor = 4k - 7k
+		//					Diploma = 1k - 3k
+//		Errors at Ph.D. = 8100 and Diploma =11000
+		s1 = new String[]  {"PhD", "PhD", "Master", "Master", "Master", "Bachelor","Bachelor", "Diploma",
+			"Diploma", "Diploma", "PhD","PhD"};
+		s2 = new String[]  {"8100", "15000", "10000", "8100", "8000", "4500", "7000", "2000",
+			"1000", "11000", "15000", "11000"};
+
+		frame1.appendColumn(b);
+		frame1.appendColumn(s1);
+		frame1.appendColumn(s2);
+		frame1.appendColumn(l);
+	}
+
+	private static FrameBlock tureOutput(double[][] data, int test) {
+		FrameBlock frame1 = new FrameBlock(schema);
+		boolean[] b = new boolean[rows];
+		String[] s1 = null, s2 = null;
+		switch (test)
+		{
+			case 1: //max case
+				s1 = new String[]  {"PhD", "PhD", "Master", "Master", "Master", "Bachelor","Bachelor", "Diploma",
+					"Diploma", "Diploma", "PhD","PhD"};
+				s2 = new String[]   {"15000.0", "15000.0", "10000.0", "8100.0", "8000.0", "4500.0", "7000.0", "2000.0",
+					"1000.0", "2000.0", "15000.0", "11000.0"};
+				break;
+
+			case 2: //min case
+				s1 = new String[]  {"PhD", "PhD", "Master", "Master", "Master", "Bachelor","Bachelor", "Diploma",
+					"Diploma", "Diploma", "PhD","PhD"};
+				s2 = new String[]  {"11000.0", "15000.0", "10000.0", "8100.0", "8000.0", "4500.0", "7000.0", "2000.0",
+					"1000.0", "1000.0", "15000.0", "11000.0"};
+				break;
+		}
+		long[] l = new long[rows];
+		for (int i = 0; i < rows; i++) {
+			data[i][1] = (b[i] = (Boolean) UtilFunctions.doubleToObject(Types.ValueType.BOOLEAN, data[i][1], false)) ? 1 : 0;
+			l[i] = (Long) UtilFunctions.doubleToObject(Types.ValueType.INT64, data[i][2], false);
+		}
+		frame1.appendColumn(b);
+		frame1.appendColumn(s1);
+		frame1.appendColumn(s2);
+		frame1.appendColumn(l);
+		return frame1;
+	}
+
+	private static void verifyFrameData(FrameBlock frame1, FrameBlock frame2, Types.ValueType[] schema) {
+		for (int i = 0; i < frame1.getNumRows(); i++)
+			for (int j = 0; j < frame1.getNumColumns(); j++) {
+				Object val1 = UtilFunctions.stringToObject(schema[j], UtilFunctions.objectToString(frame1.get(i, j)));
+				Object val2 = UtilFunctions.stringToObject(schema[j], UtilFunctions.objectToString(frame2.get(i, j)));
+				if (TestUtils.compareToR(schema[j], val1, val2, epsilon) != 0)
+					Assert.fail("The DML data for cell (" + i + "," + j + ") is " + val1 + ", not same as the expected value " + val2);
+			}
+	}
+}

--- a/src/test/scripts/functions/builtin/imputeByMVD.dml
+++ b/src/test/scripts/functions/builtin/imputeByMVD.dml
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+F = read($1, data_type="frame", format="csv", header=FALSE);
+# as the method accepts the matrix so convert the non-numeric data into matrix
+
+# detect schema for transformation
+schema = detectSchema(F)
+s=""
+for(i in 1: ncol(F)) {
+  if(as.scalar(schema[1,i]) == "STRING" | as.scalar(schema[1,i]) == "BOOLEAN" )
+    s = s+as.integer(i)+","; 
+}
+  
+# recode data frame
+jspecR = "{ids:true, recode:["+s+"]}";
+[X, M] = transformencode(target=F, spec=jspecR);
+# call the method
+Y = imputeByMVD(X, $2, $3, $4, FALSE);
+
+# getting the actual data back
+dF = transformdecode(target=Y, spec=jspecR, meta=M);
+write(dF, $5, format="binary")


### PR DESCRIPTION
Implements built-in for fixing erroneous values in the group.
for example, if two employees have the same rank, their values should fall into the same bucket the built-in identifies the values that do not follow the bin/range pattern and replace them with the mix or the max value observed in the group.