### PR TITLE
[MINOR] Force ytest argument in lmPredict

### DIFF
--- a/docs/site/builtins-reference.md
+++ b/docs/site/builtins-reference.md
@@ -824,7 +824,7 @@ The `lmPredict`-function predicts the class of a feature vector.
 ### Usage
 
 ```r
-lmPredict(X=X, B=w)
+lmPredict(X=X, B=w, ytest= Y)
 ```
 
 ### Arguments
@@ -833,7 +833,7 @@ lmPredict(X=X, B=w)
 | :------ | :------------- | -------- | :---------- |
 | X       | Matrix[Double] | required | Matrix of feature vector(s). |
 | B       | Matrix[Double] | required | 1-column matrix of weights. |
-| ytest   | Matrix[Double] | optional | Optional test labels, used only for verbose output. |
+| ytest   | Matrix[Double] | required | test labels, used only for verbose output. can be set to matrix(0,1,1) if verbose output is not wanted |
 | icpt    | Integer        | 0        | Intercept presence, shifting and rescaling of X ([Details](#icpt-argument))|
 | verbose | Boolean        | FALSE    | Print various statistics for evaluating accuracy. |
 
@@ -850,7 +850,7 @@ lmPredict(X=X, B=w)
 X = rand (rows = 50, cols = 10)
 y = X %*% rand(rows = ncol(X), cols = 1)
 w = lm(X = X, y = y)
-yp = lmPredict(X = X, B = w)
+yp = lmPredict(X = X, B = w, ytest=matrix(0,1,1))
 ```
 
 ## `mice`-Function

--- a/scripts/builtin/cvlm.dml
+++ b/scripts/builtin/cvlm.dml
@@ -42,7 +42,7 @@ m_cvlm = function(Matrix[Double] X, Matrix[Double] y, Integer k, Integer icpt = 
     }
 
     beta = lm(X=trainSet, y=trainRes, icpt=icpt, reg=reg);
-    pred = lmPredict(X=testSet, B=beta, icpt=icpt);
+    pred = lmPredict(X=testSet, B=beta, ytest=matrix(0,1,1) icpt=icpt);
     y_predict[testS:testE,] = pred;
     allbeta[i,] = t(beta);
   }

--- a/scripts/builtin/cvlm.dml
+++ b/scripts/builtin/cvlm.dml
@@ -42,7 +42,7 @@ m_cvlm = function(Matrix[Double] X, Matrix[Double] y, Integer k, Integer icpt = 
     }
 
     beta = lm(X=trainSet, y=trainRes, icpt=icpt, reg=reg);
-    pred = lmPredict(X=testSet, B=beta, ytest=matrix(0,1,1) icpt=icpt);
+    pred = lmPredict(X=testSet, B=beta, ytest=matrix(0,1,1), icpt=icpt);
     y_predict[testS:testE,] = pred;
     allbeta[i,] = t(beta);
   }

--- a/scripts/builtin/hyperband.dml
+++ b/scripts/builtin/hyperband.dml
@@ -104,7 +104,7 @@ m_hyperband = function(Matrix[Double] X_train, Matrix[Double] y_train,
           tol=as.scalar(args[1]), reg=as.scalar(args[2]), maxi=r_i, verbose=FALSE));
         
         candidateWeights[curCandidate] = t(weights)
-        preds = lmPredict(X=X_val, B=weights);
+        preds = lmPredict(X=X_val, B=weights, ytest= matrix(0,1,1));
         scoreboard[curCandidate,1] = as.matrix(sum((y_val - preds)^2));
       }
       

--- a/scripts/builtin/mice.dml
+++ b/scripts/builtin/mice.dml
@@ -140,7 +140,7 @@ m_mice= function(Matrix[Double] X, Matrix[Double] cMask, Integer iter = 3,
         # learn a regression line
         beta = lm(X=train_X, y=train_Y, verbose=FALSE, icpt=1, reg = 1e-7, tol = 1e-7);
         # predicting missing values 
-        pred = lmPredict(X=test_X, B=beta, icpt=1)
+        pred = lmPredict(X=test_X, B=beta, ytest= matrix(0,1,1), icpt=1)
         # imputing missing column values (assumes Mask_Filled being 0/1-matrix)
         R = removeEmpty(target=Mask_Filled[, in_c] * seq(1,n), margin="rows");
         # TODO modify removeEmpty to return zero row and n columns

--- a/scripts/builtin/outlierByArima.dml
+++ b/scripts/builtin/outlierByArima.dml
@@ -64,7 +64,7 @@ m_outlierByArima = function(Matrix[Double] X, Double k = 3, Integer repairMethod
 
   # TODO replace by ARIMA once fully supported, LM only emulated the AR part
   model = lm(X=features, y=X_adapted)
-  y_hat = lmPredict(X=features, B=model)
+  y_hat = lmPredict(X=features, B=model, ytest=matrix(0,1,1))
 
   upperBound = sd(X) + k * y_hat
   lowerBound = sd(X) - k * y_hat

--- a/src/test/scripts/functions/builtin/lmpredict.dml
+++ b/src/test/scripts/functions/builtin/lmpredict.dml
@@ -23,5 +23,5 @@ X = read($1) # Training data
 y = read($2) # response values
 p = read($3) # random data to predict
 w = lmDS(X = X, y = y, icpt = 1, reg = 1e-12)
-p = lmPredict(X = X, B = w, icpt = 1)
+p = lmPredict(X = X, B = w, ytest=matrix(0,1,1) icpt = 1)
 write(p, $4)

--- a/src/test/scripts/functions/builtin/lmpredict.dml
+++ b/src/test/scripts/functions/builtin/lmpredict.dml
@@ -23,5 +23,5 @@ X = read($1) # Training data
 y = read($2) # response values
 p = read($3) # random data to predict
 w = lmDS(X = X, y = y, icpt = 1, reg = 1e-12)
-p = lmPredict(X = X, B = w, ytest=matrix(0,1,1) icpt = 1)
+p = lmPredict(X = X, B = w, ytest=matrix(0,1,1), icpt = 1)
 write(p, $4)

--- a/src/test/scripts/functions/lineage/LineageReuseAlg6.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseAlg6.dml
@@ -89,7 +89,7 @@ Kc = floor(ncol(A) * 0.8);
 for (i in 1:10) {
   newA1 = PCA(A=A, K=Kc+i);
   beta1 = lm(X=newA1, y=y, icpt=1, reg=0.0001, verbose=FALSE);
-  y_predict1 = lmPredict(X=newA1, B=beta1, icpt=1);
+  y_predict1 = lmPredict(X=newA1, B=beta1, ytest=matrix(0,1,1), icpt=1);
   R2_ad1 = checkR2(newA1, y, y_predict1, beta1, 1);
   R[,i] = R2_ad1;
 }

--- a/src/test/scripts/functions/recompile/IPAFunctionArgsFor.dml
+++ b/src/test/scripts/functions/recompile/IPAFunctionArgsFor.dml
@@ -92,7 +92,7 @@ Kc = floor(ncol(A) * 0.8);
 for (i in 1:10) {
   newA1 = PCA(A=A, K=Kc+i);
   beta1 = lm(X=newA1, y=y, icpt=1, reg=0.0001, verbose=FALSE);
-  y_predict1 = lmPredict(X=newA1, B=beta1, icpt=1);
+  y_predict1 = lmPredict(X=newA1, B=beta1, ytest=matrix(0,1,1), icpt=1);
   R2_ad1 = checkR2(newA1, y, y_predict1, beta1, 1);
   R[,i] = R2_ad1;
 }
@@ -100,7 +100,7 @@ for (i in 1:10) {
 for (i in 1:10) {
   newA3 = PCA(A=A, K=Kc+5);
   beta3 = lm(X=newA3, y=y, icpt=1, reg=0.001*i, verbose=FALSE);
-  y_predict3 = lmPredict(X=newA3, B=beta3, icpt=1);
+  y_predict3 = lmPredict(X=newA3, B=beta3, ytest=matrix(0,1,1), icpt=1);
   R2_ad3 = checkR2(newA3, y, y_predict3, beta3, 1);
   R[,10+i] = R2_ad3;
 }

--- a/src/test/scripts/functions/recompile/IPAFunctionArgsParfor.dml
+++ b/src/test/scripts/functions/recompile/IPAFunctionArgsParfor.dml
@@ -92,7 +92,7 @@ Kc = floor(ncol(A) * 0.8);
 for (i in 1:10) {
   newA1 = PCA(A=A, K=Kc+i);
   beta1 = lm(X=newA1, y=y, icpt=1, reg=0.0001, verbose=FALSE);
-  y_predict1 = lmPredict(X=newA1, B=beta1, icpt=1);
+  y_predict1 = lmPredict(X=newA1, B=beta1, ytest=matrix(0,1,1), icpt=1);
   R2_ad1 = checkR2(newA1, y, y_predict1, beta1, 1);
   R[,i] = R2_ad1;
 }
@@ -100,7 +100,7 @@ for (i in 1:10) {
 parfor (i in 1:10) {
   newA3 = PCA(A=A, K=Kc+5);
   beta3 = lm(X=newA3, y=y, icpt=1, reg=0.001*i, verbose=FALSE);
-  y_predict3 = lmPredict(X=newA3, B=beta3, icpt=1);
+  y_predict3 = lmPredict(X=newA3, B=beta3, ytest=matrix(0,1,1), icpt=1);
   R2_ad3 = checkR2(newA3, y, y_predict3, beta3, 1);
   R[,10+i] = R2_ad3;
 }


### PR DESCRIPTION
This is not the ideal solution, but just to make the test pass the LMPredict now require ytest argument,
The reason i simply because the python generators does not like default parameters on matrice arguments yet.