### PR TITLE
[MINOR][DOC] update preexisting java command to openjdk8

### DIFF
--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -44,6 +44,11 @@ sudo apt install openjdk-8-jdk-headless
 sudo apt install maven
 ```
 
+Note: To update the `java` command to `openjdk-8` run:
+```sh
+update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+```
+
 Verify the install with:
 
 ```bash


### PR DESCRIPTION
Installing the openjdk-8 does not (sometimes!) update the pre-existing java installation.

```console
$ sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java to provide /usr/bin/java (java) in manual mode
```