### PR TITLE
[MINOR] maven-gpg-plugin update to version 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -686,7 +686,7 @@
 
 					<plugin>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
+						<version>3.0.1</version>
 						<executions>
 							<execution>
 								<phase>verify</phase>


### PR DESCRIPTION
**What happens with this plugin?**

This plugin would only produce `.asc` files only.

- More about the plugin:
  https://maven.apache.org/plugins/maven-gpg-plugin/plugin-info.html

---
**How maven signs artifacts with checksums?**

The following is about Maven Resolver (part of `maven core`)

- With version 1.6, it is not possible to sign artifacts with SHA-256 or higher
using

  ```sh
  mvn -P'distribution' deploy -Daether.checksums.algorithms=SHA-256
  ```

- The signing with SHA512 
  https://issues.apache.org/jira/browse/MPOM-118

because, the SHA-512 functionality has been added recently

---

Issues related to gpg-signing elsewhere:
https://github.com/j143/systemds/issues/99
