### PR TITLE
Copyright year update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache SystemDS
-Copyright [2015-2020] The Apache Software Foundation
+Copyright [2015-2021] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/src/assembly/bin/NOTICE
+++ b/src/assembly/bin/NOTICE
@@ -1,5 +1,5 @@
 Apache SystemDS
-Copyright [2015-2020] The Apache Software Foundation
+Copyright [2015-2021] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/src/assembly/extra/NOTICE
+++ b/src/assembly/extra/NOTICE
@@ -1,5 +1,5 @@
 Apache SystemDS
-Copyright [2015-2020] The Apache Software Foundation
+Copyright [2015-2021] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/src/main/python/docs/source/conf.py
+++ b/src/main/python/docs/source/conf.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'SystemDS'
-copyright = '2020, Apache SystemDS'
+copyright = '2021, Apache SystemDS'
 author = 'Apache SystemDS'
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
as per:
https://github.com/apache/systemds/search?p=1&q=2020

This PR is to pin all the files where year update is required.

Note:
If you would like to add any more files, update directly in https://github.com/j143/systemds/tree/copyright-year (maintainer access!) 
