### PR TITLE
[WIP][SYSTEMDS-3010] Add lineage support for eval and list operations

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
@@ -734,7 +734,7 @@ public class ParForProgramBlock extends ForProgramBlock
 			LocalTaskQueue<Task> queue = new LocalTaskQueue<>();
 			Thread[] threads         = new Thread[_numThreads];
 			LocalParWorker[] workers = new LocalParWorker[_numThreads];
-			IntStream.range(0, _numThreads).parallel().forEach(i -> {
+			IntStream.range(0, _numThreads).forEach(i -> {
 				workers[i] = createParallelWorker( _pwIDs[i], queue, ec, i);
 				threads[i] = new Thread( workers[i] );
 				threads[i].setPriority(Thread.MAX_PRIORITY);
@@ -1060,7 +1060,7 @@ public class ParForProgramBlock extends ForProgramBlock
 		//check for empty inputs (no iterations executed)
 		Stream<MatrixObject> results = Arrays.stream(in).filter(m -> m!=null && m!=out);
 		//perform cleanup (parallel to mitigate file deletion bottlenecks)
-		(parallel ? results.parallel() : results)
+		(parallel ? results : results)
 			.forEach(m -> ec.cleanupCacheableData(m));
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/instructions/Instruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/Instruction.java
@@ -229,11 +229,11 @@ public abstract class Instruction
 	 * @param ec execution context
 	 * @return instruction
 	 */
-	public Instruction preprocessInstruction(ExecutionContext ec){
+	public Instruction preprocessInstruction(ExecutionContext ec) {
 		// Lineage tracing
 		if (DMLScript.LINEAGE)
 			ec.traceLineage(this);
-		//return instruction ifself
+		//return the instruction itself
 		return this;
 	}
 	/**

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ListObject.java
@@ -140,6 +140,12 @@ public class ListObject extends Data implements Externalizable {
 		return slice(name);
 	}
 	
+	public LineageItem getLineageItem(String name) {
+		//lookup position by name, incl error handling
+		int pos = getPosForName(name);
+		return getLineageItem(pos);
+	}
+	
 	public List<LineageItem> getLineageItems() {
 		return _lineage;
 	}
@@ -206,6 +212,12 @@ public class ListObject extends Data implements Externalizable {
 		_data.set(ix, data);
 		return this;
 	}
+
+	public ListObject set(int ix, Data data, LineageItem li) {
+		_data.set(ix, data);
+		if (li != null) _lineage.set(ix, li);
+		return this;
+	}
 	
 	public ListObject set(int ix1, int ix2, ListObject data) {
 		int range = ix2 - ix1 + 1;
@@ -240,6 +252,13 @@ public class ListObject extends Data implements Externalizable {
 		
 		//set entry into position
 		return set(pos, data);
+	}
+	
+	public Data set(String name, Data data, LineageItem li) {
+		//lookup position by name, incl error handling
+		int pos = getPosForName(name);
+		//set entry into position
+		return set(pos, data, li);
 	}
 	
 	public ListObject set(String name1, String name2, ListObject data) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ScalarBuiltinNaryCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ScalarBuiltinNaryCPInstruction.java
@@ -95,11 +95,15 @@ public class ScalarBuiltinNaryCPInstruction extends BuiltinNaryCPInstruction imp
 		}
 		else if( "list".equals(getOpcode()) ) {
 			//obtain all input data objects, incl handling of literals
-			List<Data> data = (inputs== null) ? new ArrayList<>() :
+			List<Data> data = (inputs == null) ? new ArrayList<>() :
 				Arrays.stream(inputs).map(in -> ec.getVariable(in)).collect(Collectors.toList());
+			List<LineageItem> li = null;
+			if (DMLScript.LINEAGE)
+				li = (inputs == null) ? new ArrayList<>() :
+					Arrays.stream(inputs).map(in -> ec.getLineage().get(in)).collect(Collectors.toList());
 			
 			//create list object over all inputs
-			ListObject list = new ListObject(data);
+			ListObject list = new ListObject(data, null, li);
 			list.deriveAndSetStatusFromData();
 			
 			ec.setVariable(output.getName(), list);

--- a/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
@@ -53,6 +53,10 @@ public class Lineage {
 	}
 	
 	public void trace(Instruction inst, ExecutionContext ec) {
+		if (inst.getOpcode().equalsIgnoreCase("toString"))
+			//Silently skip toString. TODO: trace toString
+			return;
+
 		if (_activeDedupBlock == null || !_activeDedupBlock.isAllPathsTaken() || !LineageCacheConfig.ReuseCacheType.isNone())
 			_map.trace(inst, ec);
 	}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -234,6 +234,9 @@ public class LineageCache
 				Data boundValue = null;
 				//convert to matrix object
 				if (e.isMatrixValue()) {
+					MatrixBlock mb = e.getMBValue();
+					if (mb == null && e.getCacheStatus() == LineageCacheStatus.NOTCACHED)
+						return false;  //the executing thread removed this entry from cache
 					MetaDataFormat md = new MetaDataFormat(
 						e.getMBValue().getDataCharacteristics(),FileFormat.BINARY);
 					boundValue = new MatrixObject(ValueType.FP64, boundVarName, md);
@@ -242,6 +245,8 @@ public class LineageCache
 				}
 				else {
 					boundValue = e.getSOValue();
+					if (boundValue == null && e.getCacheStatus() == LineageCacheStatus.NOTCACHED)
+						return false;  //the executing thread removed this entry from cache
 				}
 
 				funcOutputs.put(boundVarName, boundValue);
@@ -310,6 +315,11 @@ public class LineageCache
 			Data outValue = null;
 			//convert to matrix object
 			if (e.isMatrixValue()) {
+				MatrixBlock mb = e.getMBValue();
+				if (mb == null && e.getCacheStatus() == LineageCacheStatus.NOTCACHED)
+					//the executing thread removed this entry from cache
+					return new FederatedResponse(FederatedResponse.ResponseType.ERROR);
+
 				MetaDataFormat md = new MetaDataFormat(
 					e.getMBValue().getDataCharacteristics(),FileFormat.BINARY);
 				outValue = new MatrixObject(ValueType.FP64, outName, md);
@@ -318,6 +328,9 @@ public class LineageCache
 			}
 			else {
 				outValue = e.getSOValue();
+				if (outValue == null && e.getCacheStatus() == LineageCacheStatus.NOTCACHED)
+					//the executing thread removed this entry from cache
+					return new FederatedResponse(FederatedResponse.ResponseType.ERROR);
 			}
 			udfOutputs.put(outName, outValue);
 			savedComputeTime = e._computeTime;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -195,9 +195,9 @@ public class LineageCacheConfig
 	}
 
 	public static boolean isReusable (Instruction inst, ExecutionContext ec) {
-		boolean insttype = inst instanceof ComputationCPInstruction 
+		boolean insttype = (inst instanceof ComputationCPInstruction 
 			|| inst instanceof ComputationFEDInstruction
-			|| inst instanceof GPUInstruction
+			|| inst instanceof GPUInstruction)
 			&& !(inst instanceof ListIndexingCPInstruction);
 		boolean rightop = (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
 			|| (inst.getOpcode().equals("append") && isVectorAppend(inst, ec))

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
@@ -167,7 +167,8 @@ public class LineageMap {
 					break;
 				}
 				case Write: {
-					processWriteLI(vcp_inst.getInput1(), vcp_inst.getInput2(), ec);
+					if (!vcp_inst.getInput1().isLiteral())
+						processWriteLI(vcp_inst.getInput1(), vcp_inst.getInput2(), ec);
 					break;
 				}
 				case MoveVariable: {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
@@ -3851,7 +3851,7 @@ public class LibMatrixMult
 			//tsmm with the existing dense block operations w/o unnecessary gather/scatter
 			SparseBlockCSR sblock = (SparseBlockCSR)m1.sparseBlock;
 			boolean convertDense = (par ?
-				IntStream.range(0, rlen).parallel() : IntStream.range(0, rlen))
+				IntStream.range(0, rlen) : IntStream.range(0, rlen))
 				.allMatch(i -> sblock.isEmpty(i) || sblock.size(i)==clen );
 			if( convertDense ) {
 				int rows = (int) sblock.size() / clen;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixNative.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixNative.java
@@ -362,7 +362,7 @@ public class LibMatrixNative
 		//copy to direct byte buffer
 		final FloatBuffer ret2 = ret;
 		if( copy ) {
-			IntStream.range(0, input.length).parallel()
+			IntStream.range(0, input.length)
 				.forEach(i -> ret2.put(i, (float)input[i]));
 		}
 		return ret2;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -1803,7 +1803,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 				double[] avals = a.valuesAt(bi);
 				int alen = a.blockSize(bi);
 				final int lroff = roff; //final for lambda
-				IntStream.range(lroff, lroff+alen).parallel().forEach(i -> {
+				IntStream.range(lroff, lroff+alen).forEach(i -> {
 					if( b.isEmpty(i) ) return;
 					int aix = (i-lroff)*clen;
 					int bpos = b.pos(i);

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseEvalTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseEvalTest.java
@@ -24,21 +24,22 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.sysds.common.Types.ExecMode;
-import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.recompile.Recompiler;
 import org.apache.sysds.runtime.lineage.Lineage;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.utils.Statistics;
+import org.junit.Assert;
 import org.junit.Test;
 
-public class LineageReuseAlg extends LineageBase {
+public class LineageReuseEvalTest extends LineageBase {
 	
 	protected static final String TEST_DIR = "functions/lineage/";
-	protected static final String TEST_NAME = "LineageReuseAlg";
-	protected static final int TEST_VARIANTS = 6;
-	protected String TEST_CLASS_DIR = TEST_DIR + LineageReuseAlg.class.getSimpleName() + "/";
+	protected static final String TEST_NAME = "LineageReuseEval";
+	protected static final int TEST_VARIANTS = 2;
+	protected String TEST_CLASS_DIR = TEST_DIR + LineageReuseEvalTest.class.getSimpleName() + "/";
 	
 	@Override
 	public void setUp() {
@@ -48,66 +49,22 @@ public class LineageReuseAlg extends LineageBase {
 	}
 
 	@Test
-	public void testStepLMHybrid() {
-		testLineageTrace(TEST_NAME+"1", ReuseCacheType.REUSE_HYBRID);
+	public void testGridsearchLM() {
+		testLineageTrace(TEST_NAME+"1", ReuseCacheType.REUSE_MULTILEVEL);
 	}
-	
+
 	@Test
-	public void testGridSearchLMHybrid() {
+	public void testGridSearchMLR() {
 		testLineageTrace(TEST_NAME+"2", ReuseCacheType.REUSE_HYBRID);
-	}
-
-	@Test
-	public void testMultiLogRegHybrid() {
-		testLineageTrace(TEST_NAME+"3", ReuseCacheType.REUSE_HYBRID);
-	}
-
-	@Test
-	public void testPCAHybrid() {
-		testLineageTrace(TEST_NAME+"4", ReuseCacheType.REUSE_HYBRID);
-	}
-
-	@Test
-	public void testGridSearchL2svmHybrid() {
-		testLineageTrace(TEST_NAME+"5", ReuseCacheType.REUSE_HYBRID);
-	}
-
-	@Test
-	public void testPCA_LM_pipeline() {
-		testLineageTrace(TEST_NAME+"6", ReuseCacheType.REUSE_HYBRID);
+		//FIXME: 2x slower with reuse. Heavy hitter function is lineageitem equals.
+		//This problem only exists with parfor.
 	}
 	
-	@Test
-	public void testStepLMFull() {
-		testLineageTrace(TEST_NAME+"1", ReuseCacheType.REUSE_FULL);
-	}
-	
-	@Test
-	public void testGridSearchLMFull() {
-		testLineageTrace(TEST_NAME+"2", ReuseCacheType.REUSE_FULL);
-	}
-
-	@Test
-	public void testMultiLogRegFull() {
-		testLineageTrace(TEST_NAME+"3", ReuseCacheType.REUSE_FULL);
-	}
-
-	@Test
-	public void testPCAFull() {
-		testLineageTrace(TEST_NAME+"4", ReuseCacheType.REUSE_FULL);
-	}
-
 	public void testLineageTrace(String testname, ReuseCacheType reuseType) {
-		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
-		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
 		ExecMode platformOld = setExecMode(ExecMode.SINGLE_NODE);
 		
 		try {
 			LOG.debug("------------ BEGIN " + testname + "------------");
-			
-			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
-			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
-			
 			getAndLoadTestConfiguration(testname);
 			fullDMLScriptName = getScript();
 			
@@ -120,6 +77,8 @@ public class LineageReuseAlg extends LineageBase {
 			Lineage.resetInternalState();
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> X_orig = readDMLMatrixFromOutputDir("X");
+			long numlmDS = Statistics.getCPHeavyHitterCount("m_lmDS");
+			long numMM = Statistics.getCPHeavyHitterCount("ba+*");
 			
 			// With lineage-based reuse enabled
 			proArgs.clear();
@@ -130,17 +89,23 @@ public class LineageReuseAlg extends LineageBase {
 			proArgs.add(output("X"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
 			Lineage.resetInternalState();
-			Lineage.setLinReuseFull();
 			
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> X_reused = readDMLMatrixFromOutputDir("X");
+			long numlmDS_reuse = Statistics.getCPHeavyHitterCount("m_lmDS");
+			long numMM_reuse = Statistics.getCPHeavyHitterCount("ba+*");
 			
 			Lineage.setLinReuseNone();
 			TestUtils.compareMatrices(X_orig, X_reused, 1e-6, "Origin", "Reused");
+
+			if (testname.equalsIgnoreCase("LineageReuseEval1")) {  //gridSearchLM
+				//lmDS call should be reused for all the 7 values of tolerance 
+				Assert.assertTrue("Violated lmDS reuse count: 7 * "+numlmDS_reuse+" == "+numlmDS, 
+						7*numlmDS_reuse == numlmDS);
+				Assert.assertTrue("Violated ba+* reuse count: "+numMM_reuse+" < "+numMM, numMM_reuse < numMM);
+			}
 		}
 		finally {
-			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
-			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
 			rtplatform = platformOld;
 			Recompiler.reinitRecompiler();
 		}

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseEvalTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageReuseEvalTest.java
@@ -55,7 +55,7 @@ public class LineageReuseEvalTest extends LineageBase {
 
 	@Test
 	public void testGridSearchMLR() {
-		testLineageTrace(TEST_NAME+"2", ReuseCacheType.REUSE_HYBRID);
+		testLineageTrace(TEST_NAME+"2", ReuseCacheType.REUSE_MULTILEVEL);
 		//FIXME: 2x slower with reuse. Heavy hitter function is lineageitem equals.
 		//This problem only exists with parfor.
 	}

--- a/src/test/scripts/functions/builtin/GridSearchLM2.dml
+++ b/src/test/scripts/functions/builtin/GridSearchLM2.dml
@@ -36,7 +36,7 @@ Xtest = X[(N+1):nrow(X),];
 ytest = y[(N+1):nrow(X),];
 
 params = list("icpt","reg", "tol", "maxi");
-paramRanges = list(seq(0,1,2),10^seq(0,-4), 10^seq(-6,-12), 10^seq(1,3));
+paramRanges = list(seq(0,2),10^seq(0,-4), 10^seq(-6,-12), 10^seq(1,3));
 [B1, opt] = gridSearch(X=Xtrain, y=ytrain, train="lm", predict="l2norm",
   numB=ncol(X)+1, params=params, paramValues=paramRanges);
 B2 = lm(X=Xtrain, y=ytrain, verbose=FALSE);

--- a/src/test/scripts/functions/lineage/LineageReuseEval1.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseEval1.dml
@@ -1,0 +1,45 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+l2norm = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B)
+  return (Matrix[Double] loss)
+{
+  yhat = lmPredict(X=X, B=B, ytest=y)
+  loss = as.matrix(sum((y - yhat)^2));
+}
+
+X = rand(rows=300, cols=20, sparsity=1.0, seed=1);
+y = rand(rows=300, cols=1, sparsity=1.0, seed=1);
+
+N = 200;
+Xtrain = X[1:N,];
+ytrain = y[1:N,];
+Xtest = X[(N+1):nrow(X),];
+ytest = y[(N+1):nrow(X),];
+
+params = list("icpt","reg", "tol"); #numValues = 3, 5, 7
+paramRanges = list(seq(0,2), 10^seq(0,-4), 10^seq(-6,-12)); #3*5*7 = 105
+[B1, opt] = gridSearch(X=Xtrain, y=ytrain, train="lm", predict="l2norm",
+  numB=ncol(X)+1, params=params, paramValues=paramRanges, verbose=FALSE);
+l1 = l2norm(Xtest, ytest, B1);
+
+write(l1, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/LineageReuseEval2.dml
+++ b/src/test/scripts/functions/lineage/LineageReuseEval2.dml
@@ -1,0 +1,46 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+accuracy = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B) return (Matrix[Double] err) {
+  [M,yhat,acc] = multiLogRegPredict(X=X, B=B, Y=y, verbose=FALSE);
+  err = as.matrix(1-(acc/100));
+}
+
+X = rand(rows=300, cols=20, sparsity=1.0, seed=1);
+y = rand(rows=300, cols=1, min=1, max=3, sparsity=1.0, seed=1);
+y = floor(y);
+
+N = 200;
+Xtrain = X[1:N,];
+ytrain = y[1:N,];
+Xtest = X[(N+1):nrow(X),];
+ytest = y[(N+1):nrow(X),];
+
+params = list("icpt", "reg", "maxii");
+paramRanges = list(seq(0,2),10^seq(1,-6), 10^seq(1,3));
+trainArgs = list(X=Xtrain, Y=ytrain, icpt=-1, reg=-1, tol=1e-9, maxi=100, maxii=-1, verbose=FALSE);
+[B1,opt] = gridSearch(X=Xtrain, y=ytrain, train="multiLogReg", predict="accuracy", numB=ncol(X)+1,
+  params=params, paramValues=paramRanges, trainArgs=trainArgs, verbose=FALSE);
+
+[M,yhat,acc] = multiLogRegPredict(X=Xtest, B=B1, Y=ytest, verbose=FALSE);
+
+write(yhat, $1, format="text");
+


### PR DESCRIPTION
This patch adds lineage support for eval and list operations.
Every list object materializes the lineage traces corresponding
to the data items. List operations then maintain the lineage items.
The eval instruction gathers the lineage items from the argument
list and passes them to the function.
In addition, this patch adds tests to apply lineage-based reuse
on the gridSearch builtin for LM and MultiLogReg.