### PR TITLE
[SYSTEMDS-3018] Federated Execution Rewriter

### DIFF
--- a/src/main/java/org/apache/sysds/hops/AggBinaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/AggBinaryOp.java
@@ -102,7 +102,6 @@ public class AggBinaryOp extends MultiThreadedHop
 		outerOp = outOp;
 		getInput().add(0, in1);
 		getInput().add(1, in2);
-		updateETFed();
 		in1.getParent().add(this);
 		in2.getParent().add(this);
 		

--- a/src/main/java/org/apache/sysds/hops/AggUnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/AggUnaryOp.java
@@ -59,7 +59,6 @@ public class AggUnaryOp extends MultiThreadedHop
 		_direction = idx;
 		getInput().add(0, inp);
 		inp.getParent().add(this);
-		updateETFed();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/BinaryOp.java
@@ -97,7 +97,6 @@ public class BinaryOp extends MultiThreadedHop
 		op = o;
 		getInput().add(0, inp1);
 		getInput().add(1, inp2);
-		updateETFed();
 
 		inp1.getParent().add(this);
 		inp2.getParent().add(this);

--- a/src/main/java/org/apache/sysds/hops/DataOp.java
+++ b/src/main/java/org/apache/sysds/hops/DataOp.java
@@ -355,6 +355,10 @@ public class DataOp extends Hop {
 		return( _op == OpOpData.PERSISTENTREAD || _op == OpOpData.PERSISTENTWRITE );
 	}
 
+	public boolean isFederatedData(){
+		return _op == OpOpData.FEDERATED;
+	}
+
 	@Override
 	public String getOpString() {
 		String s = new String("");

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -772,6 +772,10 @@ public abstract class Hop implements ParseInfo {
 		return _federatedOutput == FederatedOutput.FOUT;
 	}
 
+	public boolean someInputFederated(){
+		return getInput().stream().anyMatch(Hop::hasFederatedOutput);
+	}
+
 	public ArrayList<Hop> getParent() {
 		return _parent;
 	}

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -749,10 +749,13 @@ public abstract class Hop implements ParseInfo {
 	/**
 	 * Update the execution type if input is federated and federated compilation is activated.
 	 * Federated compilation is activated in OptimizerUtils.
+	 * This method only has an effect if FEDERATED_COMPILATION is activated.
 	 */
 	protected void updateETFed(){
-		if ( inputIsFED() )
-			_etype = ExecType.FED;
+		if ( OptimizerUtils.FEDERATED_COMPILATION ){
+			if ( inputIsFED() )
+				_etype = ExecType.FED;
+		}
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -84,9 +84,9 @@ public abstract class Hop implements ParseInfo {
 	protected ExecType _etypeForced = null; //exec type forced via platform or external optimizer
 
 	/**
-	 * Boolean defining if the output of the operation should be federated.
-	 * If it is true, the output should be kept at federated sites.
-	 * If it is false, the output should be retrieved by the coordinator.
+	 * Field defining if the output of the operation should be federated.
+	 * If it is fout, the output should be kept at federated sites.
+	 * If it is lout, the output should be retrieved by the coordinator.
 	 */
 	protected FederatedOutput _federatedOutput = FederatedOutput.NONE;
 	
@@ -163,6 +163,14 @@ public abstract class Hop implements ParseInfo {
 	public ExecType getExecType()
 	{
 		return _etype;
+	}
+
+	public void setExecType(ExecType execType){
+		_etype = execType;
+	}
+
+	public void setFederatedOutput(FederatedOutput federatedOutput){
+		_federatedOutput = federatedOutput;
 	}
 	
 	public void resetExecType()
@@ -752,24 +760,8 @@ public abstract class Hop implements ParseInfo {
 	 * This method only has an effect if FEDERATED_COMPILATION is activated.
 	 */
 	protected void updateETFed(){
-		if ( OptimizerUtils.FEDERATED_COMPILATION ){
-			if ( inputIsFED() )
-				_etype = ExecType.FED;
-		}
-	}
-
-	/**
-	 * Returns true if any input has federated ExecType.
-	 * This method can only return true if FedDecision is activated.
-	 * @return true if any input has federated ExecType
-	 */
-	protected boolean inputIsFED(){
-		if ( !OptimizerUtils.FEDERATED_COMPILATION )
-			return false;
-		for ( Hop input : _input )
-			if ( input.isFederated() || input.isFederatedOutput() )
-				return true;
-		return false;
+		if ( _federatedOutput == FederatedOutput.FOUT || _federatedOutput == FederatedOutput.LOUT )
+			_etype = ExecType.FED;
 	}
 	
 	public boolean isFederated(){

--- a/src/main/java/org/apache/sysds/hops/ReorgOp.java
+++ b/src/main/java/org/apache/sysds/hops/ReorgOp.java
@@ -61,8 +61,7 @@ public class ReorgOp extends MultiThreadedHop
 		_op = o;
 		getInput().add(0, inp);
 		inp.getParent().add(this);
-		updateETFed();
-		
+
 		//compute unknown dims and nnz
 		refreshSizeInformation();
 	}
@@ -78,8 +77,6 @@ public class ReorgOp extends MultiThreadedHop
 			in.getParent().add(this);
 		}
 
-		updateETFed();
-		
 		//compute unknown dims and nnz
 		refreshSizeInformation();
 	}

--- a/src/main/java/org/apache/sysds/hops/TernaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/TernaryOp.java
@@ -80,7 +80,6 @@ public class TernaryOp extends MultiThreadedHop
 		getInput().add(0, inp1);
 		getInput().add(1, inp2);
 		getInput().add(2, inp3);
-		updateETFed();
 		inp1.getParent().add(this);
 		inp2.getParent().add(this);
 		inp3.getParent().add(this);
@@ -98,7 +97,6 @@ public class TernaryOp extends MultiThreadedHop
 		getInput().add(3, inp4);
 		getInput().add(4, inp5);
 		getInput().add(5, inp6);
-		updateETFed();
 		inp1.getParent().add(this);
 		inp2.getParent().add(this);
 		inp3.getParent().add(this);

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
@@ -137,6 +137,9 @@ public class ProgramRewriter
 				_dagRuleSet.add( new RewriteAlgebraicSimplificationDynamic()      ); //dependencies: cse
 				_dagRuleSet.add( new RewriteAlgebraicSimplificationStatic()       ); //dependencies: cse
 			}
+			if ( OptimizerUtils.FEDERATED_COMPILATION ) {
+				_dagRuleSet.add( new RewriteFederatedExecution() );
+			}
 		}
 		
 		// cleanup after all rewrites applied 

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationDynamic.java
@@ -139,7 +139,7 @@ public class RewriteAlgebraicSimplificationDynamic extends HopRewriteRule
 		//recursively process children
 		for( int i=0; i<hop.getInput().size(); i++)
 		{
-			Hop hi = hop.getInput().get(i);
+			Hop hi = hop.getInput(i);
 			
 			//process childs recursively first (to allow roll-up)
 			if( descendFirst )

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.rewrite;
+
+import org.apache.sysds.hops.DataOp;
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
+import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+import org.apache.sysds.runtime.privacy.propagation.PrivacyPropagator;
+
+import java.util.ArrayList;
+
+public class RewriteFederatedExecution extends HopRewriteRule {
+	@Override
+	public ArrayList<Hop> rewriteHopDAGs(ArrayList<Hop> roots, ProgramRewriteStatus state) {
+		if ( roots == null )
+			return null;
+		for ( Hop root : roots )
+			visitHop(root);
+		return roots;
+	}
+
+	private void visitHop(Hop hop){
+		if (hop.isVisited())
+			return;
+
+		// Depth first to get to the input
+		for ( Hop input : hop.getInput() )
+			visitHop(input);
+
+		privacyBasedHopDecisionWithFedCall(hop);
+		hop.setVisited();
+		// See RewriteAlgebraic SimplificationDynamic.java for reference
+	}
+
+	private void privacyBasedHopDecision(Hop hop){
+		PrivacyPropagator.hopPropagation(hop);
+		PrivacyConstraint privacyConstraint = hop.getPrivacy();
+		if ( privacyConstraint != null && privacyConstraint.hasConstraints() ){
+			hop.setFederatedOutput(FEDInstruction.FederatedOutput.FOUT);
+		}
+	}
+
+	private void privacyBasedHopDecisionWithFedCall(Hop hop){
+		//TODO: Force getPrivacy call to retrieve privacy constraints from federated workers if not already done
+		// This should only be called for DataOps since the other ops get the privacy constraints
+		// from the propagations.
+		if ( hop instanceof DataOp && ( ((DataOp) hop).getName().equals("X") || ((DataOp) hop).getName().equals("Y") ))
+			hop.setPrivacy(new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+		privacyBasedHopDecision(hop);
+	}
+
+	@Override
+	public Hop rewriteHopDAG(Hop root, ProgramRewriteStatus state) {
+		return null;
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -101,7 +101,7 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 	 * @hop hop for which privacy constraints are loaded
 	 */
 	private void loadFederatedPrivacyConstraints(Hop hop){
-		if ( isFederatedDataOp(hop) ){
+		if ( isFederatedDataOp(hop) && hop.getPrivacy() == null){
 			try {
 				PrivacyConstraint privConstraint = unwrapPrivConstraint(sendPrivConstraintRequest(hop));
 				hop.setPrivacy(privConstraint);

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -19,13 +19,40 @@
 
 package org.apache.sysds.hops.rewrite;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.sysds.api.DMLException;
 import org.apache.sysds.hops.DataOp;
 import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.LiteralOp;
+import org.apache.sysds.parser.DataExpression;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedWorkerHandlerException;
+import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
+import org.apache.sysds.runtime.instructions.fed.InitFEDInstruction;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.privacy.DMLPrivacyException;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint;
 import org.apache.sysds.runtime.privacy.propagation.PrivacyPropagator;
+import org.apache.sysds.utils.JSONHelper;
+import org.apache.wink.json4j.JSONObject;
 
+import javax.net.ssl.SSLException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.concurrent.Future;
 
 public class RewriteFederatedExecution extends HopRewriteRule {
 	@Override
@@ -47,24 +74,112 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 
 		privacyBasedHopDecisionWithFedCall(hop);
 		hop.setVisited();
-		// See RewriteAlgebraic SimplificationDynamic.java for reference
 	}
 
 	private void privacyBasedHopDecision(Hop hop){
 		PrivacyPropagator.hopPropagation(hop);
 		PrivacyConstraint privacyConstraint = hop.getPrivacy();
-		if ( privacyConstraint != null && privacyConstraint.hasConstraints() ){
+		if ( privacyConstraint != null && privacyConstraint.hasConstraints() )
 			hop.setFederatedOutput(FEDInstruction.FederatedOutput.FOUT);
+		else if ( hop.someInputFederated() )
+			hop.setFederatedOutput(FEDInstruction.FederatedOutput.LOUT);
+	}
+
+	/**
+	 * Get privacy constraints of DataOps from federated worker,
+	 * propagate privacy constraints from input to current hop,
+	 * and set federated output flag.
+	 * @param hop current hop
+	 */
+	private void privacyBasedHopDecisionWithFedCall(Hop hop){
+		loadFederatedPrivacyConstraints(hop);
+		privacyBasedHopDecision(hop);
+	}
+
+	/**
+	 * Get privacy constraints from federated workers for DataOps.
+	 * @hop hop for which privacy constraints are loaded
+	 */
+	private void loadFederatedPrivacyConstraints(Hop hop){
+		if ( isFederatedDataOp(hop) ){
+			try {
+				PrivacyConstraint privConstraint = unwrapPrivConstraint(sendPrivConstraintRequest(hop));
+				hop.setPrivacy(privConstraint);
+			}
+			catch(Exception e) {
+				throw new DMLException(e.getMessage());
+			}
 		}
 	}
 
-	private void privacyBasedHopDecisionWithFedCall(Hop hop){
-		//TODO: Force getPrivacy call to retrieve privacy constraints from federated workers if not already done
-		// This should only be called for DataOps since the other ops get the privacy constraints
-		// from the propagations.
-		if ( hop instanceof DataOp && ( ((DataOp) hop).getName().equals("X") || ((DataOp) hop).getName().equals("Y") ))
-			hop.setPrivacy(new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
-		privacyBasedHopDecision(hop);
+	private Future<FederatedResponse> sendPrivConstraintRequest(Hop hop) throws UnknownHostException, SSLException {
+		String address = ((LiteralOp) hop.getInput(0).getInput(0)).getStringValue();
+		String[] parsedAddress = InitFEDInstruction.parseURL(address);
+		String host = parsedAddress[0];
+		int port = Integer.parseInt(parsedAddress[1]);
+		PrivacyConstraintRetriever retriever = new PrivacyConstraintRetriever(parsedAddress[2]);
+		FederatedRequest privacyRetrieval =
+			new FederatedRequest(FederatedRequest.RequestType.EXEC_UDF, -1, retriever);
+		InetSocketAddress inetAddress = new InetSocketAddress(InetAddress.getByName(host), port);
+		return FederatedData.executeFederatedOperation(inetAddress, privacyRetrieval);
+	}
+
+	private PrivacyConstraint unwrapPrivConstraint(Future<FederatedResponse> privConstraintFuture) throws Exception {
+		FederatedResponse privConstraintResponse = privConstraintFuture.get();
+		return (PrivacyConstraint) privConstraintResponse.getData()[0];
+	}
+
+	private boolean isFederatedDataOp(Hop hop){
+		return hop instanceof DataOp && ((DataOp) hop).isFederatedData();
+	}
+
+	/**
+	 * FederatedUDF for retrieving privacy constraint of data stored in file name.
+	 */
+	public static class PrivacyConstraintRetriever extends FederatedUDF {
+		private final String filename;
+
+		public PrivacyConstraintRetriever(String filename){
+			super(new long[]{});
+			this.filename = filename;
+		}
+
+		/**
+		 * Reads metadata JSON object, parses privacy constraint and returns the constraint in FederatedResponse.
+		 * @param ec execution context
+		 * @param data one or many data objects
+		 * @return FederatedResponse with privacy constraint object
+		 */
+		@Override
+		public FederatedResponse execute(ExecutionContext ec, Data... data) {
+			PrivacyConstraint privacyConstraint;
+			FileSystem fs = null;
+			try {
+				String mtdname = DataExpression.getMTDFileName(filename);
+				Path path = new Path(mtdname);
+				fs = IOUtilFunctions.getFileSystem(mtdname);
+				try(BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(path)))) {
+					JSONObject metadataObject = JSONHelper.parse(br);
+					privacyConstraint = PrivacyPropagator.parseAndReturnPrivacyConstraint(metadataObject);
+				}
+			}
+			catch (DMLPrivacyException | FederatedWorkerHandlerException ex){
+				throw ex;
+			}
+			catch (Exception ex) {
+				String msg = "Exception in reading metadata of: " + filename;
+				throw new DMLRuntimeException(msg);
+			}
+			finally {
+				IOUtilFunctions.closeSilently(fs);
+			}
+			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, privacyConstraint);
+		}
+
+		@Override
+		public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+			return null;
+		}
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/FEDInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/FEDInstructionParser.java
@@ -19,9 +19,11 @@
 
 package org.apache.sysds.runtime.instructions;
 
+import org.apache.sysds.lops.Append;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.instructions.fed.AggregateBinaryFEDInstruction;
 import org.apache.sysds.runtime.instructions.fed.AggregateUnaryFEDInstruction;
+import org.apache.sysds.runtime.instructions.fed.AppendFEDInstruction;
 import org.apache.sysds.runtime.instructions.fed.BinaryFEDInstruction;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FEDType;
@@ -66,6 +68,8 @@ public class FEDInstructionParser extends InstructionParser
 		// Ternary Instruction Opcodes
 		String2FEDInstructionType.put( "+*" , FEDType.Ternary);
 		String2FEDInstructionType.put( "-*" , FEDType.Ternary);
+
+		String2FEDInstructionType.put(Append.OPCODE, FEDType.Append);
 	}
 
 	public static FEDInstruction parseSingleInstruction (String str ) {
@@ -98,6 +102,8 @@ public class FEDInstructionParser extends InstructionParser
 				return TernaryFEDInstruction.parseInstruction(str);
 			case Reorg:
 				return ReorgFEDInstruction.parseInstruction(str);
+			case Append:
+				return AppendFEDInstruction.parseInstruction(str);
 			default:
 				throw new DMLRuntimeException("Invalid FEDERATED Instruction Type: " + fedtype );
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/SqlCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/SqlCPInstruction.java
@@ -136,4 +136,13 @@ public class SqlCPInstruction extends CPInstruction {
 	public CPOperand getOutput(){
 		return _output;
 	}
+
+	/**
+	 * Returns the inputs of the instruction.
+	 * Inputs are conn, user, pass, and query.
+	 * @return inputs of the instruction
+	 */
+	public CPOperand[] getInputs(){
+		return new CPOperand[]{_conn, _user, _pass, _query};
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
@@ -144,24 +145,43 @@ public class AggregateBinaryFEDInstruction extends BinaryFEDInstruction {
 		}
 		//#2 vector - federated matrix multiplication
 		else if (mo2.isFederated(FType.ROW)) {// VM + MM
-			//construct commands: broadcast rhs, fed mv, retrieve results
-			FederatedRequest[] fr1 = mo2.getFedMapping().broadcastSliced(mo1, true);
-			FederatedRequest fr2 = FederationUtils.callInstruction(instString, output,
-				new CPOperand[]{input1, input2},
-				new long[]{fr1[0].getID(), mo2.getFedMapping().getID()}, true);
-			if ( _fedOut.isForcedFederated() ){
-				// Partial aggregates (set fedmapping to the partial aggs)
-				FederatedRequest fr3 = mo2.getFedMapping().cleanup(getTID(), fr1[0].getID());
-				mo2.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
-				setPartialOutput(mo2.getFedMapping(), mo1, mo2, fr2.getID(), ec);
+			if ( mo1.isFederated(FType.COL) && isAggBinaryFedAligned(mo1,mo2) ){
+				FederatedRequest fr2 = FederationUtils.callInstruction(instString, output,
+					new CPOperand[]{input1, input2},
+					new long[]{mo1.getFedMapping().getID(), mo2.getFedMapping().getID()}, true);
+				if ( _fedOut.isForcedFederated() ){
+					// Partial aggregates (set fedmapping to the partial aggs)
+					mo2.getFedMapping().execute(getTID(), true, fr2);
+					setPartialOutput(mo2.getFedMapping(), mo1, mo2, fr2.getID(), ec);
+				}
+				else {
+					FederatedRequest fr3 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+					//execute federated operations and aggregate
+					Future<FederatedResponse>[] tmp = mo2.getFedMapping().execute(getTID(), fr2, fr3);
+					MatrixBlock ret = FederationUtils.aggAdd(tmp);
+					ec.setMatrixOutput(output.getName(), ret);
+				}
 			}
 			else {
-				FederatedRequest fr3 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
-				FederatedRequest fr4 = mo2.getFedMapping().cleanup(getTID(), fr1[0].getID(), fr2.getID());
-				//execute federated operations and aggregate
-				Future<FederatedResponse>[] tmp = mo2.getFedMapping().execute(getTID(), fr1, fr2, fr3, fr4);
-				MatrixBlock ret = FederationUtils.aggAdd(tmp);
-				ec.setMatrixOutput(output.getName(), ret);
+				//construct commands: broadcast rhs, fed mv, retrieve results
+				FederatedRequest[] fr1 = mo2.getFedMapping().broadcastSliced(mo1, true);
+				FederatedRequest fr2 = FederationUtils.callInstruction(instString, output,
+					new CPOperand[]{input1, input2},
+					new long[]{fr1[0].getID(), mo2.getFedMapping().getID()}, true);
+				if ( _fedOut.isForcedFederated() ){
+					// Partial aggregates (set fedmapping to the partial aggs)
+					FederatedRequest fr3 = mo2.getFedMapping().cleanup(getTID(), fr1[0].getID());
+					mo2.getFedMapping().execute(getTID(), true, fr1, fr2, fr3);
+					setPartialOutput(mo2.getFedMapping(), mo1, mo2, fr2.getID(), ec);
+				}
+				else {
+					FederatedRequest fr3 = new FederatedRequest(RequestType.GET_VAR, fr2.getID());
+					FederatedRequest fr4 = mo2.getFedMapping().cleanup(getTID(), fr1[0].getID(), fr2.getID());
+					//execute federated operations and aggregate
+					Future<FederatedResponse>[] tmp = mo2.getFedMapping().execute(getTID(), fr1, fr2, fr3, fr4);
+					MatrixBlock ret = FederationUtils.aggAdd(tmp);
+					ec.setMatrixOutput(output.getName(), ret);
+				}
 			}
 		}
 		//#3 col-federated matrix vector multiplication
@@ -191,6 +211,28 @@ public class AggregateBinaryFEDInstruction extends BinaryFEDInstruction {
 				+ "following federated objects: "+mo1.isFederated()+":"+mo1.getFedMapping()
 				+" "+mo2.isFederated()+":"+mo2.getFedMapping());
 		}
+	}
+
+	/**
+	 * Checks alignment of dimensions for the federated aggregate binary processing without broadcast.
+	 * If the begin and end ranges of mo1 has cols equal to the rows of the begin and end ranges of mo2,
+	 * the two inputs are aligned for the processing of the federated aggregate binary instruction without broadcasting.
+	 * @param mo1 input matrix object 1
+	 * @param mo2 input matrix object 2
+	 * @return true if the two inputs are aligned for aggregate binary processing without broadcasting
+	 */
+	private boolean isAggBinaryFedAligned(MatrixObject mo1, MatrixObject mo2){
+		FederatedRange[] mo1FederatedRanges = mo1.getFedMapping().getFederatedRanges();
+		FederatedRange[] mo2FederatedRanges = mo2.getFedMapping().getFederatedRanges();
+		for ( int i = 0; i < mo1FederatedRanges.length; i++ ){
+			FederatedRange mo1FedRange = mo1FederatedRanges[i];
+			FederatedRange mo2FedRange = mo2FederatedRanges[i];
+
+			if ( mo1FedRange.getBeginDims()[1] != mo2FedRange.getBeginDims()[0]
+				|| mo1FedRange.getEndDims()[1] != mo2FedRange.getEndDims()[0])
+				return false;
+		}
+		return true;
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/privacy/propagation/OperatorType.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/propagation/OperatorType.java
@@ -19,7 +19,54 @@
 
 package org.apache.sysds.runtime.privacy.propagation;
 
+import org.apache.sysds.lops.MMTSJ;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.instructions.cp.AggregateBinaryCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.MMChainCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.MMTSJCPInstruction;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
+
 public enum OperatorType {
 	Aggregate,
 	NonAggregate;
+
+	/**
+	 * Returns the operator type of MMChainCPInstruction based on the input data characteristics.
+	 * @param inst MMChainCPInstruction for which operator type is returned
+	 * @param ec execution context
+	 * @return operator type of instruction
+	 */
+	public static OperatorType getAggregationType(MMChainCPInstruction inst, ExecutionContext ec){
+		DataCharacteristics inputDataCharacteristics = ec.getDataCharacteristics(inst.getInputs()[0].getName());
+		if ( inputDataCharacteristics.getRows() == 1 && inputDataCharacteristics.getCols() == 1)
+			return NonAggregate;
+		else return Aggregate;
+	}
+
+	/**
+	 * Returns the operator type of MMTSJCPInstruction based on the input data characteristics and the MMTSJType.
+	 * @param inst MMTSJCPInstruction for which operator type is returned
+	 * @param ec execution context
+	 * @return operator type of instruction
+	 */
+	public static OperatorType getAggregationType(MMTSJCPInstruction inst, ExecutionContext ec){
+		DataCharacteristics inputDataCharacteristics = ec.getDataCharacteristics(inst.getInputs()[0].getName());
+		if ( (inputDataCharacteristics.getRows() == 1 && inst.getMMTSJType() == MMTSJ.MMTSJType.LEFT)
+			|| (inputDataCharacteristics.getCols() == 1 && inst.getMMTSJType() != MMTSJ.MMTSJType.LEFT) )
+			return OperatorType.NonAggregate;
+		else return OperatorType.Aggregate;
+	}
+
+	/**
+	 * Returns the operator type of AggregateBinaryCPInstruction based on the input data characteristics and the transpose.
+	 * @param inst AggregateBinaryCPInstruction for which operator type is returned
+	 * @param ec execution context
+	 * @return operator type of instruction
+	 */
+	public static OperatorType getAggregationType(AggregateBinaryCPInstruction inst, ExecutionContext ec){
+		DataCharacteristics inputDC = ec.getDataCharacteristics(inst.input1.getName());
+		if ((inputDC.getCols() == 1 && !inst.transposeLeft) || (inputDC.getRows() == 1 && inst.transposeLeft) )
+			return OperatorType.NonAggregate;
+		else return OperatorType.Aggregate;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
@@ -49,12 +49,21 @@ public class PrivacyPropagator
 	public static Data parseAndSetPrivacyConstraint(Data cd, JSONObject mtd)
 		throws JSONException
 	{
+		PrivacyConstraint mtdPrivConstraint = parseAndReturnPrivacyConstraint(mtd);
+		if ( mtdPrivConstraint != null )
+			cd.setPrivacyConstraints(mtdPrivConstraint);
+		return cd;
+	}
+
+	public static PrivacyConstraint parseAndReturnPrivacyConstraint(JSONObject mtd)
+		throws JSONException
+	{
 		if ( mtd.containsKey(DataExpression.PRIVACY) ) {
 			String privacyLevel = mtd.getString(DataExpression.PRIVACY);
 			if ( privacyLevel != null )
-				cd.setPrivacyConstraints(new PrivacyConstraint(PrivacyLevel.valueOf(privacyLevel)));
+				return new PrivacyConstraint(PrivacyLevel.valueOf(privacyLevel));
 		}
-		return cd;
+		return null;
 	}
 
 	private static boolean anyInputHasLevel(PrivacyLevel[] inputLevels, PrivacyLevel targetLevel){

--- a/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
@@ -522,6 +522,12 @@ public class PrivacyPropagator
 	private static CPOperand[] getInputOperands(Instruction inst){
 		if ( inst instanceof ComputationCPInstruction )
 			return ((ComputationCPInstruction)inst).getInputs();
+		if ( inst instanceof BuiltinNaryCPInstruction )
+			return ((BuiltinNaryCPInstruction)inst).getInputs();
+		if ( inst instanceof FunctionCallCPInstruction )
+			return ((FunctionCallCPInstruction)inst).getInputs();
+		if ( inst instanceof SqlCPInstruction )
+			return ((SqlCPInstruction)inst).getInputs();
 		else return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
@@ -398,12 +398,14 @@ public class PrivacyPropagator
 	 * @return input instruction if privacy constraints are not activated
 	 */
 	private static Instruction throwExceptionIfInputOrInstPrivacy(Instruction inst, ExecutionContext ec){
-		CPOperand[] inputOperands = getInputOperands(inst);
 		throwExceptionIfPrivacyActivated(inst);
-		for ( CPOperand input : inputOperands ){
-			PrivacyConstraint privacyConstraint = getInputPrivacyConstraint(ec, input);
-			if ( privacyConstraint != null){
-				throw new DMLPrivacyException("Input of instruction " + inst + " has privacy constraints activated, but the constraints are not propagated during preprocessing of instruction.");
+		CPOperand[] inputOperands = getInputOperands(inst);
+		if (inputOperands != null){
+			for ( CPOperand input : inputOperands ){
+				PrivacyConstraint privacyConstraint = getInputPrivacyConstraint(ec, input);
+				if ( privacyConstraint != null){
+					throw new DMLPrivacyException("Input of instruction " + inst + " has privacy constraints activated, but the constraints are not propagated during preprocessing of instruction.");
+				}
 			}
 		}
 		return inst;

--- a/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
+++ b/src/main/java/org/apache/sysds/runtime/privacy/propagation/PrivacyPropagator.java
@@ -21,6 +21,13 @@ package org.apache.sysds.runtime.privacy.propagation;
 
 import java.util.*;
 
+import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.hops.AggUnaryOp;
+import org.apache.sysds.hops.BinaryOp;
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.ReorgOp;
+import org.apache.sysds.hops.TernaryOp;
+import org.apache.sysds.hops.UnaryOp;
 import org.apache.sysds.parser.DataExpression;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
@@ -133,6 +140,15 @@ public class PrivacyPropagator
 			mergedPrivacyConstraint = mergeBinary(mergedPrivacyConstraint, privacyConstraints[i]);
 		}
 		return mergedPrivacyConstraint;
+	}
+
+	public static void hopPropagation(Hop hop){
+		PrivacyConstraint[] inputConstraints = hop.getInput().stream()
+			.map(Hop::getPrivacy).toArray(PrivacyConstraint[]::new);
+		if ( hop instanceof TernaryOp || hop instanceof BinaryOp || hop instanceof ReorgOp )
+			hop.setPrivacy(mergeNary(inputConstraints, OperatorType.NonAggregate));
+		else if ( hop instanceof AggBinaryOp || hop instanceof AggUnaryOp  || hop instanceof UnaryOp )
+			hop.setPrivacy(mergeNary(inputConstraints, OperatorType.Aggregate));
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -22,7 +22,6 @@ package org.apache.sysds.test.functions.privacy.fedplanning;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -81,7 +80,6 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void federatedRowSum(){
 		federatedTwoMatricesSingleNodeTest(TEST_NAME_2);
 	}
@@ -98,14 +96,12 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void federatedAggregateBinaryColFedSequence(){
 		cols = rows;
 		federatedTwoMatricesSingleNodeTest(TEST_NAME_5);
 	}
 
 	@Test
-	@Ignore
 	public void federatedAggregateBinarySequence2(){
 		federatedTwoMatricesSingleNodeTest(TEST_NAME_6);
 	}
@@ -147,8 +143,8 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		if ( testName.equals(TEST_NAME_5) ){
 			writeColStandardMatrix("X1", 42);
 			writeColStandardMatrix("X2", 1340);
-			writeColStandardMatrix("Y1", 44, new PrivacyConstraint(PrivacyLevel.None));
-			writeColStandardMatrix("Y2", 21, new PrivacyConstraint(PrivacyLevel.None));
+			writeColStandardMatrix("Y1", 44, null);
+			writeColStandardMatrix("Y2", 21, null);
 		}
 		else if ( testName.equals(TEST_NAME_6) ){
 			writeColStandardMatrix("X1", 42);

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -147,8 +147,8 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		if ( testName.equals(TEST_NAME_5) ){
 			writeColStandardMatrix("X1", 42);
 			writeColStandardMatrix("X2", 1340);
-			writeColStandardMatrix("Y1", 44);
-			writeColStandardMatrix("Y2", 21);
+			writeColStandardMatrix("Y1", 44, new PrivacyConstraint(PrivacyLevel.None));
+			writeColStandardMatrix("Y2", 21, new PrivacyConstraint(PrivacyLevel.None));
 		}
 		else if ( testName.equals(TEST_NAME_6) ){
 			writeColStandardMatrix("X1", 42);


### PR DESCRIPTION
This PR adds a federated execution rewriter. 
The rewriter currently loads the privacy constraints of federated data input from the federated workers and propagates these privacy constraints through the Hop DAG. The rewriter will be extended in a later PR with an execution plan builder, which will represent the different federated execution plans and evaluate the utility of each plan.
This PR additionally refactors the PrivacyPropagator to ensure that the Hop and instruction privacy propagation goes through the same core propagation. 