### PR TITLE
[SYSTEMDS-3021] Python Source reuse fix

### DIFF
--- a/src/main/python/systemds/operator/nodes/source.py
+++ b/src/main/python/systemds/operator/nodes/source.py
@@ -191,9 +191,8 @@ class Source(OperationNode):
 
         return filtered_lines
 
-    def code_line(self, unnamed_input_vars: Sequence[str], named_input_vars: Dict[str, str]) -> str:
+    def code_line(self, var_name: str, unnamed_input_vars: Sequence[str], named_input_vars: Dict[str, str]) -> str:
         line = f'source({self.operation}) as { self.__name}'
-        self._already_added = True
         return line
 
     def compute(self, verbose: bool = False, lineage: bool = False):

--- a/src/main/python/systemds/script_building/dag.py
+++ b/src/main/python/systemds/script_building/dag.py
@@ -101,7 +101,6 @@ class DAGNode(ABC):
     _output_type: OutputType
     _script: Optional["DMLScript"]
     _is_python_local_data: bool
-    _already_added: bool
     _dml_name: str
 
     def compute(self, verbose: bool = False, lineage: bool = False) -> Any:
@@ -159,10 +158,6 @@ class DAGNode(ABC):
     @property
     def output_type(self):
         return self._output_type
-    
-    @property
-    def already_added(self):
-        return self._already_added
 
     @property
     def script(self):

--- a/src/main/python/systemds/script_building/script.py
+++ b/src/main/python/systemds/script_building/script.py
@@ -185,11 +185,6 @@ class DMLScript:
         if dag_node.dml_name != "":
             return dag_node.dml_name
 
-        if dag_node._output_type == OutputType.IMPORT:
-            if not dag_node.already_added:
-                self.add_code(dag_node.code_line(None, None))
-            return None
-
         if dag_node._source_node is not None:
             self._dfs_dag_nodes(dag_node._source_node)
         # for each node do the dfs operation and save the variable names in `input_var_names`
@@ -228,6 +223,8 @@ class DMLScript:
             self._dfs_clear_dag_nodes(n)
         for name, n in dag_node.named_input_nodes.items():
             self._dfs_clear_dag_nodes(n)
+        if dag_node._source_node is not None:
+            self._dfs_clear_dag_nodes(dag_node._source_node)
 
     def _next_unique_var(self) -> str:
         """Gets the next unique variable name

--- a/src/main/python/tests/source/test_source_reuse.py
+++ b/src/main/python/tests/source/test_source_reuse.py
@@ -1,0 +1,68 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import unittest
+
+import numpy as np
+from systemds.context import SystemDSContext
+
+
+class TestSourceReuse(unittest.TestCase):
+
+    sds: SystemDSContext = None
+    source_reuse = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sds = SystemDSContext()
+        cls.source_reuse = cls.sds.source("./tests/source/source_01.dml",
+                              "test")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sds.close()
+
+    def test_01_single_call(self):
+        self.call()
+
+    def test_02_second_call(self):
+        self.call()
+
+    def test_03_same_function(self):
+        s = self.sds.source("./tests/source/source_01.dml",
+                              "test")
+        c = s.test_01().compute()
+        d = s.test_01().compute()
+        self.assertTrue(np.allclose(c, d))
+
+    def call(self):
+        c = self.source_reuse.test_01()
+        res = c.compute()
+        self.assertEqual(1, self.imports(c.script_str))
+        self.assertTrue(np.allclose(np.array([[1]]), res))
+
+
+
+    def imports(self, script:str) -> int:
+        return script.split("\n").count('source("./tests/source/source_01.dml") as test')
+
+if __name__ == "__main__":
+    unittest.main(exit=False)


### PR DESCRIPTION
This commit fix a bug in python source where if the source is used in multiple compute statements it breaks.
This is partially because the source command worked differently than other nodes. This commit now unifies this,
to a single way, and fixes the bug.

We should include this in the release.