### PR TITLE
[SYSTEMDS-3091] MatrixBlock Initialized with Zeros is Sparse

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CtableFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CtableFEDInstruction.java
@@ -197,7 +197,7 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 					continue;
 
 				// check intersect with AND and compare number of nnz
-				MatrixBlock prevExtend = new MatrixBlock(curr.getNumRows(), curr.getNumColumns(), 0.0);
+				MatrixBlock prevExtend = new MatrixBlock(curr.getNumRows(), curr.getNumColumns(), true, 0);
 				prevExtend.copy(0, prev.getNumRows()-1, 0, prev.getNumColumns()-1, prev, true);
 
 				MatrixBlock  intersect = curr.binaryOperationsInPlace(new BinaryOperator(And.getAndFnObject()), prevExtend);
@@ -240,7 +240,7 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 	}
 
 	private static MatrixBlock aggResult(Future<FederatedResponse>[] ffr) {
-		MatrixBlock resultBlock = new MatrixBlock(1, 1, 0);
+		MatrixBlock resultBlock = new MatrixBlock(1, 1, true, 0);
 		int dim1 = 0, dim2 = 0;
 		for(int i = 0; i < ffr.length; i++) {
 			try {
@@ -249,10 +249,10 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 				dim2 = mb.getNumColumns()  > dim2 ? mb.getNumColumns() : dim2;
 
 				// set next and prev to same output dimensions
-				MatrixBlock prev = new MatrixBlock(dim1, dim2, 0.0);
+				MatrixBlock prev = new MatrixBlock(dim1, dim2, true, 0);
 				prev.copy(0, resultBlock.getNumRows()-1, 0, resultBlock.getNumColumns()-1, resultBlock, true);
 
-				MatrixBlock next = new MatrixBlock(dim1, dim2, 0.0);
+				MatrixBlock next = new MatrixBlock(dim1, dim2, true, 0);
 				next.copy(0, mb.getNumRows()-1, 0, mb.getNumColumns()-1, mb, true);
 
 				// add worker results

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -181,7 +181,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	}
 	
 	public MatrixBlock(int rl, int cl, double val) {
-		reset(rl, cl, true, val == 0 ? 0 : (long)rl*cl, val);
+		reset(rl, cl, false, (long)rl*cl, val);
 	}
 	
 	/**
@@ -250,7 +250,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	
 	@Override
 	public void reset(int rl, int cl, double val) {
-		reset(rl, cl, true, -1, val);
+		reset(rl, cl, false, -1, val);
 	}
 	
 	/**
@@ -258,7 +258,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	 * 
 	 * @param rl      number of rows
 	 * @param cl      number of columns
-	 * @param sp      sparse representation (only considered if val is 0)
+	 * @param sp      sparse representation
 	 * @param estnnz  estimated number of non-zeros
 	 * @param val     initialization value
 	 */
@@ -5874,20 +5874,5 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 			estimatedNonZeros=nnzs;
 		}
 		public SparsityEstimate(){}
-
-		@Override
-		public String toString() {
-			StringBuilder sb = new StringBuilder();
-
-			sb.append("Sparse? = ");
-			sb.append(sparse);
-			sb.append("\n");
-
-			sb.append("Estimated NNZ: ");
-			sb.append(estimatedNonZeros);
-			sb.append("\n");
-
-			return sb.toString();
-		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -181,7 +181,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	}
 	
 	public MatrixBlock(int rl, int cl, double val) {
-		reset(rl, cl, false, (long)rl*cl, val);
+		reset(rl, cl, true, val == 0 ? 0 : (long)rl*cl, val);
 	}
 	
 	/**
@@ -250,7 +250,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	
 	@Override
 	public void reset(int rl, int cl, double val) {
-		reset(rl, cl, false, -1, val);
+		reset(rl, cl, true, -1, val);
 	}
 	
 	/**
@@ -258,7 +258,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	 * 
 	 * @param rl      number of rows
 	 * @param cl      number of columns
-	 * @param sp      sparse representation
+	 * @param sp      sparse representation (only considered if val is 0)
 	 * @param estnnz  estimated number of non-zeros
 	 * @param val     initialization value
 	 */
@@ -5874,5 +5874,20 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 			estimatedNonZeros=nnzs;
 		}
 		public SparsityEstimate(){}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Sparse? = ");
+			sb.append(sparse);
+			sb.append("\n");
+
+			sb.append("Estimated NNZ: ");
+			sb.append(estimatedNonZeros);
+			sb.append("\n");
+
+			return sb.toString();
+		}
 	}
 }


### PR DESCRIPTION
Hi,
This PR tries to remove the performance bottleneck inside the federated ctable instruction (caused by aggregating the sparse partial result matrices using a dense plus operator) by constructing a MatrixBlock as a sparse matrix if all the values are initialized to zero.

Thanks for review :)