### PR TITLE
[SYSTEMDS-3018] Basic Federated Planner

### DIFF
--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -91,6 +91,7 @@ public abstract class Hop implements ParseInfo {
 	 * If it is lout, the output should be retrieved by the coordinator.
 	 */
 	protected FederatedOutput _federatedOutput = FederatedOutput.NONE;
+	protected double _federatedCost = 0;
 	
 	// Estimated size for the output produced from this Hop
 	protected double _outputMemEstimate = OptimizerUtils.INVALID_SIZE;
@@ -830,10 +831,6 @@ public abstract class Hop implements ParseInfo {
 	public boolean isFederated(){
 		return getExecType() == ExecType.FED;
 	}
-	
-	public boolean isFederatedOutput(){
-		return _federatedOutput == FederatedOutput.FOUT;
-	}
 
 	public boolean someInputFederated(){
 		return getInput().stream().anyMatch(Hop::hasFederatedOutput);
@@ -887,6 +884,22 @@ public abstract class Hop implements ParseInfo {
 
 	public boolean hasFederatedOutput(){
 		return _federatedOutput == FederatedOutput.FOUT;
+	}
+
+	public boolean hasLocalOutput(){
+		return _federatedOutput == FederatedOutput.LOUT;
+	}
+
+	public boolean federatedCostInitialized(){
+		return _federatedCost > 0;
+	}
+
+	public double getFederatedCost(){
+		return _federatedCost;
+	}
+
+	public void setFederatedCost(double cost){
+		_federatedCost = cost;
 	}
 
 	public void setUpdateType(UpdateType update){

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -560,7 +560,7 @@ public abstract class Hop implements ParseInfo {
 			Hop hi = _input.get(i);
 			if( exclVars != null && exclVars.contains(hi.getName()) )
 				continue;
-			double hmout = hi.getOutputMemEstimate();
+			double hmout = hi.getOutputMemEstimate(injectedDefault);
 			if (hmout < 0)
 				hmout = injectedDefault*(Math.max(hi.getDim1(),1) * Math.max(hi.getDim2(),1));
 			if( hmout > 1024*1024 ) {//for relevant sizes
@@ -673,7 +673,7 @@ public abstract class Hop implements ParseInfo {
 	 * @param injectedDefault memory estimate to be returned in case the memory estimate defaults to a negative number
 	 * @return output memory estimate in bytes
 	 */
-	public double getOutputMemEstimate(int injectedDefault)
+	public double getOutputMemEstimate(double injectedDefault)
 	{
 		return Math.max(getOutputMemEstimate(),injectedDefault*(Math.max(getDim1(),1) * Math.max(getDim2(),1)));
 	}

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -667,13 +667,15 @@ public abstract class Hop implements ParseInfo {
 	}
 
 	/**
-	 * Output memory estimate in bytes with no negative memory estimates.
-	 * The default memory estimate is negative, hence this is likely to happen.
+	 * Output memory estimate in bytes with negative memory estimates replaced by the injected default.
+	 * The injected default represents the memory estimate per output cell, hence it is multiplied by the estimated
+	 * dimensions of the output of the hop.
+	 * @param injectedDefault memory estimate to be returned in case the memory estimate defaults to a negative number
 	 * @return output memory estimate in bytes
 	 */
-	public double getOutputMemEstimateNonNegative()
+	public double getOutputMemEstimate(int injectedDefault)
 	{
-		return Math.max(getOutputMemEstimate(),0);
+		return Math.max(getOutputMemEstimate(),injectedDefault*(Math.max(getDim1(),1) * Math.max(getDim2(),1)));
 	}
 
 	public double getIntermediateMemEstimate()

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -547,6 +547,12 @@ public abstract class Hop implements ParseInfo {
 		return getInputSize(null);
 	}
 
+	/**
+	 * Get the memory estimate of inputs as the sum of input estimates in bytes.
+	 * @param exclVars name of input hops to exclude from the input estimate
+	 * @param injectedDefault default memory estimate (bytes) used when the memory estimate of the input is negative
+	 * @return input memory estimate in bytes
+	 */
 	protected double getInputSize(Collection<String> exclVars, double injectedDefault){
 		double sum = 0;
 		int len = _input.size();
@@ -572,6 +578,11 @@ public abstract class Hop implements ParseInfo {
 		return sum;
 	}
 
+	/**
+	 * Get the memory estimate of inputs as the sum of input estimates in bytes.
+	 * @param exclVars name of input hops to exclude from the input estimate
+	 * @return input memory estimate in bytes
+	 */
 	protected double getInputSize(Collection<String> exclVars) {
 		return getInputSize(exclVars, OptimizerUtils.INVALID_SIZE);
 	}
@@ -627,12 +638,21 @@ public abstract class Hop implements ParseInfo {
 	}
 
 	//wrappers for meaningful public names to memory estimates.
-	
+
+	/**
+	 * Get the memory estimate of inputs as the sum of input estimates in bytes.
+	 * @return input memory estimate in bytes
+	 */
 	public double getInputMemEstimate()
 	{
 		return getInputSize();
 	}
 
+	/**
+	 * Get the memory estimate of inputs as the sum of input estimates in bytes.
+	 * @param injectedDefault default memory estimate (bytes) used when the memory estimate of the input is negative
+	 * @return input memory estimate in bytes
+	 */
 	public double getInputMemEstimate(double injectedDefault){
 		return getInputSize(null, injectedDefault);
 	}
@@ -914,6 +934,10 @@ public abstract class Hop implements ParseInfo {
 		return _federatedOutput == FederatedOutput.LOUT;
 	}
 
+	/**
+	 * Check if federated cost has been initialized for this Hop.
+	 * @return true if federated cost has been initialized
+	 */
 	public boolean federatedCostInitialized(){
 		return _federatedCost.getTotal() > 0;
 	}

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -823,7 +823,7 @@ public abstract class Hop implements ParseInfo {
 	 * This method only has an effect if FEDERATED_COMPILATION is activated.
 	 */
 	protected void updateETFed(){
-		if ( _federatedOutput == FederatedOutput.FOUT || _federatedOutput == FederatedOutput.LOUT )
+		if ( _federatedOutput.isForced() )
 			_etype = ExecType.FED;
 	}
 	

--- a/src/main/java/org/apache/sysds/hops/cost/ComputeCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/ComputeCost.java
@@ -46,7 +46,7 @@ public class ComputeCost {
 	 * Get compute cost for given HOP based on the number of floating point operations per output cell
 	 * and the total number of output cells.
 	 * @param currentHop for which compute cost is returned
-	 * @return compute cost of currentHop
+	 * @return compute cost of currentHop as number of floating point operations
 	 */
 	public static double getHOPComputeCost(Hop currentHop){
 		double costs = 1;

--- a/src/main/java/org/apache/sysds/hops/cost/ComputeCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/ComputeCost.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.cost;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.hops.AggUnaryOp;
+import org.apache.sysds.hops.BinaryOp;
+import org.apache.sysds.hops.DnnOp;
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.IndexingOp;
+import org.apache.sysds.hops.LiteralOp;
+import org.apache.sysds.hops.NaryOp;
+import org.apache.sysds.hops.ParameterizedBuiltinOp;
+import org.apache.sysds.hops.ReorgOp;
+import org.apache.sysds.hops.TernaryOp;
+import org.apache.sysds.hops.UnaryOp;
+import org.apache.sysds.hops.rewrite.HopRewriteUtils;
+
+/**
+ * Class with methods estimating compute costs of operations.
+ */
+public class ComputeCost {
+	private static final Log LOG = LogFactory.getLog(ComputeCost.class.getName());
+
+	/**
+	 * Get compute cost for given HOP based on the number of floating point operations per output cell
+	 * and the total number of output cells.
+	 * @param currentHop for which compute cost is returned
+	 * @return compute cost of currentHop
+	 */
+	public static double getHOPComputeCost(Hop currentHop){
+		double costs = 1;
+		if( currentHop instanceof UnaryOp) {
+			switch( ((UnaryOp)currentHop).getOp() ) {
+				case ABS:
+				case ROUND:
+				case CEIL:
+				case FLOOR:
+				case SIGN:    costs = 1; break;
+				case SPROP:
+				case SQRT:    costs = 2; break;
+				case EXP:     costs = 18; break;
+				case SIGMOID: costs = 21; break;
+				case LOG:
+				case LOG_NZ:  costs = 32; break;
+				case NCOL:
+				case NROW:
+				case PRINT:
+				case ASSERT:
+				case CAST_AS_BOOLEAN:
+				case CAST_AS_DOUBLE:
+				case CAST_AS_INT:
+				case CAST_AS_MATRIX:
+				case CAST_AS_SCALAR: costs = 1; break;
+				case SIN:     costs = 18; break;
+				case COS:     costs = 22; break;
+				case TAN:     costs = 42; break;
+				case ASIN:    costs = 93; break;
+				case ACOS:    costs = 103; break;
+				case ATAN:    costs = 40; break;
+				case SINH:    costs = 93; break; // TODO:
+				case COSH:    costs = 103; break;
+				case TANH:    costs = 40; break;
+				case CUMSUM:
+				case CUMMIN:
+				case CUMMAX:
+				case CUMPROD: costs = 1; break;
+				case CUMSUMPROD: costs = 2; break;
+				default:
+					LOG.warn("Cost model not "
+						+ "implemented yet for: "+((UnaryOp)currentHop).getOp());
+			}
+		}
+		else if( currentHop instanceof BinaryOp) {
+			switch( ((BinaryOp)currentHop).getOp() ) {
+				case MULT:
+				case PLUS:
+				case MINUS:
+				case MIN:
+				case MAX:
+				case AND:
+				case OR:
+				case EQUAL:
+				case NOTEQUAL:
+				case LESS:
+				case LESSEQUAL:
+				case GREATER:
+				case GREATEREQUAL:
+				case CBIND:
+				case RBIND:   costs = 1; break;
+				case INTDIV:  costs = 6; break;
+				case MODULUS: costs = 8; break;
+				case DIV:     costs = 22; break;
+				case LOG:
+				case LOG_NZ:  costs = 32; break;
+				case POW:     costs = (HopRewriteUtils.isLiteralOfValue(
+					currentHop.getInput().get(1), 2) ? 1 : 16); break;
+				case MINUS_NZ:
+				case MINUS1_MULT: costs = 2; break;
+				case MOMENT:
+					int type = (int) (currentHop.getInput().get(1) instanceof LiteralOp ?
+						HopRewriteUtils.getIntValueSafe((LiteralOp)currentHop.getInput().get(1)) : 2);
+					switch( type ) {
+						case 0: costs = 1; break; //count
+						case 1: costs = 8; break; //mean
+						case 2: costs = 16; break; //cm2
+						case 3: costs = 31; break; //cm3
+						case 4: costs = 51; break; //cm4
+						case 5: costs = 16; break; //variance
+					}
+					break;
+				case COV: costs = 23; break;
+				default:
+					LOG.warn("Cost model not "
+						+ "implemented yet for: "+((BinaryOp)currentHop).getOp());
+			}
+		}
+		else if( currentHop instanceof TernaryOp) {
+			switch( ((TernaryOp)currentHop).getOp() ) {
+				case IFELSE:
+				case PLUS_MULT:
+				case MINUS_MULT: costs = 2; break;
+				case CTABLE:     costs = 3; break;
+				case MOMENT:
+					int type = (int) (currentHop.getInput().get(1) instanceof LiteralOp ?
+						HopRewriteUtils.getIntValueSafe((LiteralOp)currentHop.getInput().get(1)) : 2);
+					switch( type ) {
+						case 0: costs = 2; break; //count
+						case 1: costs = 9; break; //mean
+						case 2: costs = 17; break; //cm2
+						case 3: costs = 32; break; //cm3
+						case 4: costs = 52; break; //cm4
+						case 5: costs = 17; break; //variance
+					}
+					break;
+				case COV: costs = 23; break;
+				default:
+					LOG.warn("Cost model not "
+						+ "implemented yet for: "+((TernaryOp)currentHop).getOp());
+			}
+		}
+		else if( currentHop instanceof NaryOp) {
+			costs = HopRewriteUtils.isNary(currentHop, Types.OpOpN.MIN, Types.OpOpN.MAX, Types.OpOpN.PLUS) ?
+				currentHop.getInput().size() : 1;
+		}
+		else if( currentHop instanceof ParameterizedBuiltinOp) {
+			costs = 1;
+		}
+		else if( currentHop instanceof IndexingOp) {
+			costs = 1;
+		}
+		else if( currentHop instanceof ReorgOp) {
+			costs = 1;
+		}
+		else if( currentHop instanceof DnnOp) {
+			switch( ((DnnOp)currentHop).getOp() ) {
+				case BIASADD:
+				case BIASMULT:
+					costs = 2;
+				default:
+					LOG.warn("Cost model not "
+						+ "implemented yet for: "+((DnnOp)currentHop).getOp());
+			}
+		}
+		else if( currentHop instanceof AggBinaryOp) {
+			//outer product template w/ matrix-matrix
+			//or row template w/ matrix-vector or matrix-matrix
+			costs = 2 * currentHop.getInput().get(0).getDim2();
+			if( currentHop.getInput().get(0).dimsKnown(true) )
+				costs *= currentHop.getInput().get(0).getSparsity();
+		}
+		else if( currentHop instanceof AggUnaryOp) {
+			switch(((AggUnaryOp)currentHop).getOp()) {
+				case SUM:    costs = 4; break;
+				case SUM_SQ: costs = 5; break;
+				case MIN:
+				case MAX:    costs = 1; break;
+				default:
+					LOG.warn("Cost model not "
+						+ "implemented yet for: "+((AggUnaryOp)currentHop).getOp());
+			}
+			switch(((AggUnaryOp)currentHop).getDirection()) {
+				case Col: costs *= Math.max(currentHop.getInput().get(0).getDim1(),1); break;
+				case Row: costs *= Math.max(currentHop.getInput().get(0).getDim2(),1); break;
+				case RowCol: costs *= getSize(currentHop.getInput().get(0)); break;
+			}
+		}
+
+		//scale by current output size in order to correctly reflect
+		//a mix of row and cell operations in the same fused operator
+		//(e.g., row template with fused column vector operations)
+		costs *= getSize(currentHop);
+		return costs;
+	}
+
+	/**
+	 * Get number of output cells of given hop.
+	 * @param hop for which the number of output cells are found
+	 * @return number of output cells of given hop
+	 */
+	private static long getSize(Hop hop) {
+		return Math.max(hop.getDim1(),1)
+			* Math.max(hop.getDim2(),1);
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
@@ -66,4 +66,22 @@ public class FederatedCost {
 		this.computeCost += additionalCost.computeCost;
 		this.inputTotalCost += additionalCost.inputTotalCost;
 	}
+
+	@Override
+	public String toString(){
+		StringBuilder builder = new StringBuilder();
+		builder.append("computeCost: ");
+		builder.append(computeCost);
+		builder.append("\n readCost: ");
+		builder.append(readCost);
+		builder.append("\n inputTransferCost: ");
+		builder.append(inputTransferCost);
+		builder.append("\n outputTransferCost: ");
+		builder.append(outputTransferCost);
+		builder.append("\n inputTotalCost: ");
+		builder.append(inputTotalCost);
+		builder.append("\n total cost: ");
+		builder.append(getTotal());
+		return builder.toString();
+	}
 }

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
@@ -19,6 +19,10 @@
 
 package org.apache.sysds.hops.cost;
 
+/**
+ * Class storing execution cost estimates for federated executions with cost estimates split into different categories
+ * such as compute, read, and transfer cost.
+ */
 public class FederatedCost {
 	protected double computeCost = 0;
 	protected double readCost = 0;
@@ -26,9 +30,7 @@ public class FederatedCost {
 	protected double outputTransferCost = 0;
 	protected double inputTotalCost = 0;
 
-	public FederatedCost(){
-
-	}
+	public FederatedCost(){}
 
 	public FederatedCost(double readCost, double inputTransferCost, double outputTransferCost,
 		double computeCost, double inputTotalCost){
@@ -39,14 +41,26 @@ public class FederatedCost {
 		this.inputTotalCost = inputTotalCost;
 	}
 
+	/**
+	 * Get the total sum of costs stored in this object.
+	 * @return total cost
+	 */
 	public double getTotal(){
 		return computeCost + readCost + inputTransferCost + outputTransferCost + inputTotalCost;
 	}
 
-	public void addRepititionCost(int repititionNumber){
-		this.inputTotalCost = inputTotalCost * repititionNumber;
+	/**
+	 * Multiply the input costs by the number of times the costs are repeated.
+	 * @param repetitionNumber number of repetitions of the costs
+	 */
+	public void addRepetitionCost(int repetitionNumber){
+		this.inputTotalCost = inputTotalCost * repetitionNumber;
 	}
 
+	/**
+	 * Get summed input costs.
+	 * @return summed input costs
+	 */
 	public double getInputTotalCost(){
 		return inputTotalCost;
 	}
@@ -55,10 +69,18 @@ public class FederatedCost {
 		this.inputTotalCost = inputTotalCost;
 	}
 
+	/**
+	 * Add cost to the stored input cost.
+	 * @param additionalCost to add to total input cost
+	 */
 	public void addInputTotalCost(double additionalCost){
 		this.inputTotalCost += additionalCost;
 	}
 
+	/**
+	 * Add costs of FederatedCost object to this object's current costs.
+	 * @param additionalCost object to add to this object
+	 */
 	public void addFederatedCost(FederatedCost additionalCost){
 		this.readCost += additionalCost.readCost;
 		this.inputTransferCost += additionalCost.inputTransferCost;

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.cost;
+
+public class FederatedCost {
+	protected double computeCost = 0;
+	protected double readCost = 0;
+	protected double inputTransferCost = 0;
+	protected double outputTransferCost = 0;
+	protected double inputTotalCost = 0;
+
+	public FederatedCost(){
+
+	}
+
+	public FederatedCost(double readCost, double inputTransferCost, double outputTransferCost,
+		double computeCost, double inputTotalCost){
+		this.readCost = readCost;
+		this.inputTransferCost = inputTransferCost;
+		this.outputTransferCost = outputTransferCost;
+		this.computeCost = computeCost;
+		this.inputTotalCost = inputTotalCost;
+	}
+
+	public double getTotal(){
+		return computeCost + readCost + inputTransferCost + outputTransferCost + inputTotalCost;
+	}
+
+	public void addRepititionCost(int repititionNumber){
+		this.inputTotalCost = inputTotalCost * repititionNumber;
+	}
+
+	public double getInputTotalCost(){
+		return inputTotalCost;
+	}
+
+	public void setInputTotalCost(double inputTotalCost){
+		this.inputTotalCost = inputTotalCost;
+	}
+
+	public void addInputTotalCost(double additionalCost){
+		this.inputTotalCost += additionalCost;
+	}
+
+	public void addFederatedCost(FederatedCost additionalCost){
+		this.readCost += additionalCost.readCost;
+		this.inputTransferCost += additionalCost.inputTransferCost;
+		this.outputTransferCost += additionalCost.outputTransferCost;
+		this.computeCost += additionalCost.computeCost;
+		this.inputTotalCost += additionalCost.inputTotalCost;
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
@@ -92,7 +92,7 @@ public class FederatedCost {
 	@Override
 	public String toString(){
 		StringBuilder builder = new StringBuilder();
-		builder.append("computeCost: ");
+		builder.append(" computeCost: ");
 		builder.append(computeCost);
 		builder.append("\n readCost: ");
 		builder.append(readCost);

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCost.java
@@ -78,6 +78,14 @@ public class FederatedCost {
 	}
 
 	/**
+	 * Add total of federatedCost to stored inputTotalCost.
+	 * @param federatedCost input cost from which the total is retrieved
+	 */
+	public void addInputTotalCost(FederatedCost federatedCost){
+		this.inputTotalCost += federatedCost.getTotal();
+	}
+
+	/**
 	 * Add costs of FederatedCost object to this object's current costs.
 	 * @param additionalCost object to add to this object
 	 */

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
@@ -95,7 +95,11 @@ public class FederatedCostEstimator {
 		else if ( sb instanceof ForStatementBlock){
 			// This also includes ParForStatementBlocks
 			ForStatementBlock forSB = (ForStatementBlock) sb;
-			FederatedCost forSBCost = costEstimate(forSB.getHops());
+			ArrayList<Hop> predicateHops = new ArrayList<>();
+			predicateHops.add(forSB.getFromHops());
+			predicateHops.add(forSB.getToHops());
+			predicateHops.add(forSB.getIncrementHops());
+			FederatedCost forSBCost = costEstimate(predicateHops);
 			for ( Statement statement : forSB.getStatements() ){
 				ForStatement forStatement = (ForStatement) statement;
 				for ( StatementBlock forStatementBlockBody : forStatement.getBody() )
@@ -141,7 +145,7 @@ public class FederatedCostEstimator {
 	private FederatedCost costEstimate(ArrayList<Hop> roots){
 		FederatedCost basicCost = new FederatedCost();
 		for ( Hop root : roots )
-			basicCost.addInputTotalCost(costEstimate(root).getTotal());
+			basicCost.addInputTotalCost(costEstimate(root));
 		return basicCost;
 	}
 

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
@@ -155,18 +155,26 @@ public class FederatedCostEstimator {
 				new FederatedCost(readCost, inputTransferCost, outputTransferCost, computingCost, inputCosts);
 			root.setFederatedCost(rootFedCost);
 
-			if ( printCosts ){
-				System.out.println("===============================");
-				System.out.println(root);
-				System.out.println("Is federated: " + root.isFederated());
-				System.out.println("Has federated output: " + root.hasFederatedOutput());
-				System.out.println(root.getText());
-				System.out.println(ComputeCost.getHOPComputeCost(root));
-				System.out.println(root.getFederatedCost().toString());
-				System.out.println("===============================");
-			}
+			if ( printCosts )
+				printCosts(root);
 
 			return rootFedCost;
 		}
+	}
+
+	/**
+	 * Prints costs and information about root for debugging purposes
+	 * @param root hop for which information is printed
+	 */
+	private void printCosts(Hop root){
+		System.out.println("===============================");
+		System.out.println(root);
+		System.out.println("Is federated: " + root.isFederated());
+		System.out.println("Has federated output: " + root.hasFederatedOutput());
+		System.out.println(root.getText());
+		System.out.println("Pure computeCost: " + ComputeCost.getHOPComputeCost(root));
+		System.out.println("Dim1: " + root.getDim1() + " Dim2: " + root.getDim2());
+		System.out.println(root.getFederatedCost().toString());
+		System.out.println("===============================");
 	}
 }

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.cost;
+
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.parser.DMLProgram;
+import org.apache.sysds.parser.ForStatementBlock;
+import org.apache.sysds.parser.FunctionStatementBlock;
+import org.apache.sysds.parser.IfStatementBlock;
+import org.apache.sysds.parser.StatementBlock;
+import org.apache.sysds.parser.WhileStatementBlock;
+
+import java.util.ArrayList;
+
+public class FederatedCostEstimator {
+	private static final int DEFAULT_ITERATION_NUMBER = 15;
+	private static final double WORKER_NETWORK_BANDWIDTH_BYTES = 1024*1024*1024; //Default network bandwidth in bytes per second
+	private static final double WORKER_COMPUTE_BANDWITH_FLOPS = 2.5*1024*1024*1024; //Default compute bandwidth in FLOPS
+	private static final double WORKER_DEGREE_OF_PARALLELISM = 8; //Default number of parallel processes for workers
+
+	public FederatedCost costEstimate(DMLProgram dmlProgram){
+		FederatedCost programTotalCost = new FederatedCost();
+		for ( StatementBlock stmBlock : dmlProgram.getStatementBlocks() )
+			programTotalCost.addInputTotalCost(costEstimate(stmBlock).getTotal());
+		return programTotalCost;
+	}
+
+	private FederatedCost costEstimate(StatementBlock sb){
+		if ( sb instanceof WhileStatementBlock){
+			WhileStatementBlock whileSB = (WhileStatementBlock) sb;
+			FederatedCost whileSBCost = addInitialInputCost(sb);
+			whileSBCost.addRepititionCost(DEFAULT_ITERATION_NUMBER);
+			return whileSBCost;
+		}
+		else if ( sb instanceof IfStatementBlock){
+			IfStatementBlock ifSB = (IfStatementBlock) sb;
+			//Get cost of if-block + else-block and divide by two
+			// since only one of the code blocks will be executed in the end
+			FederatedCost ifSBCost = addInitialInputCost(sb);
+			ifSBCost.setInputTotalCost(ifSBCost.getInputTotalCost() / 2);
+			return ifSBCost;
+		}
+		else if ( sb instanceof ForStatementBlock){
+			// This also includes ParForStatementBlocks
+			ForStatementBlock forSB = (ForStatementBlock) sb;
+			FederatedCost forCost = addInitialInputCost(sb);
+			forCost.addRepititionCost(forSB.getEstimateReps());
+			return forCost;
+		}
+		else if ( sb instanceof FunctionStatementBlock){
+			FederatedCost funcCost = addInitialInputCost(sb);
+			FunctionStatementBlock funcSB = (FunctionStatementBlock) sb;
+			return funcCost;
+		}
+		else {
+			// StatementBlock type (no subclass)
+			return costEstimate(sb.getHops());
+		}
+	}
+
+	private FederatedCost addInitialInputCost(StatementBlock sb){
+		FederatedCost basicCost = new FederatedCost();
+		for ( StatementBlock childSB : sb.getDMLProg().getStatementBlocks() )
+			basicCost.addInputTotalCost(costEstimate(childSB).getTotal());
+		return basicCost;
+	}
+
+	private FederatedCost costEstimate(ArrayList<Hop> roots){
+		FederatedCost basicCost = new FederatedCost();
+		for ( Hop root : roots )
+			basicCost.addInputTotalCost(costEstimate(root).getTotal());
+		return basicCost;
+	}
+
+	/**
+	 * Return cost estimate of Hop DAG starting from given root.
+	 * @param root of Hop DAG for which cost is estimated
+	 * @return cost estimation of Hop DAG starting from given root
+	 */
+	private FederatedCost costEstimate(Hop root){
+		if ( root.federatedCostInitialized() )
+			return root.getFederatedCost();
+		else {
+			// If no input has FOUT, the root will be processed by the coordinator
+			boolean hasFederatedInput = root.someInputFederated();
+			//the input cost is included the first time the input hop is used
+			//for additional usage, the additional cost is zero (disregarding potential read cost)
+			double inputCosts = root.getInput().stream()
+				.mapToDouble( in -> in.federatedCostInitialized() ? 0 : costEstimate(in).getTotal() )
+				.sum();
+			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
+				.filter(Hop::hasLocalOutput)
+				.mapToDouble(Hop::getOutputMemEstimate)
+				.map(inMem -> inMem/WORKER_NETWORK_BANDWIDTH_BYTES)
+				.sum() : 0;
+			double computingCost = ComputeCost.getHOPComputeCost(root);
+			if ( hasFederatedInput ){
+				//Find the number of inputs that has FOUT set.
+				int numWorkers = (int)root.getInput().stream().filter(Hop::hasFederatedOutput).count();
+				//divide memory usage by the number of workers the computation would be split to multiplied by
+				//the number of parallel processes at each worker multiplied by the FLOPS of each process
+				//This assumes uniform workload among the workers with FOUT data involved in the operation
+				//and assumes that the degree of parallelism and compute bandwidth are equal for all workers
+				computingCost = computingCost / (numWorkers*WORKER_DEGREE_OF_PARALLELISM*WORKER_COMPUTE_BANDWITH_FLOPS);
+			}
+			//Calculate output transfer cost if the operation is computed at federated workers and the output is forced to the coordinator
+			double outputTransferCost = ( root.hasLocalOutput() && hasFederatedInput ) ?
+				root.getOutputMemEstimate() / WORKER_NETWORK_BANDWIDTH_BYTES : 0;
+			double readCost = root.getInputMemEstimate();
+
+			FederatedCost rootFedCost =
+				new FederatedCost(readCost, inputTransferCost, outputTransferCost, computingCost, inputCosts);
+			root.setFederatedCost(rootFedCost);
+			return rootFedCost;
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
@@ -133,7 +133,7 @@ public class FederatedCostEstimator {
 				.sum();
 			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
 				.filter(Hop::hasLocalOutput)
-				.mapToDouble(Hop::getOutputMemEstimateNonNegative)
+				.mapToDouble(in -> in.getOutputMemEstimate(DEFAULT_MEMORY_ESTIMATE))
 				.map(inMem -> inMem/ WORKER_NETWORK_BANDWIDTH_BYTES_PS)
 				.sum() : 0;
 			double computingCost = ComputeCost.getHOPComputeCost(root);
@@ -148,7 +148,7 @@ public class FederatedCostEstimator {
 			} else computingCost = computingCost / (WORKER_DEGREE_OF_PARALLELISM*WORKER_COMPUTE_BANDWITH_FLOPS);
 			//Calculate output transfer cost if the operation is computed at federated workers and the output is forced to the coordinator
 			double outputTransferCost = ( root.hasLocalOutput() && hasFederatedInput ) ?
-				root.getOutputMemEstimateNonNegative() / WORKER_NETWORK_BANDWIDTH_BYTES_PS : 0;
+				root.getOutputMemEstimate(DEFAULT_MEMORY_ESTIMATE) / WORKER_NETWORK_BANDWIDTH_BYTES_PS : 0;
 			double readCost = root.getInputMemEstimate(DEFAULT_MEMORY_ESTIMATE) / WORKER_READ_BANDWIDTH_BYTES_PS;
 
 			FederatedCost rootFedCost =

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
@@ -140,6 +140,7 @@ public class ProgramRewriter
 			}
 			if ( OptimizerUtils.FEDERATED_COMPILATION ) {
 				_dagRuleSet.add( new RewriteFederatedExecution() );
+				_sbRuleSet.add( new RewriteFederatedStatementBlocks() );
 			}
 		}
 		

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -131,8 +131,10 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 		else {
 			// If no input has FOUT, the root will be processed by the coordinator
 			boolean hasFederatedInput = root.someInputFederated();
+			//the input cost is included the first time the input hop is used
+			//for additional usage, the additional cost is zero (disregarding potential read cost)
 			double inputCosts = root.getInput().stream()
-				.mapToDouble( in -> in.federatedCostInitialized() ? in.getFederatedCost() : costEstimate(in) )
+				.mapToDouble( in -> in.federatedCostInitialized() ? 0 : costEstimate(in) )
 				.sum();
 			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
 				.filter(Hop::hasLocalOutput)
@@ -223,15 +225,6 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 
 		privacyBasedHopDecisionWithFedCall(hop);
 		hop.setVisited();
-	}
-
-	private static void privacyBasedHopDecision(Hop hop){
-		PrivacyPropagator.hopPropagation(hop);
-		PrivacyConstraint privacyConstraint = hop.getPrivacy();
-		if ( privacyConstraint != null && privacyConstraint.hasConstraints() )
-			hop.setFederatedOutput(FEDInstruction.FederatedOutput.FOUT);
-		else if ( hop.someInputFederated() )
-			hop.setFederatedOutput(FEDInstruction.FederatedOutput.LOUT);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -152,7 +152,7 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 	 */
 	private long getUtilLout(Hop hop){
 		//TODO: Make better utility estimation
-		return -hop.getDim1()*hop.getDim2();
+		return -(long)hop.getMemEstimate();
 	}
 
 	private boolean isFedInstSupportedHop(Hop hop){

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedExecution.java
@@ -121,42 +121,6 @@ public class RewriteFederatedExecution extends HopRewriteRule {
 	}
 
 	/**
-	 * Return cost estimate of Hop DAG starting from given root.
-	 * @param root of Hop DAG for which cost is estimated
-	 * @return cost estimation of Hop DAG starting from given root
-	 */
-	private double costEstimate(Hop root){
-		if ( root.federatedCostInitialized() )
-			return root.getFederatedCost();
-		else {
-			// If no input has FOUT, the root will be processed by the coordinator
-			boolean hasFederatedInput = root.someInputFederated();
-			//the input cost is included the first time the input hop is used
-			//for additional usage, the additional cost is zero (disregarding potential read cost)
-			double inputCosts = root.getInput().stream()
-				.mapToDouble( in -> in.federatedCostInitialized() ? 0 : costEstimate(in) )
-				.sum();
-			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
-				.filter(Hop::hasLocalOutput)
-				.mapToDouble(Hop::getOutputMemEstimate)
-				.sum() : 0;
-			double computingCost = ComputeCost.getHOPComputeCost(root);;
-			if ( hasFederatedInput ){
-				//Find the number of inputs that has FOUT set.
-				int numWorkers = (int)root.getInput().stream().filter(Hop::hasFederatedOutput).count();
-				//divide memory usage by the number of workers the computation would be split to
-				computingCost = computingCost / numWorkers;
-			}
-			//Calculate output transfer cost if the operation is computed at federated workers and the output is forced to the coordinator
-			double outputTransferCost = ( root.hasLocalOutput() && hasFederatedInput ) ? root.getOutputMemEstimate() : 0;
-
-			double totalCost = inputCosts + inputTransferCost + computingCost + outputTransferCost;
-			root.setFederatedCost(totalCost);
-			return totalCost;
-		}
-	}
-
-	/**
 	 * Returns the FederatedOutput with the highest utility out of the valid FederatedOutput values.
 	 * @param hop for which the utility is found
 	 * @return the FederatedOutput value with highest utility for the given Hop

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedStatementBlocks.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedStatementBlocks.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.rewrite;
+
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.cost.ComputeCost;
+import org.apache.sysds.hops.cost.FederatedCost;
+import org.apache.sysds.parser.ForStatementBlock;
+import org.apache.sysds.parser.FunctionStatementBlock;
+import org.apache.sysds.parser.IfStatementBlock;
+import org.apache.sysds.parser.StatementBlock;
+import org.apache.sysds.parser.WhileStatementBlock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RewriteFederatedStatementBlocks extends StatementBlockRewriteRule {
+
+	private static final int DEFAULT_ITERATION_NUMBER = 15;
+	private static final double WORKER_NETWORK_BANDWIDTH_BYTES = 1024*1024*1024; //Default network bandwidth in bytes per second
+	private static final double WORKER_COMPUTE_BANDWITH_FLOPS = 2.5*1024*1024*1024; //Default compute bandwidth in FLOPS
+	private static final double WORKER_DEGREE_OF_PARALLELISM = 8; //Default number of parallel processes for workers
+
+	/**
+	 * Indicates if the rewrite potentially splits dags, which is used
+	 * for phase ordering of rewrites.
+	 *
+	 * @return true if dag splits are possible.
+	 */
+	@Override public boolean createsSplitDag() {
+		return false;
+	}
+
+	/**
+	 * Handle an arbitrary statement block. Specific type constraints have to be ensured
+	 * within the individual rewrites. If a rewrite does not apply to individual blocks, it
+	 * should simply return the input block.
+	 *
+	 * @param sb    statement block
+	 * @param state program rewrite status
+	 * @return list of statement blocks
+	 */
+	@Override
+	public List<StatementBlock> rewriteStatementBlock(StatementBlock sb, ProgramRewriteStatus state) {
+		return Arrays.asList(sb);
+	}
+
+	/**
+	 * Handle a list of statement blocks. Specific type constraints have to be ensured
+	 * within the individual rewrites. If a rewrite does not require sequence access, it
+	 * should simply return the input list of statement blocks.
+	 *
+	 * @param sbs   list of statement blocks
+	 * @param state program rewrite status
+	 * @return list of statement blocks
+	 */
+	@Override
+	public List<StatementBlock> rewriteStatementBlocks(List<StatementBlock> sbs, ProgramRewriteStatus state) {
+		return sbs;
+	}
+
+	private FederatedCost costEstimate(StatementBlock sb){
+		if ( sb instanceof WhileStatementBlock ){
+			WhileStatementBlock whileSB = (WhileStatementBlock) sb;
+			FederatedCost whileSBCost = addInitialInputCost(sb);
+			whileSBCost.addRepititionCost(DEFAULT_ITERATION_NUMBER);
+			return whileSBCost;
+		}
+		else if ( sb instanceof IfStatementBlock ){
+			IfStatementBlock ifSB = (IfStatementBlock) sb;
+			//Get cost of if-block + else-block and divide by two
+			// since only one of the code blocks will be executed in the end
+			FederatedCost ifSBCost = addInitialInputCost(sb);
+			ifSBCost.setInputTotalCost(ifSBCost.getInputTotalCost() / 2);
+			return ifSBCost;
+		}
+		else if ( sb instanceof ForStatementBlock ){
+			// This also includes ParForStatementBlocks
+			ForStatementBlock forSB = (ForStatementBlock) sb;
+			FederatedCost forCost = addInitialInputCost(sb);
+			forCost.addRepititionCost(forSB.getEstimateReps());
+			return forCost;
+		}
+		else if ( sb instanceof FunctionStatementBlock ){
+			FederatedCost funcCost = addInitialInputCost(sb);
+			FunctionStatementBlock funcSB = (FunctionStatementBlock) sb;
+			return funcCost;
+		}
+		else {
+			// StatementBlock type (no subclass)
+			return costEstimate(sb.getHops());
+		}
+	}
+
+	private FederatedCost addInitialInputCost(StatementBlock sb){
+		FederatedCost basicCost = new FederatedCost();
+		for ( StatementBlock childSB : sb.getDMLProg().getStatementBlocks() )
+			basicCost.setInputTotalCost(costEstimate(childSB).getTotal());
+		return basicCost;
+	}
+
+	private FederatedCost costEstimate(ArrayList<Hop> roots){
+		FederatedCost basicCost = new FederatedCost();
+		for ( Hop root : roots )
+			basicCost.setInputTotalCost(costEstimate(root).getTotal());
+		return basicCost;
+	}
+
+	/**
+	 * Return cost estimate of Hop DAG starting from given root.
+	 * @param root of Hop DAG for which cost is estimated
+	 * @return cost estimation of Hop DAG starting from given root
+	 */
+	private FederatedCost costEstimate(Hop root){
+		if ( root.federatedCostInitialized() )
+			return root.getFederatedCost();
+		else {
+			// If no input has FOUT, the root will be processed by the coordinator
+			boolean hasFederatedInput = root.someInputFederated();
+			//the input cost is included the first time the input hop is used
+			//for additional usage, the additional cost is zero (disregarding potential read cost)
+			double inputCosts = root.getInput().stream()
+				.mapToDouble( in -> in.federatedCostInitialized() ? 0 : costEstimate(in).getTotal() )
+				.sum();
+			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
+				.filter(Hop::hasLocalOutput)
+				.mapToDouble(Hop::getOutputMemEstimate)
+				.map(inMem -> inMem/WORKER_NETWORK_BANDWIDTH_BYTES)
+				.sum() : 0;
+			double computingCost = ComputeCost.getHOPComputeCost(root);
+			if ( hasFederatedInput ){
+				//Find the number of inputs that has FOUT set.
+				int numWorkers = (int)root.getInput().stream().filter(Hop::hasFederatedOutput).count();
+				//divide memory usage by the number of workers the computation would be split to multiplied by
+				//the number of parallel processes at each worker multiplied by the FLOPS of each process
+				//This assumes uniform workload among the workers with FOUT data involved in the operation
+				//and assumes that the degree of parallelism and compute bandwidth are equal for all workers
+				computingCost = computingCost / (numWorkers*WORKER_DEGREE_OF_PARALLELISM*WORKER_COMPUTE_BANDWITH_FLOPS);
+			}
+			//Calculate output transfer cost if the operation is computed at federated workers and the output is forced to the coordinator
+			double outputTransferCost = ( root.hasLocalOutput() && hasFederatedInput ) ?
+				root.getOutputMemEstimate() / WORKER_NETWORK_BANDWIDTH_BYTES : 0;
+			double readCost = root.getInputMemEstimate();
+
+			FederatedCost rootFedCost =
+				new FederatedCost(readCost, inputTransferCost, outputTransferCost, computingCost, inputCosts);
+			root.setFederatedCost(rootFedCost);
+			return rootFedCost;
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedStatementBlocks.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteFederatedStatementBlocks.java
@@ -19,25 +19,12 @@
 
 package org.apache.sysds.hops.rewrite;
 
-import org.apache.sysds.hops.Hop;
-import org.apache.sysds.hops.cost.ComputeCost;
-import org.apache.sysds.hops.cost.FederatedCost;
-import org.apache.sysds.parser.ForStatementBlock;
-import org.apache.sysds.parser.FunctionStatementBlock;
-import org.apache.sysds.parser.IfStatementBlock;
 import org.apache.sysds.parser.StatementBlock;
-import org.apache.sysds.parser.WhileStatementBlock;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class RewriteFederatedStatementBlocks extends StatementBlockRewriteRule {
-
-	private static final int DEFAULT_ITERATION_NUMBER = 15;
-	private static final double WORKER_NETWORK_BANDWIDTH_BYTES = 1024*1024*1024; //Default network bandwidth in bytes per second
-	private static final double WORKER_COMPUTE_BANDWITH_FLOPS = 2.5*1024*1024*1024; //Default compute bandwidth in FLOPS
-	private static final double WORKER_DEGREE_OF_PARALLELISM = 8; //Default number of parallel processes for workers
 
 	/**
 	 * Indicates if the rewrite potentially splits dags, which is used
@@ -75,95 +62,5 @@ public class RewriteFederatedStatementBlocks extends StatementBlockRewriteRule {
 	@Override
 	public List<StatementBlock> rewriteStatementBlocks(List<StatementBlock> sbs, ProgramRewriteStatus state) {
 		return sbs;
-	}
-
-	private FederatedCost costEstimate(StatementBlock sb){
-		if ( sb instanceof WhileStatementBlock ){
-			WhileStatementBlock whileSB = (WhileStatementBlock) sb;
-			FederatedCost whileSBCost = addInitialInputCost(sb);
-			whileSBCost.addRepititionCost(DEFAULT_ITERATION_NUMBER);
-			return whileSBCost;
-		}
-		else if ( sb instanceof IfStatementBlock ){
-			IfStatementBlock ifSB = (IfStatementBlock) sb;
-			//Get cost of if-block + else-block and divide by two
-			// since only one of the code blocks will be executed in the end
-			FederatedCost ifSBCost = addInitialInputCost(sb);
-			ifSBCost.setInputTotalCost(ifSBCost.getInputTotalCost() / 2);
-			return ifSBCost;
-		}
-		else if ( sb instanceof ForStatementBlock ){
-			// This also includes ParForStatementBlocks
-			ForStatementBlock forSB = (ForStatementBlock) sb;
-			FederatedCost forCost = addInitialInputCost(sb);
-			forCost.addRepititionCost(forSB.getEstimateReps());
-			return forCost;
-		}
-		else if ( sb instanceof FunctionStatementBlock ){
-			FederatedCost funcCost = addInitialInputCost(sb);
-			FunctionStatementBlock funcSB = (FunctionStatementBlock) sb;
-			return funcCost;
-		}
-		else {
-			// StatementBlock type (no subclass)
-			return costEstimate(sb.getHops());
-		}
-	}
-
-	private FederatedCost addInitialInputCost(StatementBlock sb){
-		FederatedCost basicCost = new FederatedCost();
-		for ( StatementBlock childSB : sb.getDMLProg().getStatementBlocks() )
-			basicCost.setInputTotalCost(costEstimate(childSB).getTotal());
-		return basicCost;
-	}
-
-	private FederatedCost costEstimate(ArrayList<Hop> roots){
-		FederatedCost basicCost = new FederatedCost();
-		for ( Hop root : roots )
-			basicCost.setInputTotalCost(costEstimate(root).getTotal());
-		return basicCost;
-	}
-
-	/**
-	 * Return cost estimate of Hop DAG starting from given root.
-	 * @param root of Hop DAG for which cost is estimated
-	 * @return cost estimation of Hop DAG starting from given root
-	 */
-	private FederatedCost costEstimate(Hop root){
-		if ( root.federatedCostInitialized() )
-			return root.getFederatedCost();
-		else {
-			// If no input has FOUT, the root will be processed by the coordinator
-			boolean hasFederatedInput = root.someInputFederated();
-			//the input cost is included the first time the input hop is used
-			//for additional usage, the additional cost is zero (disregarding potential read cost)
-			double inputCosts = root.getInput().stream()
-				.mapToDouble( in -> in.federatedCostInitialized() ? 0 : costEstimate(in).getTotal() )
-				.sum();
-			double inputTransferCost = hasFederatedInput ? root.getInput().stream()
-				.filter(Hop::hasLocalOutput)
-				.mapToDouble(Hop::getOutputMemEstimate)
-				.map(inMem -> inMem/WORKER_NETWORK_BANDWIDTH_BYTES)
-				.sum() : 0;
-			double computingCost = ComputeCost.getHOPComputeCost(root);
-			if ( hasFederatedInput ){
-				//Find the number of inputs that has FOUT set.
-				int numWorkers = (int)root.getInput().stream().filter(Hop::hasFederatedOutput).count();
-				//divide memory usage by the number of workers the computation would be split to multiplied by
-				//the number of parallel processes at each worker multiplied by the FLOPS of each process
-				//This assumes uniform workload among the workers with FOUT data involved in the operation
-				//and assumes that the degree of parallelism and compute bandwidth are equal for all workers
-				computingCost = computingCost / (numWorkers*WORKER_DEGREE_OF_PARALLELISM*WORKER_COMPUTE_BANDWITH_FLOPS);
-			}
-			//Calculate output transfer cost if the operation is computed at federated workers and the output is forced to the coordinator
-			double outputTransferCost = ( root.hasLocalOutput() && hasFederatedInput ) ?
-				root.getOutputMemEstimate() / WORKER_NETWORK_BANDWIDTH_BYTES : 0;
-			double readCost = root.getInputMemEstimate();
-
-			FederatedCost rootFedCost =
-				new FederatedCost(readCost, inputTransferCost, outputTransferCost, computingCost, inputCosts);
-			root.setFederatedCost(rootFedCost);
-			return rootFedCost;
-		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/FEDInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/FEDInstructionParser.java
@@ -64,6 +64,7 @@ public class FEDInstructionParser extends InstructionParser
 		String2FEDInstructionType.put( "r'"     , FEDType.Reorg );
 		String2FEDInstructionType.put( "rdiag"  , FEDType.Reorg );
 		String2FEDInstructionType.put( "rshape" , FEDType.Reorg );
+		String2FEDInstructionType.put( "rev"    , FEDType.Reorg );
 
 		// Ternary Instruction Opcodes
 		String2FEDInstructionType.put( "+*" , FEDType.Ternary);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
@@ -129,6 +129,12 @@ public class AggregateUnaryFEDInstruction extends UnaryFEDInstruction {
 		deriveNewOutputFedMapping(in, out, fr1);
 	}
 
+	/**
+	 * Set output fed mapping based on federated partitioning and aggregation type.
+	 * @param in matrix object from which fed partitioning originates from
+	 * @param out matrix object holding the dimensions of the instruction output
+	 * @param fr1 federated request holding the instruction execution call
+	 */
 	private void deriveNewOutputFedMapping(MatrixObject in, MatrixObject out, FederatedRequest fr1){
 		//Get agg type
 		if ( !(instOpcode.equals("uack+") || instOpcode.equals("uark+")) )

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
@@ -130,8 +130,9 @@ public class AppendFEDInstruction extends BinaryFEDInstruction {
 		}
 		else {
 			throw new DMLRuntimeException("Unsupported federated append: "
-				+ (mo1.isFederated() ? mo1.getFedMapping().getType().name():"LOCAL") + " "
-				+ (mo2.isFederated() ? mo2.getFedMapping().getType().name():"LOCAL") + " " + _cbind);
+				+ " input 1 FType is " + (mo1.isFederated() ? mo1.getFedMapping().getType().name():"LOCAL")
+				+ ", input 2 FType is " + (mo2.isFederated() ? mo2.getFedMapping().getType().name():"LOCAL")
+				+ ", and column bind is " + _cbind);
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstruction.java
@@ -60,6 +60,9 @@ public abstract class FEDInstruction extends Instruction {
 		public boolean isForcedLocal() {
 			return this == LOUT;
 		}
+		public boolean isForced(){
+			return this == FOUT || this == LOUT;
+		}
 	}
 
 	protected final FEDType _fedType;

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -2095,6 +2096,31 @@ public abstract class AutomatedTestBase {
 				if(opcode.equals(s))
 					return true;
 		return false;
+	}
+
+	/**
+	 * Checks if given strings are all in the set of heavy hitters.
+	 * @param str opcodes for which it is checked if all are in the heavy hitters
+	 * @return true if all given strings are in the set of heavy hitters
+	 */
+	protected boolean heavyHittersContainsAllString(String... str){
+		Set<String> heavyHitters = Statistics.getCPHeavyHitterOpCodes();
+		return Arrays.stream(str).allMatch(heavyHitters::contains);
+	}
+
+	/**
+	 * Returns an array of the given opcodes which are not present in the set of heavy hitter opcodes.
+	 * @param opcodes for which it is checked if they are among the heavy hitters
+	 * @return array of opcodes not found in heavy hitters
+	 */
+	protected String[] missingHeavyHitters(String... opcodes){
+		Set<String> heavyHitters = Statistics.getCPHeavyHitterOpCodes();
+		List<String> missingHeavyHitters = new ArrayList<>();
+		for (String opcode : opcodes){
+			if ( !heavyHitters.contains(opcode) )
+				missingHeavyHitters.add(opcode);
+		}
+		return missingHeavyHitters.toArray(new String[0]);
 	}
 
 	protected boolean heavyHittersContainsString(String str, int minCount) {

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
@@ -119,6 +119,10 @@ public class FederatedCostEstimatorTest extends AutomatedTestBase {
 
 	Set<Hop> hops = new HashSet<>();
 
+	/**
+	 * Recursively adds the hop and its inputs to the set of hops.
+	 * @param hop root to be added to set of hops
+	 */
 	private void addHop(Hop hop){
 		hops.add(hop);
 		for(Hop inHop : hop.getInput()){
@@ -126,6 +130,10 @@ public class FederatedCostEstimatorTest extends AutomatedTestBase {
 		}
 	}
 
+	/**
+	 * Sets dimensions of federated X and Y and sets binary multiplication to FOUT.
+	 * @param prog dml program where the HOPS are modified
+	 */
 	private void modifyFedouts(DMLProgram prog){
 		prog.getStatementBlocks().forEach(stmBlock -> stmBlock.getHops().forEach(this::addHop));
 		hops.forEach(hop -> {

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
@@ -85,6 +85,58 @@ public class FederatedCostEstimatorTest extends AutomatedTestBase {
 	}
 
 	@Test
+	public void ifElseTest(){
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double expectedCost = ((computeCost + readCost + 0.8 + 0.0625 + 0.0625) / 2) + 0.0625 + 0.8 + 0.0625;
+		runTest("IfElseCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
+	public void whileTest(){
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double expectedCost = (computeCost + readCost + 0.0625) * fedCostEstimator.DEFAULT_ITERATION_NUMBER + 0.0625 + 0.8;
+		runTest("WhileCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
+	public void forLoopTest(){
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double predicateCost = 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625;
+		double expectedCost = (computeCost + readCost + predicateCost) * 5;
+		runTest("ForLoopCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
+	public void parForLoopTest(){
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double predicateCost = 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625;
+		double expectedCost = (computeCost + readCost + predicateCost) * 5;
+		runTest("ParForLoopCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
+	public void functionTest(){
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double expectedCost = (computeCost + readCost);
+		runTest("FunctionCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
 	public void federatedMultiply() {
 		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
 		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.privacy.fedplanning;
+
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
+import org.apache.sysds.hops.cost.FederatedCost;
+import org.apache.sysds.hops.cost.FederatedCostEstimator;
+import org.apache.sysds.parser.DMLProgram;
+import org.apache.sysds.parser.DMLTranslator;
+import org.apache.sysds.parser.LanguageException;
+import org.apache.sysds.parser.ParserFactory;
+import org.apache.sysds.parser.ParserWrapper;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class FederatedCostEstimatorTest extends AutomatedTestBase {
+
+	private static final String TEST_DIR = "functions/privacy/fedplanning/";
+	private static final String HOME = SCRIPT_DIR + TEST_DIR;
+	private static final String TEST_CLASS_DIR = TEST_DIR + FederatedCostEstimatorTest.class.getSimpleName() + "/";
+	FederatedCostEstimator fedCostEstimator = new FederatedCostEstimator();
+
+	@Override
+	public void setUp() {}
+
+	@Test
+	public void simpleBinary() {
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+
+		/*
+		 * HOP			Occurences		ComputeCost		ReadCost	ComputeCostFinal	ReadCostFinal
+		 * ------------------------------------------------------------------------------------------
+		 * LiteralOp	16				1				0			0.0625				0
+		 * DataGenOp	2				100				64			6.25				6.4
+		 * BinaryOp		1				100				1600		6.25				160
+		 * TOSTRING		1				1				800			0.0625				80
+		 * UnaryOp		1				1				8			0.0625				0.8
+		 */
+		double computeCost = (16+2*100+100+1+1) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (2*64+1600+800+8) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+
+		double expectedCost = computeCost + readCost;
+		runTest("BinaryCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	@Test
+	@Ignore
+	public void federatedMultiply() {
+		fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS = 2;
+		fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+		fedCostEstimator.printCosts = true;
+
+		//TODO: Adjust expected cost
+		double computeCost = (3*10*10) / (fedCostEstimator.WORKER_COMPUTE_BANDWITH_FLOPS*fedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+		double readCost = (3*10*10) / (fedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+		double transferCost = 0;
+
+		double expectedCost = computeCost + readCost + transferCost;
+		runTest("FederatedMultiplyCostEstimatorTest.dml", false, expectedCost);
+	}
+
+	private void runTest( String scriptFilename, boolean expectedException, double expectedCost ) {
+		boolean raisedException = false;
+		try
+		{
+			setTestConfig(scriptFilename);
+			String dmlScriptString = readScript(scriptFilename);
+
+			//parsing, dependency analysis and constructing hops (step 3 and 4 in DMLScript.java)
+			ParserWrapper parser = ParserFactory.createParser();
+			DMLProgram prog = parser.parse(DMLScript.DML_FILE_PATH_ANTLR_PARSER, dmlScriptString, new HashMap<>());
+			DMLTranslator dmlt = new DMLTranslator(prog);
+			dmlt.liveVariableAnalysis(prog);
+			dmlt.validateParseTree(prog);
+			dmlt.constructHops(prog);
+
+			FederatedCost actualCost = fedCostEstimator.costEstimate(prog);
+			Assert.assertEquals(expectedCost, actualCost.getTotal(), 0.0001);
+		}
+		catch(LanguageException ex) {
+			raisedException = true;
+			if(raisedException!=expectedException)
+				ex.printStackTrace();
+		}
+		catch(Exception ex2) {
+			ex2.printStackTrace();
+			throw new RuntimeException(ex2);
+		}
+
+		//check correctness
+		Assert.assertEquals("Expected exception does not match raised exception",
+			expectedException, raisedException);
+	}
+
+	private void setTestConfig(String scriptFilename) throws FileNotFoundException {
+		int index = scriptFilename.lastIndexOf(".dml");
+		String testName = scriptFilename.substring(0, index > 0 ? index : scriptFilename.length());
+		TestConfiguration testConfig = new TestConfiguration(TEST_CLASS_DIR, testName, new String[] {});
+		addTestConfiguration(testName, testConfig);
+		loadTestConfiguration(testConfig);
+
+		DMLConfig conf = new DMLConfig(getCurConfigFile().getPath());
+		ConfigurationManager.setLocalConfig(conf);
+	}
+
+	private String readScript(String scriptFilename) throws IOException {
+		StringBuilder dmlScriptString= new StringBuilder();
+		//read script
+		try( BufferedReader in = new BufferedReader(new FileReader(HOME + scriptFilename)) ) {
+			String s1 = null;
+			while ((s1 = in.readLine()) != null)
+				dmlScriptString.append(s1).append("\n");
+		}
+		return dmlScriptString.toString();
+	}
+}

--- a/src/test/scripts/functions/privacy/fedplanning/BinaryCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/BinaryCostEstimatorTest.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+a = matrix (1, rows=10, cols=10);
+b = matrix (2, rows=10, cols=10);
+c = a * b;
+print(toString(c));

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyCostEstimatorTest.dml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+ph = "placeholder"
+rows = 10000
+cols = 10
+X = federated(addresses=list(ph, ph),
+              ranges=list(list(0, 0), list(rows / 2, cols), list(rows / 2, 0), list(rows, cols)))
+Y = federated(addresses=list(ph, ph),
+              ranges=list(list(0, 0), list(rows/2, cols), list(rows / 2, 0), list(rows, cols)))
+Z0 = X * Y
+Z = t(Z0) %*% X
+write(Z, ph)

--- a/src/test/scripts/functions/privacy/fedplanning/ForLoopCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/ForLoopCostEstimatorTest.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+for ( i in 1:5 ){
+    a = matrix (1, rows=10, cols=10);
+    b = matrix (2, rows=10, cols=10);
+    c = a * b;
+    print(toString(c));
+}

--- a/src/test/scripts/functions/privacy/fedplanning/FunctionCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FunctionCostEstimatorTest.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+multiplication = function (){
+    a = matrix (1, rows=10, cols=10);
+    b = matrix (2, rows=10, cols=10);
+    c = a * b;
+    print(toString(c));
+}
+multiplication();

--- a/src/test/scripts/functions/privacy/fedplanning/IfElseCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/IfElseCostEstimatorTest.dml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+if ( 1 ){
+    a = matrix (1, rows=10, cols=10);
+    b = matrix (2, rows=10, cols=10);
+    c = a * b;
+    print(toString(c));
+}
+else {
+    print("No result");
+}

--- a/src/test/scripts/functions/privacy/fedplanning/ParForLoopCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/ParForLoopCostEstimatorTest.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+parfor ( i in 1:5 ){
+    a = matrix (1, rows=10, cols=10);
+    b = matrix (2, rows=10, cols=10);
+    c = a * b;
+    print(toString(c));
+}

--- a/src/test/scripts/functions/privacy/fedplanning/WhileCostEstimatorTest.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/WhileCostEstimatorTest.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+while ( 1 ){
+    a = matrix (1, rows=10, cols=10);
+    b = matrix (2, rows=10, cols=10);
+    c = a * b;
+    print(toString(c));
+}


### PR DESCRIPTION
This PR contains various additions necessary for building a federated planner, which will generate and select execution plans for federated executions. The cost estimation currently added is not connected to the decisions made by the federated planner. This will be done in later PRs, where the data structure for describing the relation between Hops with different FOUT/LOUT/NONE values and the corresponding costs will be implemented. 