### PR TITLE
[SYSTEMDS-3097] Fix CSV metadata parsing in federated execution

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -197,6 +197,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		String delim = null;
 		FileSystem fs = null;
 		MetaDataAll mtd;
+		
 		try {
 			String mtdname = DataExpression.getMTDFileName(filename);
 			Path path = new Path(mtdname);
@@ -219,9 +220,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 			throw ex;
 		}
 		catch (Exception ex) {
-			String msg = "Exception in reading metadata of: " + filename;
-			log.error(msg, ex);
-			throw new DMLRuntimeException(msg);
+			throw new DMLRuntimeException(ex);
 		}
 		finally {
 			IOUtilFunctions.closeSilently(fs);

--- a/src/main/java/org/apache/sysds/runtime/meta/MetaDataAll.java
+++ b/src/main/java/org/apache/sysds/runtime/meta/MetaDataAll.java
@@ -39,6 +39,7 @@ import org.apache.sysds.parser.Expression;
 import org.apache.sysds.parser.LanguageException;
 import org.apache.sysds.parser.ParseException;
 import org.apache.sysds.parser.StringIdentifier;
+import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint;
@@ -50,6 +51,7 @@ import org.apache.wink.json4j.JSONException;
 import org.apache.wink.json4j.JSONObject;
 
 public class MetaDataAll extends DataIdentifier {
+	// private static final Log LOG = LogFactory.getLog(MetaDataAll.class.getName());
 
 	private JSONObject _metaObj;
 
@@ -79,8 +81,8 @@ public class MetaDataAll extends DataIdentifier {
 		try {
 			_metaObj = JSONHelper.parse(br);
 		}
-		catch(IOException e) {
-			e.printStackTrace();
+		catch(Exception e) {
+			throw new DMLRuntimeException(e);
 		}
 		setPrivacy(PrivacyConstraint.PrivacyLevel.None);
 		parseMetaDataParams();
@@ -174,7 +176,14 @@ public class MetaDataAll extends DataIdentifier {
 			case DataExpression.FINE_GRAINED_PRIVACY:  setFineGrainedPrivacy(val.toString()); break;
 			case DataExpression.DELIM_DELIMITER: setDelim(val.toString()); break;
 			case DataExpression.SCHEMAPARAM: setSchema(val.toString()); break;
-			case DataExpression.DELIM_HAS_HEADER_ROW: setHasHeader(true);
+			case DataExpression.DELIM_HAS_HEADER_ROW:
+				if(val instanceof Boolean){
+					boolean valB = (Boolean) val;
+					setHasHeader(valB);
+					break;
+				}
+				else
+					throw new DMLRuntimeException("Invalid type of value for header" + val.getClass());
 			case DataExpression.DELIM_SPARSE: setSparseDelim((boolean) val);
 		}
 	}
@@ -401,5 +410,10 @@ public class MetaDataAll extends DataIdentifier {
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "MetaDataAll\n" + _metaObj + "\n" + super.toString();
 	}
 }

--- a/src/main/python/tests/federated/runFedTest.sh
+++ b/src/main/python/tests/federated/runFedTest.sh
@@ -30,8 +30,8 @@
 workerdir="tests/federated/worker/"
 outputdir="tests/federated/output/"
 tmpfiledir="tests/federated/tmp/"
-mkdir $workerdir
-mkdir $outputdir
+mkdir -p $workerdir
+mkdir -p $outputdir
 w1_Output="$workerdir/w1"
 w2_Output="$workerdir/w2"
 log="$outputdir/out.log"
@@ -55,13 +55,16 @@ echo -e "\nWorker 1:"
 cat $w1_Output
 echo -e "\nWorker 2:"
 cat $w2_Output
-rm -r $workerdir
 echo -e "\n------------\nTest output:\n------------"
 cat $log
 grepvals="$(tail -n 10 $log | grep OK)"
+echo -e "------------\n"
+
+# Cleanup
+rm -r $workerdir
 rm -r $outputdir
 rm -r $tmpfiledir
-echo -e "------------\n"
+
 if [[ $grepvals == *"OK"* ]]; then
 	exit 0
 else

--- a/src/main/python/tests/federated/test_federated_aggregations_noHeader.py
+++ b/src/main/python/tests/federated/test_federated_aggregations_noHeader.py
@@ -1,0 +1,196 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import io
+import json
+import os
+import shutil
+import sys
+import unittest
+
+import numpy as np
+from systemds.context import SystemDSContext
+
+os.environ['SYSDS_QUIET'] = "1"
+
+dim = 5
+np.random.seed(132)
+m1 = np.array(np.random.randint(100, size=dim * dim) + 1.01, dtype=np.double)
+m1.shape = (dim, dim)
+m2 = np.array(np.random.randint(5, size=dim * dim) + 1, dtype=np.double)
+m2.shape = (dim, dim)
+
+tempdir = "./tests/federated/tmp/test_federated_aggregations/"
+mtd = {"format": "csv", "header": False, "rows": dim, "cols": dim, "data_type": "matrix", "value_type": "double" }
+
+# Create the testing directory if it does not exist.
+if not os.path.exists(tempdir):
+    os.makedirs(tempdir)
+
+# Save data files for the Federated workers.
+np.savetxt(tempdir + "m1.csv", m1, delimiter=",")
+with io.open(tempdir + "m1.csv.mtd", "w", encoding="utf-8") as f:
+    f.write(json.dumps(mtd, ensure_ascii=False))
+
+np.savetxt(tempdir + "m2.csv", m2, delimiter=",")
+with io.open(tempdir + "m2.csv.mtd", "w", encoding="utf-8") as f:
+    f.write(json.dumps(mtd, ensure_ascii=False))
+
+# Federated workers + file locations
+fed1 = "localhost:8001/" + tempdir + "m1.csv"
+fed2 = "localhost:8002/" + tempdir + "m2.csv"
+
+
+class TestFederatedAggFn(unittest.TestCase):
+
+    sds: SystemDSContext = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sds = SystemDSContext()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sds.close()
+
+    def test_sum3(self):
+        #   [[m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]]
+        f_m_a = (
+            self.sds.federated(
+                [fed1, fed2],
+                [([0, 0], [dim, dim]), ([0, dim], [dim, dim * 2])])
+            .sum()
+            .compute()
+        )
+        m1_m2 = m1.sum() + m2.sum()
+        self.assertAlmostEqual(f_m_a, m1_m2)
+
+    def test_sum1(self):
+        f_m1 = (
+            self.sds.federated(
+                [fed1],
+                [([0, 0], [dim, dim])])
+            .sum()
+            .compute()
+        )
+        m1_r = m1.sum()
+        self.assertAlmostEqual(f_m1, m1_r)
+
+    def test_sum2(self):
+        f_m2 = (
+            self.sds.federated(
+                [fed2],
+                [([0, 0], [dim, dim])])
+            .sum()
+            .compute()
+        )
+        m2_r = m2.sum()
+        self.assertAlmostEqual(f_m2, m2_r)
+
+    def test_sum3(self):
+        #   [[m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]]
+        f_m1_m2 = (
+            self.sds.federated(
+                [fed1, fed2],
+                [([0, 0], [dim, dim]), ([0, dim], [dim, dim * 2])])
+            .sum()
+            .compute()
+        )
+
+        m1_m2 = np.concatenate((m1, m2), axis=1).sum()
+
+        self.assertAlmostEqual(f_m1_m2, m1_m2)
+
+    def test_sum4(self):
+        #   [[m1,m1,m1,m1,m1]
+        #    [m1,m1,m1,m1,m1]
+        #    [m1,m1,m1,m1,m1]
+        #    [m1,m1,m1,m1,m1]
+        #    [m1,m1,m1,m1,m1]
+        #    [m2,m2,m2,m2,m2]
+        #    [m2,m2,m2,m2,m2]
+        #    [m2,m2,m2,m2,m2]
+        #    [m2,m2,m2,m2,m2]
+        #    [m2,m2,m2,m2,m2]]
+        f_m1_m2 = (
+            self.sds.federated( 
+                [fed1, fed2],
+                [([0, 0], [dim, dim]), ([dim, 0], [dim * 2, dim])])
+            .sum()
+            .compute()
+        )
+        m1_m2 = np.concatenate((m1, m2)).sum()
+        self.assertAlmostEqual(f_m1_m2, m1_m2)
+
+    # -----------------------------------
+    # The rest of the tests are
+    # Extended functionality not working Yet
+    # -----------------------------------
+
+    def test_sum5(self):
+        #   [[m1,m1,m1,m1,m1, 0, 0, 0, 0, 0]
+        #    [m1,m1,m1,m1,m1, 0, 0, 0, 0, 0]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [m1,m1,m1,m1,m1,m2,m2,m2,m2,m2]
+        #    [ 0, 0, 0, 0, 0,m2,m2,m2,m2,m2]
+        #    [ 0, 0, 0, 0, 0,m2,m2,m2,m2,m2]]
+        f_m_a = (
+            self.sds.federated( 
+                [fed1, fed2],
+                [([0, 0], [dim, dim]), ([2, dim], [dim + 2, dim * 2])])
+            .sum()
+            .compute()
+        )
+        m1_m2 = m1.sum() + m2.sum()
+        self.assertAlmostEqual(f_m_a, m1_m2)
+
+    def test_sum8(self):
+        #   [[ 0, 0, 0, 0, 0, 0, 0, 0]
+        #    [ 0, 0, 0, 0, 0, 0, 0, 0]
+        #    [ 0, 0, 0,m1,m1,m1,m1,m1]
+        #    [ 0, 0, 0,m1,m1,m1,m1,m1]
+        #    [ 0, 0, 0,m1,m1,m1,m1,m1]
+        #    [ 0, 0, 0,m1,m1,m1,m1,m1]
+        #    [ 0, 0, 0,m1,m1,m1,m1,m1]]
+        f_m_a = (
+            self.sds.federated( 
+                [fed1],
+                [([2, 3], [dim + 2, dim + 3])])
+            .sum()
+            .compute()
+        )
+
+        m = m1.sum()
+
+        self.assertAlmostEqual(f_m_a, m)
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -69,6 +69,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRange;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
+import org.apache.sysds.runtime.io.FileFormatProperties;
 import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.apache.sysds.runtime.io.FrameReader;
 import org.apache.sysds.runtime.io.FrameReaderFactory;
@@ -533,6 +534,19 @@ public abstract class AutomatedTestBase {
 		inputDirectories.add(baseDirectory + INPUT_DIR + name);
 
 		return matrix;
+	}
+
+	protected void writeCSVMatrix(String name, double[][] matrix, boolean header, MatrixCharacteristics mc) {
+		try {
+			final String completePath = baseDirectory + INPUT_DIR + name;
+			final String completeMTDPath = baseDirectory + INPUT_DIR + name + ".mtd";
+			TestUtils.writeCSV(completePath, matrix, header);
+			final FileFormatProperties ffp = header ? new FileFormatPropertiesCSV(true, ",", false, 0.0, "") : new FileFormatPropertiesCSV();
+			HDFSTool.writeMetaDataFile(completeMTDPath, ValueType.FP64, mc, FileFormat.CSV, ffp);
+		}
+		catch(Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	protected double[][] writeInputMatrixWithMTD(String name, MatrixBlock matrix, boolean bIncludeR) {

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -2040,6 +2040,34 @@ public class TestUtils
 		}
 	}
 
+
+	protected static void writeCSV(String completePath, double[][] matrix, boolean header){
+		try{
+			DataOutputStream out =  new DataOutputStream(new FileOutputStream(completePath));
+			try( BufferedWriter pw = new BufferedWriter(new OutputStreamWriter(out))) {
+
+				if(header){
+					pw.append("d0");
+					for(int i = 1; i < matrix[0].length; i++){
+						pw.append(",d" + i);
+					}
+					pw.append("\n");
+				}
+				for(int j = 0; j < matrix.length; j++){
+					pw.append("" + matrix[j][0]);
+					for(int i = 1; i < matrix[j].length; i++){
+						pw.append(","+matrix[j][i]);
+					}
+					pw.append("\n");
+				}
+			}
+		}
+		catch (IOException e){
+			fail("unable to write test matrix (" + completePath + "): " + e.getMessage());
+		}
+	}
+
+
 	/**
 	 * <p>
 	 * Writes a matrix to a file using the text format.

--- a/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderCSV.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderCSV.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.test.functions.federated.io;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.ExecType;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.test.functions.federated.FederatedTestObjectConstructor;
+import org.junit.Assert;
+import org.junit.Test;
+
+@net.jcip.annotations.NotThreadSafe
+public class FederatedReaderCSV extends AutomatedTestBase {
+
+    private static final Log LOG = LogFactory.getLog(FederatedReaderCSV.class.getName());
+    private final static String TEST_DIR = "functions/federated/ioR/";
+    private final static String TEST_NAME = "FederatedReaderTest";
+    private final static String TEST_CLASS_DIR = TEST_DIR + FederatedReaderCSV.class.getSimpleName() + "/";
+    private final static int blocksize = 1024;
+
+    private final static int dim = 3;
+    long[][] begins = new long[][] {new long[] {0, 0}};
+    long[][] ends = new long[][] {new long[] {dim, dim}};
+
+    @Override
+    public void setUp() {
+        TestUtils.clearAssertionInformation();
+        addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME));
+    }
+
+    @Test
+    public void testWithHeader() {
+        federatedRead(true);
+    }
+
+    @Test
+    public void testWithoutHeader() {
+        federatedRead(false);
+    }
+
+    public void federatedRead( boolean header) {
+        Types.ExecMode oldPlatform = setExecMode(ExecType.CP);
+        getAndLoadTestConfiguration(TEST_NAME);
+        setOutputBuffering(true);
+
+        
+        // empty script name because we don't execute any script, just start the worker
+        
+        fullDMLScriptName = "";
+        int port1 = getRandomAvailablePort();
+        Thread t1 = startLocalFedWorkerThread(port1);
+        String host = "localhost";
+        
+        try {
+            double[][] X1 = new double[][] {new double[] {1, 2, 3}, new double[] {4, 5, 6}, new double[] {7, 8, 9}};
+            MatrixCharacteristics mc = new MatrixCharacteristics(dim, dim, blocksize, dim * dim);
+            writeCSVMatrix("X1", X1, header, mc);
+
+            // Thread.sleep(10000);
+            MatrixObject fed = FederatedTestObjectConstructor.constructFederatedInput(dim, dim, blocksize, host, begins,
+                ends, new int[] {port1}, new String[] {input("X1")}, input("X.json"));
+            writeInputFederatedWithMTD("X.json", fed, null);
+
+            // Run reference dml script with normal matrix
+
+            fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME + "1Reference.dml";
+            programArgs = new String[] {"-stats", "-args", input("X1")};
+
+            String refOut = runTest(null).toString();
+
+            LOG.debug(refOut);
+
+            // Run federated
+            fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME + ".dml";
+            programArgs = new String[] {"-stats", "-args", input("X.json")};
+            String out = runTest(null).toString();
+
+            Assert.assertTrue(heavyHittersContainsString("fed_uak+"));
+            // Verify output
+            Assert.assertEquals(Double.parseDouble(refOut.split("\n")[0]), Double.parseDouble(out.split("\n")[0]),
+                0.00001);
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(false);
+        }
+        finally {
+            resetExecMode(oldPlatform);
+        }
+
+        TestUtils.shutdownThreads(t1);
+    }
+}

--- a/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderTest.java
@@ -67,13 +67,11 @@ public class FederatedReaderTest extends AutomatedTestBase {
 
 	@Test
 	public void federatedSingleNodeReadOneWorker() {
-		LOG.debug("1Federated");
 		federatedRead(Types.ExecMode.SINGLE_NODE, 1);
 	}
 
 	@Test
 	public void federatedSingleNodeReadTwoWorker() {
-		LOG.debug("2Federated");
 		federatedRead(Types.ExecMode.SINGLE_NODE, 2);
 	}
 
@@ -124,6 +122,8 @@ public class FederatedReaderTest extends AutomatedTestBase {
 
 			String refOut = runTest(null).toString();
 
+			LOG.debug(refOut);
+			
 			// Run federated
 			fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME + ".dml";
 			programArgs = new String[] {"-stats", "-args", input("X.json")};


### PR DESCRIPTION
#1366 mention an bug in the federated reading of CSV files, when header is set to false.
This PR Fixes this, first by adding tests in python and java that verify the bug, and then fixing it in the MetaDataAll file that always set the header to true.