### PR TITLE
[SYSTEMDS-3085] Federated CTable - Keep Output Federated

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CtableFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CtableFEDInstruction.java
@@ -148,8 +148,8 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 
 		FederatedRequest[] fr1 = fedMap.broadcastSliced(mo2, false);
 		FederatedRequest[] fr2 = null;
-		FederatedRequest fr3, fr4, fr5, fr6, fr7;
-		fr3 = fr4 = fr5 = fr6 = fr7 = null;
+		FederatedRequest fr3, fr4, fr5;
+		fr3 = fr4 = fr5 = null;
 		Future<FederatedResponse>[] ffr = null;
 
 		if(mo3 != null && mo1.isFederated() && mo3.isFederated()
@@ -160,8 +160,6 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 			else
 				fr3 = FederationUtils.callInstruction(instString, output, new CPOperand[] {input1, input2, input3},
 					new long[] {fr1[0].getID(), fedMap.getID(), mo3.getFedMapping().getID()});
-
-			fr5 = fedMap.cleanup(getTID(), fr1[0].getID());
 		}
 		else if(mo3 == null) {
 			if(!reversed)
@@ -170,8 +168,6 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 			else
 				fr3 = FederationUtils.callInstruction(instString, output, new CPOperand[] {input1, input2},
 					new long[] {fr1[0].getID(), fedMap.getID()});
-
-			fr5 = fedMap.cleanup(getTID(), fr1[0].getID());
 		}
 		else {
 			fr2 = fedMap.broadcastSliced(mo3, false);
@@ -184,16 +180,13 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 			else
 				fr3 = FederationUtils.callInstruction(instString, output, new CPOperand[] {input1, input2, input3},
 					new long[] {fr1[0].getID(), fr2[0].getID(), fedMap.getID()});
-
-			fr5 = fedMap.cleanup(getTID(), fr1[0].getID());
-			fr6 = fedMap.cleanup(getTID(), fr2[0].getID());
 		}
 
 		if(fedOutput) {
-			if(fr2 != null && fr6 != null) // broadcasted mo3
-				fedMap.execute(getTID(), true, fr1, fr2, fr3, fr5, fr6);
+			if(fr2 != null) // broadcasted mo3
+				fedMap.execute(getTID(), true, fr1, fr2, fr3);
 			else
-				fedMap.execute(getTID(), true, fr1, fr3, fr5);
+				fedMap.execute(getTID(), true, fr1, fr3);
 
 			MatrixObject out = ec.getMatrixObject(output);
 			FederationMap newFedMap = modifyFedRanges(fedMap.copyWithNewID(fr3.getID()),
@@ -201,11 +194,11 @@ public class CtableFEDInstruction extends ComputationFEDInstruction {
 			setFedOutput(mo1, out, newFedMap, staticDim, dims2, reversed);
 		} else {
 			fr4 = new FederatedRequest(FederatedRequest.RequestType.GET_VAR, fr3.getID());
-			fr7 = fedMap.cleanup(getTID(), fr3.getID());
-			if(fr2 != null && fr6 != null) // broadcasted mo3
-				ffr = fedMap.execute(getTID(), true, fr1, fr2, fr3, fr4, fr5, fr6, fr7);
+			fr5 = fedMap.cleanup(getTID(), fr3.getID());
+			if(fr2 != null) // broadcasted mo3
+				ffr = fedMap.execute(getTID(), true, fr1, fr2, fr3, fr4, fr5);
 			else
-				ffr = fedMap.execute(getTID(), true, fr1, fr3, fr4, fr5, fr7);
+				ffr = fedMap.execute(getTID(), true, fr1, fr3, fr4, fr5);
 
 			ec.setMatrixOutput(output.getName(), aggResult(ffr));
 		}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -182,7 +182,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	}
 	
 	public MatrixBlock(int rl, int cl, double val) {
-		reset(rl, cl, true, val == 0 ? 0 : (long)rl*cl, val);
+		reset(rl, cl, false, (long)rl*cl, val);
 	}
 	
 	/**
@@ -264,7 +264,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	 * 
 	 * @param rl      number of rows
 	 * @param cl      number of columns
-	 * @param sp      sparse representation (only considered if val is 0)
+	 * @param sp      sparse representation
 	 * @param estnnz  estimated number of non-zeros
 	 * @param val     initialization value
 	 */
@@ -5951,20 +5951,5 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 			estimatedNonZeros=nnzs;
 		}
 		public SparsityEstimate(){}
-
-		@Override
-		public String toString() {
-			StringBuilder sb = new StringBuilder();
-
-			sb.append("Sparse? = ");
-			sb.append(sparse);
-			sb.append("\n");
-
-			sb.append("Estimated NNZ: ");
-			sb.append(estimatedNonZeros);
-			sb.append("\n");
-
-			return sb.toString();
-		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -182,7 +182,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	}
 	
 	public MatrixBlock(int rl, int cl, double val) {
-		reset(rl, cl, false, (long)rl*cl, val);
+		reset(rl, cl, true, val == 0 ? 0 : (long)rl*cl, val);
 	}
 	
 	/**
@@ -264,7 +264,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	 * 
 	 * @param rl      number of rows
 	 * @param cl      number of columns
-	 * @param sp      sparse representation
+	 * @param sp      sparse representation (only considered if val is 0)
 	 * @param estnnz  estimated number of non-zeros
 	 * @param val     initialization value
 	 */
@@ -5951,5 +5951,20 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 			estimatedNonZeros=nnzs;
 		}
 		public SparsityEstimate(){}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Sparse? = ");
+			sb.append(sparse);
+			sb.append("\n");
+
+			sb.append("Estimated NNZ: ");
+			sb.append(estimatedNonZeros);
+			sb.append("\n");
+
+			return sb.toString();
+		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedCtableTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedCtableTest.java
@@ -85,6 +85,9 @@ public class FederatedCtableTest extends AutomatedTestBase {
 	@Test
 	public void federatedCtableMatrixInputSinglenode() { runCtable(Types.ExecMode.SINGLE_NODE, false, true); }
 
+	@Test
+	public void federatedCtableMatrixInputFedOutputSingleNode() { runCtable(Types.ExecMode.SINGLE_NODE, true, true); }
+
 
 	public void runCtable(Types.ExecMode execMode, boolean fedOutput, boolean matrixInput) {
 		String TEST_NAME = fedOutput ? TEST_NAME2 : TEST_NAME1;
@@ -108,7 +111,7 @@ public class FederatedCtableTest extends AutomatedTestBase {
 		loadTestConfiguration(config);
 
 		if(fedOutput)
-			runFedCtable(HOME, TEST_NAME, port1, port2, port3, port4);
+			runFedCtable(HOME, TEST_NAME, matrixInput, port1, port2, port3, port4);
 		else
 			runNonFedCtable(HOME, TEST_NAME, matrixInput, port1, port2, port3, port4);
 		checkResults();
@@ -155,7 +158,7 @@ public class FederatedCtableTest extends AutomatedTestBase {
 		runTest(true, false, null, -1);
 	}
 
-	private void runFedCtable(String HOME, String TEST_NAME, int port1, int port2, int port3, int port4) {
+	private void runFedCtable(String HOME, String TEST_NAME, boolean matrixInput, int port1, int port2, int port3, int port4) {
 		int r = rows / 4;
 		int c = cols;
 
@@ -174,7 +177,8 @@ public class FederatedCtableTest extends AutomatedTestBase {
 		fullDMLScriptName = HOME + TEST_NAME2 + "Reference.dml";
 		programArgs = new String[]{"-stats", "100", "-args",
 			input("X1"), input("X2"), input("X3"), input("X4"), Boolean.toString(reversedInputs).toUpperCase(),
-			Boolean.toString(weighted).toUpperCase(), expected("F")};
+			Boolean.toString(weighted).toUpperCase(), Boolean.toString(matrixInput).toUpperCase(),
+			expected("F")};
 		runTest(true, false, null, -1);
 
 		// Run actual dml script with federated matrix
@@ -185,6 +189,7 @@ public class FederatedCtableTest extends AutomatedTestBase {
 			"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
 			"in_X4=" + TestUtils.federatedAddress(port4, input("X4")),
 			"rows=" + rows, "cols=" + cols, "revIn=" + Boolean.toString(reversedInputs).toUpperCase(),
+			"matrixInput=" + Boolean.toString(matrixInput).toUpperCase(),
 			"weighted=" + Boolean.toString(weighted).toUpperCase(), "out=" + output("F")
 		};
 		runTest(true, false, null, -1);

--- a/src/test/scripts/functions/federated/FederatedCtableFedOutput.dml
+++ b/src/test/scripts/functions/federated/FederatedCtableFedOutput.dml
@@ -28,8 +28,14 @@ n = ncol(X);
 
 # prepare offset vectors and one-hot encoded X
 maxs = colMaxs(X);
-rix = matrix(seq(1,m)%*%matrix(1,1,n), m*n, 1);
-cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m*n, 1);
+if($matrixInput) {
+  rix = matrix(seq(1,m)%*%matrix(1,1,n), m, n);
+  cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m, n);
+}
+else {
+  rix = matrix(seq(1,m)%*%matrix(1,1,n), m*n, 1);
+  cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m*n, 1);
+}
 
 W = rix + cix;
 

--- a/src/test/scripts/functions/federated/FederatedCtableFedOutputReference.dml
+++ b/src/test/scripts/functions/federated/FederatedCtableFedOutputReference.dml
@@ -27,8 +27,14 @@ n = ncol(X);
 # prepare offset vectors and one-hot encoded X
 maxs = colMaxs(X);
 
-rix = matrix(seq(1,m)%*%matrix(1,1,n), m*n, 1)
-cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m*n, 1);
+if($7) { # matrix input
+  rix = matrix(seq(1,m)%*%matrix(1,1,n), m, n);
+  cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m, n);
+}
+else {
+  rix = matrix(seq(1,m)%*%matrix(1,1,n), m*n, 1);
+  cix = matrix(X + (t(cumsum(t(maxs))) - maxs), m*n, 1);
+}
 
 W = rix + cix;
 
@@ -43,4 +49,4 @@ else
   else
     X2 = table(rix, cix);
 
-write(X2, $7);
+write(X2, $8);


### PR DESCRIPTION
Hi,
This PR adds support for keeping the output of the ctable instruction federated whenever it is possible. Previously, the partial outputs were always pulled to the coordinator.
Since there were some assumptions that the federated partitions would be the same size, I rewrote some methods.
I also added a testcase to test the creation of the federated output using matrices as input instead of just vectors.

Please have a close look at it :monocle_face: 

Thanks for review :)