### PR TITLE
[SYSTEMDS-3101] Federated Spoof Instruction with Federated Output

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/SpoofFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/SpoofFEDInstruction.java
@@ -50,6 +50,7 @@ import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
 public class SpoofFEDInstruction extends FEDInstruction
 {
@@ -82,37 +83,39 @@ public class SpoofFEDInstruction extends FEDInstruction
 
 	@Override
 	public void processInstruction(ExecutionContext ec) {
-		Class<?> scla = _op.getClass().getSuperclass();
-		SpoofFEDType spoofType = null;
-		if(scla == SpoofCellwise.class)
-			spoofType = new SpoofFEDCellwise(_op, _output);
-		else if(scla == SpoofRowwise.class)
-			spoofType = new SpoofFEDRowwise(_op, _output);
-		else if(scla == SpoofMultiAggregate.class)
-			spoofType = new SpoofFEDMultiAgg(_op, _output);
-		else if(scla == SpoofOuterProduct.class)
-			spoofType = new SpoofFEDOuterProduct(_op, _output);
-		else
-			throw new DMLRuntimeException("Federated code generation only supported" +
-				" for cellwise, rowwise, multiaggregate, and outerproduct templates.");
-
-
 		FederationMap fedMap = null;
-		long id = 0;
 		for(CPOperand cpo : _inputs) { // searching for the first federated matrix to obtain the federation map
 			Data tmpData = ec.getVariable(cpo);
 			if(tmpData instanceof MatrixObject && ((MatrixObject)tmpData).isFederatedExcept(FType.BROADCAST)) {
 				fedMap = ((MatrixObject)tmpData).getFedMapping();
-				id = ((MatrixObject)tmpData).getUniqueID();
 				break;
 			}
 		}
+
+		Class<?> scla = _op.getClass().getSuperclass();
+		SpoofFEDType spoofType = null;
+		if(scla == SpoofCellwise.class)
+			spoofType = new SpoofFEDCellwise(_op, _output, fedMap.getType());
+		else if(scla == SpoofRowwise.class)
+			spoofType = new SpoofFEDRowwise(_op, _output, fedMap.getType());
+		else if(scla == SpoofMultiAggregate.class)
+			spoofType = new SpoofFEDMultiAgg(_op, _output, fedMap.getType());
+		else if(scla == SpoofOuterProduct.class)
+			spoofType = new SpoofFEDOuterProduct(_op, _output, fedMap.getType(), _inputs);
+		else
+			throw new DMLRuntimeException("Federated code generation only supported" +
+				" for cellwise, rowwise, multiaggregate, and outerproduct templates.");
+
+		processRequest(ec, fedMap, spoofType);
+	}
+
+	private void processRequest(ExecutionContext ec, FederationMap fedMap, SpoofFEDType spoofType) {
 
 		ArrayList<FederatedRequest> frBroadcast = new ArrayList<>();
 		ArrayList<FederatedRequest[]> frBroadcastSliced = new ArrayList<>();
 		long[] frIds = new long[_inputs.length];
 		int index = 0;
-		
+
 		for(CPOperand cpo : _inputs) {
 			Data tmpData = ec.getVariable(cpo);
 			if(tmpData instanceof MatrixObject) {
@@ -121,7 +124,7 @@ public class SpoofFEDInstruction extends FEDInstruction
 					frIds[index++] = mo.getFedMapping().getID();
 				}
 				else if(spoofType.needsBroadcastSliced(fedMap, mo.getNumRows(), mo.getNumColumns(), index)) {
-					FederatedRequest[] tmpFr = spoofType.broadcastSliced(mo, fedMap, id);
+					FederatedRequest[] tmpFr = spoofType.broadcastSliced(mo, fedMap);
 					frIds[index++] = tmpFr[0].getID();
 					frBroadcastSliced.add(tmpFr);
 				}
@@ -144,46 +147,53 @@ public class SpoofFEDInstruction extends FEDInstruction
 
 		FederatedRequest frCompute = FederationUtils.callInstruction(instString, _output, _inputs, frIds);
 
-		// get partial results from federated workers
-		FederatedRequest frGet = new FederatedRequest(RequestType.GET_VAR, frCompute.getID());
-
+		FederatedRequest frGet = null;
 		ArrayList<FederatedRequest> frCleanup = new ArrayList<>();
-		frCleanup.add(fedMap.cleanup(getTID(), frCompute.getID()));
+		if(!spoofType.isFedOutput()) {
+			// get partial results from federated workers
+			frGet = new FederatedRequest(RequestType.GET_VAR, frCompute.getID());
+			// cleanup the federated request of callInstruction
+			frCleanup.add(fedMap.cleanup(getTID(), frCompute.getID()));
+		}
+
 		for(FederatedRequest[] fr : frBroadcastSliced)
 			frCleanup.add(fedMap.cleanup(getTID(), fr[0].getID()));
 
-		FederatedRequest[] frAll = ArrayUtils.addAll(ArrayUtils.addAll(
-			frBroadcast.toArray(new FederatedRequest[0]), frCompute, frGet),
-			frCleanup.toArray(new FederatedRequest[0]));
+		FederatedRequest[] frAll = (frGet == null ? ArrayUtils.addAll(
+				ArrayUtils.addAll(frBroadcast.toArray(new FederatedRequest[0]),
+				frCompute), frCleanup.toArray(new FederatedRequest[0]))
+			: ArrayUtils.addAll(ArrayUtils.addAll(
+				frBroadcast.toArray(new FederatedRequest[0]), frCompute, frGet),
+				frCleanup.toArray(new FederatedRequest[0])));
 		Future<FederatedResponse>[] response = fedMap.executeMultipleSlices(
 			getTID(), true, frBroadcastSliced.toArray(new FederatedRequest[0][]), frAll);
 
 		// setting the output with respect to the different aggregation types
 		// of the different spoof templates
-		spoofType.setOutput(ec, response, fedMap);
+		spoofType.setOutput(ec, response, fedMap, frCompute.getID());
 	}
 
 
 	private static abstract class SpoofFEDType {
 		CPOperand _output;
+		FType _fedType;
 
-		protected SpoofFEDType(CPOperand out) {
+		protected SpoofFEDType(CPOperand out, FType fedType) {
 			_output = out;
+			_fedType = fedType;
 		}
 		
-		protected FederatedRequest[] broadcastSliced(MatrixObject mo, FederationMap fedMap, long id) {
+		protected FederatedRequest[] broadcastSliced(MatrixObject mo, FederationMap fedMap) {
 			return fedMap.broadcastSliced(mo, false);
 		}
 
 		protected boolean needsBroadcastSliced(FederationMap fedMap, long rowNum, long colNum, int inputIndex) {
-			FType fedType = fedMap.getType();
-
 			//TODO fix check by num rows/cols
 			boolean retVal = (rowNum == fedMap.getMaxIndexInRange(0) && colNum == fedMap.getMaxIndexInRange(1));
-			if(fedType == FType.ROW)
+			if(_fedType == FType.ROW)
 				retVal |= (rowNum == fedMap.getMaxIndexInRange(0) 
 					&& (colNum == 1 || colNum == fedMap.getSize() || fedMap.getMaxIndexInRange(1) == 1));
-			else if(fedType == FType.COL)
+			else if(_fedType == FType.COL)
 				retVal |= (colNum == fedMap.getMaxIndexInRange(1)
 					&& (rowNum == 1 || rowNum == fedMap.getSize() || fedMap.getMaxIndexInRange(0) == 1));
 			else {
@@ -193,174 +203,214 @@ public class SpoofFEDInstruction extends FEDInstruction
 			return retVal;
 		}
 
-		protected abstract void setOutput(ExecutionContext ec,
-			Future<FederatedResponse>[] response, FederationMap fedMap);
+		protected void setOutput(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap, long frComputeID) {
+			if(isFedOutput())
+				setFedOutput(ec, fedMap, frComputeID);
+			else
+				aggResult(ec, response, fedMap);
+		}
+
+		protected abstract boolean isFedOutput();
+		protected abstract void setFedOutput(ExecutionContext ec, FederationMap fedMap, long frComputeID);
+		protected abstract void aggResult(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap);
 	}
 
 	private static class SpoofFEDCellwise extends SpoofFEDType {
 		private final SpoofCellwise _op;
 
-		SpoofFEDCellwise(SpoofOperator op, CPOperand out) {
-			super(out);
+		SpoofFEDCellwise(SpoofOperator op, CPOperand out, FType fedType) {
+			super(out, fedType);
 			_op = (SpoofCellwise)op;
 		}
 
-		protected void setOutput(ExecutionContext ec, Future<FederatedResponse>[] response, FederationMap fedMap) {
-			FType fedType = fedMap.getType();
-			AggOp aggOp = ((SpoofCellwise)_op).getAggOp();
-			CellType cellType = ((SpoofCellwise)_op).getCellType();
-			if(cellType == CellType.FULL_AGG) { // full aggregation
-				AggregateUnaryOperator aop = null;
-				if(aggOp == AggOp.SUM || aggOp == AggOp.SUM_SQ)
-					aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
-				else if(aggOp == AggOp.MIN)
-					aop = InstructionUtils.parseBasicAggregateUnaryOperator("uamin");
-				else if(aggOp == AggOp.MAX)
-					aop = InstructionUtils.parseBasicAggregateUnaryOperator("uamax");
-				else
+		protected boolean isFedOutput() {
+			CellType cellType = _op.getCellType();
+
+			boolean retVal = false;
+			retVal |= (cellType == CellType.ROW_AGG && _fedType == FType.ROW);
+			retVal |= (cellType == CellType.COL_AGG && _fedType == FType.COL);
+			retVal |= (cellType == CellType.NO_AGG);
+
+			return retVal;
+		}
+
+		protected void setFedOutput(ExecutionContext ec, FederationMap fedMap, long frComputeID) {
+			// derive output federated mapping
+			MatrixObject out = ec.getMatrixObject(_output);
+			FederationMap newFedMap = modifyFedRanges(fedMap.copyWithNewID(frComputeID));
+			out.setFedMapping(newFedMap);
+		}
+
+		private FederationMap modifyFedRanges(FederationMap fedMap) {
+			CellType cellType = _op.getCellType();
+			if(cellType == CellType.ROW_AGG || cellType == CellType.COL_AGG) {
+				int dim = (cellType == CellType.COL_AGG ? 0 : 1);
+				// crop federation map to a vector
+				IntStream.range(0, fedMap.getFederatedRanges().length).forEach(i -> {
+					fedMap.getFederatedRanges()[i].setBeginDim(dim, 0);
+					fedMap.getFederatedRanges()[i].setEndDim(dim, 1);
+				});
+			}
+			return fedMap;
+		}
+
+		protected void aggResult(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap) {
+			CellType cellType = _op.getCellType();
+			AggOp aggOp = _op.getAggOp();
+
+			// create the instruction for aggregation
+			String aggInst = "ua";
+			switch(cellType) {
+				case FULL_AGG:
+					break;
+				case ROW_AGG:
+					aggInst += "r";
+					break;
+				case COL_AGG:
+					aggInst += "c";
+					break;
+				case NO_AGG:
+				default:
+					throw new DMLRuntimeException("Aggregation type not supported yet.");
+			}
+
+			switch(aggOp) {
+				case SUM:
+				case SUM_SQ:
+					aggInst += "k+";
+					break;
+				case MIN:
+					aggInst += "min";
+					break;
+				case MAX:
+					aggInst += "max";
+					break;
+				default:
 					throw new DMLRuntimeException("Aggregation operation not supported yet.");
+			}
+
+			AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator(aggInst);
+			if(cellType == CellType.FULL_AGG)
 				ec.setVariable(_output.getName(), FederationUtils.aggScalar(aop, response));
-			}
-			else if(cellType == CellType.ROW_AGG) { // row aggregation
-				if(fedType == FType.ROW) {
-					// bind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				}
-				else if(fedType == FType.COL) {
-					AggregateUnaryOperator aop = null;
-					if(aggOp == AggOp.SUM || aggOp == AggOp.SUM_SQ)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uark+");
-					else if(aggOp == AggOp.MIN)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uarmin");
-					else if(aggOp == AggOp.MAX)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uarmax");
-					else
-						throw new DMLRuntimeException("Aggregation operation not supported yet.");
-					ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-				}
-				else {
-					throw new DMLRuntimeException("Aggregation type for federated spoof instructions not supported yet.");
-				}
-			}
-			else if(cellType == CellType.COL_AGG) { // col aggregation
-				if(fedType == FType.ROW) {
-					AggregateUnaryOperator aop = null;
-					if(aggOp == AggOp.SUM || aggOp == AggOp.SUM_SQ)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uack+");
-					else if(aggOp == AggOp.MIN)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uacmin");
-					else if(aggOp == AggOp.MAX)
-						aop = InstructionUtils.parseBasicAggregateUnaryOperator("uacmax");
-					else
-						throw new DMLRuntimeException("Aggregation operation not supported yet.");
-					ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-				}
-				else if(fedType == FType.COL) {
-					// cbind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, true));
-				}
-				else {
-					throw new DMLRuntimeException("Aggregation type for federated spoof instructions not supported yet.");
-				}
-			}
-			else if(cellType == CellType.NO_AGG) { // no aggregation
-				if(fedType == FType.ROW) //rbind
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				else if(fedType == FType.COL) //cbind
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, true));
-				else
-					throw new DMLRuntimeException("Only row partitioned or column" +
-						" partitioned federated matrices supported yet.");
-			}
-			else {
-				throw new DMLRuntimeException("Aggregation type not supported yet.");
-			}
+			else
+				ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
 		}
 	}
 
 	private static class SpoofFEDRowwise extends SpoofFEDType {
 		private final SpoofRowwise _op;
 
-		SpoofFEDRowwise(SpoofOperator op, CPOperand out) {
-			super(out);
+		SpoofFEDRowwise(SpoofOperator op, CPOperand out, FType fedType) {
+			super(out, fedType);
 			_op = (SpoofRowwise)op;
 		}
 
-		protected void setOutput(ExecutionContext ec, Future<FederatedResponse>[] response, FederationMap fedMap) {
-			RowType rowType = ((SpoofRowwise)_op).getRowType();
-			if(rowType == RowType.FULL_AGG) { // full aggregation
-				// aggregate partial results from federated responses as sum
-				AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
-				ec.setVariable(_output.getName(), FederationUtils.aggScalar(aop, response));
-			}
-			else if(rowType == RowType.ROW_AGG) { // row aggregation
-				// aggregate partial results from federated responses as rowSum
-				AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uark+");
-				ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-			}
-			else if(rowType == RowType.COL_AGG
-				|| rowType == RowType.COL_AGG_T
-				|| rowType == RowType.COL_AGG_B1
-				|| rowType == RowType.COL_AGG_B1_T
-				|| rowType == RowType.COL_AGG_B1R
-				|| rowType == RowType.COL_AGG_CONST) { // col aggregation
-				// aggregate partial results from federated responses as colSum
-				AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uack+");
-				ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-			}
-			else if(rowType == RowType.NO_AGG
-				|| rowType == RowType.NO_AGG_B1
-				|| rowType == RowType.NO_AGG_CONST) { // no aggregation
-				if(fedMap.getType() == FType.ROW) {
-					// bind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				}
-				else {
-					throw new DMLRuntimeException("Only row partitioned federated matrices supported yet.");
-				}
-			}
-			else {
+		protected boolean isFedOutput() {
+			RowType rowType = _op.getRowType();
+
+			boolean retVal = false;
+			retVal |= (rowType == RowType.NO_AGG);
+			retVal |= (rowType == RowType.NO_AGG_B1);
+			retVal |= (rowType == RowType.NO_AGG_CONST);
+			retVal &= (_fedType == FType.ROW);
+			return retVal;
+		}
+
+		protected void setFedOutput(ExecutionContext ec, FederationMap fedMap, long frComputeID) {
+			// derive output federated mapping
+			MatrixObject out = ec.getMatrixObject(_output);
+			FederationMap newFedMap = modifyFedRanges(fedMap.copyWithNewID(frComputeID), out.getNumColumns());
+			out.setFedMapping(newFedMap);
+		}
+
+		private FederationMap modifyFedRanges(FederationMap fedMap, long cols) {
+			IntStream.range(0, fedMap.getFederatedRanges().length).forEach(i -> {
+				fedMap.getFederatedRanges()[i].setBeginDim(1, 0);
+				fedMap.getFederatedRanges()[i].setEndDim(1, cols);
+			});
+			return fedMap;
+		}
+
+		protected void aggResult(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap) {
+			if(_fedType != FType.ROW)
+				throw new DMLRuntimeException("Only row partitioned federated matrices supported yet.");
+
+			RowType rowType = _op.getRowType();
+
+			// create the instruction for aggregation
+			String aggInst = "ua";
+			if(rowType == RowType.FULL_AGG) // full aggregation
+				aggInst += "k+";
+			else if(rowType == RowType.ROW_AGG) // row aggregation
+				aggInst += "rk+";
+			else if(rowType.isColumnAgg()) // col aggregation
+				aggInst += "ck+";
+			else
 				throw new DMLRuntimeException("AggregationType not supported yet.");
-			}
+
+			// aggregate partial results from federated responses as sum/rowSum/colSum
+			AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator(aggInst);
+			if(rowType == RowType.FULL_AGG)
+				ec.setVariable(_output.getName(), FederationUtils.aggScalar(aop, response));
+			else
+				ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
 		}
 	}
 
 	private static class SpoofFEDMultiAgg extends SpoofFEDType {
 		private final SpoofMultiAggregate _op;
 
-		SpoofFEDMultiAgg(SpoofOperator op, CPOperand out) {
-			super(out);
+		SpoofFEDMultiAgg(SpoofOperator op, CPOperand out, FType fedType) {
+			super(out, fedType);
 			_op = (SpoofMultiAggregate)op;
 		}
 
-		protected void setOutput(ExecutionContext ec, Future<FederatedResponse>[] response, FederationMap fedMap) {
-			MatrixBlock[] partRes = FederationUtils.getResults(response);
-			SpoofCellwise.AggOp[] aggOps = ((SpoofMultiAggregate)_op).getAggOps();
-			for(int counter = 1; counter < partRes.length; counter++) {
-				SpoofMultiAggregate.aggregatePartialResults(aggOps, partRes[0], partRes[counter]);
-			}
-			ec.setMatrixOutput(_output.getName(), partRes[0]);
+		protected boolean isFedOutput() {
+			return false;
 		}
+
+		protected void setFedOutput(ExecutionContext ec, FederationMap fedMap, long frComputeID) {
+			throw new DMLRuntimeException("SpoofFEDMultiAgg cannot create a federated output.");
+		}
+
+		protected void aggResult(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap) {
+				MatrixBlock[] partRes = FederationUtils.getResults(response);
+				SpoofCellwise.AggOp[] aggOps = _op.getAggOps();
+				for(int counter = 1; counter < partRes.length; counter++) {
+					SpoofMultiAggregate.aggregatePartialResults(aggOps, partRes[0], partRes[counter]);
+				}
+				ec.setMatrixOutput(_output.getName(), partRes[0]);
+			}
 	}
 
 
 	private static class SpoofFEDOuterProduct extends SpoofFEDType {
 		private final SpoofOuterProduct _op;
+		private CPOperand[] _inputs;
 
-		SpoofFEDOuterProduct(SpoofOperator op, CPOperand out) {
-			super(out);
+		SpoofFEDOuterProduct(SpoofOperator op, CPOperand out, FType fedType, CPOperand[] inputs) {
+			super(out, fedType);
 			_op = (SpoofOuterProduct)op;
+			_inputs = inputs;
+		}
+
+		protected FederatedRequest[] broadcastSliced(MatrixObject mo, FederationMap fedMap) {
+			return fedMap.broadcastSliced(mo, (_fedType == FType.COL));
 		}
 
 		protected boolean needsBroadcastSliced(FederationMap fedMap, long rowNum, long colNum, int inputIndex) {
 			boolean retVal = false;
-			FType fedType = fedMap.getType();
 			
 			retVal |= (rowNum == fedMap.getMaxIndexInRange(0) && colNum == fedMap.getMaxIndexInRange(1));
 			
-			if(fedType == FType.ROW)
+			if(_fedType == FType.ROW)
 				retVal |= (rowNum == fedMap.getMaxIndexInRange(0)) && (inputIndex != 2); // input at index 2 is V
-			else if(fedType == FType.COL)
+			else if(_fedType == FType.COL)
 				retVal |= (rowNum == fedMap.getMaxIndexInRange(1)) && (inputIndex != 1); // input at index 1 is U
 			else
 				throw new DMLRuntimeException("Only row partitioned or column" +
@@ -369,60 +419,73 @@ public class SpoofFEDInstruction extends FEDInstruction
 			return retVal;
 		}
 
-		protected void setOutput(ExecutionContext ec, Future<FederatedResponse>[] response, FederationMap fedMap) {
-			FType fedType = fedMap.getType();
-			OutProdType outProdType = ((SpoofOuterProduct)_op).getOuterProdType();
-			if(outProdType == OutProdType.LEFT_OUTER_PRODUCT) {
-				if(fedType == FType.ROW) {
+		protected boolean isFedOutput() {
+			OutProdType outProdType = _op.getOuterProdType();
+
+			boolean retVal = false;
+			retVal |= (outProdType == OutProdType.LEFT_OUTER_PRODUCT && _fedType == FType.COL);
+			retVal |= (outProdType == OutProdType.RIGHT_OUTER_PRODUCT && _fedType == FType.ROW);
+			retVal |= (outProdType == OutProdType.CELLWISE_OUTER_PRODUCT);
+
+			return retVal;
+		}
+
+		protected void setFedOutput(ExecutionContext ec, FederationMap fedMap, long frComputeID) {
+			FederationMap newFedMap = fedMap.copyWithNewID(frComputeID);
+			OutProdType outProdType = _op.getOuterProdType();
+			long[] outDims = new long[2];
+
+			// find the resulting output dimensions
+			MatrixObject X = ec.getMatrixObject(_inputs[0]);
+			switch(outProdType) {
+				case LEFT_OUTER_PRODUCT:
+					newFedMap = newFedMap.transpose();
+					outDims[0] = X.getNumColumns();
+					outDims[1] = ec.getMatrixObject(_inputs[1]).getNumColumns();
+					break;
+				case RIGHT_OUTER_PRODUCT:
+					outDims[0] = X.getNumRows();
+					outDims[1] = ec.getMatrixObject(_inputs[2]).getNumColumns();
+					break;
+				case CELLWISE_OUTER_PRODUCT:
+					outDims[0] = X.getNumRows();
+					outDims[1] = X.getNumColumns();
+					break;
+				default:
+					throw new DMLRuntimeException("Outer Product Type " + outProdType + " not supported yet.");
+			}
+
+			// derive output federated mapping
+			MatrixObject out = ec.getMatrixObject(_output);
+			int dim = (newFedMap.getType() == FType.ROW ? 1 : 0);
+			newFedMap = modifyFedRanges(newFedMap, dim, outDims[dim]);
+			out.setFedMapping(newFedMap);
+		}
+
+		private FederationMap modifyFedRanges(FederationMap fedMap, int dim, long value) {
+			IntStream.range(0, fedMap.getFederatedRanges().length).forEach(i -> {
+				fedMap.getFederatedRanges()[i].setBeginDim(dim, 0);
+				fedMap.getFederatedRanges()[i].setEndDim(dim, value);
+			});
+			return fedMap;
+		}
+
+		protected void aggResult(ExecutionContext ec, Future<FederatedResponse>[] response,
+			FederationMap fedMap) {
+			OutProdType outProdType = _op.getOuterProdType();
+			AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
+			switch(outProdType) {
+				case LEFT_OUTER_PRODUCT:
+				case RIGHT_OUTER_PRODUCT:
 					// aggregate partial results from federated responses as elementwise sum
-					AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
 					ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-				}
-				else if(fedType == FType.COL) {
-					// bind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				}
-				else {
-					throw new DMLRuntimeException("Only row partitioned or column" +
-						" partitioned federated matrices supported yet.");
-				}
-			}
-			else if(outProdType == OutProdType.RIGHT_OUTER_PRODUCT) {
-				if(fedType == FType.ROW) {
-					// bind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				}
-				else if(fedType == FType.COL) {
-					// aggregate partial results from federated responses as elementwise sum
-					AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
-					ec.setMatrixOutput(_output.getName(), FederationUtils.aggMatrix(aop, response, fedMap));
-				}
-				else {
-					throw new DMLRuntimeException("Only row partitioned or column" +
-						" partitioned federated matrices supported yet.");
-				}
-			}
-			else if(outProdType == OutProdType.CELLWISE_OUTER_PRODUCT) {
-				if(fedType == FType.ROW) {
-					// rbind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, false));
-				}
-				else if(fedType == FType.COL) {
-					// cbind partial results from federated responses
-					ec.setMatrixOutput(_output.getName(), FederationUtils.bind(response, true));
-				}
-				else {
-					throw new DMLRuntimeException("Only row partitioned or column" +
-						" partitioned federated matrices supported yet.");
-				}
-			}
-			else if(outProdType == OutProdType.AGG_OUTER_PRODUCT) {
-				// aggregate partial results from federated responses as sum
-				AggregateUnaryOperator aop = InstructionUtils.parseBasicAggregateUnaryOperator("uak+");
-				ec.setVariable(_output.getName(), FederationUtils.aggScalar(aop, response));
-			}
-			else {
-				throw new DMLRuntimeException("Outer Product Type " + outProdType + " not supported yet.");
+					break;
+				case AGG_OUTER_PRODUCT:
+					// aggregate partial results from federated responses as sum
+					ec.setVariable(_output.getName(), FederationUtils.aggScalar(aop, response));
+					break;
+				default:
+					throw new DMLRuntimeException("Outer Product Type " + outProdType + " not supported yet.");
 			}
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedCodegenMultipleFedMOTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedCodegenMultipleFedMOTest.java
@@ -104,7 +104,7 @@ public class FederatedCodegenMultipleFedMOTest extends AutomatedTestBase
 			// row partitioned
 			// {201, 6, 4, 6, 4, true},
 			{202, 6, 4, 6, 4, true},
-			// {203, 20, 1, 20, 1, true},
+			// FIXME: [SYSTEMDS-3110] {203, 20, 1, 20, 1, true},
 			// col partitioned
 			{201, 6, 4, 6, 4, false},
 			{202, 6, 4, 6, 4, false},
@@ -123,9 +123,9 @@ public class FederatedCodegenMultipleFedMOTest extends AutomatedTestBase
 			{308, 1000, 2000, 10, 2000, false},
 			// {310, 1000, 2000, 10, 2000, false},
 			// row and col partitioned
-			// {311, 1000, 2000, 1000, 10, true}, // not working yet - ArrayIndexOutOfBoundsException in dotProduct
+			// {311, 1000, 2000, 1000, 10, true}, // FIXME: ArrayIndexOutOfBoundsException in dotProduct
 			{312, 1000, 2000, 10, 2000, false},
-			// {313, 4000, 2000, 4000, 10, true}, // not working yet - ArrayIndexOutOfBoundsException in dotProduct
+			// {313, 4000, 2000, 4000, 10, true}, // FIXME: ArrayIndexOutOfBoundsException in dotProduct
 			{314, 4000, 2000, 10, 2000, false},
 
 			// combined tests

--- a/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedOuterProductTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedOuterProductTmplTest.java
@@ -86,14 +86,14 @@ public class FederatedOuterProductTmplTest extends AutomatedTestBase
 			{9, 1000, 2000, true},
 
 			// column partitioned
-			//FIXME {1, 2000, 2000, false},
+			{1, 2000, 2000, false},
 			// {2, 4000, 2000, false},
 			// {3, 1000, 1000, false},
-			//FIXME {4, 4000, 2000, false},
-			//FIXME {5, 4000, 2000, false},
+			{4, 4000, 2000, false},
+			{5, 4000, 2000, false},
 			// {6, 4000, 2000, false},
 			//FIXME {7, 2000, 2000, false},
-			//FIXME {8, 1000, 2000, false},
+			{8, 1000, 2000, false},
 			// {9, 1000, 2000, false},
 		});
 	}

--- a/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedRowwiseTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/codegen/FederatedRowwiseTmplTest.java
@@ -117,7 +117,7 @@ public class FederatedRowwiseTmplTest extends AutomatedTestBase
 	}
 
 	@Test
-	public void federatedCodegenCellwiseHybrid() {
+	public void federatedCodegenRowwiseHybrid() {
 		testFederatedCodegenRowwise(ExecMode.HYBRID);
 	}
 


### PR DESCRIPTION
Hi,
This PR adds support to keep the output of the federated spoof instruction on the federated sites instead of binding it on the coordinator.
I've always split the method _setOutput_ into _setFedOutput_ and _aggResult_ to clearly differentiate between creating a federated output and aggregating the results locally.

Thanks for review :)