### PR TITLE
[SYSTEMDS-3098] Add synchronization to async. broadcast

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/TriggerBroadcastTask.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/TriggerBroadcastTask.java
@@ -36,9 +36,6 @@ public class TriggerBroadcastTask implements Runnable {
 
 	@Override
 	public void run() {
-		// TODO: Synchronization. Although it is harmless if to threads create separate
-		// broadcast handles as only one will stay with the MatrixObject. However, redundant
-		// partitioning increases untraced memory usage.
 		try {
 			SparkExecutionContext sec = (SparkExecutionContext)_ec;
 			sec.setBroadcastHandle(_broadcastMO);
@@ -47,6 +44,7 @@ public class TriggerBroadcastTask implements Runnable {
 			e.printStackTrace();
 		}
 
+		//TODO: Count only if successful (owned lock)
 		if (DMLScript.STATISTICS)
 			Statistics.incSparkAsyncBroadcastCount(1);
 		

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -511,6 +511,8 @@ public class Statistics
 		parforMergeTime = 0;
 		
 		sparkCtxCreateTime = 0;
+		sparkBroadcast.reset();
+		sparkBroadcastCount.reset();
 		sparkAsyncPrefetchCount.reset();
 		sparkAsyncBroadcastCount.reset();
 		


### PR DESCRIPTION
This patch wraps the creation of partitioned broadcast handle
code inside a synchronized block to remove redundant partitioning
by the CP or the new early-broadcast thread.
Moreover, this patch fixes a bug in broadcast count stat collection.