### PR TITLE
[MINOR] Remove Redundant Parameters and Initializers in ProgramBlocks

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ForProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ForProgramBlock.java
@@ -165,12 +165,12 @@ public class ForProgramBlock extends ProgramBlock
 		}
 		
 		//execute exit instructions
-		executeExitInstructions(_exitInstruction, "for", ec);
+		executeExitInstructions("for", ec);
 	}
 
 	protected ScalarObject executePredicateInstructions( int pos, ArrayList<Instruction> instructions, ExecutionContext ec, boolean downCast )
 	{
-		ScalarObject ret = null;
+		ScalarObject ret;
 		ValueType vt = downCast ? ValueType.INT64 : null;
 		
 		try
@@ -221,7 +221,7 @@ public class ForProgramBlock extends ProgramBlock
 	/**
 	 * Utility class for iterating over positive or negative predicate sequences.
 	 */
-	protected class SequenceIterator implements Iterator<IntObject>, Iterable<IntObject>
+	protected static class SequenceIterator implements Iterator<IntObject>, Iterable<IntObject>
 	{
 		private long _cur = -1;
 		private long _to = -1;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/IfProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/IfProgramBlock.java
@@ -128,12 +128,12 @@ public class IfProgramBlock extends ProgramBlock
 		}
 		
 		//execute exit instructions
-		executeExitInstructions(_exitInstruction, "if", ec);
+		executeExitInstructions("if", ec);
 	}
 
 	private BooleanObject executePredicate(ExecutionContext ec) 
 	{
-		BooleanObject result = null;
+		BooleanObject result;
 		try {
 			if( _sb != null ) {
 				IfStatementBlock isb = (IfStatementBlock)_sb;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/Program.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/Program.java
@@ -35,8 +35,8 @@ public class Program
 	public static final String KEY_DELIM = "::";
 	
 	private DMLProgram _prog;
-	private ArrayList<ProgramBlock> _programBlocks;
-	private HashMap<String, FunctionDictionary<FunctionProgramBlock>> _namespaces;
+	private final ArrayList<ProgramBlock> _programBlocks;
+	private final HashMap<String, FunctionDictionary<FunctionProgramBlock>> _namespaces;
 	
 	public Program() {
 		_namespaces = new HashMap<>();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
@@ -181,7 +181,7 @@ public abstract class ProgramBlock implements ParseInfo {
 		return executePredicateInstructions(tmp, retType, ec);
 	}
 
-	protected void executeExitInstructions(Instruction inst, String ctx, ExecutionContext ec) {
+	protected void executeExitInstructions(String ctx, ExecutionContext ec) {
 		try {
 			if(_exitInstruction != null)
 				executeSingleInstruction(_exitInstruction, ec);
@@ -279,7 +279,7 @@ public abstract class ProgramBlock implements ParseInfo {
 			// variables in symbol table (for tracking source of wrong representation)
 			if(CHECK_MATRIX_PROPERTIES) {
 				checkSparsity(tmp, ec.getVariables(), ec);
-				checkFederated(tmp, ec.getVariables());
+				checkFederated(ec.getVariables());
 			}
 		}
 		catch(DMLScriptException e) {
@@ -377,7 +377,7 @@ public abstract class ProgramBlock implements ParseInfo {
 		}
 	}
 
-	private static void checkFederated(Instruction lastInst, LocalVariableMap vars) {
+	private static void checkFederated(LocalVariableMap vars) {
 		for(String varname : vars.keySet()) {
 			Data dat = vars.get(varname);
 			if(!(dat instanceof CacheableData))

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/WhileProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/WhileProgramBlock.java
@@ -69,7 +69,7 @@ public class WhileProgramBlock extends ProgramBlock
 	
 	private BooleanObject executePredicate(ExecutionContext ec) 
 	{
-		BooleanObject result = null;
+		BooleanObject result;
 		try
 		{
 			if( _sb!=null )
@@ -140,7 +140,7 @@ public class WhileProgramBlock extends ProgramBlock
 		}
 		
 		//execute exit instructions
-		executeExitInstructions(_exitInstruction, "while", ec);
+		executeExitInstructions("while", ec);
 	}
 	
 	public void setChildBlocks(ArrayList<ProgramBlock> childs) {


### PR DESCRIPTION
This PR has small adjustments to the ProgramBlock classes to remove redundant parameters and initializers. 