### PR TITLE
[SYSTEMDS-2972] Single interface for multi- and single-threaded trans…

### DIFF
--- a/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
+++ b/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
@@ -174,7 +174,15 @@ public class ConfigurationManager
 	public static boolean isParallelTransform() {
 		return getDMLConfig().getBooleanValue(DMLConfig.PARALLEL_ENCODE);
 	}
-	
+
+	public static int getParallelApplyBlocks(){
+		return getDMLConfig().getIntValue(DMLConfig.PARALLEL_ENCODE_APPLY_BLOCKS);
+	}
+
+	public static int getParallelBuildBlocks(){
+		return getDMLConfig().getIntValue(DMLConfig.PARALLEL_ENCODE_BUILD_BLOCKS);
+	}
+
 	public static boolean isParallelParFor() {
 		return getCompilerConfigFlag(ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR);
 	}

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -68,6 +68,8 @@ public class DMLConfig
 	public static final String CP_PARALLEL_OPS      = "sysds.cp.parallel.ops";
 	public static final String CP_PARALLEL_IO       = "sysds.cp.parallel.io";
 	public static final String PARALLEL_ENCODE      = "sysds.parallel.encode";  // boolean: enable multi-threaded transformencode and apply
+	public static final String PARALLEL_ENCODE_APPLY_BLOCKS = "sysds.parallel.encode.applyBlocks";
+	public static final String PARALLEL_ENCODE_BUILD_BLOCKS = "sysds.parallel.encode.buildBlocks";
 	public static final String COMPRESSED_LINALG    = "sysds.compressed.linalg";
 	public static final String COMPRESSED_LOSSY     = "sysds.compressed.lossy";
 	public static final String COMPRESSED_VALID_COMPRESSIONS = "sysds.compressed.valid.compressions";
@@ -128,6 +130,8 @@ public class DMLConfig
 		_defaultVals.put(CP_PARALLEL_OPS,        "true" );
 		_defaultVals.put(CP_PARALLEL_IO,         "true" );
 		_defaultVals.put(PARALLEL_ENCODE,        "false" );
+		_defaultVals.put(PARALLEL_ENCODE_APPLY_BLOCKS, "1");
+		_defaultVals.put(PARALLEL_ENCODE_BUILD_BLOCKS, "1");
 		_defaultVals.put(COMPRESSED_LINALG,      Compression.CompressConfig.FALSE.name() );
 		_defaultVals.put(COMPRESSED_LOSSY,       "false" );
 		_defaultVals.put(COMPRESSED_VALID_COMPRESSIONS, "SDC,DDC");

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlock.java
@@ -121,4 +121,31 @@ public interface CacheBlock extends Writable
 	 * @param appendOnly ?
 	 */
 	public void merge(CacheBlock that, boolean appendOnly);
+
+	/**
+	 * Returns the double value at the passed row and column.
+	 * If the value is missing 0 is returned.
+	 * @param r row of the value
+	 * @param c column of the value
+	 * @return double value at the passed row and column
+	 */
+	double getDouble(int r, int c);
+
+	/**
+	 * Returns the double value at the passed row and column.
+	 * If the value is missing NaN is returned.
+	 * @param r row of the value
+	 * @param c column of the value
+	 * @return double value at the passed row and column
+	 */
+	double getDoubleNaN(int r, int c);
+
+	/**
+	 * Returns the string of the value at the passed row and column.
+	 * If the value is missing or NaN, null is returned.
+	 * @param r row of the value
+	 * @param c column of the value
+	 * @return string of the value at the passed row and column
+	 */
+	String getString(int r, int c);
 }

--- a/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
@@ -19,6 +19,14 @@
 
 package org.apache.sysds.runtime.data;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Arrays;
+
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.BlockType;
 import org.apache.sysds.common.Types.ValueType;
@@ -30,14 +38,6 @@ import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.TensorCharacteristics;
 import org.apache.sysds.runtime.util.UtilFunctions;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Arrays;
 
 /**
  * A <code>TensorBlock</code> is the most top level representation of a tensor. There are two types of data representation
@@ -307,6 +307,25 @@ public class TensorBlock implements CacheBlock, Externalizable {
 	@Override
 	public void merge(CacheBlock that, boolean appendOnly) {
 		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public double getDouble(int r, int c) {
+		return get(r, c);
+	}
+
+	@Override
+	public double getDoubleNaN(int r, int c) {
+		return getDouble(r, c);
+	}
+
+	@Override
+	public String getString(int r, int c) {
+		double v = get(r, c);
+		// NaN gets converted to null here since check for null is faster than string comp
+		if(Double.isNaN(v))
+			return null;
+		return String.valueOf(v);
 	}
 
 	public int getDim(int i) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
@@ -71,7 +71,7 @@ import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 @SuppressWarnings({"rawtypes","unchecked"}) //allow generic native arrays
-public class FrameBlock implements CacheBlock, Externalizable  {
+public class FrameBlock implements CacheBlock, Externalizable {
 	private static final long serialVersionUID = -3993450030207130665L;
 	private static final Log LOG = LogFactory.getLog(FrameBlock.class.getName());
 	private static final IDSequence CLASS_ID = new IDSequence();
@@ -157,6 +157,32 @@ public class FrameBlock implements CacheBlock, Externalizable  {
 	@Override
 	public int getNumRows() {
 		return _numRows;
+	}
+
+	@Override
+	public double getDouble(int r, int c) {
+		Object o = get(r, c);
+		if(o == null || (getSchema()[c] == ValueType.STRING && o.toString().isEmpty()))
+			return 0;
+		return UtilFunctions.objectToDouble(getSchema()[c], o);
+	}
+
+	@Override
+	public double getDoubleNaN(int r, int c) {
+		Object o = get(r, c);
+		if(o == null || (getSchema()[c] == ValueType.STRING && o.toString().isEmpty()))
+			return Double.NaN;
+		return UtilFunctions.objectToDouble(getSchema()[c], o);
+
+	}
+
+	@Override
+	public String getString(int r, int c) {
+		Object o = get(r, c);
+		String s = (o == null) ? null : o.toString();
+		if(s != null && s.isEmpty())
+			return null;
+		return s;
 	}
 
 	public void setNumRows(int numRows) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -467,7 +467,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	public final int getNumRows() {
 		return rlen;
 	}
-	
+
 	/**
 	 * NOTE: setNumRows() and setNumColumns() are used only in ternaryInstruction (for contingency tables)
 	 * and pmm for meta corrections.
@@ -5958,6 +5958,23 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 		return sb.toString();
 	}
 
+
+	public double getDouble(int r, int c){
+		return quickGetValue(r, c);
+	}
+
+	@Override
+	public double getDoubleNaN(int r, int c) {
+		return getDouble(r, c);
+	}
+
+	public String getString(int r, int c){
+		double v = quickGetValue(r, c);
+		// NaN gets converted to null here since check for null is faster than string comp
+		if(Double.isNaN(v))
+			return null;
+		return String.valueOf(v);
+	}
 
 	///////////////////////////
 	// Helper classes

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.transform.encode;
 
 import static org.apache.sysds.runtime.transform.encode.EncoderFactory.getEncoderType;
 import static org.apache.sysds.runtime.util.UtilFunctions.getBlockSizes;
+import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -29,16 +30,23 @@ import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
+import org.apache.sysds.runtime.data.SparseRowVector;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.DependencyTask;
 import org.apache.sysds.runtime.util.DependencyThreadPool;
+import org.apache.sysds.utils.Statistics;
 
 /**
  * Base class for all transform encoders providing both a row and block interface for decoding frames to matrices.
@@ -50,6 +58,11 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 	public static int BUILD_ROW_BLOCKS_PER_COLUMN = 1;
 	private static final long serialVersionUID = 2299156350718979064L;
 	protected int _colID;
+	protected Set<Integer> _sparseRowsWZeros = null;
+
+	protected enum TransformType{
+		BIN, RECODE, DUMMYCODE, FEATURE_HASH, PASS_THROUGH, N_A
+	}
 
 	protected ColumnEncoder(int colID) {
 		_colID = colID;
@@ -65,18 +78,62 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 	 * @return same as out
 	 *
 	 */
-	public MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol){
+
+	public MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol){
 		return apply(in, out, outputCol, 0, -1);
 	}
 
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol){
-		return apply(in, out, outputCol, 0, -1);
+	public MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
+		if(out.isInSparseFormat())
+			applySparse(in, out, outputCol, rowStart, blk);
+		else
+			applyDense(in, out, outputCol, rowStart, blk);
+
+		if (DMLScript.STATISTICS){
+			long t = System.nanoTime()-t0;
+			switch (this.getTransformType()){
+				case RECODE:
+					Statistics.incTransformRecodeApplyTime(t);
+					break;
+				case BIN:
+					Statistics.incTransformBinningApplyTime(t);
+					break;
+				case DUMMYCODE:
+					Statistics.incTransformDummyCodeApplyTime(t);
+					break;
+				case FEATURE_HASH:
+					Statistics.incTransformFeatureHashingApplyTime(t);
+					break;
+				case PASS_THROUGH:
+					Statistics.incTransformPassThroughApplyTime(t);
+					break;
+				default:
+					break;
+			}
+		}
+		return out;
 	}
 
-	public abstract MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol, int rowStart, int blk);
+	protected abstract double getCode(CacheBlock in, int row);
 
-	public abstract MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int rowStart, int blk);
 
+	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+		int index = _colID - 1;
+		for(int r = rowStart; r < getEndIndex(in.getNumRows(), rowStart, blk); r++) {
+			SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(r);
+			row.values()[index] = getCode(in, r);
+			row.indexes()[index] = outputCol;
+		}
+	}
+
+	protected void applyDense(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+		for(int i = rowStart; i < getEndIndex(in.getNumRows(), rowStart, blk); i++) {
+			out.quickSetValue(i, outputCol, getCode(in, i));
+		}
+	}
+
+	protected abstract TransformType getTransformType();
 	/**
 	 * Indicates if this encoder is applicable, i.e, if there is a column to encode.
 	 *
@@ -191,7 +248,7 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 	 * complete if all previous tasks are done. This is so that we can use the last task as a dependency for the whole
 	 * build, reducing unnecessary dependencies.
 	 */
-	public List<DependencyTask<?>> getBuildTasks(FrameBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
 		List<Callable<Object>> tasks = new ArrayList<>();
 		List<List<? extends Callable<?>>> dep = null;
 		int nRows = in.getNumRows();
@@ -210,12 +267,12 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 		return DependencyThreadPool.createDependencyTasks(tasks, dep);
 	}
 
-	public Callable<Object> getBuildTask(FrameBlock in) {
+	public Callable<Object> getBuildTask(CacheBlock in) {
 		throw new DMLRuntimeException("Trying to get the Build task of an Encoder which does not require building");
 	}
 
-	public Callable<Object> getPartialBuildTask(FrameBlock in, int startRow, int blockSize,
-		HashMap<Integer, Object> ret) {
+	public Callable<Object> getPartialBuildTask(CacheBlock in, int startRow, 
+			int blockSize, HashMap<Integer, Object> ret) {
 		throw new DMLRuntimeException(
 			"Trying to get the PartialBuild task of an Encoder which does not support  partial building");
 	}
@@ -225,33 +282,16 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 			"Trying to get the BuildMergeTask task of an Encoder which does not support partial building");
 	}
 
-	public List<DependencyTask<?>> getApplyTasks(FrameBlock in, MatrixBlock out, int outputCol) {
-		return getApplyTasks(in, null, out, outputCol);
-	}
 
-	public List<DependencyTask<?>> getApplyTasks(MatrixBlock in, MatrixBlock out, int outputCol) {
-		return getApplyTasks(null, in, out, outputCol);
-	}
-
-	private List<DependencyTask<?>> getApplyTasks(FrameBlock inF, MatrixBlock inM, MatrixBlock out, int outputCol){
+	public List<DependencyTask<?>> getApplyTasks(CacheBlock in, MatrixBlock out, int outputCol){
 		List<Callable<Object>> tasks = new ArrayList<>();
 		List<List<? extends Callable<?>>> dep = null;
-		if ((inF != null && inM != null) || (inF == null && inM == null))
-			throw new DMLRuntimeException("getApplyTasks needs to be called with either FrameBlock input " +
-					"or MatrixBlock input");
-		int nRows = inF == null ? inM.getNumRows() : inF.getNumRows();
-		int[] blockSizes = getBlockSizes(nRows, getNumApplyRowPartitions());
+		int[] blockSizes = getBlockSizes(in.getNumRows(), getNumApplyRowPartitions());
 		for(int startRow = 0, i = 0; i < blockSizes.length; startRow+=blockSizes[i], i++){
-			if(inF != null)
-				if(out.isInSparseFormat())
-					tasks.add(getSparseTask(inF, out, outputCol, startRow, blockSizes[i]));
-				else
-					tasks.add(new ColumnApplyTask<>(this, inF, out, outputCol, startRow, blockSizes[i]));
-			else
 			if(out.isInSparseFormat())
-				tasks.add(getSparseTask(inM, out, outputCol, startRow, blockSizes[i]));
+				tasks.add(getSparseTask(in, out, outputCol, startRow, blockSizes[i]));
 			else
-				tasks.add(new ColumnApplyTask<>(this, inM, out, outputCol, startRow, blockSizes[i]));
+				tasks.add(getDenseTask(in, out, outputCol, startRow, blockSizes[i]));
 		}
 		if(tasks.size() > 1){
 			dep = new ArrayList<>(Collections.nCopies(tasks.size(), null));
@@ -262,18 +302,34 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 		return DependencyThreadPool.createDependencyTasks(tasks, dep);
 	}
 
-	protected abstract ColumnApplyTask<? extends ColumnEncoder> 
-			getSparseTask(FrameBlock in, MatrixBlock out, int outputCol, int startRow, int blk);
+	protected ColumnApplyTask<? extends ColumnEncoder>
+			getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk){
+		return new ColumnApplyTask<>(this, in, out, outputCol, startRow, blk);
+	}
 
-	protected abstract ColumnApplyTask<? extends ColumnEncoder> 
-			getSparseTask(MatrixBlock in, MatrixBlock out, int outputCol, int startRow, int blk);
+	protected ColumnApplyTask<? extends ColumnEncoder>
+			getDenseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk){
+		return new ColumnApplyTask<>(this, in, out, outputCol, startRow, blk);
+	}
+
+	public Set<Integer> getSparseRowsWZeros(){
+		return _sparseRowsWZeros;
+	}
+
+	protected void addSparseRowsWZeros(Set<Integer> sparseRowsWZeros){
+		synchronized (this){
+			if(_sparseRowsWZeros == null)
+				_sparseRowsWZeros = new HashSet<>();
+			_sparseRowsWZeros.addAll(sparseRowsWZeros);
+		}
+	}
 
 	protected int getNumApplyRowPartitions(){
-		return APPLY_ROW_BLOCKS_PER_COLUMN;
+		return ConfigurationManager.getParallelApplyBlocks();
 	}
 
 	protected int getNumBuildRowPartitions(){
-		return BUILD_ROW_BLOCKS_PER_COLUMN;
+		return ConfigurationManager.getParallelBuildBlocks();
 	}
 
 	public enum EncoderType {
@@ -287,33 +343,19 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 	protected static class ColumnApplyTask<T extends ColumnEncoder> implements Callable<Object> {
 
 		protected final T _encoder;
-		protected final FrameBlock _inputF;
-		protected final MatrixBlock _inputM;
+		protected final CacheBlock _input;
 		protected final MatrixBlock _out;
 		protected final int _outputCol;
 		protected final int _startRow;
 		protected final int _blk;
 
-		protected ColumnApplyTask(T encoder, FrameBlock input, MatrixBlock out, int outputCol){
+		protected ColumnApplyTask(T encoder, CacheBlock input, MatrixBlock out, int outputCol){
 			this(encoder, input, out, outputCol, 0, -1);
 		}
 
-		protected ColumnApplyTask(T encoder, MatrixBlock input, MatrixBlock out, int outputCol){
-			this(encoder, input, out, outputCol, 0, -1);
-		}
-
-		protected ColumnApplyTask(T encoder, FrameBlock input, MatrixBlock out, int outputCol, int startRow, int blk) {
-			this(encoder, input, null, out, outputCol, startRow, blk);
-		}
-
-		protected ColumnApplyTask(T encoder, MatrixBlock input, MatrixBlock out, int outputCol, int startRow, int blk) {
-			this(encoder, null, input, out, outputCol, startRow, blk);
-		}
-		private  ColumnApplyTask(T encoder, FrameBlock inputF, MatrixBlock inputM, MatrixBlock out, int outputCol,
-								 int startRow, int blk){
+		protected ColumnApplyTask(T encoder, CacheBlock input, MatrixBlock out, int outputCol, int startRow, int blk) {
 			_encoder = encoder;
-			_inputM = inputM;
-			_inputF = inputF;
+			_input = input;
 			_out = out;
 			_outputCol = outputCol;
 			_startRow = startRow;
@@ -323,15 +365,7 @@ public abstract class ColumnEncoder implements Externalizable, Encoder, Comparab
 		@Override
 		public Object call() throws Exception {
 			assert _outputCol >= 0;
-			if(_out.isInSparseFormat()){
-				// this is an issue since most sparse Tasks modify the sparse structure so normal get and set calls are
-				// not possible.
-				throw new DMLRuntimeException("ColumnApplyTask called although output is in sparse format.");
-			}
-			if(_inputF == null)
-				_encoder.apply(_inputM, _out, _outputCol, _startRow, _blk);
-			else
-				_encoder.apply(_inputF, _out, _outputCol, _startRow, _blk);
+			_encoder.apply(_input, _out, _outputCol, _startRow, _blk);
 			return null;
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -28,14 +28,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.lops.Lop;
-import org.apache.sysds.runtime.data.SparseRowVector;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.Statistics;
 
 public class ColumnEncoderBin extends ColumnEncoder {
@@ -86,7 +84,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(FrameBlock in) {
+	public void build(CacheBlock in) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		if(!isApplicable())
 			return;
@@ -96,12 +94,33 @@ public class ColumnEncoderBin extends ColumnEncoder {
 			Statistics.incTransformBinningBuildTime(System.nanoTime()-t0);
 	}
 
-	private static double[] getMinMaxOfCol(FrameBlock in, int colID, int startRow, int blockSize) {
+	protected double getCode(CacheBlock in, int row){
+		if( _binMins.length == 0 || _binMaxs.length == 0 ) {
+			LOG.warn("ColumnEncoderBin: applyValue without bucket boundaries, assign 1");
+			return 1; //robustness in case of missing bins
+		}
+		// Returns NaN if value is missing, so can't be assigned a Bin
+		double inVal = in.getDoubleNaN(row, _colID - 1);
+		if (Double.isNaN(inVal) || inVal < _binMins[0] || inVal > _binMaxs[_binMaxs.length-1] )
+			return Double.NaN;
+		int ix = Arrays.binarySearch(_binMaxs, inVal);
+
+		return ((ix < 0) ? Math.abs(ix + 1) : ix) + 1;
+	}
+
+	@Override
+	protected TransformType getTransformType() {
+		return TransformType.BIN;
+	}
+
+	private static double[] getMinMaxOfCol(CacheBlock in, int colID, int startRow, int blockSize) {
 		// derive bin boundaries from min/max per column
 		double min = Double.POSITIVE_INFINITY;
 		double max = Double.NEGATIVE_INFINITY;
 		for(int i = startRow; i < getEndIndex(in.getNumRows(), startRow, blockSize); i++) {
-			double inVal = UtilFunctions.objectToDouble(in.getSchema()[colID - 1], in.get(i, colID - 1));
+			double inVal = in.getDouble(i, colID - 1);
+			if(Double.isNaN(inVal))
+				continue;
 			min = Math.min(min, inVal);
 			max = Math.max(max, inVal);
 		}
@@ -109,13 +128,13 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	@Override
-	public Callable<Object> getBuildTask(FrameBlock in) {
+	public Callable<Object> getBuildTask(CacheBlock in) {
 		return new ColumnBinBuildTask(this, in);
 	}
 
 	@Override
-	public Callable<Object> getPartialBuildTask(FrameBlock in, int startRow, int blockSize,
-		HashMap<Integer, Object> ret) {
+	public Callable<Object> getPartialBuildTask(CacheBlock in, int startRow, int blockSize, 
+			HashMap<Integer, Object> ret) {
 		return new BinPartialBuildTask(in, _colID, startRow, blockSize, ret);
 	}
 
@@ -152,55 +171,9 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	@Override
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		for(int i = rowStart; i < getEndIndex(in.getNumRows(), rowStart, blk); i++) {
-			double inVal = UtilFunctions.objectToDouble(in.getSchema()[_colID - 1], in.get(i, _colID - 1));
-			double binID = applyValue(inVal);
-			out.quickSetValue(i, outputCol, binID);
-		}
-		if (DMLScript.STATISTICS)
-			Statistics.incTransformBinningApplyTime(System.nanoTime()-t0);
-		return out;
-	}
-
-	@Override
-	public MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		int end = getEndIndex(in.getNumRows(), rowStart, blk);
-		for(int i = rowStart; i < end; i++) {
-			double inVal = in.quickGetValueThreadSafe(i, _colID - 1);
-			double binID = applyValue(inVal);
-			out.quickSetValue(i, outputCol, binID);
-		}
-		if (DMLScript.STATISTICS)
-			Statistics.incTransformBinningApplyTime(System.nanoTime()-t0);
-		return out;
-	}
-	
-	private double applyValue(double inVal) {
-		if( _binMins.length == 0 || _binMaxs.length == 0 ) {
-			LOG.warn("ColumnEncoderBin: applyValue without bucket boundaries, assign 1");
-			return 1; //robustness in case of missing bins
-		}
-		if( inVal < _binMins[0] || inVal > _binMaxs[_binMaxs.length-1] ) {
-			return Double.NaN; //value outside min/max range
-		}
-		int ix = Arrays.binarySearch(_binMaxs, inVal);
-		int binID = ((ix < 0) ? Math.abs(ix + 1) : ix) + 1;
-		return binID;
-	}
-
-	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(FrameBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new BinSparseApplyTask(this, in, out, outputCol);
-	}
-
-	@Override
-	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(MatrixBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
-		throw new NotImplementedException("Sparse Binning for MatrixBlocks not jet implemented");
 	}
 
 	@Override
@@ -291,28 +264,20 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class BinSparseApplyTask extends ColumnApplyTask<ColumnEncoderBin> {
 
-		public BinSparseApplyTask(ColumnEncoderBin encoder, FrameBlock input, 
+		public BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock input,
 				MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
-		private BinSparseApplyTask(ColumnEncoderBin encoder, FrameBlock input, MatrixBlock out, int outputCol) {
+		private BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock input, MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
 		public Object call() throws Exception {
 			long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-			int index = _encoder._colID - 1;
 			if(_out.getSparseBlock() == null)
 				return null;
-			assert _inputF != null;
-			for(int r = _startRow; r < getEndIndex(_inputF.getNumRows(), _startRow, _blk); r++) {
-				SparseRowVector row = (SparseRowVector) _out.getSparseBlock().get(r);
-				double inVal = UtilFunctions.objectToDouble(_inputF.getSchema()[index], _inputF.get(r, index));
-				double binID = _encoder.applyValue(inVal);
-				row.values()[index] = binID;
-				row.indexes()[index] = _outputCol;
-			}
+			_encoder.applySparse(_input, _out, _outputCol, _startRow, _blk);
 			if(DMLScript.STATISTICS)
 				Statistics.incTransformBinningApplyTime(System.nanoTime()-t0);
 			return null;
@@ -326,15 +291,15 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class BinPartialBuildTask implements Callable<Object> {
 
-		private final FrameBlock _input;
+		private final CacheBlock _input;
 		private final int _blockSize;
 		private final int _startRow;
 		private final int _colID;
 		private final HashMap<Integer, Object> _partialMinMax;
 
 		// if a pool is passed the task may be split up into multiple smaller tasks.
-		protected BinPartialBuildTask(FrameBlock input, int colID, int startRow, int blocksize,
-			HashMap<Integer, Object> partialMinMax) {
+		protected BinPartialBuildTask(CacheBlock input, int colID, int startRow, 
+				int blocksize, HashMap<Integer, Object> partialMinMax) {
 			_input = input;
 			_blockSize = blocksize;
 			_colID = colID;
@@ -393,9 +358,9 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class ColumnBinBuildTask implements Callable<Object> {
 		private final ColumnEncoderBin _encoder;
-		private final FrameBlock _input;
+		private final CacheBlock _input;
 
-		protected ColumnBinBuildTask(ColumnEncoderBin encoder, FrameBlock input) {
+		protected ColumnBinBuildTask(ColumnEncoderBin encoder, CacheBlock input) {
 			_encoder = encoder;
 			_input = input;
 		}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
@@ -19,17 +19,13 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
-import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.List;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.api.DMLScript;
-import org.apache.sysds.runtime.DMLRuntimeException;
-import org.apache.sysds.runtime.data.SparseRowVector;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.DependencyTask;
@@ -58,64 +54,37 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 		super(-1);
 		_K = 0;
 	}
+	public long getK(){
+		return _K;
+	}
 
-	private long getCode(String key) {
+	@Override
+	protected TransformType getTransformType() {
+		return TransformType.FEATURE_HASH;
+	}
+
+	@Override
+	protected double getCode(CacheBlock in, int row) {
+		String key = in.getString(row, _colID - 1);
+		if(key == null)
+			return Double.NaN;
 		return (key.hashCode() % _K) + 1;
 	}
 
 	@Override
-	public void build(FrameBlock in) {
+	public void build(CacheBlock in) {
 		// do nothing (no meta data other than K)
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(FrameBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
 		return null;
 	}
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(FrameBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new FeatureHashSparseApplyTask(this, in, out, outputCol, startRow, blk);
-	}
-
-	@Override
-	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(MatrixBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
-		throw new NotImplementedException("Sparse FeatureHashing for MatrixBlocks not jet implemented");
-	}
-
-	@Override
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		// apply feature hashing column wise
-		for(int i = rowStart; i < getEndIndex(in.getNumRows(), rowStart, blk); i++) {
-			Object okey = in.get(i, _colID - 1);
-			String key = (okey != null) ? okey.toString() : null;
-			if(key == null)
-				throw new DMLRuntimeException("Missing Value encountered in input Frame for FeatureHash");
-			long code = getCode(key);
-			out.quickSetValue(i, outputCol, (code >= 0) ? code : Double.NaN);
-		}
-		if(DMLScript.STATISTICS)
-			Statistics.incTransformFeatureHashingApplyTime(System.nanoTime()-t0);
-		return out;
-	}
-
-	@Override
-	public MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		int end = getEndIndex(in.getNumRows(), rowStart, blk);
-		// apply feature hashing column wise
-		for(int i = rowStart; i < end; i++) {
-			Object okey = in.quickGetValueThreadSafe(i, _colID - 1);
-			String key = okey.toString();
-			long code = getCode(key);
-			out.quickSetValue(i, outputCol, (code >= 0) ? code : Double.NaN);
-		}
-		if(DMLScript.STATISTICS)
-			Statistics.incTransformFeatureHashingApplyTime(System.nanoTime()-t0);
-		return out;
 	}
 
 	@Override
@@ -160,12 +129,12 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 
 	public static class FeatureHashSparseApplyTask extends ColumnApplyTask<ColumnEncoderFeatureHash>{
 
-		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, FrameBlock input, 
+		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock input,
 				MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
-		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, FrameBlock input, 
+		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock input,
 				MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
@@ -175,18 +144,7 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 			if(_out.getSparseBlock() == null)
 				return null;
 			long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-			int index = _encoder._colID - 1;
-			assert _inputF != null;
-			for(int r = _startRow; r < getEndIndex(_inputF.getNumRows(), _startRow, _blk); r++){
-				SparseRowVector row = (SparseRowVector) _out.getSparseBlock().get(r);
-				Object okey = _inputF.get(r, index);
-				String key = (okey != null) ? okey.toString() : null;
-				if(key == null)
-					throw new DMLRuntimeException("Missing Value encountered in input Frame for FeatureHash");
-				long code = _encoder.getCode(key);
-				row.values()[index] = code;
-				row.indexes()[index] = _outputCol;
-			}
+			_encoder.applySparse(_input, _out, _outputCol, _startRow, _blk);
 			if(DMLScript.STATISTICS)
 				Statistics.incTransformFeatureHashingApplyTime(System.nanoTime()-t0);
 			return null;

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -21,22 +21,20 @@ package org.apache.sysds.runtime.transform.encode;
 
 import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.api.DMLScript;
-import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.data.SparseRowVector;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.DependencyTask;
-import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.Statistics;
 
 public class ColumnEncoderPassThrough extends ColumnEncoder {
 	private static final long serialVersionUID = -8473768154646831882L;
-	private List<Integer> sparseRowsWZeros = null;
 
 	protected ColumnEncoderPassThrough(int ptCols) {
 		super(ptCols); // 1-based
@@ -46,65 +44,52 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 		this(-1);
 	}
 
-	public List<Integer> getSparseRowsWZeros(){
-		return sparseRowsWZeros;
-	}
-
 	@Override
-	public void build(FrameBlock in) {
+	public void build(CacheBlock in) {
 		// do nothing
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(FrameBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
 		return null;
 	}
 
 	@Override
-	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(FrameBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+	protected ColumnApplyTask<? extends ColumnEncoder>
+		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new PassThroughSparseApplyTask(this, in, out, outputCol, startRow, blk);
 	}
 
 	@Override
-	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(MatrixBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
-		throw new NotImplementedException("Sparse PassThrough for MatrixBlocks not jet implemented");
+	protected double getCode(CacheBlock in, int row) {
+		return in.getDoubleNaN(row, _colID - 1);
+	}
+
+
+	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+		Set<Integer> sparseRowsWZeros = null;
+		int index = _colID - 1;
+		for(int r = rowStart; r < getEndIndex(in.getNumRows(), rowStart, blk); r++) {
+			double v = getCode(in, r);
+			SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(r);
+			if(v == 0) {
+				if(sparseRowsWZeros == null)
+					sparseRowsWZeros = new HashSet<>();
+				sparseRowsWZeros.add(r);
+			}
+			row.values()[index] = v;
+			row.indexes()[index] = outputCol;
+		}
+		if(sparseRowsWZeros != null){
+			addSparseRowsWZeros(sparseRowsWZeros);
+		}
 	}
 
 	@Override
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		int col = _colID - 1; // 1-based
-		ValueType vt = in.getSchema()[col];
-		for(int i = rowStart; i < getEndIndex(in.getNumRows(), rowStart, blk); i++) {
-			Object val = in.get(i, col);
-			double v = (val == null ||
-				(vt == ValueType.STRING && val.toString().isEmpty())) 
-					? Double.NaN : UtilFunctions.objectToDouble(vt, val);
-			out.quickSetValue(i, outputCol, v);
-		}
-		if(DMLScript.STATISTICS)
-			Statistics.incTransformPassThroughApplyTime(System.nanoTime()-t0);
-		return out;
+	protected TransformType getTransformType() {
+		return TransformType.PASS_THROUGH;
 	}
 
-	@Override
-	public MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		// only transfer from in to out
-		if(in == out)
-			return out;
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		int col = _colID - 1; // 1-based
-		int end = getEndIndex(in.getNumRows(), rowStart, blk);
-		for(int i = rowStart; i < end; i++) {
-			double val = in.quickGetValueThreadSafe(i, col);
-			out.quickSetValue(i, outputCol, val);
-		}
-		if(DMLScript.STATISTICS)
-			Statistics.incTransformPassThroughApplyTime(System.nanoTime()-t0);
-		return out;
-	}
 
 	@Override
 	public void mergeAt(ColumnEncoder other) {
@@ -128,13 +113,13 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 	public static class PassThroughSparseApplyTask extends ColumnApplyTask<ColumnEncoderPassThrough>{
 
 
-		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, FrameBlock input, 
+		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, CacheBlock input,
 				MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
-		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, FrameBlock input, MatrixBlock out, 
-				int outputCol, int startRow, int blk) {
+		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, 
+				CacheBlock input, MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
@@ -143,30 +128,7 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 			if(_out.getSparseBlock() == null)
 				return null;
 			long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-			int index = _encoder._colID - 1;
-			assert _inputF != null;
-			List<Integer> sparseRowsWZeros = null;
-			ValueType vt = _inputF.getSchema()[index];
-			for(int r = _startRow; r < getEndIndex(_inputF.getNumRows(), _startRow, _blk); r++) {
-				Object val = _inputF.get(r, index);
-				double v = (val == null || (vt == ValueType.STRING && val.toString().isEmpty())) ?
-						Double.NaN : UtilFunctions.objectToDouble(vt, val);
-				SparseRowVector row = (SparseRowVector) _out.getSparseBlock().get(r);
-				if(v == 0) {
-					if(sparseRowsWZeros == null)
-						sparseRowsWZeros = new ArrayList<>();
-					sparseRowsWZeros.add(r);
-				}
-				row.values()[index] = v;
-				row.indexes()[index] = _outputCol;
-			}
-			if(sparseRowsWZeros != null){
-				synchronized (_encoder){
-					if(_encoder.sparseRowsWZeros == null)
-						_encoder.sparseRowsWZeros = new ArrayList<>();
-					_encoder.sparseRowsWZeros.addAll(sparseRowsWZeros);
-				}
-			}
+			_encoder.applySparse(_input, _out, _outputCol, _startRow, _blk);
 			if(DMLScript.STATISTICS)
 				Statistics.incTransformPassThroughApplyTime(System.nanoTime()-t0);
 			return null;

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
@@ -27,7 +27,6 @@ import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -35,8 +34,7 @@ import java.util.concurrent.Callable;
 
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.lops.Lop;
-import org.apache.sysds.runtime.DMLRuntimeException;
-import org.apache.sysds.runtime.data.SparseRowVector;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.utils.Statistics;
@@ -114,16 +112,12 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 			putCode(map, key);
 	}
 
-	private static void makeRcdMap(FrameBlock in, HashMap<String, Long> map, int colID, int startRow, int blk) {
-		Iterator<String[]> iter = in.getStringRowIterator(startRow, getEndIndex(in.getNumRows(), startRow, blk), colID);
-		while(iter.hasNext()) {
-			String[] row = iter.next();
-			// probe and build column map
-			String key = row[0]; // 0 since there is only one column in the row
+	private static void makeRcdMap(CacheBlock in, HashMap<String, Long> map, int colID, int startRow, int blk) {
+		for(int row = startRow; row < getEndIndex(in.getNumRows(), startRow, blk); row++){
+			String key = in.getString(row, colID - 1);
 			if(key != null && !key.isEmpty() && !map.containsKey(key))
 				putCode(map, key);
 		}
-
 		if(SORT_RECODE_MAP) {
 			sortCPRecodeMaps(map);
 		}
@@ -135,7 +129,12 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(FrameBlock in) {
+	protected TransformType getTransformType() {
+		return TransformType.RECODE;
+	}
+
+	@Override
+	public void build(CacheBlock in) {
 		if(!isApplicable())
 			return;
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
@@ -146,13 +145,13 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	}
 
 	@Override
-	public Callable<Object> getBuildTask(FrameBlock in) {
+	public Callable<Object> getBuildTask(CacheBlock in) {
 		return new ColumnRecodeBuildTask(this, in);
 	}
 
 	@Override
-	public Callable<Object> getPartialBuildTask(FrameBlock in, int startRow, int blockSize,
-		HashMap<Integer, Object> ret) {
+	public Callable<Object> getPartialBuildTask(CacheBlock in, int startRow, 
+			int blockSize, HashMap<Integer, Object> ret) {
 		return new RecodePartialBuildTask(in, _colID, startRow, blockSize, ret);
 	}
 
@@ -169,6 +168,15 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	 */
 	protected static void putCode(HashMap<String, Long> map, String key) {
 		map.put(key, (long) (map.size() + 1));
+	}
+
+	protected double getCode(CacheBlock in, int r){
+		Object okey = in.getString(r, _colID - 1);
+		String key = (okey != null) ? okey.toString() : null;
+		if(key == null || key.isEmpty())
+			return Double.NaN;
+		long code = lookupRCDMap(key);
+		return (code < 0) ? Double.NaN : code;
 	}
 
 	@Override
@@ -192,39 +200,11 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 		_rcdMapPart.remove("");
 	}
 
-	@Override
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		// FrameBlock is column Major and MatrixBlock row Major this results in cache inefficiencies :(
-		for(int i = rowStart; i < getEndIndex(in.getNumRows(), rowStart, blk); i++) {
-			Object okey = in.get(i, _colID - 1);
-			String key = (okey != null) ? okey.toString() : null;
-			long code = lookupRCDMap(key);
-			out.quickSetValue(i, outputCol, (code >= 0) ? code : Double.NaN);
-		}
-		if(DMLScript.STATISTICS){
-			Statistics.incTransformRecodeApplyTime(System.nanoTime() - t0);
-		}
-		return out;
-	}
-
-	@Override
-	public MatrixBlock apply(MatrixBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
-		throw new DMLRuntimeException(
-			"Recode called with MatrixBlock. Should not happen since Recode is the first " + "encoder in the Stack");
-	}
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(FrameBlock in, MatrixBlock out, int outputCol, int startRow, int blk){
+		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk){
 		return new RecodeSparseApplyTask(this, in ,out, outputCol, startRow, blk);
-	}
-
-	@Override
-	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(MatrixBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
-		throw new DMLRuntimeException("Recode called with MatrixBlock. Should not happen since Recode is the first " +
-				"encoder in the Stack");
 	}
 
 	@Override
@@ -328,30 +308,20 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 
 	private static class RecodeSparseApplyTask extends ColumnApplyTask<ColumnEncoderRecode>{
 
-		public RecodeSparseApplyTask(ColumnEncoderRecode encoder, FrameBlock input, MatrixBlock out, int outputCol) {
+		public RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock input, MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
-		protected RecodeSparseApplyTask(ColumnEncoderRecode encoder, FrameBlock input, MatrixBlock out, 
-				int outputCol, int startRow, int blk) {
+		protected RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock input, MatrixBlock out,
+										int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
 		public Object call() throws Exception {
-			int index = _encoder._colID - 1;
 			long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 			if(_out.getSparseBlock() == null)
 				return null;
-			assert _inputF != null;
-			for(int r = _startRow; r < getEndIndex(_inputF.getNumRows(), _startRow, _blk); r++) {
-				SparseRowVector row = (SparseRowVector) _out.getSparseBlock().get(r);
-				Object okey = _inputF.get(r, index);
-				String key = (okey != null) ? okey.toString() : null;
-				long code = _encoder.lookupRCDMap(key);
-				double val = (code < 0) ? Double.NaN : code;
-				row.values()[index] = val;
-				row.indexes()[index] = _outputCol;
-			}
+			_encoder.applySparse(_input, _out, _outputCol, _startRow, _blk);
 			if(DMLScript.STATISTICS){
 				Statistics.incTransformRecodeApplyTime(System.nanoTime() - t0);
 			}
@@ -370,14 +340,14 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 
 	private static class RecodePartialBuildTask implements Callable<Object> {
 
-		private final FrameBlock _input;
+		private final CacheBlock _input;
 		private final int _blockSize;
 		private final int _startRow;
 		private final int _colID;
 		private final HashMap<Integer, Object> _partialMaps;
 
-		protected RecodePartialBuildTask(FrameBlock input, int colID, int startRow, int blocksize,
-			HashMap<Integer, Object> partialMaps) {
+		protected RecodePartialBuildTask(CacheBlock input, int colID, int startRow, 
+				int blocksize, HashMap<Integer, Object> partialMaps) {
 			_input = input;
 			_blockSize = blocksize;
 			_colID = colID;
@@ -442,9 +412,9 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	private static class ColumnRecodeBuildTask implements Callable<Object> {
 
 		private final ColumnEncoderRecode _encoder;
-		private final FrameBlock _input;
+		private final CacheBlock _input;
 
-		protected ColumnRecodeBuildTask(ColumnEncoderRecode encoder, FrameBlock input) {
+		protected ColumnRecodeBuildTask(ColumnEncoderRecode encoder, CacheBlock input) {
 			_encoder = encoder;
 			_input = input;
 		}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.transform.encode;
 
 import java.io.Externalizable;
 
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
@@ -35,7 +36,7 @@ public interface Encoder extends Externalizable {
 	 *
 	 * @param in input frame block
 	 */
-	void build(FrameBlock in);
+	void build(CacheBlock in);
 
 	/**
 	 * Apply the generated metadata to the FrameBlock and saved the result in out.
@@ -45,7 +46,7 @@ public interface Encoder extends Externalizable {
 	 * @param outputCol is a offset in the output matrix. column in FrameBlock + outputCol = column in out
 	 * @return output matrix block
 	 */
-	MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol);
+	MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol);
 
 	/**
 	 * Construct a frame block out of the transform meta data.

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -41,6 +41,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.data.SparseBlockMCSR;
 import org.apache.sysds.runtime.data.SparseRowVector;
@@ -57,7 +58,7 @@ public class MultiColumnEncoder implements Encoder {
 	protected static final Log LOG = LogFactory.getLog(MultiColumnEncoder.class.getName());
 	private static final boolean MULTI_THREADED = true;
 	// If true build and apply separately by placing a synchronization barrier
-	public static boolean MULTI_THREADED_STAGES = false;  
+	public static boolean MULTI_THREADED_STAGES = false;
 
 	// Only affects if  MULTI_THREADED_STAGES is true
 	// if true apply tasks for each column will complete
@@ -79,11 +80,11 @@ public class MultiColumnEncoder implements Encoder {
 		_columnEncoders = new ArrayList<>();
 	}
 
-	public MatrixBlock encode(FrameBlock in) {
+	public MatrixBlock encode(CacheBlock in) {
 		return encode(in, 1);
 	}
 
-	public MatrixBlock encode(FrameBlock in, int k) {
+	public MatrixBlock encode(CacheBlock in, int k) {
 		MatrixBlock out;
 		try {
 			if(MULTI_THREADED && k > 1 && !MULTI_THREADED_STAGES && !hasLegacyEncoder()) {
@@ -122,7 +123,7 @@ public class MultiColumnEncoder implements Encoder {
 		return out;
 	}
 
-	private List<DependencyTask<?>> getEncodeTasks(FrameBlock in, MatrixBlock out, DependencyThreadPool pool) {
+	private List<DependencyTask<?>> getEncodeTasks(CacheBlock in, MatrixBlock out, DependencyThreadPool pool) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		List<DependencyTask<?>> applyTAgg = null;
 		Map<Integer[], Integer[]> depMap = new HashMap<>();
@@ -179,11 +180,13 @@ public class MultiColumnEncoder implements Encoder {
 		return DependencyThreadPool.createDependencyTasks(tasks, deps);
 	}
 
-	public void build(FrameBlock in) {
+	public void build(CacheBlock in) {
 		build(in, 1);
 	}
 
-	public void build(FrameBlock in, int k) {
+	public void build(CacheBlock in, int k) {
+		if(hasLegacyEncoder() && !(in instanceof FrameBlock))
+			throw new DMLRuntimeException("LegacyEncoders do not support non FrameBlock Inputs");
 		if(MULTI_THREADED && k > 1) {
 			buildMT(in, k);
 		}
@@ -193,10 +196,11 @@ public class MultiColumnEncoder implements Encoder {
 				columnEncoder.updateAllDCEncoders();
 			}
 		}
-		legacyBuild(in);
+		if(hasLegacyEncoder())
+			legacyBuild((FrameBlock) in);
 	}
 
-	private List<DependencyTask<?>> getBuildTasks(FrameBlock in) {
+	private List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		for(ColumnEncoderComposite columnEncoder : _columnEncoders) {
 			tasks.addAll(columnEncoder.getBuildTasks(in));
@@ -204,7 +208,7 @@ public class MultiColumnEncoder implements Encoder {
 		return tasks;
 	}
 
-	private void buildMT(FrameBlock in, int k) {
+	private void buildMT(CacheBlock in, int k) {
 		DependencyThreadPool pool = new DependencyThreadPool(k);
 		try {
 			pool.submitAllAndWait(getBuildTasks(in));
@@ -223,11 +227,12 @@ public class MultiColumnEncoder implements Encoder {
 			_legacyMVImpute.build(in);
 	}
 
-	public MatrixBlock apply(FrameBlock in) {
+
+	public MatrixBlock apply(CacheBlock in) {
 		return apply(in, 1);
 	}
 
-	public MatrixBlock apply(FrameBlock in, int k) {
+	public MatrixBlock apply(CacheBlock in, int k) {
 		int numCols = in.getNumColumns() + getNumExtraCols();
 		long estNNz = (long) in.getNumColumns() * (long) in.getNumRows();
 		boolean sparse = MatrixBlock.evalSparseFormatInMemory(in.getNumRows(), numCols, estNNz);
@@ -235,20 +240,22 @@ public class MultiColumnEncoder implements Encoder {
 		return apply(in, out, 0, k);
 	}
 
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol) {
+	public MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol) {
 		return apply(in, out, outputCol, 1);
 	}
 
-	public MatrixBlock apply(FrameBlock in, MatrixBlock out, int outputCol, int k) {
+	public MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol, int k) {
 		// There should be a encoder for every column
+		if(hasLegacyEncoder() && !(in instanceof FrameBlock))
+			throw new DMLRuntimeException("LegacyEncoders do not support non FrameBlock Inputs");
 		int numEncoders = getFromAll(ColumnEncoderComposite.class, ColumnEncoder::getColID).size();
 		if(in.getNumColumns() != numEncoders)
 			throw new DMLRuntimeException("Not every column in has a CompositeEncoder. Please make sure every column "
 				+ "has a encoder or slice the input accordingly");
 		// TODO smart checks
+		// Block allocation for MT access
+		outputMatrixPreProcessing(out, in);
 		if(MULTI_THREADED && k > 1) {
-			// Block allocation for MT access
-			outputMatrixPreProcessing(out, in);
 			applyMT(in, out, outputCol, k);
 		}
 		else {
@@ -263,14 +270,14 @@ public class MultiColumnEncoder implements Encoder {
 		// TODO set NNZ explicit count them in the encoders
 		outputMatrixPostProcessing(out);
 		if(_legacyOmit != null)
-			out = _legacyOmit.apply(in, out);
+			out = _legacyOmit.apply((FrameBlock) in, out);
 		if(_legacyMVImpute != null)
-			out = _legacyMVImpute.apply(in, out);
+			out = _legacyMVImpute.apply((FrameBlock) in, out);
 
 		return out;
 	}
 
-	private List<DependencyTask<?>> getApplyTasks(FrameBlock in, MatrixBlock out, int outputCol) {
+	private List<DependencyTask<?>> getApplyTasks(CacheBlock in, MatrixBlock out, int outputCol) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		int offset = outputCol;
 		for(ColumnEncoderComposite e : _columnEncoders) {
@@ -281,7 +288,7 @@ public class MultiColumnEncoder implements Encoder {
 		return tasks;
 	}
 
-	private void applyMT(FrameBlock in, MatrixBlock out, int outputCol, int k) {
+	private void applyMT(CacheBlock in, MatrixBlock out, int outputCol, int k) {
 		DependencyThreadPool pool = new DependencyThreadPool(k);
 		try {
 			if(APPLY_ENCODER_SEPARATE_STAGES){
@@ -302,7 +309,7 @@ public class MultiColumnEncoder implements Encoder {
 		pool.shutdown();
 	}
 
-	private static void outputMatrixPreProcessing(MatrixBlock output, FrameBlock input) {
+	private static void outputMatrixPreProcessing(MatrixBlock output, CacheBlock input) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		output.allocateBlock();
 		if(output.isInSparseFormat()) {
@@ -326,8 +333,8 @@ public class MultiColumnEncoder implements Encoder {
 
 	private void outputMatrixPostProcessing(MatrixBlock output){
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		Set<Integer> indexSet = getColumnEncoders(ColumnEncoderPassThrough.class).stream()
-				.map(ColumnEncoderPassThrough::getSparseRowsWZeros).flatMap(l -> {
+		Set<Integer> indexSet = _columnEncoders.stream()
+				.map(ColumnEncoderComposite::getSparseRowsWZeros).flatMap(l -> {
 					if(l == null)
 						return null;
 					return l.stream();
@@ -740,10 +747,10 @@ public class MultiColumnEncoder implements Encoder {
 
 	private static class InitOutputMatrixTask implements Callable<Object> {
 		private final MultiColumnEncoder _encoder;
-		private final FrameBlock _input;
+		private final CacheBlock _input;
 		private final MatrixBlock _output;
 
-		private InitOutputMatrixTask(MultiColumnEncoder encoder, FrameBlock input, MatrixBlock output) {
+		private InitOutputMatrixTask(MultiColumnEncoder encoder, CacheBlock input, MatrixBlock output) {
 			_encoder = encoder;
 			_input = input;
 			_output = output;
@@ -769,12 +776,12 @@ public class MultiColumnEncoder implements Encoder {
 	private static class ApplyTasksWrapperTask extends DependencyWrapperTask<Object> {
 		private final ColumnEncoder _encoder;
 		private final MatrixBlock _out;
-		private final FrameBlock _in;
+		private final CacheBlock _in;
 		private int _offset = -1; // offset dude to dummycoding in
 									// previous columns needs to be updated by external task!
 
-		private ApplyTasksWrapperTask(ColumnEncoder encoder, FrameBlock in, MatrixBlock out,
-			DependencyThreadPool pool) {
+		private ApplyTasksWrapperTask(ColumnEncoder encoder, CacheBlock in, 
+				MatrixBlock out, DependencyThreadPool pool) {
 			super(pool);
 			_encoder = encoder;
 			_out = out;

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
@@ -44,8 +44,9 @@ public class TransformFrameEncodeMultithreadedTest extends AutomatedTestBase {
 	private final static String TEST_CLASS_DIR = TEST_DIR + TransformFrameEncodeMultithreadedTest.class.getSimpleName()
 		+ "/";
 
-	// dataset and transform tasks without missing values
+	// Datasets and transform tasks without missing values
 	private final static String DATASET1 = "homes3/homes.csv";
+	//private final static String DATASET2 = "homes/homes.csv"; // missing vals
 	private final static String SPEC1 = "homes3/homes.tfspec_recode.json";
 	private final static String SPEC2 = "homes3/homes.tfspec_dummy.json";
 	private final static String SPEC2sparse = "homes3/homes.tfspec_dummy_sparse.json";


### PR DESCRIPTION
…formations

This patch introduces the Transformable Interface which defines the needed
functions for the Encoders. It is implemented by the MatrixBlock and FrameBlock.
This interface merges code paths for Multi- and Single-threaded operations and
makes the code more readable.
There is still redundant code in SparseApply Tasks. Those can be removed in the
future but at the moment they help in debugging.
Furthermore, this patch reworked the missing value handling in the encoders.