### PR TITLE
[MINOR] Add dry run to pypi upload script

### DIFF
--- a/dev/release/pypi-upload.sh
+++ b/dev/release/pypi-upload.sh
@@ -43,8 +43,8 @@ read -p "RELEASE_TAG : " RELEASE_TAG
 
 BASE_DIR=$PWD # SystemDS top level folder
 
-# Checkout the voted commit and build the publish distribution
 git checkout $RELEASE_TAG
+printf "\n Checkout $RELEASE_TAG for building artifacts \n"
 
 mvn clean package -P distribution
 
@@ -52,7 +52,20 @@ cd $BASE_DIR/src/main/python
 
 # Steps:
 # 1. update systemds/project_info.py with the new version
-sed -i "s/$RELEASE_VERSION-SNAPSHOT/$RELEASE_TAG/" systemds/project_info.py
+
+printf "\n ======== "
+printf "\nA release candidate (RC) after successful voting will be called Approved release version\n"
+printf "Is this RC voted and approved by PMC? [Yes/No]: \n"
+
+# case and select
+# Docs: https://www.gnu.org/software/bash/manual/bash.html#index-case
+select yn in "Yes" "No"; do
+  case $yn in
+      Yes ) sed -i "s/$RELEASE_VERSION-SNAPSHOT/$RELEASE_VERSION/" systemds/project_info.py; break ;;
+      No ) sed -i "s/$RELEASE_VERSION-SNAPSHOT/$RELEASE_TAG/" systemds/project_info.py; break ;;
+      * ) echo "Yes or No response is required.";;
+  esac
+done
 
 # 2. generate distribution archives
 python3 create_python_dist.py


### PR DESCRIPTION
**Usage:**

For publish to test.pypi.org

```bash
./dev/release/pypi-upload.sh -n
```

Publish to pypi.org

```bash
./dev/release/pypi-upload.sh
```

> 🌩 Includes a logic for updating version name to `2.2.0` instead of `2.2.0-rc1` for the approved candidate.