### PR TITLE
[SYSTEMDS-3193] Promote svn repo `dev/systemds/2.x-rc` to `release/systemds/2.x`

### DIFF
--- a/dev/release/release-to-svn.sh
+++ b/dev/release/release-to-svn.sh
@@ -69,8 +69,7 @@ cd svn-release-systemds
 
 if [[ $dry_run_flag != 1 ]]; then
   # This step prompts for the Apache Credentials
-  svn info
-#   svn ci --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache
+  svn ci --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache
   echo $?
 else
   printf "\n==========\n"

--- a/dev/release/release-to-svn.sh
+++ b/dev/release/release-to-svn.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+################################################################################
+##  File:  release-to-svn.sh
+##  Desc:  Promote release candidate from dev/systemds to release/systemds
+################################################################################
+
+SELF=$(cd $(dirname $0) && pwd)
+
+
+RELEASE_STAGING_LOCATION="https://dist.apache.org/repos/dist/dev/systemds"
+RELEASE_LOCATION="https://dist.apache.org/repos/dist/dev/systemds"
+
+RELEASE_VERSION=2.2.0
+APPROVED_RELEASE_TAG=2.2.0-rc1
+
+svn co $RELEASE_STAGING_LOCATION svn-dev-systemds
+svn co --depth=empty $RELEASE_LOCATION svn-release-systemds
+mkdir -p svn-release-systemds/$RELEASE_VERSION
+
+cp svn-dev-systemds/${APPROVED_RELEASE_TAG}/systemds-* svn-release-systemds/$RELEASE_VERSION
+
+svn add svn-release-systemds/$RELEASE_VERSION
+
+cd svn-release-systemds
+svn ci --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache

--- a/dev/release/release-to-svn.sh
+++ b/dev/release/release-to-svn.sh
@@ -70,7 +70,7 @@ cd svn-release-systemds
 if [[ $dry_run_flag != 1 ]]; then
   # This step prompts for the Apache Credentials
   svn ci --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache
-  echo $?
+  [[ $? == 0 ]] && printf "\n Publishing to $RELEASE_LOCATION is complete!\n"
 else
   printf "\n==========\n"
   printf "This step would commit to the SVN release repo\n"

--- a/dev/release/svn-staging-to-release.sh
+++ b/dev/release/svn-staging-to-release.sh
@@ -23,6 +23,7 @@
 ################################################################################
 ##  File:  release-to-svn.sh
 ##  Desc:  Promote release candidate from svn dev/systemds to release/systemds
+##  Note:  This file to be run only after the succesful voting
 ################################################################################
 
 SELF=$(cd $(dirname $0) && pwd)
@@ -69,8 +70,11 @@ cd svn-release-systemds
 
 if [[ $dry_run_flag != 1 ]]; then
   # This step prompts for the Apache Credentials
-  svn ci --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache
-  [[ $? == 0 ]] && printf "\n Publishing to $RELEASE_LOCATION is complete!\n"
+  printf "\n==========\n"
+  printf "You might want to manually check the files and run the following:\n"
+  printf "svn ci --username $ASF_USERNAME --password $ASF_PASSWORD -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache"
+  printf "[[ $? == 0 ]] && printf '\n Publishing to $RELEASE_LOCATION is complete!\n'"
+  printf "\n==========\n"
 else
   printf "\n==========\n"
   printf "This step would commit to the SVN release repo\n"

--- a/dev/release/svn-staging-to-release.sh
+++ b/dev/release/svn-staging-to-release.sh
@@ -43,8 +43,12 @@ RELEASE_LOCATION="https://dist.apache.org/repos/dist/release/systemds"
 RELEASE_VERSION=
 APPROVED_RELEASE_TAG=
 
+ASF_USERNAME=
+
 read -p "RELEASE_VERSION : " RELEASE_VERSION
 read -p "APPROVED_RELEASE_TAG : " APPROVED_RELEASE_TAG
+
+read -p "ASF_USERNAME : " ASF_USERNAME
 
 tmp_repo=$(mktemp -d systemds-repo-tmp-XXXXX)
 
@@ -70,17 +74,16 @@ cd svn-release-systemds
 
 if [[ $dry_run_flag != 1 ]]; then
   # This step prompts for the Apache Credentials
-  printf "\n==========\n"
-  printf "You might want to manually check the files and run the following:\n"
-  printf "svn ci --username $ASF_USERNAME --password $ASF_PASSWORD -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache"
-  printf "[[ $? == 0 ]] && printf '\n Publishing to $RELEASE_LOCATION is complete!\n'"
-  printf "\n==========\n"
+  svn ci --username $ASF_USERNAME -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache \n
+  [[ $? == 0 ]] && printf '\n Publishing to $RELEASE_LOCATION is complete!\n'
 else
   printf "\n==========\n"
   printf "This step would commit to the SVN release repo\n"
   printf "At $RELEASE_LOCATION \n"
   printf "\n==========\n"
+  printf "You might want to manually check the files and run the following:\n"
+  printf "svn ci --username $ASF_USERNAME -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache \n"
+  printf "\n==========\n"
 fi
 
-popd
 


### PR DESCRIPTION
Usage:

<details>
  <summary><code>~/repo/systemds$ ./dev/release/release-to-svn.sh -n</code> </summary>

```console
ubuntu@ip-10-0-0-5:~/repo/systemds$ ./dev/release/release-to-svn.sh -n
RELEASE_VERSION : 2.2.0
APPROVED_RELEASE_TAG : 2.2.0-rc1
~/repo/systemds/systemds-repo-tmp-ZQWlk ~/repo/systemds
Checked out revision 50697.
Updating '2.2.0-rc1':
A    2.2.0-rc1
A    2.2.0-rc1/systemds-2.2.0-bin.tgz
A    2.2.0-rc1/systemds-2.2.0-bin.tgz.asc
A    2.2.0-rc1/systemds-2.2.0-bin.tgz.md5
A    2.2.0-rc1/systemds-2.2.0-bin.tgz.sha1
A    2.2.0-rc1/systemds-2.2.0-bin.tgz.sha512
A    2.2.0-rc1/systemds-2.2.0-bin.zip
A    2.2.0-rc1/systemds-2.2.0-bin.zip.asc
A    2.2.0-rc1/systemds-2.2.0-bin.zip.md5
A    2.2.0-rc1/systemds-2.2.0-bin.zip.sha1
A    2.2.0-rc1/systemds-2.2.0-bin.zip.sha512
A    2.2.0-rc1/systemds-2.2.0-javadoc.jar
A    2.2.0-rc1/systemds-2.2.0-javadoc.jar.asc
A    2.2.0-rc1/systemds-2.2.0-javadoc.jar.md5
A    2.2.0-rc1/systemds-2.2.0-javadoc.jar.sha1
A    2.2.0-rc1/systemds-2.2.0-javadoc.jar.sha512
A    2.2.0-rc1/systemds-2.2.0-src.tgz
A    2.2.0-rc1/systemds-2.2.0-src.tgz.asc
A    2.2.0-rc1/systemds-2.2.0-src.tgz.md5
A    2.2.0-rc1/systemds-2.2.0-src.tgz.sha1
A    2.2.0-rc1/systemds-2.2.0-src.tgz.sha512
A    2.2.0-rc1/systemds-2.2.0-src.zip
A    2.2.0-rc1/systemds-2.2.0-src.zip.asc
A    2.2.0-rc1/systemds-2.2.0-src.zip.md5
A    2.2.0-rc1/systemds-2.2.0-src.zip.sha1
A    2.2.0-rc1/systemds-2.2.0-src.zip.sha512
Updated to revision 50697.
Checked out revision 50697.
A         svn-release-systemds/2.2.0
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.tgz.sha512
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.zip.asc
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.zip.md5
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.tgz.asc
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.tgz.md5
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.zip.sha1
A         svn-release-systemds/2.2.0/systemds-2.2.0-javadoc.jar.md5
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.tgz.sha1
A  (bin)  svn-release-systemds/2.2.0/systemds-2.2.0-bin.zip
A  (bin)  svn-release-systemds/2.2.0/systemds-2.2.0-bin.tgz
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.zip.sha512
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.zip.md5
A         svn-release-systemds/2.2.0/systemds-2.2.0-javadoc.jar.sha1
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.tgz.sha512
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.zip.asc
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.tgz.md5
A         svn-release-systemds/2.2.0/systemds-2.2.0-bin.tgz.asc
A  (bin)  svn-release-systemds/2.2.0/systemds-2.2.0-javadoc.jar
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.zip.sha1
A         svn-release-systemds/2.2.0/systemds-2.2.0-javadoc.jar.sha512
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.tgz.sha1
A         svn-release-systemds/2.2.0/systemds-2.2.0-javadoc.jar.asc
A  (bin)  svn-release-systemds/2.2.0/systemds-2.2.0-src.zip
A  (bin)  svn-release-systemds/2.2.0/systemds-2.2.0-src.tgz
A         svn-release-systemds/2.2.0/systemds-2.2.0-src.zip.sha512
This step would commit to the SVN release repo.
At https://dist.apache.org/repos/dist/release/systemds~/repo/systemds

```

</details>
