### PR TITLE
[MINOR] Python `SYSTEMDS_BIN` update for all the version types

### DIFF
--- a/dev/release/pypi-upload.sh
+++ b/dev/release/pypi-upload.sh
@@ -86,7 +86,7 @@ python3 -m twine check dist/*
 # password: pypi-DU5y...
 
 if [[ $dry_run_flag != 1 ]]; then
-  python twine upload dist/*
+  python -m twine upload dist/*
 else
   python -m twine upload --repository testpypi dist/*
 fi

--- a/src/main/python/pre_setup.py
+++ b/src/main/python/pre_setup.py
@@ -39,7 +39,7 @@ if os.path.exists(TMP_DIR):
     shutil.rmtree(TMP_DIR, True)
 os.mkdir(TMP_DIR)
 
-SYSTEMDS_BIN = 'systemds-*-SNAPSHOT-bin.zip'
+SYSTEMDS_BIN = 'systemds-*-bin.zip'
 for file in os.listdir(os.path.join(root_dir, 'target')):
     if fnmatch.fnmatch(file, SYSTEMDS_BIN):
         new_path = os.path.join(TMP_DIR, file)


### PR DESCRIPTION
```python
>>> regex1 = fnmatch.translate('systemds-*-bin.zip')
>>> regex1
'(?s:systemds\\-.*\\-bin\\.zip)\\Z'
>>> resobj1 = re.compile(regex1)
>>> resobj1.match('systemds-2.3.0-SNAPSHOT-bin.zip')
<re.Match object; span=(0, 31), match='systemds-2.3.0-SNAPSHOT-bin.zip'>
>>> resobj1.match('systemds-2.3.0-bin.zip')
<re.Match object; span=(0, 22), match='systemds-2.3.0-bin.zip'>
```

Resolves bug with 8df051fedfd60c9613c6aa4158af0c1b89968f48

References:
[1] https://docs.python.org/3/library/fnmatch.html
[2] https://docs.python.org/3/using/cmdline.html#command-line