### PR TITLE
Federated multiplication python tests

### DIFF
--- a/src/main/python/systemds/context/systemds_context.py
+++ b/src/main/python/systemds/context/systemds_context.py
@@ -21,15 +21,11 @@
 
 __all__ = ["SystemDSContext"]
 
-import copy
 import json
 import os
 import socket
-import threading
-import time
-import sys
 from glob import glob
-from queue import Empty, Queue
+from queue import Queue
 from subprocess import PIPE, Popen
 from threading import Thread
 from time import sleep
@@ -123,7 +119,6 @@ class SystemDSContext(object):
             message += "standard error  :\n" + "\n".join(stdErr)
         message += exception_str
         self.close()
-        sys.tracebacklimit = 0
         raise RuntimeError(message)
 
     def __try_startup(self, command, port, rep=0):

--- a/src/main/python/systemds/context/systemds_context.py
+++ b/src/main/python/systemds/context/systemds_context.py
@@ -27,6 +27,7 @@ import os
 import socket
 import threading
 import time
+import sys
 from glob import glob
 from queue import Empty, Queue
 from subprocess import PIPE, Popen
@@ -105,7 +106,7 @@ class SystemDSContext(object):
         else:
             return [self.__stderr.get() for x in range(lines)]
 
-    def exception_and_close(self, e: Exception):
+    def exception_and_close(self, exception_str: str):
         """
         Method for printing exception, printing stdout and error, while also closing the context correctly.
 
@@ -113,11 +114,16 @@ class SystemDSContext(object):
         """
 
         # e = sys.exc_info()[0]
-        message = "Exception Encountered! closing JVM\n"
-        message += "standard out    :\n" + "\n".join(self.get_stdout())
-        message += "standard error  :\n" + "\n".join(self.get_stdout())
-        message += "Exception       : " + str(e)
+        message = ""
+        stdOut = self.get_stdout()
+        if stdOut:
+            message += "standard out    :\n" + "\n".join(stdOut)
+        stdErr = self.get_stderr()
+        if stdErr:
+            message += "standard error  :\n" + "\n".join(stdErr)
+        message += exception_str
         self.close()
+        sys.tracebacklimit = 0
         raise RuntimeError(message)
 
     def __try_startup(self, command, port, rep=0):

--- a/src/main/python/systemds/context/systemds_context.py
+++ b/src/main/python/systemds/context/systemds_context.py
@@ -24,6 +24,7 @@ __all__ = ["SystemDSContext"]
 import json
 import os
 import socket
+import sys
 from glob import glob
 from queue import Queue
 from subprocess import PIPE, Popen
@@ -102,7 +103,7 @@ class SystemDSContext(object):
         else:
             return [self.__stderr.get() for x in range(lines)]
 
-    def exception_and_close(self, exception_str: str):
+    def exception_and_close(self, exception_str: str, trace_back_limit : int = None):
         """
         Method for printing exception, printing stdout and error, while also closing the context correctly.
 
@@ -118,6 +119,7 @@ class SystemDSContext(object):
         if stdErr:
             message += "standard error  :\n" + "\n".join(stdErr)
         message += exception_str
+        sys.tracebacklimit = trace_back_limit
         self.close()
         raise RuntimeError(message)
 

--- a/src/main/python/systemds/script_building/script.py
+++ b/src/main/python/systemds/script_building/script.py
@@ -82,9 +82,11 @@ class DMLScript:
             return ret
         except Py4JNetworkError:
             exception_str = "Py4JNetworkError: no connection to JVM, most likely due to previous crash"
+            trace_back_limit = 0
         except Exception as e:
             exception_str = str(e)
-        self.sds_context.exception_and_close(exception_str)
+            trace_back_limit = None
+        self.sds_context.exception_and_close(exception_str, trace_back_limit)
         
 
     def execute_with_lineage(self) -> Tuple[JavaObject, str]:
@@ -110,9 +112,11 @@ class DMLScript:
 
         except Py4JNetworkError:
             exception_str = "Py4JNetworkError: no connection to JVM, most likely due to previous crash"
+            trace_back_limit = 0
         except Exception as e:
             exception_str = str(e)
-        self.sds_context.exception_and_close(exception_str)
+            trace_back_limit = None
+        self.sds_context.exception_and_close(exception_str, trace_back_limit)
 
     def __prepare_script(self):
         gateway = self.sds_context.java_gateway

--- a/src/main/python/systemds/script_building/script.py
+++ b/src/main/python/systemds/script_building/script.py
@@ -19,11 +19,12 @@
 #
 # -------------------------------------------------------------
 
-from typing import Any, Collection, KeysView, Tuple, Union, Optional, Dict, TYPE_CHECKING, List
+from typing import (TYPE_CHECKING, Any, Collection, Dict, KeysView, List,
+                    Optional, Tuple, Union)
 
+from py4j.protocol import Py4JNetworkError
 from py4j.java_collections import JavaArray
-from py4j.java_gateway import JavaObject, JavaGateway
-
+from py4j.java_gateway import JavaGateway, JavaObject
 from systemds.script_building.dag import DAGNode, OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
@@ -79,9 +80,12 @@ class DMLScript:
             self.__prepare_script()
             ret = self.prepared_script.executeScript()
             return ret
+        except Py4JNetworkError:
+            exception_str = "Py4JNetworkError: no connection to JVM, most likely due to previous crash"
         except Exception as e:
-            self.sds_context.exception_and_close(e)
-            return None
+            exception_str = str(e)
+        self.sds_context.exception_and_close(exception_str)
+        
 
     def execute_with_lineage(self) -> Tuple[JavaObject, str]:
         """If not already created, create a preparedScript from our DMLCode, pass python local data to our prepared
@@ -104,9 +108,11 @@ class DMLScript:
                     traces.append(self.prepared_script.getLineageTrace(output))
                 return ret, traces
 
+        except Py4JNetworkError:
+            exception_str = "Py4JNetworkError: no connection to JVM, most likely due to previous crash"
         except Exception as e:
-            self.sds_context.exception_and_close(e)
-            return None, None
+            exception_str = str(e)
+        self.sds_context.exception_and_close(exception_str)
 
     def __prepare_script(self):
         gateway = self.sds_context.java_gateway

--- a/src/main/python/tests/federated/runFedTest.sh
+++ b/src/main/python/tests/federated/runFedTest.sh
@@ -48,7 +48,7 @@ Fed3=$!
 echo "Starting workers" && sleep 3 && echo "Starting tests"
 
 # Run test
-python -m unittest discover -s tests/federated -p 'test_federated_tutorial.py' $1 >$log 2>&1
+python -m unittest discover -s tests/federated -p 'test_*.py' $1 >$log 2>&1
 pkill -P $Fed1
 pkill -P $Fed2
 pkill -P $Fed3

--- a/src/main/python/tests/federated/runFedTest.sh
+++ b/src/main/python/tests/federated/runFedTest.sh
@@ -48,7 +48,7 @@ Fed3=$!
 echo "Starting workers" && sleep 3 && echo "Starting tests"
 
 # Run test
-python -m unittest discover -s tests/federated -p 'test_*.py' $1 >$log 2>&1
+python -m unittest discover -s tests/federated -p 'test_federated_tutorial.py' $1 >$log 2>&1
 pkill -P $Fed1
 pkill -P $Fed2
 pkill -P $Fed3

--- a/src/main/python/tests/federated/test_federated_matrix_mult.py
+++ b/src/main/python/tests/federated/test_federated_matrix_mult.py
@@ -97,80 +97,57 @@ class TestFederatedAggFn(unittest.TestCase):
 
     def test_single_fed_site_same_matrix(self):
         f_m = self.sds.read(fed1_file)
-        fed = f_m @ f_m
-        loc = m @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m, f_m, f_m)
 
     def test_single_fed_left_same_size(self):
         f_m = self.sds.read(fed1_file)
         m_s = self.sds.from_numpy(m)
-        fed = m_s @ f_m
-        loc = m @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m, m_s, f_m)
 
     def test_single_fed_left_plus_one_row(self):
         f_m = self.sds.read(fed1_file)
-        m_row_plus1 = np.reshape(np.arange(1, dim*(dim+1) + 1, 1), (dim+1, dim))
+        m_row_plus1 = np.reshape(
+            np.arange(1, dim*(dim+1) + 1, 1), (dim+1, dim))
         m_s = self.sds.from_numpy(m_row_plus1)
-        fed = m_s @ f_m
-        loc = m_row_plus1 @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_row_plus1, m, m_s, f_m)
 
     def test_single_fed_left_minus_one_row(self):
         f_m = self.sds.read(fed1_file)
-        m_row_minus1 = np.reshape(np.arange(1, dim*(dim-1) + 1, 1), (dim-1, dim))
+        m_row_minus1 = np.reshape(
+            np.arange(1, dim*(dim-1) + 1, 1), (dim-1, dim))
         m_s = self.sds.from_numpy(m_row_minus1)
-        fed = m_s @ f_m
-        loc = m_row_minus1 @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_row_minus1, m, m_s, f_m)
 
     def test_single_fed_left_vector_row(self):
         f_m = self.sds.read(fed1_file)
         v_row = np.arange(1, dim + 1, 1)
         v_s = self.sds.from_numpy(v_row).t()
-        fed = v_s @ f_m
-        loc = v_row @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(v_row, m, v_s, f_m)
 
     def test_single_fed_right_same_size(self):
         f_m = self.sds.read(fed1_file)
         m_s = self.sds.from_numpy(m)
-        fed = f_m @ m_s
-        loc = m @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m, f_m, m_s)
 
     def test_single_fed_right_plus_one_row(self):
         f_m = self.sds.read(fed1_file)
-        m_col_plus1 = np.reshape(np.arange(1, dim*(dim+1) + 1, 1), (dim, dim+1))
+        m_col_plus1 = np.reshape(
+            np.arange(1, dim*(dim+1) + 1, 1), (dim, dim+1))
         m_s = self.sds.from_numpy(m_col_plus1)
-        fed = f_m @ m_s
-        loc = m @ m_col_plus1
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_col_plus1, f_m, m_s)
 
     def test_single_fed_right_minus_one_row(self):
         f_m = self.sds.read(fed1_file)
-        m_col_minus1 = np.reshape(np.arange(1, dim*(dim-1) + 1, 1), (dim, dim-1))
+        m_col_minus1 = np.reshape(
+            np.arange(1, dim*(dim-1) + 1, 1), (dim, dim-1))
         m_s = self.sds.from_numpy(m_col_minus1)
-        fed = f_m @ m_s
-        loc = m @ m_col_minus1
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_col_minus1, f_m, m_s)
 
     def test_single_fed_right_vector(self):
         f_m = self.sds.read(fed1_file)
         v_col = np.reshape(np.arange(1, dim + 1, 1), (1, dim))
         v_col_sds = self.sds.from_numpy(v_col).t()
-        fed = f_m @ v_col_sds
-        loc = m @ np.transpose(v_col)
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, np.transpose(v_col), f_m, v_col_sds)
 
     ##################################
     # start two federated site tests #
@@ -180,72 +157,50 @@ class TestFederatedAggFn(unittest.TestCase):
         f_m2 = self.sds.read(fed_c2_file)
         m = np.reshape(np.arange(1, dim*(dim + dim) + 1, 1), (dim*2, dim))
         m_s = self.sds.from_numpy(m)
-        fed = m_s @ f_m2
-        loc = m @ m_c2
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_c2, m_s, f_m2)
 
     def test_two_fed_left_minus_one_row(self):
         f_m2 = self.sds.read(fed_c2_file)
         m = np.reshape(np.arange(1, dim*(dim + dim-1)+1, 1), (dim*2 - 1, dim))
         m_s = self.sds.from_numpy(m)
-        fed = m_s @ f_m2
-        loc = m @ m_c2
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_c2, m_s, f_m2)
 
     def test_two_fed_left_plus_one_row(self):
         f_m2 = self.sds.read(fed_c2_file)
         m = np.reshape(np.arange(1, dim*(dim + dim+1)+1, 1), (dim*2 + 1, dim))
         m_s = self.sds.from_numpy(m)
-        fed = m_s @ f_m2
-        loc = m @ m_c2
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_c2, m_s, f_m2)
 
     def test_two_fed_left_vector_row(self):
         f_m2 = self.sds.read(fed_c2_file)
         m = np.arange(1, dim+1, 1)
         m_s = self.sds.from_numpy(m).t()
-        fed = m_s @ f_m2
-        loc = m @ m_c2
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m, m_c2, m_s, f_m2)
 
     def test_two_fed_right_standard(self):
         f_m2 = self.sds.read(fed_c2_file)
         m_s = self.sds.from_numpy(m_r2)
-        fed = f_m2 @ m_s
-        loc = m_c2 @ m_r2
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_c2, m_r2, f_m2, m_s)
 
     def test_two_fed_right_col_minus_1(self):
         f_m2 = self.sds.read(fed_c2_file)
-        m = np.reshape(np.arange(1, (dim-1)*(dim + dim)+1, 1), (dim * 2, dim-1))
+        m = np.reshape(np.arange(1, (dim-1)*(dim + dim)+1, 1),
+                       (dim * 2, dim-1))
         m_s = self.sds.from_numpy(m)
-        fed = f_m2 @ m_s
-        loc = m_c2 @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_c2, m, f_m2, m_s)
 
     def test_two_fed_right_col_plus_1(self):
         f_m2 = self.sds.read(fed_c2_file)
-        m = np.reshape(np.arange(1, (dim+1)*(dim + dim)+1, 1), (dim * 2, dim+1))
+        m = np.reshape(np.arange(1, (dim+1)*(dim + dim)+1, 1),
+                       (dim * 2, dim+1))
         m_s = self.sds.from_numpy(m)
-        fed = f_m2 @ m_s
-        loc = m_c2 @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_c2, m, f_m2, m_s)
 
     def test_two_fed_right_vector(self):
         f_m2 = self.sds.read(fed_c2_file)
         m = np.reshape(np.arange(1, (dim + dim)+1, 1), (dim * 2, 1))
         m_s = self.sds.from_numpy(m)
-        fed = f_m2 @ m_s
-        loc = m_c2 @ m
-        fed_res = fed.compute()
-        self.assertTrue(np.allclose(fed_res, loc))
+        self.exec_test(m_c2, m, f_m2, m_s)
 
     ####################################
     # Start three federated site tests #
@@ -330,13 +285,20 @@ class TestFederatedAggFn(unittest.TestCase):
             [1, 2, 3, 4, 5, 6, 7, 8, 9]])
         # Multiply local and federated
         ret_loc = loc @ m_r3
-        
+
         for i in range(1, 100):
             loc_systemds = self.sds.from_numpy(loc)
             fed = self.sds.read(fed_r3_file)
             ret_fed = (loc_systemds @ fed).compute()
             if not np.allclose(ret_fed, ret_loc):
-                self.fail("not equal outputs of federated matrix multiplications")
+                self.fail(
+                    "not equal outputs of federated matrix multiplications")
+
+    def exec_test(self, left, right, f_left, f_right):
+        fed = f_left @ f_right
+        loc = left @ right
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
 
 
 if __name__ == "__main__":

--- a/src/main/python/tests/federated/test_federated_matrix_mult.py
+++ b/src/main/python/tests/federated/test_federated_matrix_mult.py
@@ -206,76 +206,69 @@ class TestFederatedAggFn(unittest.TestCase):
     # Start three federated site tests #
     ####################################
 
-    # def test_three_fed_standard(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, dim*(dim * 3) + 1, 1), (dim*3, dim))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = m_s @ f_m3
-    #     loc = m @ m_c3
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_standard(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, dim*(dim * 3) + 1, 1), (dim*3, dim))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m, m_c3, m_s, f_m3)
 
-    # def test_three_fed_left_minus_one_row(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, dim*(dim + dim-1)+1, 1), (dim*2 - 1, dim))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = m_s @ f_m3
-    #     loc = m @ m_c2
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_left_minus_one_row(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, dim*(dim * 3-1)+1, 1), (dim*3 - 1, dim))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m, m_c3, m_s, f_m3)
 
-    # def test_three_fed_left_plus_one_row(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, dim*(dim + dim+1)+1, 1), (dim*2 + 1, dim))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = m_s @ f_m3
-    #     loc = m @ m_c2
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_left_plus_one_row(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, dim*(dim *3+1)+1, 1), (dim*3 + 1, dim))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m, m_c3, m_s, f_m3)
 
-    # def test_three_fed_left_vector_row(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.arange(1, dim+1, 1)
-    #     m_s = self.sds.from_numpy(m).t()
-    #     fed = m_s @ f_m3
-    #     loc = m @ m_c2
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_left_vector_row(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.arange(1, dim+1, 1)
+        m_s = self.sds.from_numpy(m).t()
+        self.exec_test(m, m_c3, m_s, f_m3)
 
-    # def test_three_fed_right_standard(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m_s = self.sds.from_numpy(m_r2)
-    #     fed = f_m3 @ m_s
-    #     loc = m_c2 @ m_r2
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_right_standard(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m_s = self.sds.from_numpy(m_r3)
+        self.exec_test(m_c3, m_r3, f_m3, m_s)
 
-    # def test_three_fed_right_col_minus_1(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, (dim-1)*(dim + dim)+1, 1), (dim * 2, dim-1))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = f_m3 @ m_s
-    #     loc = m_c2 @ m
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_right_col_minus_1(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, (dim-1)*(dim*3)+1, 1), (dim * 3, dim-1))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m_c3, m, f_m3, m_s)
 
-    # def test_three_fed_right_col_plus_1(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, (dim+1)*(dim + dim)+1, 1), (dim * 2, dim+1))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = f_m3 @ m_s
-    #     loc = m_c2 @ m
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_right_col_plus_1(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, (dim+1)*(dim *3)+1, 1), (dim * 3, dim+1))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m_c3, m, f_m3, m_s)
 
-    # def test_three_fed_right_vector(self):
-    #     f_m3 = self.sds.read(fed_c3_file)
-    #     m = np.reshape(np.arange(1, (dim + dim)+1, 1), (dim * 2, 1))
-    #     m_s = self.sds.from_numpy(m)
-    #     fed = f_m3 @ m_s
-    #     loc = m_c2 @ m
-    #     fed_res = fed.compute()
-    #     self.assertTrue(np.allclose(fed_res, loc))
+    def test_three_fed_right_vector(self):
+        f_m3 = self.sds.read(fed_c3_file)
+        m = np.reshape(np.arange(1, (dim *3)+1, 1), (dim * 3, 1))
+        m_s = self.sds.from_numpy(m)
+        self.exec_test(m_c3, m, f_m3, m_s)
+
+    ###################
+    # row bind matrix #
+    ###################
+
+    def test_federated_row2_binded(self):
+        fed = self.sds.read(fed_r2_file)
+        s_m = self.sds.from_numpy(m_c2)
+        self.exec_test(m_c2, m_r2, s_m, fed)
+
+    def test_federated_row3_binded(self):
+        fed = self.sds.read(fed_r3_file)
+        s_m = self.sds.from_numpy(m_c3)
+        self.exec_test(m_c3, m_r3, s_m, fed)
+
+
+
 
     def test_previously_failing(self):
         # local matrix to multiply with

--- a/src/main/python/tests/federated/test_federated_matrix_mult.py
+++ b/src/main/python/tests/federated/test_federated_matrix_mult.py
@@ -330,14 +330,13 @@ class TestFederatedAggFn(unittest.TestCase):
             [1, 2, 3, 4, 5, 6, 7, 8, 9]])
         # Multiply local and federated
         ret_loc = loc @ m_r3
-        print(ret_loc)
         
         for i in range(1, 100):
             loc_systemds = self.sds.from_numpy(loc)
             fed = self.sds.read(fed_r3_file)
             ret_fed = (loc_systemds @ fed).compute()
-            print(ret_fed)
-            self.assertTrue(np.allclose(ret_fed, ret_loc))
+            if not np.allclose(ret_fed, ret_loc):
+                self.fail("not equal outputs of federated matrix multiplications")
 
 
 if __name__ == "__main__":

--- a/src/main/python/tests/federated/test_federated_matrix_mult.py
+++ b/src/main/python/tests/federated/test_federated_matrix_mult.py
@@ -1,0 +1,344 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import io
+import json
+import os
+import time
+import unittest
+
+import numpy as np
+from systemds.context import SystemDSContext
+
+os.environ['SYSDS_QUIET'] = "1"
+
+dim = 3
+
+m = np.reshape(np.arange(1, dim * dim + 1, 1), (dim, dim))
+m_c2 = np.column_stack((m, m))
+m_c3 = np.column_stack((m, m_c2))
+m_r2 = np.row_stack((m, m))
+m_r3 = np.row_stack((m, m_r2))
+
+tempdir = "./tests/federated/tmp/test_federated_matrixmult/"
+mtd = {"format": "csv", "header": False, "rows": dim,
+       "cols": dim, "data_type": "matrix", "value_type": "double"}
+
+# Create the testing directory if it does not exist.
+if not os.path.exists(tempdir):
+    os.makedirs(tempdir)
+
+# Save data files for the Federated workers.
+np.savetxt(tempdir + "m.csv", m, delimiter=",")
+with io.open(tempdir + "m.csv.mtd", "w", encoding="utf-8") as f:
+    f.write(json.dumps(mtd, ensure_ascii=False))
+
+# Federated workers + file locations
+fed1 = "localhost:8001/" + tempdir + "m.csv"
+fed2 = "localhost:8002/" + tempdir + "m.csv"
+fed3 = "localhost:8003/" + tempdir + "m.csv"
+
+fed1_file = tempdir+"m1.fed"
+fed_c2_file = tempdir+"m_c2.fed"
+fed_c3_file = tempdir+"m_c3.fed"
+fed_r2_file = tempdir+"m_r2.fed"
+fed_r3_file = tempdir+"m_r3.fed"
+
+
+class TestFederatedAggFn(unittest.TestCase):
+
+    sds: SystemDSContext = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sds = SystemDSContext()
+        cls.sds.federated([fed1], [([0, 0], [dim, dim])]
+                          ).write(fed1_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2], [
+            ([0, 0], [dim, dim]),
+            ([0, dim], [dim, dim*2])]).write(fed_c2_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2, fed3],  [
+            ([0, 0], [dim, dim]),
+            ([0, dim], [dim, dim*2]),
+            ([0, dim*2], [dim, dim*3])]).write(fed_c3_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2], [
+            ([0, 0], [dim, dim]),
+            ([dim, 0], [dim*2, dim])]).write(fed_r2_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2, fed3],  [
+            ([0, 0], [dim, dim]),
+            ([dim, 0], [dim*2, dim]),
+            ([dim*2, 0], [dim*3, dim])]).write(fed_r3_file, format="federated").compute()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sds.close()
+
+    #####################
+    # Single site tests #
+    #####################
+
+    def test_single_fed_site_same_matrix(self):
+        f_m = self.sds.read(fed1_file)
+        fed = f_m @ f_m
+        loc = m @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_left_same_size(self):
+        f_m = self.sds.read(fed1_file)
+        m_s = self.sds.from_numpy(m)
+        fed = m_s @ f_m
+        loc = m @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_left_plus_one_row(self):
+        f_m = self.sds.read(fed1_file)
+        m_row_plus1 = np.reshape(np.arange(1, dim*(dim+1) + 1, 1), (dim+1, dim))
+        m_s = self.sds.from_numpy(m_row_plus1)
+        fed = m_s @ f_m
+        loc = m_row_plus1 @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_left_minus_one_row(self):
+        f_m = self.sds.read(fed1_file)
+        m_row_minus1 = np.reshape(np.arange(1, dim*(dim-1) + 1, 1), (dim-1, dim))
+        m_s = self.sds.from_numpy(m_row_minus1)
+        fed = m_s @ f_m
+        loc = m_row_minus1 @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_left_vector_row(self):
+        f_m = self.sds.read(fed1_file)
+        v_row = np.arange(1, dim + 1, 1)
+        v_s = self.sds.from_numpy(v_row).t()
+        fed = v_s @ f_m
+        loc = v_row @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_right_same_size(self):
+        f_m = self.sds.read(fed1_file)
+        m_s = self.sds.from_numpy(m)
+        fed = f_m @ m_s
+        loc = m @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_right_plus_one_row(self):
+        f_m = self.sds.read(fed1_file)
+        m_col_plus1 = np.reshape(np.arange(1, dim*(dim+1) + 1, 1), (dim, dim+1))
+        m_s = self.sds.from_numpy(m_col_plus1)
+        fed = f_m @ m_s
+        loc = m @ m_col_plus1
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_right_minus_one_row(self):
+        f_m = self.sds.read(fed1_file)
+        m_col_minus1 = np.reshape(np.arange(1, dim*(dim-1) + 1, 1), (dim, dim-1))
+        m_s = self.sds.from_numpy(m_col_minus1)
+        fed = f_m @ m_s
+        loc = m @ m_col_minus1
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_single_fed_right_vector(self):
+        f_m = self.sds.read(fed1_file)
+        v_col = np.reshape(np.arange(1, dim + 1, 1), (1, dim))
+        v_col_sds = self.sds.from_numpy(v_col).t()
+        fed = f_m @ v_col_sds
+        loc = m @ np.transpose(v_col)
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    ##################################
+    # start two federated site tests #
+    ##################################
+
+    def test_two_fed_standard(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, dim*(dim + dim) + 1, 1), (dim*2, dim))
+        m_s = self.sds.from_numpy(m)
+        fed = m_s @ f_m2
+        loc = m @ m_c2
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_left_minus_one_row(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, dim*(dim + dim-1)+1, 1), (dim*2 - 1, dim))
+        m_s = self.sds.from_numpy(m)
+        fed = m_s @ f_m2
+        loc = m @ m_c2
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_left_plus_one_row(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, dim*(dim + dim+1)+1, 1), (dim*2 + 1, dim))
+        m_s = self.sds.from_numpy(m)
+        fed = m_s @ f_m2
+        loc = m @ m_c2
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_left_vector_row(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.arange(1, dim+1, 1)
+        m_s = self.sds.from_numpy(m).t()
+        fed = m_s @ f_m2
+        loc = m @ m_c2
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_right_standard(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m_s = self.sds.from_numpy(m_r2)
+        fed = f_m2 @ m_s
+        loc = m_c2 @ m_r2
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_right_col_minus_1(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, (dim-1)*(dim + dim)+1, 1), (dim * 2, dim-1))
+        m_s = self.sds.from_numpy(m)
+        fed = f_m2 @ m_s
+        loc = m_c2 @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_right_col_plus_1(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, (dim+1)*(dim + dim)+1, 1), (dim * 2, dim+1))
+        m_s = self.sds.from_numpy(m)
+        fed = f_m2 @ m_s
+        loc = m_c2 @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_two_fed_right_vector(self):
+        f_m2 = self.sds.read(fed_c2_file)
+        m = np.reshape(np.arange(1, (dim + dim)+1, 1), (dim * 2, 1))
+        m_s = self.sds.from_numpy(m)
+        fed = f_m2 @ m_s
+        loc = m_c2 @ m
+        fed_res = fed.compute()
+        self.assertTrue(np.allclose(fed_res, loc))
+
+    ####################################
+    # Start three federated site tests #
+    ####################################
+
+    # def test_three_fed_standard(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, dim*(dim * 3) + 1, 1), (dim*3, dim))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = m_s @ f_m3
+    #     loc = m @ m_c3
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_left_minus_one_row(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, dim*(dim + dim-1)+1, 1), (dim*2 - 1, dim))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = m_s @ f_m3
+    #     loc = m @ m_c2
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_left_plus_one_row(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, dim*(dim + dim+1)+1, 1), (dim*2 + 1, dim))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = m_s @ f_m3
+    #     loc = m @ m_c2
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_left_vector_row(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.arange(1, dim+1, 1)
+    #     m_s = self.sds.from_numpy(m).t()
+    #     fed = m_s @ f_m3
+    #     loc = m @ m_c2
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_right_standard(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m_s = self.sds.from_numpy(m_r2)
+    #     fed = f_m3 @ m_s
+    #     loc = m_c2 @ m_r2
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_right_col_minus_1(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, (dim-1)*(dim + dim)+1, 1), (dim * 2, dim-1))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = f_m3 @ m_s
+    #     loc = m_c2 @ m
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_right_col_plus_1(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, (dim+1)*(dim + dim)+1, 1), (dim * 2, dim+1))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = f_m3 @ m_s
+    #     loc = m_c2 @ m
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    # def test_three_fed_right_vector(self):
+    #     f_m3 = self.sds.read(fed_c3_file)
+    #     m = np.reshape(np.arange(1, (dim + dim)+1, 1), (dim * 2, 1))
+    #     m_s = self.sds.from_numpy(m)
+    #     fed = f_m3 @ m_s
+    #     loc = m_c2 @ m
+    #     fed_res = fed.compute()
+    #     self.assertTrue(np.allclose(fed_res, loc))
+
+    def test_previously_failing(self):
+        # local matrix to multiply with
+        loc = np.array([
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9]])
+        # Multiply local and federated
+        ret_loc = loc @ m_r3
+        print(ret_loc)
+        
+        for i in range(1, 100):
+            loc_systemds = self.sds.from_numpy(loc)
+            fed = self.sds.read(fed_r3_file)
+            ret_fed = (loc_systemds @ fed).compute()
+            print(ret_fed)
+            self.assertTrue(np.allclose(ret_fed, ret_loc))
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/src/main/python/tests/federated/test_federated_read_federated.py
+++ b/src/main/python/tests/federated/test_federated_read_federated.py
@@ -1,0 +1,103 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import io
+import json
+import os
+import shutil
+import sys
+import unittest
+
+import numpy as np
+from systemds.context import SystemDSContext
+
+os.environ['SYSDS_QUIET'] = "1"
+
+dim = 3
+
+m = np.reshape(np.arange(1, dim * dim + 1, 1), (dim, dim))
+
+tempdir = "./tests/federated/tmp/test_federated_matrixmult/"
+mtd = {"format": "csv", "header": False, "rows": dim,
+       "cols": dim, "data_type": "matrix", "value_type": "double"}
+
+# Create the testing directory if it does not exist.
+if not os.path.exists(tempdir):
+    os.makedirs(tempdir)
+
+# Save data files for the Federated workers.
+np.savetxt(tempdir + "m.csv", m, delimiter=",")
+with io.open(tempdir + "m.csv.mtd", "w", encoding="utf-8") as f:
+    f.write(json.dumps(mtd, ensure_ascii=False))
+
+# Federated workers + file locations
+fed1 = "localhost:8001/" + tempdir + "m.csv"
+fed2 = "localhost:8002/" + tempdir + "m.csv"
+fed3 = "localhost:8003/" + tempdir + "m.csv"
+
+fed1_file = tempdir+"m1.fed"
+fed2_file = tempdir+"m2.fed"
+fed3_file = tempdir+"m3.fed"
+
+
+class TestFederatedAggFn(unittest.TestCase):
+
+    sds: SystemDSContext = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sds = SystemDSContext()
+        cls.sds.federated([fed1], [
+            ([0, 0], [dim, dim])]).write(fed1_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2], [
+            ([0, 0], [dim, dim]),
+            ([0, dim], [dim, dim*2])]).write(fed2_file, format="federated").compute()
+        cls.sds.federated([fed1, fed2, fed3],  [
+            ([0, 0], [dim, dim]),
+            ([0, dim], [dim, dim*2]),
+            ([0, dim*2], [dim, dim*3])]).write(fed3_file, format="federated").compute()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sds.close()
+
+    def test_verify_same_input(self):
+        f_m = self.sds.federated([fed1], [([0, 0], [dim, dim])]).compute()
+        self.assertTrue(np.allclose(f_m, m))
+
+    def test_verify_same_input_if_reading_fed(self):
+        f_m = self.sds.read(fed1_file).compute()
+        self.assertTrue(np.allclose(f_m, m))
+
+    def test_verify_same_input_if_reading_fed2(self):
+        f_m = self.sds.read(fed2_file).compute()
+        m2 = np.column_stack((m,m))
+        self.assertTrue(np.allclose(f_m, m2))
+
+    def test_verify_same_input_if_reading_fed3(self):
+        f_m = self.sds.read(fed3_file).compute()
+        m2 = np.column_stack((m,m))
+        m3 = np.column_stack((m,m2))
+        self.assertTrue(np.allclose(f_m, m3))
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)


### PR DESCRIPTION
federated python tests that consistently fail the matrix multiplication.

It happens in cases where the federated workers get corrupted.

to reproduce locally simply run go to src/main/python and run the federated tests.

``` bash
./tests/federated/runFedTest.sh
```

it is required to have set python up, and environment variables, like in the github actions.