### PR TITLE
[SYSTEMDS-3196] Update `org.apache` parent pom version to 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>18</version>
+		<version>24</version>
 	</parent>
 	<groupId>org.apache.systemds</groupId>
 	<version>2.3.0-SNAPSHOT</version>
@@ -45,6 +45,7 @@
 		<scala.version>2.12.0</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
+		<project.build.outputTimestamp>1</project.build.outputTimestamp>
 		<enableGPU>false</enableGPU>
 		<jcuda.scope>provided</jcuda.scope>
 		<jcuda.version>10.2.0</jcuda.version>

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -85,7 +85,7 @@
 				<include>*:commons-cli*</include>
 				<include>*:commons-collections*</include>
 				<include>*:commons-configuration*</include>
-				<include>*:commons-httpclient*</include>
+				<!-- <include>*:commons-httpclient*</include> -->
 				<include>*:commons-io*</include>
 				<include>*:commons-lang</include>
 				<include>*:commons-lang3</include>


### PR DESCRIPTION
**resources:**
[1] https://maven.apache.org/guides/mini/guide-reproducible-builds.html
[2] https://lists.apache.org/thread/9wk97dwjlcoxlk1onxotfo8k98b2v0sk
[3] https://github.com/apache/maven-apache-parent/compare/apache-18...apache-24#diff

Following apache projects 😺 
https://github.com/apache/zeppelin/pull/3930
https://github.com/apache/drill/pull/2360
https://github.com/apache/flink/pull/17005