### PR TITLE
[MINOR] Fix warnings from extend keyword

### DIFF
--- a/src/main/java/org/apache/sysds/hops/rewrite/IPAPassRewriteFederatedPlan.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/IPAPassRewriteFederatedPlan.java
@@ -231,6 +231,7 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 	 * The cost estimates of the hops are also updated when FederatedOutput is updated in the hops.
 	 * @param roots starting point for going through the Hop DAG to update the FederatedOutput fields.
 	 */
+	@SuppressWarnings("unused")
 	private void selectFederatedExecutionPlan(ArrayList<Hop> roots){
 		for ( Hop root : roots )
 			selectFederatedExecutionPlan(root);

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -1266,16 +1266,16 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			{
 				checkNumParameters(4);
 				if (in[3].getOutput().getValueType() != ValueType.INT64) 
-					throw new LanguageException("Fourth arugment, seed, to sample() must be an integer value.");
+					throw new LanguageException("Fourth argument, seed, to sample() must be an integer value.");
 				if (in[2].getOutput().getValueType() != ValueType.BOOLEAN ) 
-					throw new LanguageException("Third arugment to sample() must either denote replacement policy (boolean) or seed (integer).");
+					throw new LanguageException("Third argument to sample() must either denote replacement policy (boolean) or seed (integer).");
 			}
 			else if(in.length == 3) 
 			{
 				checkNumParameters(3);
 				if (in[2].getOutput().getValueType() != ValueType.BOOLEAN 
 						&& in[2].getOutput().getValueType() != ValueType.INT64 ) 
-					throw new LanguageException("Third arugment to sample() must either denote replacement policy (boolean) or seed (integer).");
+					throw new LanguageException("Third argument to sample() must either denote replacement policy (boolean) or seed (integer).");
 			}
 			
 			if ( check && in.length >= 3 

--- a/src/main/java/org/apache/sysds/parser/DataExpression.java
+++ b/src/main/java/org/apache/sysds/parser/DataExpression.java
@@ -340,7 +340,7 @@ public class DataExpression extends DataIdentifier
 			
 			for (int i=1; i<passedParamExprs.size(); i++){
 				if (passedParamExprs.get(i).getName() == null){
-					errorListener.validationError(parseInfo, "for matrix statement, cannot mix named and unnamed parameters, only data parameter can be unnammed");
+					errorListener.validationError(parseInfo, "for matrix statement, cannot mix named and unnamed parameters, only data parameter can be unnamed");
 					return null;
 				} else {
 					dataExpr.addMatrixExprParam(passedParamExprs.get(i).getName(), passedParamExprs.get(i).getExpr());
@@ -398,7 +398,7 @@ public class DataExpression extends DataIdentifier
 
 			for (int i=1; i<passedParamExprs.size(); i++){
 				if (passedParamExprs.get(i).getName() == null){
-					errorListener.validationError(parseInfo, "for frame statement, cannot mix named and unnamed parameters, only data parameter can be unnammed");
+					errorListener.validationError(parseInfo, "for frame statement, cannot mix named and unnamed parameters, only data parameter can be unnamed");
 					return null;
 				} else {
 					dataExpr.addFrameExprParam(passedParamExprs.get(i).getName(), passedParamExprs.get(i).getExpr());
@@ -454,7 +454,7 @@ public class DataExpression extends DataIdentifier
 
 			for (int i=1; i<passedParamExprs.size(); i++){
 				if (passedParamExprs.get(i).getName() == null){
-					errorListener.validationError(parseInfo, "for tensor statement, cannot mix named and unnamed parameters, only data parameter can be unnammed");
+					errorListener.validationError(parseInfo, "for tensor statement, cannot mix named and unnamed parameters, only data parameter can be unnamed");
 					return null;
 				}
 				else {

--- a/src/main/java/org/apache/sysds/protobuf/SysdsProtos.java
+++ b/src/main/java/org/apache/sysds/protobuf/SysdsProtos.java
@@ -20,6 +20,7 @@
  */
 package org.apache.sysds.protobuf;
 
+@SuppressWarnings({"unused","unchecked"})
 public final class SysdsProtos {
 	private static final com.google.protobuf.Descriptors.Descriptor internal_static_sysds_Frame_descriptor;
 	private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internal_static_sysds_Frame_fieldAccessorTable;
@@ -2214,7 +2215,7 @@ public final class SysdsProtos {
 		private static final long serialVersionUID = 0L;
 		private static final com.google.protobuf.Internal.ListAdapter.Converter<java.lang.Integer, org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType> valueType_converter_ = new com.google.protobuf.Internal.ListAdapter.Converter<java.lang.Integer, org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType>() {
 			public org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType convert(java.lang.Integer from) {
-				@SuppressWarnings("deprecation")
+				// @SuppressWarnings("deprecation")
 				org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType result = org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType
 					.valueOf(from);
 				return result == null ? org.apache.sysds.protobuf.SysdsProtos.Schema.ValueType.UNRECOGNIZED : result;

--- a/src/main/java/org/apache/sysds/runtime/codegen/SpoofCellwise.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/SpoofCellwise.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.runtime.codegen;
 
-import java.io.Serializable;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,11 +31,11 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
+import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 import org.apache.sysds.runtime.functionobjects.KahanFunction;
 import org.apache.sysds.runtime.functionobjects.KahanPlus;
 import org.apache.sysds.runtime.functionobjects.KahanPlusSq;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
-import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.KahanObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
@@ -46,7 +44,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
-public abstract class SpoofCellwise extends SpoofOperator implements Serializable
+public abstract class SpoofCellwise extends SpoofOperator
 {
 	private static final long serialVersionUID = 3442528770573293590L;
 	

--- a/src/main/java/org/apache/sysds/runtime/codegen/SpoofMultiAggregate.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/SpoofMultiAggregate.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.runtime.codegen;
 
-import java.io.Serializable;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -32,18 +30,18 @@ import org.apache.sysds.runtime.codegen.SpoofCellwise.AggOp;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
+import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 import org.apache.sysds.runtime.functionobjects.KahanFunction;
 import org.apache.sysds.runtime.functionobjects.KahanPlus;
 import org.apache.sysds.runtime.functionobjects.KahanPlusSq;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
-import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 import org.apache.sysds.runtime.instructions.cp.KahanObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
-public abstract class SpoofMultiAggregate extends SpoofOperator implements Serializable
+public abstract class SpoofMultiAggregate extends SpoofOperator
 {
 	private static final long serialVersionUID = -6164871955591089349L;
 	

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibLeftMultBy.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibLeftMultBy.java
@@ -363,7 +363,7 @@ public class CLALibLeftMultBy {
 		// The number of rows to process together
 		final int rowBlockSize = 1;
 		// The number of column groups to process together
-		// the value should ideally be set so that the colgroups fits into cache together with a row block.
+		// the value should ideally be set so that the colGroups fits into cache together with a row block.
 		// currently we only try to avoid having a dangling small number of column groups in the last block.
 		final int colGroupBlocking = ColGroupValues.size() % 16 < 4 ? 20 : 16;
 
@@ -434,7 +434,7 @@ public class CLALibLeftMultBy {
 
 	private static MatrixBlock[] populatePreAggregate(int colGroupBlocking) {
 		final MatrixBlock[] preAgg = new MatrixBlock[colGroupBlocking];
-		// poplate the preAgg array.
+		// populate the preAgg array.
 		for(int j = 0; j < colGroupBlocking; j++) {
 			MatrixBlock m = new MatrixBlock(1, 1, false);
 			m.allocateDenseBlock();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/DataPartitionerSparkAggregator.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/DataPartitionerSparkAggregator.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
-import java.io.Serializable;
 import java.util.LinkedList;
 
 import org.apache.spark.api.java.function.PairFunction;
@@ -28,7 +27,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 import scala.Tuple2;
 
-public class DataPartitionerSparkAggregator implements PairFunction<Tuple2<Integer,LinkedList<Tuple2<Long,Tuple2<MatrixBlock,MatrixBlock>>>>, Integer, Tuple2<MatrixBlock, MatrixBlock>>, Serializable {
+public class DataPartitionerSparkAggregator implements PairFunction<Tuple2<Integer,LinkedList<Tuple2<Long,Tuple2<MatrixBlock,MatrixBlock>>>>, Integer, Tuple2<MatrixBlock, MatrixBlock>> {
 
 	private static final long serialVersionUID = -1245300852709085117L;
 	private long _fcol;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/DataPartitionerSparkMapper.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/dp/DataPartitionerSparkMapper.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.runtime.controlprogram.paramserv.dp;
 
-import java.io.Serializable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,7 +30,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 import scala.Tuple2;
 
-public class DataPartitionerSparkMapper implements PairFlatMapFunction<Tuple2<Long, Tuple2<MatrixBlock, MatrixBlock>>, Integer, Tuple2<Long, Tuple2<MatrixBlock, MatrixBlock>>>, Serializable {
+public class DataPartitionerSparkMapper implements PairFlatMapFunction<Tuple2<Long, Tuple2<MatrixBlock, MatrixBlock>>, Integer, Tuple2<Long, Tuple2<MatrixBlock, MatrixBlock>>> {
 
 	private static final long serialVersionUID = 1710721606050403296L;
 	private int _workersNum;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/ResultMergeMatrix.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/ResultMergeMatrix.java
@@ -19,12 +19,11 @@
 
 package org.apache.sysds.runtime.controlprogram.parfor;
 
+import java.util.List;
+
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-
-import java.io.Serializable;
-import java.util.List;
 
 /**
  * Due to independence of all iterations, any result has the following properties:
@@ -32,7 +31,7 @@ import java.util.List;
  * These properties allow us to realize result merging in parallel without any synchronization. 
  * 
  */
-public abstract class ResultMergeMatrix extends ResultMerge<MatrixObject> implements Serializable
+public abstract class ResultMergeMatrix extends ResultMerge<MatrixObject>
 {
 	private static final long serialVersionUID = 5319002218804570071L;
 	

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/stat/InfrastructureAnalyzer.java
@@ -274,7 +274,7 @@ public class InfrastructureAnalyzer
 		JobConf job = ConfigurationManager.getCachedJobConf();
 		JobClient client = new JobClient(job);
 		ClusterStatus stat = client.getClusterStatus();
-		
+		client.close();
 		double ret = 0.0;
 		if( stat != null ) { //if in cluster mode
 			if( mapOnly ) {
@@ -312,6 +312,7 @@ public class InfrastructureAnalyzer
 			JobConf job = ConfigurationManager.getCachedJobConf();
 			JobClient client = new JobClient(job);
 			ClusterStatus stat = client.getClusterStatus();
+			client.close();
 			if( stat != null ) { //if in cluster mode
 				//analyze cluster status
 				_remotePar = stat.getTaskTrackers();

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
@@ -139,7 +139,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 		if(opcode.equalsIgnoreCase("replace")) {
 			// similar to unary federated instructions, get federated input
 			// execute instruction, and derive federated output matrix
-			CacheableData mo = getTarget(ec);
+			CacheableData<?> mo = getTarget(ec);
 			FederatedRequest fr1 = FederationUtils.callInstruction(instString,
 				output,
 				new CPOperand[] {getTargetOperand()},
@@ -147,7 +147,7 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 			mo.getFedMapping().execute(getTID(), true, fr1);
 
 			// derive new fed mapping for output
-			CacheableData out = ec.getCacheableData(output);
+			CacheableData<?> out = ec.getCacheableData(output);
 			if(mo instanceof FrameObject)
 				((FrameObject)out).setSchema(((FrameObject) mo).getSchema());
 			out.getDataCharacteristics().set(mo.getDataCharacteristics());

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/SpoofCUDAInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/SpoofCUDAInstruction.java
@@ -19,7 +19,8 @@
 
 package org.apache.sysds.runtime.instructions.gpu;
 
-import jcuda.Sizeof;
+import java.util.ArrayList;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,8 +28,8 @@ import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.codegen.CodegenUtils;
-import org.apache.sysds.runtime.codegen.SpoofOperator;
 import org.apache.sysds.runtime.codegen.SpoofCUDAOperator;
+import org.apache.sysds.runtime.codegen.SpoofOperator;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
@@ -37,12 +38,11 @@ import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.instructions.gpu.context.GPUObject;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
-import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.utils.GPUStatistics;
 
-import java.util.ArrayList;
+import jcuda.Sizeof;
 
-public class SpoofCUDAInstruction extends GPUInstruction implements LineageTraceable {
+public class SpoofCUDAInstruction extends GPUInstruction {
 	private static final Log LOG = LogFactory.getLog(SpoofCUDAInstruction.class.getName());
 	
 	public static SpoofCUDAOperator.PrecisionProxy proxy = null;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/CM_N_COVCell.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/CM_N_COVCell.java
@@ -25,7 +25,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.instructions.cp.CM_COV_Object;
 import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
@@ -38,8 +37,7 @@ import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 import org.apache.sysds.runtime.util.IndexRange;
 
-@SuppressWarnings("rawtypes")
-public class CM_N_COVCell extends MatrixValue implements WritableComparable
+public class CM_N_COVCell extends MatrixValue
 {
 	private CM_COV_Object cm=new CM_COV_Object();
 	

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixCell.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixCell.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.functionobjects.CTable;
 import org.apache.sysds.runtime.functionobjects.ReduceDiag;
@@ -40,8 +39,7 @@ import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 import org.apache.sysds.runtime.util.IndexRange;
 
-@SuppressWarnings("rawtypes")
-public class MatrixCell extends MatrixValue implements WritableComparable, Serializable
+public class MatrixCell extends MatrixValue implements Serializable
 {
 	private static final long serialVersionUID = -7755996717411912578L;
 	

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -23,7 +23,6 @@ import static org.apache.sysds.runtime.transform.encode.EncoderFactory.getEncode
 import static org.apache.sysds.runtime.util.UtilFunctions.getBlockSizes;
 import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
 
-import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -52,7 +51,7 @@ import org.apache.sysds.utils.Statistics;
  * Base class for all transform encoders providing both a row and block interface for decoding frames to matrices.
  *
  */
-public abstract class ColumnEncoder implements Externalizable, Encoder, Comparable<ColumnEncoder> {
+public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder> {
 	protected static final Log LOG = LogFactory.getLog(ColumnEncoder.class.getName());
 	protected static final int APPLY_ROW_BLOCKS_PER_COLUMN = 1;
 	public static int BUILD_ROW_BLOCKS_PER_COLUMN = 1;


### PR DESCRIPTION
This commit fixes warnings, the main warning have been from extending
classes that are already extended in super classes.
Also contained is a few spelling fixes.
The protobuf file is also modified to ignore warnings since this is an
auto generated file it is done with SuppressWarnings commands.