### PR TITLE
[SYSTEMDS-3215] Federated Worker deriving SparkExecutionMode

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContextFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContextFactory.java
@@ -58,8 +58,9 @@ public class ExecutionContextFactory
 	}
 
 	public static boolean needsSparkEC(Program prog) {
-		boolean retVal = OptimizerUtils.getDefaultExecutionMode()==ExecMode.HYBRID
-			&& !(prog!=null && prog.getDMLProg()!=null && prog.getDMLProg().containsRemoteParfor());
+		boolean retVal = DMLScript.getGlobalExecMode() == ExecMode.SINGLE_NODE
+			&& (OptimizerUtils.getDefaultExecutionMode() != ExecMode.HYBRID
+				|| (prog != null && prog.getDMLProg() != null && prog.getDMLProg().containsRemoteParfor()));
 		retVal |= DMLScript.getGlobalExecMode() == ExecMode.SPARK;
 		retVal |= DMLScript.getGlobalExecMode() == ExecMode.HYBRID;
 		return retVal;


### PR DESCRIPTION
Hi,
This PR adds a workaround to the problem of running into a ClassCastException because of casting an ExecutionContext into a SparkExecutionContext.
It simply checks if there is a need for having a SparkExecutionContext instead of a casual ExecutionContext at every get call to the ExecutionContextMap, and derives a new SparkExecutionContext from the actual ExecutionContext if this is the case.
The PR also includes the change of setting the global dml execution mode of the federated worker to HYBRID if there is an incoming SPARK Exec_Inst request and the worker is on SINGLE_NODE execution mode.

Thanks for review :)