### PR TITLE
[SYSTEMDS-3203] Remove empty columns frame out of bounds

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
@@ -30,7 +30,14 @@ import java.lang.ref.SoftReference;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -48,7 +55,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.Writable;
 import org.apache.sysds.api.DMLException;
-import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.codegen.CodegenUtils;
@@ -66,6 +72,7 @@ import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.transform.encode.ColumnEncoderRecode;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.DMVUtils;
+import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.runtime.util.EMAUtils;
 import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
@@ -2520,32 +2527,35 @@ public class FrameBlock implements CacheBlock, Externalizable {
 	}
 
 	private FrameBlock removeEmptyRows(MatrixBlock select, boolean emptyReturn) {
-		boolean selectColVector = select != null && select.getNumRows() != this.getNumRows();
-
-		if(select != null && (select.getNumRows() != this.getNumRows() && select.getNumColumns() != this.getNumRows())) {
+		if(select != null && (select.getNumRows() != this.getNumRows() && select.getNumColumns() != this.getNumRows()))
 			throw new DMLRuntimeException("Frame rmempty: Incorrect select vector dimensions.");
-		}
 
 		FrameBlock ret = new FrameBlock(_schema, _colnames);
 
-		for(int i = 0; i < _numRows; i++) {
-			boolean isEmpty = true;
-			Object[] row = new Object[getNumColumns()];
+		if (select == null) {
+			for(int i = 0; i < _numRows; i++) {
+				boolean isEmpty = true;
+				Object[] row = new Object[getNumColumns()];
+				for(int j = 0; j < getNumColumns() && isEmpty; j++) {
+					row[j] = _coldata[j].get(i);
+					isEmpty = isEmpty && (ArrayUtils.contains(new double[]{0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(_schema[j], _coldata[j].get(i))));
+				}
 
-			for(int j = 0; j < getNumColumns(); j++) {
-				Array colData = _coldata[j].clone();
-				row[j] = colData.get(i);
-				ValueType type = _schema[j];
-				isEmpty = isEmpty && (ArrayUtils.contains(new double[]{0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(type, colData.get(i))));
+				if(!isEmpty)
+					ret.appendRow(row);
 			}
+		} else {
+			List<Integer> indices = DataConverter.convertVectorToIndicesList(select);
 
-			double selectValue = select != null ? !selectColVector ? select.getValue(i, 0) : select.getValue( 0, i) : 0.0;
-			if(selectValue == 1.0 || (!isEmpty && select == null)) {
+			for(int i : indices) {
+				Object[] row = new Object[getNumColumns()];
+				for(int j = 0; j < getNumColumns(); j++)
+					row[j] = _coldata[j].get(i);
 				ret.appendRow(row);
 			}
 		}
 
-		if(ret.getNumRows() == 0 && emptyReturn) {
+		if (ret.getNumRows() == 0 && emptyReturn) {
 			String[][] arr = new String[1][getNumColumns()];
 			Arrays.fill(arr, new String[]{null});
 			ValueType[] schema = new ValueType[getNumColumns()];
@@ -2557,8 +2567,6 @@ public class FrameBlock implements CacheBlock, Externalizable {
 	}
 
 	private FrameBlock removeEmptyColumns(MatrixBlock select, boolean emptyReturn) {
-		boolean selectRowVector = select != null && select.getNumColumns() != this.getNumColumns();
-
 		if(select != null && (select.getNumRows() != this.getNumColumns() && select.getNumColumns() != this.getNumColumns())) {
 			throw new DMLRuntimeException("Frame rmempty: Incorrect select vector dimensions.");
 		}
@@ -2566,21 +2574,26 @@ public class FrameBlock implements CacheBlock, Externalizable {
 		FrameBlock ret = new FrameBlock();
 		List<ColumnMetadata> columnMetadata = new ArrayList<>();
 
-		for(int i = 0; i < getNumColumns(); i++) {
-			Array colData = _coldata[i];
-
-			boolean isEmpty = false;
-			if(select == null) {
+		if (select == null) {
+			for(int i = 0; i < getNumColumns(); i++) {
+				Array colData = _coldata[i];
 				ValueType type = _schema[i];
-				isEmpty = IntStream.range(0, colData._size).mapToObj((IntFunction<Object>) colData::get)
+				boolean isEmpty = IntStream.range(0, colData._size).mapToObj((IntFunction<Object>) colData::get)
 					.allMatch(e -> ArrayUtils.contains(new double[]{0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(type, e)));
-			}
 
-			double selectValue = select != null ? !selectRowVector ? select.getValue(0, i) : select.getValue(i, 0) : 0.0;
-			if(selectValue == 1.0 || (!isEmpty && select == null)) {
-				Types.ValueType vt = _schema[i];
-				ret.appendColumn(vt, _coldata[i].clone());
+				if(!isEmpty) {
+					ret.appendColumn(_schema[i], _coldata[i].clone());
+					columnMetadata.add(new ColumnMetadata(_colmeta[i]));
+				}
+			}
+		} else {
+			List<Integer> indices = DataConverter.convertVectorToIndicesList(select);
+			int k = 0;
+			for(int i : indices) {
+				ret.appendColumn(_schema[i], _coldata[i].clone());
 				columnMetadata.add(new ColumnMetadata(_colmeta[i]));
+				if(_colnames != null)
+					ret._colnames[k++] = _colnames[i];
 			}
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/FrameBlock.java
@@ -2536,16 +2536,19 @@ public class FrameBlock implements CacheBlock, Externalizable {
 			for(int i = 0; i < _numRows; i++) {
 				boolean isEmpty = true;
 				Object[] row = new Object[getNumColumns()];
-				for(int j = 0; j < getNumColumns() && isEmpty; j++) {
+				for(int j = 0; j < getNumColumns(); j++) {
 					row[j] = _coldata[j].get(i);
-					isEmpty = isEmpty && (ArrayUtils.contains(new double[]{0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(_schema[j], _coldata[j].get(i))));
+					isEmpty = isEmpty && ArrayUtils.contains(new double[]{0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(_schema[j], _coldata[j].get(i)));
 				}
 
 				if(!isEmpty)
 					ret.appendRow(row);
 			}
 		} else {
-			List<Integer> indices = DataConverter.convertVectorToIndicesList(select);
+			if(select.getNonZeros() == getNumRows())
+				return new FrameBlock(this);
+
+			int[] indices = DataConverter.convertVectorToIndicesList(select);
 
 			for(int i : indices) {
 				Object[] row = new Object[getNumColumns()];
@@ -2587,7 +2590,10 @@ public class FrameBlock implements CacheBlock, Externalizable {
 				}
 			}
 		} else {
-			List<Integer> indices = DataConverter.convertVectorToIndicesList(select);
+			if(select.getNonZeros() == getNumColumns())
+				return new FrameBlock(this);
+
+			int[] indices = DataConverter.convertVectorToIndicesList(select);
 			int k = 0;
 			for(int i : indices) {
 				ret.appendColumn(_schema[i], _coldata[i].clone());

--- a/src/main/java/org/apache/sysds/runtime/util/DataConverter.java
+++ b/src/main/java/org/apache/sysds/runtime/util/DataConverter.java
@@ -307,6 +307,34 @@ public class DataConverter {
 		return ret;
 	}
 
+	public static List<Integer> convertVectorToIndicesList(MatrixBlock mb)
+	{
+		int rows = mb.getNumRows();
+		int cols = mb.getNumColumns();
+		ArrayList<Integer> indices = new ArrayList<>();
+
+		if( mb.getNonZeros() > 0 )
+		{
+			if( mb.isInSparseFormat() )
+			{
+				Iterator<IJV> iter = mb.getSparseBlockIterator();
+				while( iter.hasNext() ) {
+					IJV cell = iter.next();
+					if( cell.getV() != 0.0)
+						indices.add(cell.getI()*cols+cell.getJ());
+				}
+			}
+			else {
+				for( int i=0, cix=0; i<rows; i++ )
+					for( int j=0; j<cols; j++, cix++)
+						if( mb.getValueDenseUnsafe(i, j) != 0.0 )
+							indices.add(cix);
+			}
+		}
+
+		return indices;
+	}
+
 	public static int[] convertToIntVector( MatrixBlock mb) {
 		int rows = mb.getNumRows();
 		int cols = mb.getNumColumns();

--- a/src/main/python/tests/frame/test_slice.py
+++ b/src/main/python/tests/frame/test_slice.py
@@ -69,18 +69,26 @@ class TestFederatedAggFn(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.sds.from_pandas(df)[[-1]]
 
-    # https://issues.apache.org/jira/browse/SYSTEMDS-3203
-    # def test_slice_first_third_col(self):
-    #     sm = self.sds.from_pandas(df)[:, [0, 2]]
-    #     sr = sm.compute()
-    #     e = df.loc[:, [0, 2]]
-    #     self.assertTrue((e.values == sr.values).all())
+    def test_slice_first_third_col(self):
+        sm = self.sds.from_pandas(df)[:, [0, 2]]
+        sr = sm.compute()
+        e = pd.DataFrame(
+            {
+                "col1": ["col1_hello_3", "col1_world_3", "col1_hello_3"],
+                "col3": [0.6, 0.7, 0.8],
+            }
+        )
+        self.assertTrue((e.values == sr.values).all())
 
-    # def test_slice_single_col(self):
-    #     sm = self.sds.from_pandas(df)[:, [1]]
-    #     sr = sm.compute()
-    #     e = df.loc[:, [1]]
-    #     self.assertTrue((e.values == sr.values).all())
+    def test_slice_single_col(self):
+        sm = self.sds.from_pandas(df)[:, [1]]
+        sr = sm.compute()
+        e = pd.DataFrame(
+            {
+                "col1": ["col1_hello_3", "col1_world_3", "col1_hello_3"]
+            }
+        )
+        self.assertTrue((e.values == sr.values).all())
 
     def test_slice_row_col_both(self):
         with self.assertRaises(NotImplementedError):

--- a/src/main/python/tests/frame/test_slice.py
+++ b/src/main/python/tests/frame/test_slice.py
@@ -85,7 +85,7 @@ class TestFederatedAggFn(unittest.TestCase):
         sr = sm.compute()
         e = pd.DataFrame(
             {
-                "col1": ["col1_hello_3", "col1_world_3", "col1_hello_3"]
+                "col2": [6, 7, 8]
             }
         )
         self.assertTrue((e.values == sr.values).all())

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmptyTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmptyTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.test.component.frame;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -27,15 +29,15 @@ import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.apache.sysds.test.functions.unary.matrix.RemoveEmptyTest;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FrameRemoveEmptyTest extends AutomatedTestBase {
 	private final static String TEST_NAME1 = "removeEmpty1";
+	private final static String TEST_NAME2 = "removeEmpty2";
 	private final static String TEST_DIR = "functions/frame/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + RemoveEmptyTest.class.getSimpleName() + "/";
 
-	private final static int _rows = 100;
+	private final static int _rows = 10;
 	private final static int _cols = 6;
 
 	private final static double _sparsityDense = 0.7;
@@ -43,32 +45,38 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 	@Override
 	public void setUp() {
 		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"V"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"V"}));
 	}
 
 	@Test
 	public void testRemoveEmptyRowsCP() {
-		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.CP, false);
+		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.CP, false, false);
 	}
 
 	@Test
 	public void testRemoveEmptyColsCP() {
-		runTestRemoveEmpty(TEST_NAME1, "cols", Types.ExecType.CP, true);
+		runTestRemoveEmpty(TEST_NAME1, "cols", Types.ExecType.CP, false, false);
 	}
 
 	@Test
-	@Ignore
-	public void testRemoveEmptyRowsSP() {
-		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.SPARK, false);
+	public void testRemoveEmptyRowsSelectFullCP() {
+		runTestRemoveEmpty(TEST_NAME2, "rows", Types.ExecType.CP, true, true);
 	}
 
 	@Test
-	@Ignore
-	public void testRemoveEmptyColsSP() {
-		runTestRemoveEmpty(TEST_NAME1, "cols", Types.ExecType.SPARK, true);
+	public void testRemoveEmptyColsSelectFullCP() { runTestRemoveEmpty(TEST_NAME2, "cols", Types.ExecType.CP, true, true); }
+
+	@Test
+	public void testRemoveEmptyRowsSelectCP() {
+		runTestRemoveEmpty(TEST_NAME2, "rows", Types.ExecType.CP, true, false);
 	}
 
-	private void runTestRemoveEmpty(String testname, String margin, Types.ExecType et, boolean bSelectIndex) {
-		// rtplatform for MR
+	@Test
+	public void testRemoveEmptyColsSelectCP() {
+		runTestRemoveEmpty(TEST_NAME2, "cols", Types.ExecType.CP, true, false);
+	}
+
+	private void runTestRemoveEmpty(String testname, String margin, Types.ExecType et, boolean bSelectIndex, boolean fullSelect) {
 		Types.ExecMode platformOld = rtplatform;
 		switch(et) {
 			case SPARK:
@@ -90,24 +98,25 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 			config.addVariable("cols", _cols);
 			loadTestConfiguration(config);
 
-			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[] {"-explain", "-args", input("V"), margin, output("V")};
+			programArgs = new String[] {"-explain", "-args", input("V"), input("I"), margin, output("V")};
 
-			MatrixBlock in = createInputMatrix(margin, _rows, _cols, _sparsityDense, bSelectIndex);
+			Pair<MatrixBlock, MatrixBlock> data = createInputMatrix(margin, bSelectIndex, fullSelect);
+			MatrixBlock in = data.getKey();
+			MatrixBlock select = data.getValue();
 
 			runTest(true, false, null, -1);
+
+			MatrixBlock expected;
 			double[][] outArray = TestUtils.convertHashMapToDoubleArray(readDMLMatrixFromOutputDir("V"));
 			MatrixBlock out = new MatrixBlock(outArray.length, outArray[0].length, false);
 			out.init(outArray, outArray.length, outArray[0].length);
 
-			MatrixBlock in2 = new MatrixBlock(_rows, _cols + 2, 0.0);
-			in2.copy(0, _rows - 1, 0, _cols - 1, in, true);
-			in2.copy(0, (_rows / 2) - 1, _cols, _cols + 1, new MatrixBlock(_rows / 2, 2, 1.0), true);
-			MatrixBlock expected = in2.removeEmptyOperations(new MatrixBlock(), margin.equals("rows"), false, null);
-			expected = expected.slice(0, expected.getNumRows() - 1, 0, expected.getNumColumns() - 3);
-
+			if(!fullSelect)
+				expected = in.removeEmptyOperations(new MatrixBlock(), margin.equals("rows"), false, select);
+			else
+				expected = in;
 			TestUtils.compareMatrices(expected, out, 0);
 		}
 		finally {
@@ -117,79 +126,83 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 		}
 	}
 
-	private MatrixBlock createInputMatrix(String margin, int rows, int cols, double sparsity, boolean bSelectIndex) {
+	private Pair<MatrixBlock, MatrixBlock> createInputMatrix(String margin, boolean bSelectIndex, boolean fullSelect) {
 		int rowsp = -1, colsp = -1;
 		if(margin.equals("rows")) {
-			rowsp = rows / 2;
-			colsp = cols;
+			rowsp = _rows / 2;
+			colsp = _cols;
 		}
 		else {
-			rowsp = rows;
-			colsp = cols / 2;
+			rowsp = _rows;
+			colsp = _cols / 2;
 		}
 
 		// long seed = System.nanoTime();
-		double[][] V = getRandomMatrix(rows, cols, 0, 1, sparsity, 7);
+		double[][] V = getRandomMatrix(_rows, _cols, 0, 1,
+			FrameRemoveEmptyTest._sparsityDense, 7);
 		double[][] Vp = new double[rowsp][colsp];
-		double[][] Ix = null;
+		double[][] Ix;
 		int innz = 0, vnnz = 0;
 
 		// clear out every other row/column
 		if(margin.equals("rows")) {
-			Ix = new double[rows][1];
-			for(int i = 0; i < rows; i++) {
+			Ix = new double[_rows][1];
+			for(int i = 0; i < _rows; i++) {
 				boolean clear = i % 2 != 0;
-				if(clear) {
-					for(int j = 0; j < cols; j++)
+				if(clear  && !fullSelect) {
+					for(int j = 0; j < _cols; j++)
 						V[i][j] = 0;
 					Ix[i][0] = 0;
 				}
 				else {
 					boolean bNonEmpty = false;
-					for(int j = 0; j < cols; j++) {
+					for(int j = 0; j < _cols; j++) {
 						Vp[i / 2][j] = V[i][j];
-						bNonEmpty |= (V[i][j] != 0.0) ? true : false;
+						bNonEmpty |= V[i][j] != 0.0;
 						vnnz += (V[i][j] == 0.0) ? 0 : 1;
 					}
-					Ix[i][0] = (bNonEmpty) ? 1 : 0;
+					Ix[i][0] = (bNonEmpty || fullSelect) ? 1 : 0;
 					innz += Ix[i][0];
 				}
 			}
 		}
 		else {
-			Ix = new double[1][cols];
-			for(int j = 0; j < cols; j++) {
+			Ix = new double[1][_cols];
+			for(int j = 0; j < _cols; j++) {
 				boolean clear = j % 2 != 0;
-				if(clear) {
-					for(int i = 0; i < rows; i++)
+				if(clear && !fullSelect) {
+					for(int i = 0; i < _rows; i++)
 						V[i][j] = 0;
 					Ix[0][j] = 0;
 				}
 				else {
 					boolean bNonEmpty = false;
-					for(int i = 0; i < rows; i++) {
+					for(int i = 0; i < _rows; i++) {
 						Vp[i][j / 2] = V[i][j];
-						bNonEmpty |= (V[i][j] != 0.0) ? true : false;
+						bNonEmpty |= V[i][j] != 0.0;
 						vnnz += (V[i][j] == 0.0) ? 0 : 1;
 					}
-					Ix[0][j] = (bNonEmpty) ? 1 : 0;
+					Ix[0][j] = (bNonEmpty || fullSelect) ? 1 : 0;
 					innz += Ix[0][j];
 				}
 			}
 		}
 
-		MatrixCharacteristics imc = new MatrixCharacteristics(margin.equals("rows") ? rows : 1,
-			margin.equals("rows") ? 1 : cols, 1000, innz);
-		MatrixCharacteristics vmc = new MatrixCharacteristics(rows, cols, 1000, vnnz);
+		MatrixCharacteristics imc = new MatrixCharacteristics(margin.equals("rows") ? FrameRemoveEmptyTest._rows : 1,
+			margin.equals("rows") ? 1 : _cols, 1000, innz);
+		MatrixCharacteristics vmc = new MatrixCharacteristics(_rows, _cols, 1000, vnnz);
 
-		MatrixBlock in = new MatrixBlock(rows, cols, false);
+		MatrixBlock in = new MatrixBlock(_rows, _cols, false);
 		in.init(V, _rows, _cols);
+
+		MatrixBlock select = new MatrixBlock(Ix.length, Ix[0].length, false);
+		select.init(Ix, Ix.length, Ix[0].length);
 
 		writeInputMatrixWithMTD("V", V, false, vmc); // always text
 		writeExpectedMatrix("V", Vp);
 		if(bSelectIndex)
 			writeInputMatrixWithMTD("I", Ix, false, imc);
 
-		return in;
+		return new ImmutablePair(in, select);
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmptyTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmptyTest.java
@@ -35,7 +35,7 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 	private final static String TEST_DIR = "functions/frame/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + RemoveEmptyTest.class.getSimpleName() + "/";
 
-	private final static int _rows = 10;
+	private final static int _rows = 100;
 	private final static int _cols = 6;
 
 	private final static double _sparsityDense = 0.7;
@@ -46,25 +46,25 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void testRemoveEmptyRowsDenseCP() {
+	public void testRemoveEmptyRowsCP() {
 		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.CP, false);
 	}
 
 	@Test
-	public void testRemoveEmptyRowsSparseCP() {
+	public void testRemoveEmptyColsCP() {
 		runTestRemoveEmpty(TEST_NAME1, "cols", Types.ExecType.CP, true);
 	}
 
 	@Test
 	@Ignore
-	public void testRemoveEmptyRowsDenseSP() {
+	public void testRemoveEmptyRowsSP() {
 		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.SPARK, false);
 	}
 
 	@Test
 	@Ignore
-	public void testRemoveEmptyRowsSparseSP() {
-		runTestRemoveEmpty(TEST_NAME1, "rows", Types.ExecType.SPARK, true);
+	public void testRemoveEmptyColsSP() {
+		runTestRemoveEmpty(TEST_NAME1, "cols", Types.ExecType.SPARK, true);
 	}
 
 	private void runTestRemoveEmpty(String testname, String margin, Types.ExecType et, boolean bSelectIndex) {

--- a/src/test/scripts/functions/frame/removeEmpty2.dml
+++ b/src/test/scripts/functions/frame/removeEmpty2.dml
@@ -22,5 +22,5 @@
 
 A = read($1, naStrings= ["NA", "null","  ","NaN", "nan", "", "?", "99999"])
 V = as.frame(A)
-Vp = removeEmpty(target=V, margin=$3)
+Vp = removeEmpty(target=V, margin=$3, select=read($2))
 write(Vp, $4);


### PR DESCRIPTION
rmempty instruction parameter select can be either row or column vector now, independent of the margin (before for margin cols - row vector,  margin rows - column vector).
Additionally, tests failed because of the incorrect pd.DataFrame column slices.