### PR TITLE
[SYSTEMDS-3236] Cache-friendly Apply phase for dense target matrix

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
@@ -208,6 +208,11 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	}
 
 	@Override
+	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+		throw new DMLRuntimeException("CompositeEncoder does not have a Code");
+	}
+
+	@Override
 	protected TransformType getTransformType() {
 		return TransformType.N_A;
 	}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -75,6 +75,11 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 		throw new DMLRuntimeException("DummyCoder does not have a code");
 	}
 
+	@Override
+	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+		throw new DMLRuntimeException("DummyCoder does not have a code");
+	}
+
 	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		if (!(in instanceof MatrixBlock)){
 			throw new DMLRuntimeException("ColumnEncoderDummycode called with: " + in.getClass().getSimpleName() +

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
+import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -65,10 +66,25 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 
 	@Override
 	protected double getCode(CacheBlock in, int row) {
+		// hash a single row
 		String key = in.getString(row, _colID - 1);
 		if(key == null)
 			return Double.NaN;
 		return (key.hashCode() % _K) + 1;
+	}
+
+	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+		// hash a block of rows
+		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
+		double codes[] = new double[endInd-startInd];
+		for (int i=startInd; i<endInd; i++) {
+			String key = in.getString(i, _colID - 1);
+			if(key == null || key.isEmpty())
+				codes[i-startInd] = Double.NaN;
+			else
+				codes[i-startInd] = (key.hashCode() % _K) + 1;
+		}
+		return codes;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -65,6 +65,15 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 		return in.getDoubleNaN(row, _colID - 1);
 	}
 
+	@Override
+	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
+		double codes[] = new double[endInd-startInd];
+		for (int i=startInd; i<endInd; i++) {
+			codes[i-startInd] = in.getDoubleNaN(i, _colID-1);
+		}
+		return codes;
+	}
 
 	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		Set<Integer> sparseRowsWZeros = null;


### PR DESCRIPTION
This patch adds loop-tiling logic to the apply phase of transformencode
to exploit CPU caches. Currently, the changes are limited to dense
matrices.
Loop-tiling shows 2x performance improvement in recoding a frame
having 5M rows, 100 columens (100K unique in each) and w/ 32 threads.