### PR TITLE
[SYSTEMDS-3236] Cache-friendly Apply phase for sparse target matrix

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -119,12 +119,28 @@ public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder
 	protected abstract double[] getCodeCol(CacheBlock in, int startInd, int blkSize);
 
 
-	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+	/*protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		int index = _colID - 1;
 		for(int r = rowStart; r < getEndIndex(in.getNumRows(), rowStart, blk); r++) {
 			SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(r);
 			row.values()[index] = getCode(in, r);
 			row.indexes()[index] = outputCol;
+		}
+	}*/
+
+	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+		int index = _colID - 1;
+		// Apply loop tiling to exploit CPU caches
+		double[] codes = getCodeCol(in, rowStart, blk);
+		int rowEnd = getEndIndex(in.getNumRows(), rowStart, blk);
+		int B = 32; //tile size
+		for(int i = rowStart; i < rowEnd; i+=B) {
+			int lim = Math.min(i+B, rowEnd);
+			for (int ii=i; ii<lim; ii++) {
+				SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(ii);
+				row.values()[index] = codes[ii-rowStart];
+				row.indexes()[index] = outputCol;
+			}
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -78,16 +78,23 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		Set<Integer> sparseRowsWZeros = null;
 		int index = _colID - 1;
-		for(int r = rowStart; r < getEndIndex(in.getNumRows(), rowStart, blk); r++) {
-			double v = getCode(in, r);
-			SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(r);
-			if(v == 0) {
-				if(sparseRowsWZeros == null)
-					sparseRowsWZeros = new HashSet<>();
-				sparseRowsWZeros.add(r);
+		// Apply loop tiling to exploit CPU caches
+		double[] codes = getCodeCol(in, rowStart, blk);
+		int rowEnd = getEndIndex(in.getNumRows(), rowStart, blk);
+		int B = 32; //tile size
+		for(int i = rowStart; i < rowEnd; i+=B) {
+			int lim = Math.min(i+B, rowEnd);
+			for (int ii=i; ii<lim; ii++) {
+				double v = codes[ii-rowStart];
+				SparseRowVector row = (SparseRowVector) out.getSparseBlock().get(ii);
+				if(v == 0) {
+					if(sparseRowsWZeros == null)
+						sparseRowsWZeros = new HashSet<>();
+					sparseRowsWZeros.add(ii);
+				}
+				row.values()[index] = v;
+				row.indexes()[index] = outputCol;
 			}
-			row.values()[index] = v;
-			row.indexes()[index] = outputCol;
 		}
 		if(sparseRowsWZeros != null){
 			addSparseRowsWZeros(sparseRowsWZeros);


### PR DESCRIPTION
This patch extends the loop-tiling logic for the apply phases
to sparse matrices as well.