### PR TITLE
[SYSTEMDS-3018] Edit Federated Planner to Handle Double Hop Output Cases

### DIFF
--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -93,6 +93,13 @@ public abstract class Hop implements ParseInfo {
 	 */
 	protected FederatedOutput _federatedOutput = FederatedOutput.NONE;
 	protected FederatedCost _federatedCost = new FederatedCost();
+	/**
+	 * Field defining if prefetch should be activated for operation.
+	 * When prefetch is activated, the output will be transferred from
+	 * remote federated sites to local before one of the subsequent
+	 * local operations.
+	 */
+	protected boolean activatePrefetch;
 	
 	// Estimated size for the output produced from this Hop in bytes
 	protected double _outputMemEstimate = OptimizerUtils.INVALID_SIZE;
@@ -186,6 +193,13 @@ public abstract class Hop implements ParseInfo {
 
 	public void setFederatedOutput(FederatedOutput federatedOutput){
 		_federatedOutput = federatedOutput;
+	}
+
+	/**
+	 * Activate prefetch of HOP.
+	 */
+	public void activatePrefetch(){
+		activatePrefetch = true;
 	}
 	
 	public void resetExecType()

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,6 +93,7 @@ public abstract class Hop implements ParseInfo {
 	 */
 	protected FederatedOutput _federatedOutput = FederatedOutput.NONE;
 	protected FederatedCost _federatedCost = new FederatedCost();
+
 	/**
 	 * Field defining if prefetch should be activated for operation.
 	 * When prefetch is activated, the output will be transferred from
@@ -204,6 +203,10 @@ public abstract class Hop implements ParseInfo {
 		activatePrefetch = true;
 	}
 
+	/**
+	 * Checks if prefetch is activated for this hop.
+	 * @return true if prefetch is activated
+	 */
 	public boolean prefetchActivated(){
 		return activatePrefetch;
 	}
@@ -896,24 +899,12 @@ public abstract class Hop implements ParseInfo {
 			_etype = ExecType.FED;
 	}
 
+	/**
+	 * Checks if some input to this hop has prefetch activated.
+	 * @return true if some input has prefetch activated
+	 */
 	private boolean someInputPrefetch(){
 		return getInput().stream().anyMatch(Hop::prefetchActivated);
-	}
-
-	/**
-	 * Check if any input needs to be prefetched.
-	 * @return true if any input needs to be prefetched.
-	 */
-	public boolean needsPrefetch(){
-		return !isFederated() && someInputFederated();
-	}
-
-	/**
-	 * Get list of input which needs to be prefetched.
-	 * @return list of input which needs to be prefetched.
-	 */
-	public List<Hop> getPrefetchInput(){
-		return getInput().stream().filter(Hop::hasFederatedOutput).collect(Collectors.toList());
 	}
 
 	/**
@@ -1239,8 +1230,6 @@ public abstract class Hop implements ParseInfo {
 
 	public void setLops(Lop lops) {
 		_lops = lops;
-		if ( needsPrefetch() )
-			_lops.setPrefetchLops(getPrefetchInput().stream().map(Hop::getLops).collect(Collectors.toList()));
 	}
 
 	public boolean isVisited() {

--- a/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
+++ b/src/main/java/org/apache/sysds/hops/cost/FederatedCostEstimator.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.hops.cost;
 
 import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.ipa.MemoTable;
 import org.apache.sysds.parser.DMLProgram;
 import org.apache.sysds.parser.ForStatement;
 import org.apache.sysds.parser.ForStatementBlock;
@@ -33,8 +34,6 @@ import org.apache.sysds.parser.WhileStatement;
 import org.apache.sysds.parser.WhileStatementBlock;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Cost estimator for federated executions with methods and constants for going through DML programs to estimate costs.
@@ -200,10 +199,9 @@ public class FederatedCostEstimator {
 	 * @param hopRelMemo memo table of HopRels for calculating input costs
 	 * @return cost estimation of Hop DAG starting from given root HopRel
 	 */
-	public FederatedCost costEstimate(HopRel root, Map<Long, List<HopRel>> hopRelMemo){
+	public FederatedCost costEstimate(HopRel root, MemoTable hopRelMemo){
 		// Check if root is in memo table.
-		if ( hopRelMemo.containsKey(root.hopRef.getHopID())
-			&& hopRelMemo.get(root.hopRef.getHopID()).stream().anyMatch(h -> h.fedOut == root.fedOut) ){
+		if ( hopRelMemo.containsHopRel(root) ){
 			return root.getCostObject();
 		}
 		else {

--- a/src/main/java/org/apache/sysds/hops/cost/HopRel.java
+++ b/src/main/java/org/apache/sysds/hops/cost/HopRel.java
@@ -149,7 +149,7 @@ public class HopRel {
 			} else {
 				inputDependency.addAll(
 					hopRef.getInput().stream()
-						.map(input -> hopRelMemo.getMinCostAlternative(input) )
+						.map(hopRelMemo::getMinCostAlternative)
 						.collect(Collectors.toList()));
 			}
 		}

--- a/src/main/java/org/apache/sysds/hops/cost/HopRel.java
+++ b/src/main/java/org/apache/sysds/hops/cost/HopRel.java
@@ -21,15 +21,14 @@ package org.apache.sysds.hops.cost;
 
 import org.apache.sysds.api.DMLException;
 import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.ipa.MemoTable;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FederatedOutput;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,7 +51,7 @@ public class HopRel {
 	 * @param fedOut FederatedOutput value assigned to this HopRel
 	 * @param hopRelMemo memo table storing other HopRels including the inputs of associatedHop
 	 */
-	public HopRel(Hop associatedHop, FEDInstruction.FederatedOutput fedOut, Map<Long, List<HopRel>> hopRelMemo){
+	public HopRel(Hop associatedHop, FEDInstruction.FederatedOutput fedOut, MemoTable hopRelMemo){
 		hopRef = associatedHop;
 		this.fedOut = fedOut;
 		setInputDependency(hopRelMemo);
@@ -108,27 +107,15 @@ public class HopRel {
 	 * @param hopRelMemo memo table storing HopRels
 	 * @return FOUT HopRel found in hopRelMemo
 	 */
-	private HopRel getFOUTHopRel(Hop hop, Map<Long, List<HopRel>> hopRelMemo){
-		return hopRelMemo.get(hop.getHopID()).stream().filter(in->in.fedOut==FederatedOutput.FOUT).findFirst().orElse(null);
-	}
-
-	/**
-	 * Get the HopRel with minimum cost for given hop
-	 * @param hopRelMemo memo table storing HopRels
-	 * @param input hop for which minimum cost HopRel is found
-	 * @return HopRel with minimum cost for given hop
-	 */
-	private HopRel getMinOfInput(Map<Long, List<HopRel>> hopRelMemo, Hop input){
-		return hopRelMemo.get(input.getHopID()).stream()
-			.min(Comparator.comparingDouble(a -> a.cost.getTotal()))
-			.orElseThrow(() -> new DMLException("No element in Memo Table found for input"));
+	private HopRel getFOUTHopRel(Hop hop, MemoTable hopRelMemo){
+		return hopRelMemo.getFederatedOutputAlternativeOrNull(hop);
 	}
 
 	/**
 	 * Set valid and optimal input dependency for this HopRel as a field.
 	 * @param hopRelMemo memo table storing input HopRels
 	 */
-	private void setInputDependency(Map<Long, List<HopRel>> hopRelMemo){
+	private void setInputDependency(MemoTable hopRelMemo){
 		if (hopRef.getInput() != null && hopRef.getInput().size() > 0) {
 			if ( fedOut == FederatedOutput.FOUT && !hopRef.isFederatedDataOp() ) {
 				int lowestFOUTIndex = 0;
@@ -152,7 +139,7 @@ public class HopRel {
 				for(int i = 0; i < hopRef.getInput().size(); i++) {
 					if(i != lowestFOUTIndex) {
 						Hop input = hopRef.getInput(i);
-						inputHopRels[i] = getMinOfInput(hopRelMemo, input);
+						inputHopRels[i] = hopRelMemo.getMinCostAlternative(input);
 					}
 					else {
 						inputHopRels[i] = lowestFOUTHopRel;
@@ -162,7 +149,7 @@ public class HopRel {
 			} else {
 				inputDependency.addAll(
 					hopRef.getInput().stream()
-						.map(input -> getMinOfInput(hopRelMemo, input))
+						.map(input -> hopRelMemo.getMinCostAlternative(input) )
 						.collect(Collectors.toList()));
 			}
 		}

--- a/src/main/java/org/apache/sysds/hops/ipa/IPAPassRewriteFederatedPlan.java
+++ b/src/main/java/org/apache/sysds/hops/ipa/IPAPassRewriteFederatedPlan.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.hops.ipa;
 
-import org.apache.sysds.api.DMLException;
 import org.apache.sysds.hops.AggBinaryOp;
 import org.apache.sysds.hops.AggUnaryOp;
 import org.apache.sysds.hops.BinaryOp;
@@ -45,10 +44,9 @@ import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 /**
  * This rewrite generates a federated execution plan by estimating and setting costs and the FederatedOutput values of
@@ -57,7 +55,8 @@ import java.util.Map;
  */
 public class IPAPassRewriteFederatedPlan extends IPAPass {
 
-	private final static Map<Long, List<HopRel>> hopRelMemo = new HashMap<>();
+	private final static MemoTable hopRelMemo = new MemoTable();
+	private final static Set<Long> hopRelUpdatedFinal = new HashSet<>();
 
 	/**
 	 * Indicates if an IPA pass is applicable for the current configuration.
@@ -189,9 +188,7 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 	 * @param root hop for which FederatedOutput needs to be set
 	 */
 	private void setFinalFedout(Hop root) {
-		HopRel optimalRootHopRel = hopRelMemo.get(root.getHopID()).stream()
-			.min(Comparator.comparingDouble(HopRel::getCost))
-			.orElseThrow(() -> new DMLException("Hop root " + root + " has no feasible federated output alternatives"));
+		HopRel optimalRootHopRel = hopRelMemo.getMinCostAlternative(root);
 		setFinalFedout(root, optimalRootHopRel);
 	}
 
@@ -202,8 +199,21 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 	 * @param rootHopRel from which FederatedOutput value and cost is retrieved
 	 */
 	private void setFinalFedout(Hop root, HopRel rootHopRel) {
-		updateFederatedOutput(root, rootHopRel);
-		visitInputDependency(rootHopRel);
+		if ( hopRelUpdatedFinal.contains(root.getHopID()) ){
+			if((rootHopRel.hasLocalOutput() ^ root.hasLocalOutput()) && hopRelMemo.hasFederatedOutputAlternative(root)){
+				// Update with FOUT alternative without visiting inputs
+				updateFederatedOutput(root, hopRelMemo.getFederatedOutputAlternative(root));
+				root.activatePrefetch();
+			}
+			else {
+				// Update without visiting inputs
+				updateFederatedOutput(root, rootHopRel);
+			}
+		}
+		else {
+			updateFederatedOutput(root, rootHopRel);
+			visitInputDependency(rootHopRel);
+		}
 	}
 
 	/**
@@ -226,6 +236,7 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 	private void updateFederatedOutput(Hop root, HopRel updateHopRel) {
 		root.setFederatedOutput(updateHopRel.getFederatedOutput());
 		root.setFederatedCost(updateHopRel.getCostObject());
+		hopRelUpdatedFinal.add(root.getHopID());
 	}
 
 	/**
@@ -257,7 +268,7 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 	 */
 	private void visitFedPlanHop(Hop currentHop) {
 		// If the currentHop is in the hopRelMemo table, it means that it has been visited
-		if(hopRelMemo.containsKey(currentHop.getHopID()))
+		if(hopRelMemo.containsHop(currentHop))
 			return;
 		// If the currentHop has input, then the input should be visited depth-first
 		if(currentHop.getInput() != null && currentHop.getInput().size() > 0) {
@@ -273,7 +284,7 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 		}
 		if(hopRels.isEmpty())
 			hopRels.add(new HopRel(currentHop, FEDInstruction.FederatedOutput.NONE, hopRelMemo));
-		hopRelMemo.put(currentHop.getHopID(), hopRels);
+		hopRelMemo.put(currentHop, hopRels);
 	}
 
 	/**
@@ -319,8 +330,8 @@ public class IPAPassRewriteFederatedPlan extends IPAPass {
 		if(associatedHop instanceof AggUnaryOp && associatedHop.isScalar())
 			return false;
 		// It can only be FOUT if at least one of the inputs are FOUT, except if it is a federated DataOp
-		if(associatedHop.getInput().stream().noneMatch(input -> hopRelMemo.get(input.getHopID()).stream()
-			.anyMatch(HopRel::hasFederatedOutput)) && !associatedHop.isFederatedDataOp())
+		if(associatedHop.getInput().stream().noneMatch(hopRelMemo::hasFederatedOutputAlternative)
+			&& !associatedHop.isFederatedDataOp())
 			return false;
 		return true;
 	}

--- a/src/main/java/org/apache/sysds/hops/ipa/MemoTable.java
+++ b/src/main/java/org/apache/sysds/hops/ipa/MemoTable.java
@@ -1,0 +1,96 @@
+package org.apache.sysds.hops.ipa;
+
+import org.apache.sysds.api.DMLException;
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.cost.HopRel;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Memoization of federated execution alternatives.
+ * This memoization data structure is used when generating optimal federated execution plans.
+ * The alternative executions are stored as HopRels and the methods of this class are used to
+ * add, update, and retrieve the alternatives.
+ */
+public class MemoTable {
+	/**
+	 * Map holding the relation between Hop IDs and execution plan alternatives.
+	 */
+	private final static Map<Long, List<HopRel>> hopRelMemo = new HashMap<>();
+
+	/**
+	 * Get the HopRel with minimum cost for given root hop
+	 * @param root hop for which minimum cost HopRel is found
+	 * @return HopRel with minimum cost for given hop
+	 */
+	public HopRel getMinCostAlternative(Hop root){
+		return hopRelMemo.get(root.getHopID()).stream()
+			.min(Comparator.comparingDouble(HopRel::getCost))
+			.orElseThrow(() -> new DMLException("Hop root " + root + " has no feasible federated output alternatives"));
+	}
+
+	/**
+	 * Checks if any of the federated execution alternatives for the given root hop has federated output.
+	 * @param root hop for which execution alternatives are checked
+	 * @return true if root has federated output as an execution alternative
+	 */
+	public boolean hasFederatedOutputAlternative(Hop root){
+		return hopRelMemo.get(root.getHopID()).stream().anyMatch(HopRel::hasFederatedOutput);
+	}
+
+	/**
+	 * Get the federated output alternative for given root hop or throw exception if not found.
+	 * @param root hop for which federated output HopRel is returned
+	 * @return federated output HopRel for given root hop
+	 */
+	public HopRel getFederatedOutputAlternative(Hop root){
+		return getFederatedOutputAlternativeOptional(root).orElseThrow(
+			() -> new DMLException("Hop root " + root + " has no FOUT alternative"));
+	}
+
+	/**
+	 * Get the federated output alternative for given root hop or null if not found.
+	 * @param root hop for which federated output HopRel is returned
+	 * @return federated output HopRel for given root hop
+	 */
+	public HopRel getFederatedOutputAlternativeOrNull(Hop root){
+		return getFederatedOutputAlternativeOptional(root).orElse(null);
+	}
+
+	private Optional<HopRel> getFederatedOutputAlternativeOptional(Hop root){
+		return hopRelMemo.get(root.getHopID()).stream().filter(HopRel::hasFederatedOutput).findFirst();
+	}
+
+	/**
+	 * Memoize hopRels related to given root.
+	 * @param root for which hopRels are added
+	 * @param hopRels execution alternatives related to the given root
+	 */
+	public void put(Hop root, List<HopRel> hopRels){
+		hopRelMemo.put(root.getHopID(), hopRels);
+	}
+
+	/**
+	 * Checks if root hop has been added to memo.
+	 * @param root hop
+	 * @return true if root has been added to memo.
+	 */
+	public boolean containsHop(Hop root){
+		return hopRelMemo.containsKey(root.getHopID());
+	}
+
+	/**
+	 * Checks if given HopRel has been added to memo.
+	 * @param root HopRel
+	 * @return true if root HopRel has been added to memo.
+	 */
+	public boolean containsHopRel(HopRel root){
+		return containsHop(root.getHopRef())
+			&& hopRelMemo.get(root.getHopRef().getHopID()).stream()
+			.anyMatch(h -> h.getFederatedOutput() == root.getFederatedOutput());
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/ipa/MemoTable.java
+++ b/src/main/java/org/apache/sysds/hops/ipa/MemoTable.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysds.hops.ipa;
 
 import org.apache.sysds.api.DMLException;

--- a/src/main/java/org/apache/sysds/lops/Lop.java
+++ b/src/main/java/org/apache/sysds/lops/Lop.java
@@ -20,7 +20,6 @@
 package org.apache.sysds.lops;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
@@ -117,8 +116,12 @@ public abstract class Lop
 	 */
 	protected PrivacyConstraint privacyConstraint;
 
-	protected List<Lop> prefetchLops;
-
+	/**
+	 * Field defining if prefetch should be activated for operation.
+	 * When prefetch is activated, the output will be transferred from
+	 * remote federated sites to local before one of the subsequent
+	 * local operations.
+	 */
 	protected boolean activatePrefetch;
 
 	/**
@@ -319,10 +322,6 @@ public abstract class Lop
 
 	public PrivacyConstraint getPrivacyConstraint(){
 		return privacyConstraint;
-	}
-
-	public void setPrefetchLops(List<Lop> prefetchLops){
-		this.prefetchLops = prefetchLops;
 	}
 
 	public void activatePrefetch(){

--- a/src/main/java/org/apache/sysds/lops/Lop.java
+++ b/src/main/java/org/apache/sysds/lops/Lop.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.lops;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
@@ -115,6 +116,10 @@ public abstract class Lop
 	 * Privacy Constraint
 	 */
 	protected PrivacyConstraint privacyConstraint;
+
+	protected List<Lop> prefetchLops;
+
+	protected boolean activatePrefetch;
 
 	/**
 	 * Enum defining if the output of the operation should be forced federated, forced local or neither.
@@ -316,8 +321,24 @@ public abstract class Lop
 		return privacyConstraint;
 	}
 
+	public void setPrefetchLops(List<Lop> prefetchLops){
+		this.prefetchLops = prefetchLops;
+	}
+
+	public void activatePrefetch(){
+		activatePrefetch = true;
+	}
+
+	public boolean prefetchActivated(){
+		return activatePrefetch;
+	}
+
 	public void setFederatedOutput(FederatedOutput fedOutput){
 		_fedOutput = fedOutput;
+	}
+
+	public FederatedOutput getFederatedOutput(){
+		return _fedOutput;
 	}
 	
 	public void setConsumerCount(int cc) {

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
@@ -591,17 +591,16 @@ public class FederationMap {
 		}
 		// derive output type
 		switch(_type) {
-			case FULL:
-				_type = FType.FULL;
-				break;
 			case ROW:
 				_type = FType.COL;
 				break;
 			case COL:
 				_type = FType.ROW;
 				break;
+			case FULL:
 			case PART:
-				_type = FType.PART;
+				// FULL and PART are not changed
+				break;
 			default:
 				_type = FType.OTHER;
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BroadcastCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BroadcastCPInstruction.java
@@ -44,8 +44,8 @@ public class BroadcastCPInstruction extends UnaryCPInstruction {
 	public void processInstruction(ExecutionContext ec) {
 		ec.setVariable(output.getName(), ec.getMatrixObject(input1));
 
-		if (CommonThreadPool.triggerRDDPool == null)
-			CommonThreadPool.triggerRDDPool = Executors.newCachedThreadPool();
-		CommonThreadPool.triggerRDDPool.submit(new TriggerBroadcastTask(ec, ec.getMatrixObject(output)));
+		if (CommonThreadPool.triggerRemoteOPsPool == null)
+			CommonThreadPool.triggerRemoteOPsPool = Executors.newCachedThreadPool();
+		CommonThreadPool.triggerRemoteOPsPool.submit(new TriggerBroadcastTask(ec, ec.getMatrixObject(output)));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/PrefetchCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/PrefetchCPInstruction.java
@@ -49,8 +49,8 @@ public class PrefetchCPInstruction extends UnaryCPInstruction {
 		// If the next instruction which takes this output as an input comes before
 		// the prefetch thread triggers, that instruction will start the operations.
 		// In that case this Prefetch instruction will act like a NOOP. 
-		if (CommonThreadPool.triggerRDDPool == null)
-			CommonThreadPool.triggerRDDPool = Executors.newCachedThreadPool();
-		CommonThreadPool.triggerRDDPool.submit(new TriggerRDDOperationsTask(ec.getMatrixObject(output)));
+		if (CommonThreadPool.triggerRemoteOPsPool == null)
+			CommonThreadPool.triggerRemoteOPsPool = Executors.newCachedThreadPool();
+		CommonThreadPool.triggerRemoteOPsPool.submit(new TriggerRemoteOperationsTask(ec.getMatrixObject(output)));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/util/CommonThreadPool.java
+++ b/src/main/java/org/apache/sysds/runtime/util/CommonThreadPool.java
@@ -49,7 +49,7 @@ public class CommonThreadPool implements ExecutorService
 	private static final int size = InfrastructureAnalyzer.getLocalParallelism();
 	private static final ExecutorService shared = ForkJoinPool.commonPool();
 	private final ExecutorService _pool;
-	public static ExecutorService triggerRDDPool = null;
+	public static ExecutorService triggerRemoteOPsPool = null;
 
 	public CommonThreadPool(ExecutorService pool) {
 		_pool = pool;
@@ -80,10 +80,10 @@ public class CommonThreadPool implements ExecutorService
 	}
 
 	public static void shutdownAsyncRDDPool() {
-		if (triggerRDDPool != null) {
+		if (triggerRemoteOPsPool != null) {
 			//shutdown prefetch/broadcast thread pool
-			triggerRDDPool.shutdown();
-			triggerRDDPool = null;
+			triggerRemoteOPsPool.shutdown();
+			triggerRemoteOPsPool = null;
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -177,6 +177,7 @@ public class Statistics
 	private static final LongAdder federatedGetCount = new LongAdder();
 	private static final LongAdder federatedExecuteInstructionCount = new LongAdder();
 	private static final LongAdder federatedExecuteUDFCount = new LongAdder();
+	private static final LongAdder fedAsyncPrefetchCount = new LongAdder();
 
 	private static LongAdder numNativeFailures = new LongAdder();
 	public static LongAdder numNativeLibMatrixMultCalls = new LongAdder();
@@ -443,6 +444,10 @@ public class Statistics
 		}
 	}
 
+	public static void incFedAsyncPrefetchCount(long c) {
+		fedAsyncPrefetchCount.add(c);
+	}
+
 	public static void startCompileTimer() {
 		if( DMLScript.STATISTICS )
 			compileStartTime = System.nanoTime();
@@ -550,6 +555,7 @@ public class Statistics
 		federatedGetCount.reset();
 		federatedExecuteInstructionCount.reset();
 		federatedExecuteUDFCount.reset();
+		fedAsyncPrefetchCount.reset();
 
 		DMLCompressionStatistics.reset();
 	}
@@ -1220,6 +1226,8 @@ public class Statistics
 				sb.append("Federated Execute (Inst, UDF):\t" +
 					federatedExecuteInstructionCount.longValue() + "/" +
 					federatedExecuteUDFCount.longValue() + ".\n");
+				sb.append("Federated prefetch count:\t" +
+					fedAsyncPrefetchCount.longValue() + ".\n");
 			}
 			if( transformEncoderCount.longValue() > 0) {
 				//TODO: Cleanup and condense

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -162,7 +162,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	}
 
 	private void writeInputMatrices(String testName){
-		if ( testName.equals(TEST_NAME_5) || testName.equals(TEST_NAME_8) ){
+		if ( testName.equals(TEST_NAME_5) ){
 			writeColStandardMatrix("X1", 42);
 			writeColStandardMatrix("X2", 1340);
 			writeColStandardMatrix("Y1", 44, null);
@@ -173,6 +173,14 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 			writeColStandardMatrix("X2", 1340);
 			writeRowFederatedVector("Y1", 44);
 			writeRowFederatedVector("Y2", 21);
+		}
+		else if ( testName.equals(TEST_NAME_8) ){
+			writeColStandardMatrix("X1", 42, null);
+			writeColStandardMatrix("X2", 1340, null);
+			writeColStandardMatrix("Y1", 44, null);
+			writeColStandardMatrix("Y2", 21, null);
+			writeColStandardMatrix("W1", 76, null);
+			writeColStandardMatrix("W2", 11, null);
 		}
 		else {
 			writeStandardMatrix("X1", 42);
@@ -217,12 +225,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 			"X2=" + TestUtils.federatedAddress(port2, input("X2")),
 			"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
 			"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
-		if ( testName.equals(TEST_NAME_4) || testName.equals(TEST_NAME_5) || testName.equals(TEST_NAME_8) ){
-			programArgs = new String[] {"-stats","-explain", "-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
-				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
-				"Y1=" + input("Y1"),
-				"Y2=" + input("Y2"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
-		}
+		rewriteRealProgramArgs(testName, port1, port2);
 		runTest(true, false, null, -1);
 
 		OptimizerUtils.FEDERATED_COMPILATION = false;
@@ -231,6 +234,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		fullDMLScriptName = HOME + testName + "Reference.dml";
 		programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
 			"Y2=" + input("Y2"), "Z=" + expected("Z")};
+		rewriteReferenceProgramArgs(testName);
 		runTest(true, false, null, -1);
 
 		// compare via files
@@ -243,6 +247,30 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 
 		rtplatform = platformOld;
 		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+	}
+
+	private void rewriteRealProgramArgs(String testName, int port1, int port2){
+		if ( testName.equals(TEST_NAME_4) || testName.equals(TEST_NAME_5) ){
+			programArgs = new String[] {"-stats","-explain", "-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"Y1=" + input("Y1"),
+				"Y2=" + input("Y2"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+		} else if ( testName.equals(TEST_NAME_8) ){
+			programArgs = new String[] {"-stats","-explain", "-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
+				"Y2=" + TestUtils.federatedAddress(port2, input("Y2")),
+				"W1=" + input("W1"),
+				"W2=" + input("W2"),
+				"r=" + rows, "c=" + cols, "Z=" + output("Z")};
+		}
+	}
+
+	private void rewriteReferenceProgramArgs(String testName){
+		if ( testName.equals(TEST_NAME_8) ){
+			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
+				"Y2=" + input("Y2"), "W1=" + input("W1"), "W2=" + input("W2"), "Z=" + expected("Z")};
+		}
 	}
 }
 

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -47,6 +47,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	private final static String TEST_NAME_4 = "FederatedMultiplyPlanningTest4";
 	private final static String TEST_NAME_5 = "FederatedMultiplyPlanningTest5";
 	private final static String TEST_NAME_6 = "FederatedMultiplyPlanningTest6";
+	private final static String TEST_NAME_7 = "FederatedMultiplyPlanningTest7";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedMultiplyPlanningTest.class.getSimpleName() + "/";
 
 	private final static int blocksize = 1024;
@@ -64,6 +65,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		addTestConfiguration(TEST_NAME_4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_4, new String[] {"Z"}));
 		addTestConfiguration(TEST_NAME_5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_5, new String[] {"Z"}));
 		addTestConfiguration(TEST_NAME_6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_6, new String[] {"Z"}));
+		addTestConfiguration(TEST_NAME_7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_7, new String[] {"Z"}));
 	}
 
 	@Parameterized.Parameters
@@ -110,6 +112,12 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	public void federatedAggregateBinarySequence2(){
 		String[] expectedHeavyHitters = new String[]{"fed_ba+*","fed_fedinit"};
 		federatedTwoMatricesSingleNodeTest(TEST_NAME_6, expectedHeavyHitters);
+	}
+
+	@Test
+	public void federatedMultiplyDoubleHop() {
+		String[] expectedHeavyHitters = new String[]{"fed_*", "fed_fedinit", "fed_r'", "fed_ba+*"};
+		federatedTwoMatricesSingleNodeTest(TEST_NAME_7, expectedHeavyHitters);
 	}
 
 	private void writeStandardMatrix(String matrixName, long seed){

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -48,6 +48,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	private final static String TEST_NAME_5 = "FederatedMultiplyPlanningTest5";
 	private final static String TEST_NAME_6 = "FederatedMultiplyPlanningTest6";
 	private final static String TEST_NAME_7 = "FederatedMultiplyPlanningTest7";
+	private final static String TEST_NAME_8 = "FederatedMultiplyPlanningTest8";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedMultiplyPlanningTest.class.getSimpleName() + "/";
 
 	private final static int blocksize = 1024;
@@ -66,6 +67,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		addTestConfiguration(TEST_NAME_5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_5, new String[] {"Z"}));
 		addTestConfiguration(TEST_NAME_6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_6, new String[] {"Z"}));
 		addTestConfiguration(TEST_NAME_7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_7, new String[] {"Z"}));
+		addTestConfiguration(TEST_NAME_8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_8, new String[] {"Z.scalar"}));
 	}
 
 	@Parameterized.Parameters
@@ -120,6 +122,12 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 		federatedTwoMatricesSingleNodeTest(TEST_NAME_7, expectedHeavyHitters);
 	}
 
+	@Test
+	public void federatedMultiplyDoubleHop2() {
+		String[] expectedHeavyHitters = new String[]{"fed_fedinit", "fed_ba+*"};
+		federatedTwoMatricesSingleNodeTest(TEST_NAME_8, expectedHeavyHitters);
+	}
+
 	private void writeStandardMatrix(String matrixName, long seed){
 		writeStandardMatrix(matrixName, seed, new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
 	}
@@ -154,7 +162,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 	}
 
 	private void writeInputMatrices(String testName){
-		if ( testName.equals(TEST_NAME_5) ){
+		if ( testName.equals(TEST_NAME_5) || testName.equals(TEST_NAME_8) ){
 			writeColStandardMatrix("X1", 42);
 			writeColStandardMatrix("X2", 1340);
 			writeColStandardMatrix("Y1", 44, null);
@@ -209,7 +217,7 @@ public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
 			"X2=" + TestUtils.federatedAddress(port2, input("X2")),
 			"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
 			"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
-		if ( testName.equals(TEST_NAME_4) || testName.equals(TEST_NAME_5) ){
+		if ( testName.equals(TEST_NAME_4) || testName.equals(TEST_NAME_5) || testName.equals(TEST_NAME_8) ){
 			programArgs = new String[] {"-stats","-explain", "-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
 				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
 				"Y1=" + input("Y1"),

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest7.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest7.dml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = federated(addresses=list($X1, $X2),
+              ranges=list(list(0, 0), list($r / 2, $c), list($r / 2, 0), list($r, $c)))
+Y = federated(addresses=list($Y1, $Y2),
+              ranges=list(list(0, 0), list($r/2, $c), list($r / 2, 0), list($r, $c)))
+Z0 = X * Y
+Z = t(Z0) %*% X
+Z1 = Z %*% t(colSums(Z0))
+write(Z1, $Z)

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest7Reference.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest7Reference.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = rbind(read($X1), read($X2))
+Y = rbind(read($Y1), read($Y2))
+Z0 = X * Y
+Z = t(Z0) %*% X
+Z1 = Z %*% t(colSums(Z0))
+write(Z1, $Z)

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8.dml
@@ -21,8 +21,11 @@
 
 X = federated(addresses=list($X1, $X2),
               ranges=list(list(0, 0), list($r, $c / 2), list(0, $c / 2), list($r, $c)))
-Y = cbind(read($Y1), read($Y2))
-Z1 = sum(Y)
-Z2 = Y %*% t(X)
-Z3 = Z1 * sum(Z2)
-write(Z3, $Z)
+Y = federated(addresses=list($Y1, $Y2),
+              ranges=list(list(0, 0), list($r, $c / 2), list(0, $c / 2), list($r, $c)))
+W = cbind(read($W1), read($W2))
+Z1 = Y
+Z2 = Z1 %*% t(X)
+Z3 = Z1 %*% t(W)
+Z4 = sum(Z3) * sum(Z2)
+write(Z4, $Z)

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = federated(addresses=list($X1, $X2),
+              ranges=list(list(0, 0), list($r, $c / 2), list(0, $c / 2), list($r, $c)))
+Y = cbind(read($Y1), read($Y2))
+Z1 = sum(Y)
+Z2 = Y %*% t(X)
+Z3 = Z1 * sum(Z2)
+write(Z3, $Z)

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8Reference.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8Reference.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = cbind(read($X1), read($X2))
+Y = cbind(read($Y1), read($Y2))
+Z1 = sum(Y)
+Z2 = Y %*% t(X)
+Z3 = Z1 * sum(Z2)
+write(Z3, $Z)

--- a/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8Reference.dml
+++ b/src/test/scripts/functions/privacy/fedplanning/FederatedMultiplyPlanningTest8Reference.dml
@@ -21,7 +21,9 @@
 
 X = cbind(read($X1), read($X2))
 Y = cbind(read($Y1), read($Y2))
-Z1 = sum(Y)
-Z2 = Y %*% t(X)
-Z3 = Z1 * sum(Z2)
-write(Z3, $Z)
+W = cbind(read($W1), read($W2))
+Z1 = Y
+Z2 = Z1 %*% t(X)
+Z3 = Z1 %*% t(W)
+Z4 = sum(Z3) * sum(Z2)
+write(Z4, $Z)


### PR DESCRIPTION
This PR: 

- Creates a separate class for HopRel memo table to avoid code duplication and to have a cleaner interface to the data structure. 
- Changes the final setting of fedouts in the federated planner to avoid visiting the same hops more than once and to cover the case where a single hop is used as input to two different hops. In the latter case, the hop needs to be set to FOUT and then be prefetched before being used as input to a locally executed operation. 
- Adds prefetch of hops and lops depending on a field set in the federated planner and the ExecType of the operation.