### PR TITLE
[MINOR] Change ytest to an optional input to lmPredict

### DIFF
--- a/scripts/builtin/lmPredict.dml
+++ b/scripts/builtin/lmPredict.dml
@@ -20,7 +20,7 @@
 #-------------------------------------------------------------
 
 m_lmPredict = function(Matrix[Double] X, Matrix[Double] B, 
-  Matrix[Double] ytest, Integer icpt = 0, Boolean verbose = FALSE) 
+  Matrix[Double] ytest = matrix(0,1,1), Integer icpt = 0, Boolean verbose = FALSE) 
   return (Matrix[Double] yhat)
 {
   intercept = ifelse(icpt>0 | ncol(X)+1==nrow(B), as.scalar(B[nrow(B),]), 0);


### PR DESCRIPTION
This patch reverts a change that made ytest a mandatory input
to lmPredict builtin. ytest is unavailable for unseen data.