### PR TITLE
[SYSTEMDS-2784] Fix lineage tracing of PUT_VAR

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -332,7 +332,8 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 
 		// set variable and construct empty response
 		ec.setVariable(varName, data);
-		if(DMLScript.LINEAGE)
+		if(DMLScript.LINEAGE && request.getNumParams()==1)
+			// don't trace if the data contains only metadata
 			ec.getLineage().set(varName, new LineageItem(String.valueOf(request.getChecksum(0))));
 
 		return new FederatedResponse(ResponseType.SUCCESS_EMPTY);

--- a/src/test/java/org/apache/sysds/test/functions/lineage/FedFullReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/FedFullReuseTest.java
@@ -31,7 +31,6 @@ import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.apache.sysds.utils.Statistics;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -70,7 +69,6 @@ public class FedFullReuseTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void federatedOutputReuse() {
 		//don't cache federated outputs in the coordinator
 		//reuse inside federated workers
@@ -78,7 +76,6 @@ public class FedFullReuseTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void nonfederatedOutputReuse() {
 		//cache non-federated outputs in the coordinator
 		federatedReuse(TEST_NAME2);


### PR DESCRIPTION
This patch fixes a minor issue with tracing PUT in the
workers, which was introduced when we supported sending
only the metadata (MatrixCharacteristics) via PUT. This fix
allows re-enabling the FedFullReuseTests.