### PR TITLE
[SYSTEMDS-????] Equi-height binning in transformencode

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/TfUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/TfUtils.java
@@ -54,6 +54,12 @@ public class TfUtils implements Serializable
 		}
 	}
 	
+	//binning methods
+	public enum BinningMethod {
+		EQUIWIDTH, 
+		EQUIHEIGHT
+	}
+	
 	//transform meta data constants (frame-based transform)
 	public static final String TXMTD_MVPREFIX = "#Meta"+Lop.DATATYPE_PREFIX+"MV";
 	public static final String TXMTD_NDPREFIX = "#Meta"+Lop.DATATYPE_PREFIX+"ND";

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -56,7 +56,7 @@ import org.apache.sysds.utils.Statistics;
 public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder> {
 	protected static final Log LOG = LogFactory.getLog(ColumnEncoder.class.getName());
 	protected static final int APPLY_ROW_BLOCKS_PER_COLUMN = 1;
-	public static int BUILD_ROW_BLOCKS_PER_COLUMN = 1;
+	public static int BUILD_ROW_BLOCKS_PER_COLUMN = -1;
 	private static final long serialVersionUID = 2299156350718979064L;
 	protected int _colID;
 	protected Set<Integer> _sparseRowsWZeros = null;
@@ -370,7 +370,10 @@ public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder
 	}
 
 	protected int getNumBuildRowPartitions(){
-		return ConfigurationManager.getParallelBuildBlocks();
+		if (BUILD_ROW_BLOCKS_PER_COLUMN == -1)
+			return ConfigurationManager.getParallelBuildBlocks();
+		else
+			return BUILD_ROW_BLOCKS_PER_COLUMN; //for testing
 	}
 
 	public enum EncoderType {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -24,6 +24,7 @@ import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
+import org.apache.sysds.runtime.transform.TfUtils.BinningMethod;
 import org.apache.sysds.runtime.transform.TfUtils.TfMethod;
 import org.apache.sysds.runtime.transform.encode.ColumnEncoder.EncoderType;
 import org.apache.sysds.runtime.transform.meta.TfMetaUtils;
@@ -114,10 +115,16 @@ public class EncoderFactory {
 				for(Object o : (JSONArray) jSpec.get(TfMethod.BIN.toString())) {
 					JSONObject colspec = (JSONObject) o;
 					int numBins = colspec.containsKey("numbins") ? colspec.getInt("numbins") : 1;
+					BinningMethod method = BinningMethod.EQUIWIDTH; //default method
+					String specMethod = colspec.containsKey("method") ? colspec.getString("method") : null;
+					if (specMethod != null && specMethod.equalsIgnoreCase("equi-height"))
+						method = BinningMethod.EQUIHEIGHT;
+					if (specMethod != null && !specMethod.equalsIgnoreCase("equi-height") && !specMethod.equalsIgnoreCase("equi-width"))
+						throw new DMLRuntimeException("Unsupported Binning method: " + specMethod);
 					int id = TfMetaUtils.parseJsonObjectID(colspec, colnames, minCol, maxCol, ids);
 					if(id <= 0)
 						continue;
-					ColumnEncoderBin bin = new ColumnEncoderBin(id, numBins);
+					ColumnEncoderBin bin = new ColumnEncoderBin(id, numBins, method);
 					addEncoderToMap(bin, colEncoders);
 				}
 			if(!dcIDs.isEmpty())

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameBuildMultithreadedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameBuildMultithreadedTest.java
@@ -52,8 +52,9 @@ public class TransformFrameBuildMultithreadedTest extends AutomatedTestBase {
 	//private final static String SPEC1b = "homes3/homes.tfspec_recode2.json";
 	private final static String SPEC2 = "homes3/homes.tfspec_dummy.json";
 	//private final static String SPEC2b = "homes3/homes.tfspec_dummy2.json";
-	private final static String SPEC3 = "homes3/homes.tfspec_bin.json"; // recode
+	private final static String SPEC3a = "homes3/homes.tfspec_bin.json"; // recode
 	//private final static String SPEC3b = "homes3/homes.tfspec_bin2.json"; // recode
+	private final static String SPEC3b = "homes3/homes.tfspec_bin3.json"; // recode
 	private final static String SPEC6 = "homes3/homes.tfspec_recode_dummy.json";
 	//private final static String SPEC6b = "homes3/homes.tfspec_recode_dummy2.json";
 	private final static String SPEC7 = "homes3/homes.tfspec_binDummy.json"; // recode+dummy
@@ -65,7 +66,7 @@ public class TransformFrameBuildMultithreadedTest extends AutomatedTestBase {
 	private final static String SPEC10 = "homes3/homes.tfspec_recode_bin.json";
 
 	public enum TransformType {
-		RECODE, DUMMY, RECODE_DUMMY, BIN, BIN_DUMMY, HASH, HASH_RECODE, RECODE_BIN,
+		RECODE, DUMMY, RECODE_DUMMY, BIN_WIDTH, BIN_HEIGHT, BIN_DUMMY, HASH, HASH_RECODE, RECODE_BIN,
 	}
 
 	@Override
@@ -101,12 +102,22 @@ public class TransformFrameBuildMultithreadedTest extends AutomatedTestBase {
 
 	@Test
 	public void testHomesBuildBinSingleNodeCSV() {
-		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN, 0);
+		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN_WIDTH, 0);
 	}
 
 	@Test
 	public void testHomesBuild50BinSingleNodeCSV() {
-		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN, 50);
+		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN_WIDTH, 50);
+	}
+
+	@Test
+	public void testHomesBuildBinEQHTCSV() {
+		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN_HEIGHT, 0);
+	}
+
+	@Test
+	public void testHomesBuild50BinEQHTCSV() {
+		runTransformTest(Types.ExecMode.SINGLE_NODE, "csv", TransformType.BIN_HEIGHT, 50);
 	}
 
 	@Test
@@ -132,8 +143,12 @@ public class TransformFrameBuildMultithreadedTest extends AutomatedTestBase {
 				SPEC = SPEC2;
 				DATASET = DATASET1;
 				break;
-			case BIN:
-				SPEC = SPEC3;
+			case BIN_WIDTH:
+				SPEC = SPEC3a;
+				DATASET = DATASET1;
+				break;
+			case BIN_HEIGHT:
+				SPEC = SPEC3b;
 				DATASET = DATASET1;
 				break;
 			case RECODE_DUMMY:
@@ -191,7 +206,7 @@ public class TransformFrameBuildMultithreadedTest extends AutomatedTestBase {
 					assertEquals(encodersS.get(i).getRcdMap().keySet(), encodersM.get(i).getRcdMap().keySet());
 				}
 			}
-			else if(type == TransformType.BIN) {
+			else if(type == TransformType.BIN_WIDTH	|| type == TransformType.BIN_HEIGHT) {
 				List<ColumnEncoderBin> encodersS = encoderS.getColumnEncoders(ColumnEncoderBin.class);
 				List<ColumnEncoderBin> encodersM = encoderM.getColumnEncoders(ColumnEncoderBin.class);
 				assertEquals(encodersS.size(), encodersM.size());

--- a/src/test/resources/datasets/homes3/homes.tfspec_bin3.json
+++ b/src/test/resources/datasets/homes3/homes.tfspec_bin3.json
@@ -1,0 +1,5 @@
+{
+ "ids": true, "recode": [ 1, 2, 7 ], "bin": [
+ { "id": 8  , "method": "equi-height", "numbins": 3 }
+ ,{ "id": 3, "method": "equi-height", "numbins": 4 }]
+  }


### PR DESCRIPTION
This patch introduces single- and multi-threaded equi-height
binning. Currently we use partition-wise sorting and heap-based
merging of sorted blocks.