### PR TITLE
[SYSTEMDS-3260] Builtin for Matthews Correlation Coefficient

### DIFF
--- a/scripts/builtin/mcc.dml
+++ b/scripts/builtin/mcc.dml
@@ -76,16 +76,21 @@ m_mcc = function(Matrix[Double] predictions = matrix(0,0,0), Matrix[Double] labe
         if (sum(confusionM) == 0) {
           stop("@mcc Input Error: confusion matrix contains only zeros")
         }
-        mode = 0
+        mattCC = s_mcc(TN=as.scalar(confusionM[1,1]), FP=as.scalar(confusionM[1,2]), 
+                    FN=as.scalar(confusionM[2,1]), TP=as.scalar(confusionM[2,2]))
     } else {
         if (length(predictions) == 0 | length(labels) == 0) {
             stop("@mcc Input Error: predictions and/or labels are not set!")
         }
         [predictions, labels] = mcc_binaryVectorCheck(predictions, labels)
-        confusionM = table(labels + 1, predictions + 1, 2, 2)
+        confM = table(labels + 1, predictions + 1, 2, 2)
+
+        # currently recursive call on confusion matrix so checks are applied
+        # for the purpose of testing if confusion matrix input works
+        # can be (re)moved of else branch to outer scope if considered bad idea
+        mattCC = m_mcc(confusionM=confM)
     }
-    mattCC = s_mcc(TN=as.scalar(confusionM[1,1]), FP=as.scalar(confusionM[1,2]), 
-                    FN=as.scalar(confusionM[2,1]), TP=as.scalar(confusionM[2,2]))
+    
 }
 
 s_mcc = function(Integer TN = -1, Integer FP = -1, Integer FN = -1, Integer TP = -1) return (Double mattCC) {
@@ -101,7 +106,7 @@ s_mcc = function(Integer TN = -1, Integer FP = -1, Integer FN = -1, Integer TP =
     # MCC = (TP*TN - FP*FN) / sqrt((TP + FP) * (TP * FN) * (TN + FP) * (TN + FN))
     # if row and/or column of zeros,
     if (min(rowSums(confusionM)) == 0 | min(colSums(confusionM)) == 0) {
-        # epsilon approximation --> 0 --> setting mattCC to 0 directly
+        # epsilon approximation --> 0 --> setting mattCC to 0 directly avoids calculation
         mattCC = 0.0
     } else {
         mattCC = (TP*TN - FP*FN) / sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN))
@@ -126,8 +131,10 @@ mcc_binaryVectorCheck = function(Matrix[Double] predictionsIn, Matrix[Double] la
     if (sum(labelsIn == min(labelsIn) | labelsIn == max(labelsIn)) != length(labelsIn)) {
         stop("@mcc Input Error: labels contain more than two distinct values")
     }
+    # check for match between encoding of predictions and labels 
     if (sum(min(predictionsIn) == labelsIn | max(predictionsIn) == labelsIn) != length(predictionsIn)) {
-        # all values in predictions are equal and all values in labels are equal but distinct is allowed
+        # at the moment allowing values in predictions are equal and all values in labels are equal but distinct
+        # if not the case throw value mismatch
         if (!(sum(predictionsIn == min(predictionsIn)) == length(predictionsIn) 
                 & sum(labelsIn == min(labelsIn)) == length(labelsIn))) {
             stop("@mcc Input Error: mismatch between predictions and labels. Predictions contain " 
@@ -137,6 +144,7 @@ mcc_binaryVectorCheck = function(Matrix[Double] predictionsIn, Matrix[Double] la
         }
     }
     #check if only contains 0s and/or 1s, else transform
+    # returned vectors should now always be binary
     if (sum(predictionsIn == 0 | predictionsIn == 1) != length(predictionsIn) | 
             sum(labelsIn == 0 | labelsIn == 1) != length(labelsIn)) {
         lowerValue = min(min(labelsIn), min(predictionsIn))
@@ -150,5 +158,6 @@ mcc_binaryVectorCheck = function(Matrix[Double] predictionsIn, Matrix[Double] la
         labelsOut = replace(target=labelsOut, pattern=lowerValue, replacement=0)
         labelsOut = replace(target=labelsOut, pattern=higherValue, replacement=1)
     }
+    
    
 }

--- a/scripts/builtin/mcc.dml
+++ b/scripts/builtin/mcc.dml
@@ -1,0 +1,154 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Built-in function mcc: Matthews' Correlation Coefficient for binary classification evaluation
+#
+# INPUT PARAMETERS:
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE               DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# predictions     Matrix[Integer]      ---     Vector of predicted 0/1 values. 
+#                                                 (requires setting 'labels' parameter)
+# labels          Matrix[Integer]      ---     Vector of 0/1 labels.
+# confusionM      Matrix[Integer]      ---     Alternatively a 2x2 confusion matrix containing
+#                                                 TN, FP, FN, TP (row major order) e.g. 
+#                                                                 Predictions
+#                                                                   0    1
+#                                                               0   TN | FP
+#                                                      Labels      ----+----
+#                                                               1   FN | TP
+#
+#                                                 TN = True Negatives
+#                                                 FP = False Positives
+#                                                 FN = False Negatives
+#                                                 TP = True Positives
+#
+# TN              Integer              ---     Or as a third option, a count of True Negatives. 
+#                                                (requires setting FP, FN and TP aswell)
+# FP              Integer              ---     Count of False Positives. 
+# FN              Integer              ---     Count of False Negatives. 
+# TP              Integer              ---     Count of True Positives.
+# ---------------------------------------------------------------------------------------------
+ 
+#Output(s)
+# ---------------------------------------------------------------------------------------------
+# NAME            TYPE    DEFAULT     MEANING
+# ---------------------------------------------------------------------------------------------
+# mattCC          Double    ---       Matthews' Correlation Coefficient
+# ---------------------------------------------------------------------------------------------
+
+m_mcc = function(Matrix[Double] predictions = matrix(0,0,0), Matrix[Double] labels = matrix(0,0,0),
+                    Matrix[Double] confusionM = matrix(0,0,0)
+                   )
+        return (Double mattCC)
+{
+    ################
+    ## SANITY CHECKS
+    if (length(confusionM) > 0) {
+        if (nrow(confusionM) != 2 | ncol(confusionM) != 2) {
+            stop("@mcc Input Error: Confusion matrix is set but doesn't comply to 2x2 matrix")
+        }
+        if (length(predictions) > 0 | length(labels) > 0) {
+            print("@mcc Input Warning: confusion matrix and (predictions or labels) are set! " 
+                    + "Using confusion matrix")
+        }
+        if (sum(confusionM < 0) > 0) {
+          stop("@mcc Input Error: confusion matrix contains negative values")
+        }
+        if (sum(confusionM) == 0) {
+          stop("@mcc Input Error: confusion matrix contains only zeros")
+        }
+        mode = 0
+    } else {
+        if (length(predictions) == 0 | length(labels) == 0) {
+            stop("@mcc Input Error: predictions and/or labels are not set!")
+        }
+        [predictions, labels] = mcc_binaryVectorCheck(predictions, labels)
+        confusionM = table(labels + 1, predictions + 1, 2, 2)
+    }
+    mattCC = s_mcc(TN=as.scalar(confusionM[1,1]), FP=as.scalar(confusionM[1,2]), 
+                    FN=as.scalar(confusionM[2,1]), TP=as.scalar(confusionM[2,2]))
+}
+
+s_mcc = function(Integer TN = -1, Integer FP = -1, Integer FN = -1, Integer TP = -1) return (Double mattCC) {
+    if (TN < 0 | FP < 0 | FN < 0 | TP < 0) {
+        stop("@mcc Error: one or more confusion matrix entries are < 0")
+    } 
+    confusionM = matrix(0, 2, 2)
+    confusionM[1,1] = TN; confusionM[1,2] = FP; confusionM[2,1] = FN; confusionM[2,2] = TP;
+    if (sum(confusionM) == 0) {
+        print("@mcc Warning: TN, FP, FN and TP are all 0")
+    }
+    # from https://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-019-6413-7
+    # MCC = (TP*TN - FP*FN) / sqrt((TP + FP) * (TP * FN) * (TN + FP) * (TN + FN))
+    # if row and/or column of zeros,
+    if (min(rowSums(confusionM)) == 0 | min(colSums(confusionM)) == 0) {
+        # epsilon approximation --> 0 --> setting mattCC to 0 directly
+        mattCC = 0.0
+    } else {
+        mattCC = (TP*TN - FP*FN) / sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN))
+    }
+    
+}
+
+mcc_binaryVectorCheck = function(Matrix[Double] predictionsIn, Matrix[Double] labelsIn) 
+                    return (Matrix[Double] predictionsOut, Matrix[Double] labelsOut) {
+
+    predictionsOut = predictionsIn
+    labelsOut = labelsIn
+    # same length
+    if (length(predictionsIn) != length(labelsIn)) {
+        stop("@mcc Input Error: amount of predictions doesn't match amount of labels")
+    }
+    # max two distinct prediction values
+    if (sum(predictionsIn == min(predictionsIn) | predictionsIn == max(predictionsIn)) != length(predictionsIn)) {
+        stop("@mcc Input Error: predictions contain more than two distinct values")
+    }
+    # max two distinct label values
+    if (sum(labelsIn == min(labelsIn) | labelsIn == max(labelsIn)) != length(labelsIn)) {
+        stop("@mcc Input Error: labels contain more than two distinct values")
+    }
+    if (sum(min(predictionsIn) == labelsIn | max(predictionsIn) == labelsIn) != length(predictionsIn)) {
+        # all values in predictions are equal and all values in labels are equal but distinct is allowed
+        if (!(sum(predictionsIn == min(predictionsIn)) == length(predictionsIn) 
+                & sum(labelsIn == min(labelsIn)) == length(labelsIn))) {
+            stop("@mcc Input Error: mismatch between predictions and labels. Predictions contain " 
+                + min(predictionsIn) + "," + max(predictionsIn) + " while labels contain "
+                + min(labelsIn) + "," + max(labelsIn)
+            )
+        }
+    }
+    #check if only contains 0s and/or 1s, else transform
+    if (sum(predictionsIn == 0 | predictionsIn == 1) != length(predictionsIn) | 
+            sum(labelsIn == 0 | labelsIn == 1) != length(labelsIn)) {
+        lowerValue = min(min(labelsIn), min(predictionsIn))
+        higherValue = max(max(labelsIn), max(predictionsIn))
+        print("@mcc Input Warning: prediction and label entries deviate from 0 and 1! " + 
+                "Interpreting lower value as negative, higher as positive.\n" + 
+                + lowerValue + " --> " + 0 + " and " + higherValue + " --> " + 1
+        )
+        predictionsOut = replace(target=predictionsOut, pattern=lowerValue, replacement=0)
+        predictionsOut = replace(target=predictionsOut, pattern=higherValue, replacement=1)
+        labelsOut = replace(target=labelsOut, pattern=lowerValue, replacement=0)
+        labelsOut = replace(target=labelsOut, pattern=higherValue, replacement=1)
+    }
+   
+}

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -192,6 +192,7 @@ public enum Builtins {
 	MAX("max", "pmax", false),
 	MAX_POOL("max_pool", false),
 	MAX_POOL_BACKWARD("max_pool_backward", false),
+	MCC("mcc", true),
 	MEAN("mean", "avg", false),
 	MEDIAN("median", false),
 	MICE("mice", true),

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinMCCTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinMCCTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.builtin.part2;
+
+import org.apache.sysds.common.Types.ExecMode;
+
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class BuiltinMCCTest extends AutomatedTestBase {
+    private final static String TEST_NAME = "mcc";
+	private final static String TEST_DIR = "functions/builtin/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + BuiltinMCCTest.class.getSimpleName() + "/";
+
+    private final static String OUTPUT_IDENTIFIER = "mattCorrCoeff.scalar";
+    private final static double epsilon = 1e-10;
+
+    @Override
+	public void setUp() {
+        TestConfiguration tc = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[]{OUTPUT_IDENTIFIER});
+		addTestConfiguration(TEST_NAME, tc);
+	}
+
+    @Test
+    public void testMCCCorrect() {
+        double[][] predictions = {{1},{1},{1},{0},{1},{1},{0},{0},{0},{1}};
+        double[][] labels = {{1},{1},{1},{1},{1},{0},{0},{0},{0},{0}};
+        boolean expectException = false;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+    @Test
+    public void testMCCCorrect_2() {
+        double[][] predictions = {{99},{99},{99},{-1},{99},{99},{-1},{-1},{-1},{99}};
+        double[][] labels = {{99},{99},{99},{99},{99},{-1},{-1},{-1},{-1},{-1}};
+        boolean expectException = false;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+    @Test
+    public void testMCCCorrect_3() {
+        double[][] predictions = {{0},{0},{0},{0},{0},{0},{0},{0},{0},{0}};
+        double[][] labels = {{1},{1},{1},{1},{1},{1},{1},{1},{1},{1}};
+        boolean expectException = false;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+    @Test
+    public void testMCCCorrect_4() {
+        double[][] predictions = {{-1},{-1},{-1},{-1},{-1},{-1},{-1},{-1},{-1},{-1}};
+        double[][] labels = {{99},{99},{99},{99},{99},{99},{99},{99},{99},{99}};
+        boolean expectException = false;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+    @Test
+    public void testMCCCorrectLarge() {
+        double[][] predictions = getRandomMatrix(100000, 1, 0.0, 1.0, 1.0, 7);
+        double[][] labels = getRandomMatrix(100000, 1, 0.0, 1.0, 1.0, 11);
+        for (int row = 0; row < predictions.length; row++) {
+            predictions[row][0] = Math.round(predictions[row][0]);
+            labels[row][0] = Math.round(labels[row][0]);
+        }
+        boolean expectException = false;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+
+    @Test
+    public void testMCCIncorrect() {
+        double[][] predictions = {{99},{1},{1},{0},{1},{1},{0},{0},{0},{1}};
+        double[][] labels = {{1},{1},{1},{1},{1},{0},{0},{0},{0},{0}};
+        boolean expectException = true;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+
+    @Test
+    public void testMCCIncorrect_2() {
+        double[][] predictions = {{1},{1},{1},{0},{1},{1},{0},{0},{0},{-1}};
+        double[][] labels = {{99},{1},{1},{1},{1},{0},{0},{0},{0},{0}};
+        boolean expectException = true;
+        runMCCTest(predictions, labels, false, ExecMode.HYBRID, expectException);
+    }
+    
+    private void runMCCTest(double[][] predictions, double[][] labels, boolean lineage, ExecMode mode, boolean expectException) {
+        ExecMode execModeOld = setExecMode(mode);
+        try {
+            loadTestConfiguration(getTestConfiguration(TEST_NAME));
+            String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+            programArgs = new String[]{
+                "-nvargs", 
+                "predictions="+input("predictions"),
+                "labels=" + input("labels"),
+                "mattCorrCoeff=" + output(OUTPUT_IDENTIFIER),
+            };
+            if (lineage) {
+                programArgs = (String[]) ArrayUtils.addAll(programArgs, new String[] {
+                    "-stats","-lineage", ReuseCacheType.REUSE_HYBRID.name().toLowerCase()});
+            }
+            writeInputMatrixWithMTD("labels", labels, true);
+            writeInputMatrixWithMTD("predictions", predictions, true);
+
+            fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = getRCmd(inputDir(), expected(OUTPUT_IDENTIFIER));
+
+            runTest(true, expectException, null, -1); 
+            if (!expectException) {
+                runRScript(true);
+                Double mattCorrCoeffDML = readDMLScalarFromOutputDir(OUTPUT_IDENTIFIER).get(new CellIndex(1,1));
+                Assert.assertTrue(-1 <= mattCorrCoeffDML && mattCorrCoeffDML <= 1);
+                Double mattCorrCoeffR = readRScalarFromExpectedDir(OUTPUT_IDENTIFIER).get(new CellIndex(1,1));
+                TestUtils.compareScalars(mattCorrCoeffDML, mattCorrCoeffR, epsilon);
+            }
+            
+        } finally {
+            resetExecMode(execModeOld);
+        }
+    }
+
+}

--- a/src/test/scripts/functions/builtin/mcc.R
+++ b/src/test/scripts/functions/builtin/mcc.R
@@ -21,11 +21,11 @@
 args<-commandArgs(TRUE)
 options(digits=22)
 
-library('Matrix')
-library('mltools')
+library("Matrix")
+library("mltools")
 
 predictions = as.vector(readMM(paste(args[1], "predictions.mtx", sep="")))
 labels = as.vector(readMM(paste(args[1], "labels.mtx", sep="")))
-mattCorrCoeff = mcc(predictions, labels)
+mattCorrCoeff = mcc(preds=predictions, actuals=labels)
 
 write(mattCorrCoeff, args[2])

--- a/src/test/scripts/functions/builtin/mcc.R
+++ b/src/test/scripts/functions/builtin/mcc.R
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+args<-commandArgs(TRUE)
+options(digits=22)
+
+library('Matrix')
+library('mltools')
+
+predictions = as.vector(readMM(paste(args[1], "predictions.mtx", sep="")))
+labels = as.vector(readMM(paste(args[1], "labels.mtx", sep="")))
+mattCorrCoeff = mcc(predictions, labels)
+
+write(mattCorrCoeff, args[2])

--- a/src/test/scripts/functions/builtin/mcc.R
+++ b/src/test/scripts/functions/builtin/mcc.R
@@ -21,6 +21,10 @@
 args<-commandArgs(TRUE)
 options(digits=22)
 
+if(!("mltools" %in% rownames(installed.packages()))){
+   install.packages("mltools")
+}
+
 library("Matrix")
 library("mltools")
 

--- a/src/test/scripts/functions/builtin/mcc.dml
+++ b/src/test/scripts/functions/builtin/mcc.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+predictionsIn = read($predictions)
+labelsIn = read($labels)
+
+mattCorrCoeff = mcc(predictions=predictionsIn, labels=labelsIn)
+write(mattCorrCoeff, $mattCorrCoeff)

--- a/src/test/scripts/installDependencies.R
+++ b/src/test/scripts/installDependencies.R
@@ -63,6 +63,7 @@ custom_install("class");
 custom_install("unbalanced");
 custom_install("naivebayes");
 custom_install("BiocManager");
+custom_install("mltools");
 BiocManager::install("rhdf5");
 
 print("Installation Done")


### PR DESCRIPTION
This feature implements the Matthews Correlation Coefficient (MCC) calculation as a metric for binary classification evaluation.

The selected builtin function name  is "mcc" and its signature allows three modes of calculating the MCC:

* one vector for predictions and one vector for labels, entries should be binary but are tested. If they are not binary, values are interpreted as lower value -> 0, higher value -> 1

* alternatively a 2x2 confusion matrix can be used containing TN, FP, FN, TP counts in row major order

* option three is the calculation based on using named params TN, FP, FN, TP  as parameters for the mcc call directly.


Currently it contains a recursive call so checks on the confusion matrix are performed even if input were two vectors for predictions and labels, can be easily removed if unwanted. 

There are also some tests included, where some of those are expected to fail due to invalid input, the ones not expected to fail are compared against the result of a R mcc implementation. 