### PR TITLE
[SYSTEMDS-3267] Explain for transformencode task-graph

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -132,6 +132,7 @@ public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder
 
 	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
+		mcsr = false; //force CSR for transformencode
 		int index = _colID - 1;
 		// Apply loop tiling to exploit CPU caches
 		double[] codes = getCodeCol(in, rowStart, blk);

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -88,6 +88,7 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 					" and not MatrixBlock");
 		}
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
+		mcsr = false; //force CSR for transformencode
 		Set<Integer> sparseRowsWZeros = null;
 		int index = _colID - 1;
 		for(int r = rowStart; r < getEndIndex(in.getNumRows(), rowStart, blk); r++) {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -80,6 +80,7 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		Set<Integer> sparseRowsWZeros = null;
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
+		mcsr = false; //force CSR for transformencode
 		int index = _colID - 1;
 		// Apply loop tiling to exploit CPU caches
 		double[] codes = getCodeCol(in, rowStart, blk);

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -43,6 +43,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -134,46 +135,67 @@ public class MultiColumnEncoder implements Encoder {
 		return out;
 	}
 
+	/* TASK DETAILS:
+	 * InitOutputMatrixTask:        Allocate output matrix
+	 * AllocMetaTask:               Allocate metadata frame
+	 * BuildTask:                   Build an encoder
+	 * ColumnCompositeUpdateDCTask: Update domain size of a DC encoder based on #distincts, #bins, K
+	 * ColumnMetaDataTask:          Fill up metadata of an encoder
+	 * ApplyTasksWrapperTask:       Wrapper task for an Apply
+	 * UpdateOutputColTask:         Sets starting offsets of the DC columns
+	 */
 	private List<DependencyTask<?>> getEncodeTasks(CacheBlock in, MatrixBlock out, DependencyThreadPool pool) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		List<DependencyTask<?>> applyTAgg = null;
 		Map<Integer[], Integer[]> depMap = new HashMap<>();
 		boolean hasDC = getColumnEncoders(ColumnEncoderDummycode.class).size() > 0;
 		boolean applyOffsetDep = false;
+		_meta = new FrameBlock(in.getNumColumns(), ValueType.STRING);
+		// Create the output and metadata allocation tasks
 		tasks.add(DependencyThreadPool.createDependencyTask(new InitOutputMatrixTask(this, in, out)));
-		for(ColumnEncoderComposite e : _columnEncoders) {
-			List<DependencyTask<?>> buildTasks = e.getBuildTasks(in);
+		tasks.add(DependencyThreadPool.createDependencyTask(new AllocMetaTask(this, _meta)));
 
+		for(ColumnEncoderComposite e : _columnEncoders) {
+			// Create the build tasks
+			List<DependencyTask<?>> buildTasks = e.getBuildTasks(in);
 			tasks.addAll(buildTasks);
 			if(buildTasks.size() > 0) {
-				// Apply Task dependency to build completion task
-				depMap.put(new Integer[] {tasks.size(), tasks.size() + 1},
-					new Integer[] {tasks.size() - 1, tasks.size()});
+				// Apply Task depends on build completion task
+				depMap.put(new Integer[] {tasks.size(), tasks.size() + 1},      //ApplyTask
+					new Integer[] {tasks.size() - 1, tasks.size()});            //BuildTask
+				// getMetaDataTask depends on build completion
+				depMap.put(new Integer[] {tasks.size() + 1, tasks.size() + 2}, //MetaDataTask
+					new Integer[] {tasks.size() - 1, tasks.size()});           //BuildTask
+				// getMetaDataTask depends on AllocMeta task
+				depMap.put(new Integer[] {tasks.size() + 1, tasks.size() + 2}, //MetaDataTask
+					new Integer[] {1, 2});                                     //AllocMetaTask (2nd task)
+				// AllocMetaTask depends on the build completion tasks
+				depMap.put(new Integer[] {1, 2},                               //AllocMetaTask (2nd task)
+					new Integer[] {tasks.size() - 1, tasks.size()});           //BuildTask
 			}
 
-			// Apply Task dependency to InitOutputMatrixTask
-			depMap.put(new Integer[] {tasks.size(), tasks.size() + 1}, new Integer[] {0, 1});
+			// Apply Task depends on InitOutputMatrixTask (output allocation)
+			depMap.put(new Integer[] {tasks.size(), tasks.size() + 1},         //ApplyTask
+					new Integer[] {0, 1});                                     //Allocation task (1st task)
 			ApplyTasksWrapperTask applyTaskWrapper = new ApplyTasksWrapperTask(e, in, out, pool);
 
 			if(e.hasEncoder(ColumnEncoderDummycode.class)) {
-				// InitMatrix dependency to build of recode if a DC is present
-				// Since they are the only ones that change the domain size which would influence the Matrix creation
-				depMap.put(new Integer[] {0, 1}, // InitMatrix Task first in list
-					new Integer[] {tasks.size() - 1, tasks.size()});
-				// output col update task dependent on Build completion only for Recode and binning since they can
-				// change dummycode domain size
-				// colUpdateTask can start when all domain sizes, because it can now calculate the offsets for
-				// each column
-				depMap.put(new Integer[] {-2, -1}, new Integer[] {tasks.size() - 1, tasks.size()});
+				// Allocation depends on build if DC is in the list.
+				// Note, DC is the only encoder that changes dimensionality
+				depMap.put(new Integer[] {0, 1},                               //Allocation task (1st task)
+					new Integer[] {tasks.size() - 1, tasks.size()});           //BuildTask
+				// UpdateOutputColTask, that sets the starting offsets of the DC columns,
+				// depends on the Build completion tasks
+				depMap.put(new Integer[] {-2, -1},                             //UpdateOutputColTask (last task) 
+						new Integer[] {tasks.size() - 1, tasks.size()});       //BuildTask
 				buildTasks.forEach(t -> t.setPriority(5));
 				applyOffsetDep = true;
 			}
 
 			if(hasDC && applyOffsetDep) {
-				// Apply Task dependency to output col update task (is last in list)
-				// All ApplyTasks need to wait for this task, so they all have the correct offsets.
-				// But only for the columns that come after the first DC coder since they don't have an offset
-				depMap.put(new Integer[] {tasks.size(), tasks.size() + 1}, new Integer[] {-2, -1});
+				// Apply tasks depend on UpdateOutputColTask
+				depMap.put(new Integer[] {tasks.size(), tasks.size() + 1},     //ApplyTask 
+						new Integer[] {-2, -1});                               //UpdateOutputColTask (last task)
 
 				applyTAgg = applyTAgg == null ? new ArrayList<>() : applyTAgg;
 				applyTAgg.add(applyTaskWrapper);
@@ -181,9 +203,13 @@ public class MultiColumnEncoder implements Encoder {
 			else {
 				applyTaskWrapper.setOffset(0);
 			}
+			// Create the ApplyTask (wrapper)
 			tasks.add(applyTaskWrapper);
+			// Create the getMetadata task
+			tasks.add(DependencyThreadPool.createDependencyTask(new ColumnMetaDataTask<ColumnEncoder>(e, _meta)));
 		}
 		if(hasDC)
+			// Create the last task, UpdateOutputColTask
 			tasks.add(DependencyThreadPool.createDependencyTask(new UpdateOutputColTask(this, applyTAgg)));
 
 		List<List<? extends Callable<?>>> deps = new ArrayList<>(Collections.nCopies(tasks.size(), null));
@@ -330,6 +356,7 @@ public class MultiColumnEncoder implements Encoder {
 					&& MatrixBlock.DEFAULT_SPARSEBLOCK != SparseBlock.Type.MCSR)
 				throw new RuntimeException("Transformapply is only supported for MCSR and CSR output matrix");
 			boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
+			mcsr = false; //force CSR for transformencode
 			if (mcsr) {
 				output.allocateBlock();
 				SparseBlock block = output.getSparseBlock();
@@ -933,6 +960,27 @@ public class MultiColumnEncoder implements Encoder {
 			return null;
 		}
 	}
+
+	private static class AllocMetaTask implements Callable<Object> {
+		private final MultiColumnEncoder _encoder;
+		private final FrameBlock _meta;
+		
+		private AllocMetaTask (MultiColumnEncoder encoder, FrameBlock meta) {
+			_encoder = encoder;
+			_meta = meta;
+		}
+
+		@Override
+		public Object call() throws Exception {
+			_encoder.allocateMetaData(_meta);
+			return null;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName();
+		}
+	}
 	
 	private static class ColumnMetaDataTask<T extends ColumnEncoder> implements Callable<Object> {
 		private final T _colEncoder;
@@ -947,6 +995,11 @@ public class MultiColumnEncoder implements Encoder {
 		public Object call() throws Exception {
 			_colEncoder.getMetaData(_out);
 			return null;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "<ColId: " + _colEncoder._colID + ">";
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/utils/Explain.java
+++ b/src/main/java/org/apache/sysds/utils/Explain.java
@@ -830,7 +830,7 @@ public class Explain
 		return OptimizerUtils.toMB(mem) + (units?"MB":"");
 	}
 
-	private static String createOffset( int level )
+	public static String createOffset( int level )
 	{
 		StringBuilder sb = new StringBuilder();
 		for( int i=0; i<level; i++ )

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.apache.sysds.runtime.io.FrameReaderFactory;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
@@ -211,11 +212,19 @@ public class TransformFrameEncodeMultithreadedTest extends AutomatedTestBase {
 			MultiColumnEncoder.MULTI_THREADED_STAGES = staged;
 
 			MatrixBlock outputS = encoder.encode(input, 1);
+			FrameBlock metaS = encoder.getMetaData(new FrameBlock(input.getNumColumns(), ValueType.STRING), 1);
 			MatrixBlock outputM = encoder.encode(input, 12);
+			FrameBlock metaM = encoder.getMetaData(new FrameBlock(input.getNumColumns(), ValueType.STRING), 12);
 
+			// Match encoded matrices
 			double[][] R1 = DataConverter.convertToDoubleMatrix(outputS);
 			double[][] R2 = DataConverter.convertToDoubleMatrix(outputM);
 			TestUtils.compareMatrices(R1, R2, R1.length, R1[0].length, 0);
+			// Match the metadata frames
+			String[][] M1 = DataConverter.convertToStringFrame(metaS);
+			String[][] M2 = DataConverter.convertToStringFrame(metaM);
+			TestUtils.compareFrames(M1, M2, M1.length, M1[0].length);
+
 			Assert.assertEquals(outputS.getNonZeros(), outputM.getNonZeros());
 			Assert.assertTrue(outputM.getNonZeros() > 0);
 


### PR DESCRIPTION
This patch adds a method to print the task-graph of
transformencode. Moreover, this commit integrates
getMetadata tasks within the task-graph.