### PR TITLE
[SYSTEMDS-3268] Publish Docker images on schedule

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -24,7 +24,7 @@ name: Docker Image CI and CD
 
 on:
   schedule:
-    - cron: '15 12 * * *' # everyday at 6:00 PM UTC
+    - cron: '30 1 * * *' # everyday at 1:30 PM UTC
   workflow_dispatch:
   
 

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -24,7 +24,7 @@ name: Docker Image CI and CD
 
 on:
   schedule:
-    - cron: '0 12 * * *' # everyday at 6:00 PM UTC
+    - cron: '15 12 * * *' # everyday at 6:00 PM UTC
   workflow_dispatch:
   
 

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -23,6 +23,8 @@
 name: Docker Image CI and CD
 
 on:
+  schedule:
+    - cron: '0 12 * * *' # everyday at 6:00 PM UTC
   workflow_dispatch:
   
 
@@ -34,6 +36,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    
+    - name: Configure Docker metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: return01/systemds
+        tags: |
+          type=schedule,pattern=nightly
 
     # https://github.com/docker/setup-buildx-action
     - name: Set up Docker Buildx
@@ -68,5 +78,6 @@ jobs:
         context: .
         file: ./docker/sysds.Dockerfile
         push: true
-        tags: apache/systemds:nightly
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -41,7 +41,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: return01/systemds
+        images: apache/systemds
         tags: |
           type=schedule,pattern=nightly
 


### PR DESCRIPTION
Use [metadata action](https://github.com/docker/metadata-action)
to parameterize tags, to accommodate tagged releases.