### PR TITLE
[SYSTEMDS-3271] Publish docker test image when requested

### DIFF
--- a/.github/workflows/docker-testImage.yml
+++ b/.github/workflows/docker-testImage.yml
@@ -22,29 +22,18 @@
 
 name: Docker Image CI and CD
 
+# This job only tricker if requested in github.
 on:
-  schedule:
-    cron: '30 1 * * *' # everyday at 1:30 PM UTC
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.html'
-      - 'src/test/**'
-      - 'src/assembly/**'
-      - 'dev/**'
   workflow_dispatch:
-  
+
 jobs:
-  build-nightly:
+  build-test-image:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - image-pattern: nightly
-            docker-file: sysds.Dockerfile
-        include:
-          - image-pattern: python-nightly
-            docker-file: pythonsysds.Dockerfile
+          - image-pattern: testing-latest
+            docker-file: testsysds.Dockerfile
 
     steps:
     - name: Checkout
@@ -62,7 +51,7 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
-
+      
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
Adds a new docker-testImage.yml to allow manual initialization of building
our test image. This allows us to update the image used in our github
actions if for instance a new R package is added.

This commit also slightly modify the docker action to also build
the python image, when the default night cpu build is made.