### PR TITLE
[SYSTEMDS-2837] Improve DAG linearization order

### DIFF
--- a/conf/SystemDS-config.xml.template
+++ b/conf/SystemDS-config.xml.template
@@ -38,6 +38,9 @@
     
     <!-- enables compressed linear algebra, experimental feature -->
     <sysds.compressed.linalg>false</sysds.compressed.linalg>
+
+    <!-- set the dag linearization algorithm (topological, min_intermediate) -->
+    <sysds.compile.linearization>topological</sysds.compile.linearization>
     
     <!-- enables operator fusion via code generation, experimental feature -->
     <sysds.codegen.enabled>false</sysds.codegen.enabled>

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -43,6 +43,7 @@ import org.apache.sysds.hops.codegen.SpoofCompiler.CompilerType;
 import org.apache.sysds.hops.codegen.SpoofCompiler.GeneratorAPI;
 import org.apache.sysds.hops.codegen.SpoofCompiler.PlanSelector;
 import org.apache.sysds.lops.Compression;
+import org.apache.sysds.lops.compile.Dag;
 import org.apache.sysds.parser.ParseException;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
@@ -82,6 +83,7 @@ public class DMLConfig
 	public static final String COMPRESSED_TRANSPOSE = "sysds.compressed.transpose";
 	public static final String NATIVE_BLAS          = "sysds.native.blas";
 	public static final String NATIVE_BLAS_DIR      = "sysds.native.blas.directory";
+	public static final String DAG_LINEARIZATION    = "sysds.compile.linearization";
 	public static final String CODEGEN              = "sysds.codegen.enabled"; //boolean
 	public static final String CODEGEN_API          = "sysds.codegen.api"; // see SpoofCompiler.API
 	public static final String CODEGEN_COMPILER     = "sysds.codegen.compiler"; //see SpoofCompiler.CompilerType
@@ -144,6 +146,7 @@ public class DMLConfig
 		_defaultVals.put(COMPRESSED_COCODE,      "AUTO");
 		_defaultVals.put(COMPRESSED_COST_MODEL,  "AUTO");
 		_defaultVals.put(COMPRESSED_TRANSPOSE,   "auto");
+		_defaultVals.put(DAG_LINEARIZATION,      Dag.DagLinearization.TOPOLOGICAL.name());
 		_defaultVals.put(CODEGEN,                "false" );
 		_defaultVals.put(CODEGEN_API,            GeneratorAPI.JAVA.name() );
 		_defaultVals.put(CODEGEN_COMPILER,       CompilerType.AUTO.name() );
@@ -412,7 +415,7 @@ public class DMLConfig
 			LOCAL_TMP_DIR,SCRATCH_SPACE,OPTIMIZATION_LEVEL, DEFAULT_BLOCK_SIZE,
 			CP_PARALLEL_OPS, CP_PARALLEL_IO, PARALLEL_ENCODE, NATIVE_BLAS, NATIVE_BLAS_DIR,
 			COMPRESSED_LINALG, COMPRESSED_LOSSY, COMPRESSED_VALID_COMPRESSIONS, COMPRESSED_OVERLAPPING,
-			COMPRESSED_SAMPLING_RATIO, COMPRESSED_COCODE, COMPRESSED_TRANSPOSE,
+			COMPRESSED_SAMPLING_RATIO, COMPRESSED_COCODE, COMPRESSED_TRANSPOSE, DAG_LINEARIZATION,
 			CODEGEN, CODEGEN_API, CODEGEN_COMPILER, CODEGEN_OPTIMIZER, CODEGEN_PLANCACHE, CODEGEN_LITERALS,
 			STATS_MAX_WRAP_LEN, LINEAGECACHESPILL, COMPILERASSISTED_RW, PRINT_GPU_MEMORY_INFO,
 			AVAILABLE_GPUS, SYNCHRONIZE_GPU, EAGER_CUDA_FREE, FLOATING_POINT_PRECISION, GPU_EVICTION_POLICY, 

--- a/src/main/java/org/apache/sysds/lops/compile/Dag.java
+++ b/src/main/java/org/apache/sysds/lops/compile/Dag.java
@@ -65,7 +65,16 @@ import org.apache.sysds.runtime.instructions.cp.CPInstruction.CPType;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/main/java/org/apache/sysds/lops/compile/Dag.java
+++ b/src/main/java/org/apache/sysds/lops/compile/Dag.java
@@ -258,8 +258,6 @@ public class Dag<N extends Lop>
 			v.stream().filter(l -> !l.getOutputs().isEmpty()).sorted(Comparator.comparing(l -> l.getID())),
 			v.stream().filter(l -> l.getOutputs().isEmpty())).collect(Collectors.toList());
 
-		//printStats(nodes);
-
 		//NOTE: in contrast to hadoop execution modes, we avoid computing the transitive
 		//closure here to ensure linear time complexity because its unnecessary for CP and Spark
 		return nodes;
@@ -268,28 +266,7 @@ public class Dag<N extends Lop>
 	private static List<Lop> doBreadthFirstSort(List<Lop> v) {
 		List<Lop> nodes = v.stream().sorted(Comparator.comparing(Lop::getLevel)).collect(Collectors.toList());
 
-		//printStats(nodes);
-
 		return nodes;
-	}
-
-	private static void printStats(List<Lop> v) {
-		for (Lop l : v) {
-			long memEst = OptimizerUtils.estimateSizeExactSparsity(l.getOutputParameters().getNumRows(),
-				l.getOutputParameters().getNumCols(), l.getOutputParameters().getNnz());
-
-			System.out.println("ID: " + l.getID());
-			System.out.println("Level: " + l.getLevel());
-			System.out.println("Memory estimate: " + memEst);
-			System.out.println("Output params: " + l.getOutputParameters());
-			System.out.println("Class: " + l.getClass());
-			System.out.println("Type: " + l.getDataType() + ", data exec location: " + l.isDataExecLocation() +
-				", variable: " + l.isVariable() + ", exec type: " + l.getExecType());
-			System.out.println("Inputs: " + l.getInputs());
-			System.out.println("Outputs: " + l.getOutputs());
-			System.out.println("Str: " + l.toString());
-			System.out.println("=============================");
-		}
 	}
 
 	/**
@@ -320,8 +297,6 @@ public class Dag<N extends Lop>
 
 		// All lops were added bottom up, from highest to lowest memory consumption, now reverse this
 		Collections.reverse(nodes);
-
-		//printStats(nodes);
 
 		return nodes;
 	}

--- a/src/test/java/org/apache/sysds/test/component/misc/DagLinearizationTest.java
+++ b/src/test/java/org/apache/sysds/test/component/misc/DagLinearizationTest.java
@@ -1,0 +1,53 @@
+package org.apache.sysds.test.component.misc;
+
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.fail;
+
+public class DagLinearizationTest extends AutomatedTestBase  {
+
+	private final String testName = "dag_linearization", testDir = "component/misc/";
+
+	@Override
+	public void setUp() {
+		setOutputBuffering(true);
+		disableConfigFile = true;
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(testName, new TestConfiguration(testDir, testName));
+	}
+
+	private String getPath(String filename) {
+		return SCRIPT_DIR + "/" + testDir + filename;
+	}
+
+	@Test
+	public void testMatrixMultSameOutput() {
+		try {
+			fullDMLScriptName = getPath("MatrixMult.dml");
+			loadTestConfiguration(getTestConfiguration(testName));
+
+			// Default arguments
+			programArgs = new String[] {"-config", "", "-args", output("totalResult")};
+
+			programArgs[1] = getPath("SystemDS-config-default.xml");
+			System.out.println(runTest(null).toString());
+			HashMap<MatrixValue.CellIndex, Double> totalResultTopo = readDMLMatrixFromOutputDir("totalResult");
+
+			programArgs[1] = getPath("SystemDS-config-minintermediate.xml");
+			System.out.println(runTest(null).toString());
+			HashMap<MatrixValue.CellIndex, Double> totalResultMin = readDMLMatrixFromOutputDir("totalResult");
+
+			TestUtils.compareMatrices(totalResultTopo, totalResultMin, 0, "topological", "minintermediate");
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+}

--- a/src/test/java/org/apache/sysds/test/component/misc/DagLinearizationTest.java
+++ b/src/test/java/org/apache/sysds/test/component/misc/DagLinearizationTest.java
@@ -6,20 +6,28 @@ import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class DagLinearizationTest extends AutomatedTestBase  {
 
-	private final String testName = "dag_linearization", testDir = "component/misc/";
+	private final String
+		testNames[] = {"matrixmult_dag_linearization", "csplineCG_dag_linearization",
+						"linear_regression_dag_linearization"},
+		testDir = "component/misc/";
 
 	@Override
 	public void setUp() {
 		setOutputBuffering(true);
 		disableConfigFile = true;
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(testName, new TestConfiguration(testDir, testName));
+		for (String testname : testNames) {
+			addTestConfiguration(testname, new TestConfiguration(testDir, testname));
+		}
 	}
 
 	private String getPath(String filename) {
@@ -30,7 +38,7 @@ public class DagLinearizationTest extends AutomatedTestBase  {
 	public void testMatrixMultSameOutput() {
 		try {
 			fullDMLScriptName = getPath("MatrixMult.dml");
-			loadTestConfiguration(getTestConfiguration(testName));
+			loadTestConfiguration(getTestConfiguration(testNames[0]));
 
 			// Default arguments
 			programArgs = new String[] {"-config", "", "-args", output("totalResult")};
@@ -44,6 +52,110 @@ public class DagLinearizationTest extends AutomatedTestBase  {
 			HashMap<MatrixValue.CellIndex, Double> totalResultMin = readDMLMatrixFromOutputDir("totalResult");
 
 			TestUtils.compareMatrices(totalResultTopo, totalResultMin, 0, "topological", "minintermediate");
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testCsplineCGSameOutput() {
+		try {
+			int rows = 10;
+			int cols = 1;
+			int numIter = rows;
+
+			loadTestConfiguration(getTestConfiguration(testNames[1]));
+
+			List<String> proArgs = new ArrayList<>();
+			proArgs.add("-config");
+			proArgs.add("");
+			proArgs.add("-nvargs");
+			proArgs.add("X=" + input("X"));
+			proArgs.add("Y=" + input("Y"));
+			proArgs.add("K=" + output("K"));
+			proArgs.add("O=" + output("pred_y"));
+			proArgs.add("maxi=" + numIter);
+			proArgs.add("inp_x=" + 4.5);
+
+			fullDMLScriptName = SCRIPT_DIR + "applications/cspline/CsplineCG.dml";
+
+			double[][] X = new double[rows][cols];
+
+			// X axis is given in the increasing order
+			for(int rid = 0; rid < rows; rid++) {
+				for(int cid = 0; cid < cols; cid++) {
+					X[rid][cid] = rid + 1;
+				}
+			}
+
+			double[][] Y = getRandomMatrix(rows, cols, 0, 5, 1.0, -1);
+
+			writeInputMatrixWithMTD("X", X, true);
+			writeInputMatrixWithMTD("Y", Y, true);
+
+			// Default
+			proArgs.set(1, getPath("SystemDS-config-default.xml"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			String outputTopo = runTest(true, EXCEPTION_NOT_EXPECTED, null, -1).toString();
+			System.out.println(outputTopo);
+			HashMap<MatrixValue.CellIndex, Double> predYTopo = readDMLMatrixFromOutputDir("pred_y");
+
+			// Min Intermediate
+			proArgs.set(1, getPath("SystemDS-config-minintermediate.xml"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			String outputMin = runTest(true, EXCEPTION_NOT_EXPECTED, null, -1).toString();
+			System.out.println(outputMin);
+			HashMap<MatrixValue.CellIndex, Double> predYMin = readDMLMatrixFromOutputDir("pred_y");
+
+			TestUtils.compareMatrices(predYTopo, predYMin, Math.pow(10, -5), "topological", "minintermediate");
+
+			outputTopo = outputTopo.split("SystemDS Statistics:")[0];
+			outputMin = outputMin.split("SystemDS Statistics:")[0];
+			assertEquals("Outputs do not match!", outputTopo, outputMin);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testLinearRegressionSameOutput() {
+		try {
+			int rows = 100;
+			int cols = 50;
+
+			loadTestConfiguration(getTestConfiguration(testNames[2]));
+
+			List<String> proArgs = new ArrayList<>();
+			proArgs.add("-config");
+			proArgs.add("");
+			proArgs.add("-args");
+			proArgs.add(input("v"));
+			proArgs.add(input("y"));
+			proArgs.add(Double.toString(Math.pow(10, -8)));
+			proArgs.add(output("w"));
+
+			fullDMLScriptName = SCRIPT_DIR + "applications/linear_regression/LinearRegression.dml";
+
+			double[][] v = getRandomMatrix(rows, cols, 0, 1, 0.01, -1);
+			double[][] y = getRandomMatrix(rows, 1, 1, 10, 1, -1);
+			writeInputMatrixWithMTD("v", v, true);
+			writeInputMatrixWithMTD("y", y, true);
+
+			int expectedNumberOfJobs = 16;
+
+			proArgs.set(1, getPath("SystemDS-config-default.xml"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, expectedNumberOfJobs);
+			HashMap<MatrixValue.CellIndex, Double> wTopo = readDMLMatrixFromOutputDir("w");
+
+			proArgs.set(1, getPath("SystemDS-config-minintermediate.xml"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, expectedNumberOfJobs);
+			HashMap<MatrixValue.CellIndex, Double> wMin = readDMLMatrixFromOutputDir("w");
+
+			TestUtils.compareMatrices(wTopo, wMin, Math.pow(10, -10), "topological", "minintermediate");
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			fail("Exception in execution: " + ex.getMessage());

--- a/src/test/scripts/component/misc/MatrixMult.dml
+++ b/src/test/scripts/component/misc/MatrixMult.dml
@@ -1,0 +1,12 @@
+totalResult = matrix(0, rows=1000, cols=1)
+for (i in 1:2) {
+    A = matrix(1.0 * i, rows=1000, cols=1000)
+    B = matrix(1.0 * (i + 1), rows=1000, cols=1000)
+    C = matrix(1.0 * (i + 2), rows=1000, cols=1000)
+    D = matrix(1.0 * (i + 3), rows=1000, cols=1000)
+    result = (A + B) %*% (rowMaxs(C + D))
+    totalResult = totalResult + result
+}
+
+print(toString(totalResult))
+write(totalResult, $1, format="text")

--- a/src/test/scripts/component/misc/MatrixMult.dml
+++ b/src/test/scripts/component/misc/MatrixMult.dml
@@ -1,3 +1,24 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
 totalResult = matrix(0, rows=1000, cols=1)
 for (i in 1:2) {
     A = matrix(1.0 * i, rows=1000, cols=1000)

--- a/src/test/scripts/component/misc/SystemDS-config-default.xml
+++ b/src/test/scripts/component/misc/SystemDS-config-default.xml
@@ -1,0 +1,21 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+</root>

--- a/src/test/scripts/component/misc/SystemDS-config-minintermediate.xml
+++ b/src/test/scripts/component/misc/SystemDS-config-minintermediate.xml
@@ -1,0 +1,23 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+    <!-- set the dag linearization algorithm (topological, min_intermediate) -->
+    <sysds.compile.linearization>min_intermediate</sysds.compile.linearization>
+</root>


### PR DESCRIPTION
Improve linearization order of LOPs in the DAG to reduce memory consumption of intermediates.

The existing solution is a depth-first algorithm. We modify this to execute LOPs that result in smaller intermediates first in order to reduce maximum memory consumption. This is achieved using a bottom-up approach considering memory estimates (OptimizerUtils.estimateSizeExactSparsity) of parent LOPs.

**Results**
We've compared the implementations using this script:
```
totalResult = matrix(0, rows=1000, cols=1)
for (i in 1:100) {
    A = rand(rows=1000, cols=1000)
    b = rand(rows=1000, cols=1000)
    C = rand(rows=1000, cols=1000)
    d = rand(rows=1000, cols=1000)
    result = (A + b) %*% rowMaxs(C + d)
    totalResult = totalResult + result
}
print(toString(totalResult))
```
In the existing implementations to calculate the result `A + b` is  executed first and results in a 1000x1000 matrix as an intermediate while calculating `rowMaxs`. In our solution, `rowMaxs` is executed first, which only leads to an intermediate vector of 1000x1.

For the following data, we've forced the garbage collector to run after every instruction.

When enabling JMLC_MEM_STATISTICS we get these results:
**Max size of live objects:**
Depth-first (existing): 30.526 MB (5 total objects)
Breadth-first: 38.155 MB (6 total objects)
Min-intermediate (ours): 22.904 MB (5 total objects)

This is a graph of memory consumption over time for the test script:
![mem_consumption](https://user-images.githubusercontent.com/95644983/149497162-bf954b3c-2309-4069-a671-90f9b5feae14.png)

For a more detailed view, the same graph but only the first 45 instructions. This includes two loop iterations.
![mem_consumption_parts](https://user-images.githubusercontent.com/95644983/149497177-9d0acfe8-9478-4b6b-a3ec-7c1a2aa608c8.png)

