### PR TITLE
[SYSTEMDS-3273] Federated Timeout

### DIFF
--- a/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
+++ b/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
@@ -205,6 +205,10 @@ public class ConfigurationManager
 		return compress.isEnabled();
 	}
 	
+	public static int getFederatedTimeout(){
+		return getDMLConfig().getIntValue(DMLConfig.FEDERATED_TIMEOUT);
+	}
+
 	///////////////////////////////////////
 	// Thread-local classes
 	

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -108,6 +108,7 @@ public class DMLConfig
 
 	public static final String USE_SSL_FEDERATED_COMMUNICATION = "sysds.federated.ssl"; // boolean
 	public static final String DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT = "sysds.federated.initialization.timeout"; // int seconds
+	public static final String FEDERATED_TIMEOUT = "sysds.federated.timeout"; // single request timeout default -1 to indicate infinite.
 	public static final int DEFAULT_FEDERATED_PORT = 4040; // borrowed default Spark Port
 	public static final int DEFAULT_NUMBER_OF_FEDERATED_WORKER_THREADS = 2;
 	
@@ -168,6 +169,7 @@ public class DMLConfig
 		_defaultVals.put(FLOATING_POINT_PRECISION, "double" );
 		_defaultVals.put(USE_SSL_FEDERATED_COMMUNICATION, "false");
 		_defaultVals.put(DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT, "10");
+		_defaultVals.put(FEDERATED_TIMEOUT, "-1");
 	}
 	
 	public DMLConfig() {
@@ -417,7 +419,7 @@ public class DMLConfig
 			STATS_MAX_WRAP_LEN, LINEAGECACHESPILL, COMPILERASSISTED_RW, PRINT_GPU_MEMORY_INFO,
 			AVAILABLE_GPUS, SYNCHRONIZE_GPU, EAGER_CUDA_FREE, FLOATING_POINT_PRECISION, GPU_EVICTION_POLICY, 
 			LOCAL_SPARK_NUM_THREADS, EVICTION_SHADOW_BUFFERSIZE, GPU_MEMORY_ALLOCATOR, GPU_MEMORY_UTILIZATION_FACTOR,
-			USE_SSL_FEDERATED_COMMUNICATION, DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT
+			USE_SSL_FEDERATED_COMMUNICATION, DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT, FEDERATED_TIMEOUT
 		}; 
 		
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -275,7 +275,9 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 			throw ex;
 		}
 		catch(Exception ex) {
-			throw new DMLRuntimeException(ex);
+			String msg = "Exception of type " + ex.getClass() + " thrown when processing READ request";
+			LOG.error(msg, ex);
+			throw new DMLRuntimeException(msg);
 		}
 		finally {
 			IOUtilFunctions.closeSilently(fs);
@@ -425,6 +427,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		catch(Exception ex) {
 			// Note it is unsafe to throw the ex trace along with the exception here.
 			String msg = "Exception of type " + ex.getClass() + " thrown when processing EXEC_UDF request";
+			LOG.error(msg, ex);
 			throw new FederatedWorkerHandlerException(msg);
 		}
 	}
@@ -438,6 +441,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		}
 		catch(Exception ex) {
 			String msg = "Exception of type " + ex.getClass() + " thrown when processing CLEAR request";
+			LOG.error(msg, ex);
 			throw new FederatedWorkerHandlerException(msg);
 		}
 		return new FederatedResponse(ResponseType.SUCCESS_EMPTY);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
@@ -450,7 +450,7 @@ public class FederatedPSControlThread extends PSWorker implements Callable<Void>
 		catch(Exception e) {
 			if(DMLScript.STATISTICS)
 				tFedCommunication.stop();
-			throw new DMLRuntimeException("FederatedLocalPSThread: failed to execute UDF" + e.getMessage());
+			throw new DMLRuntimeException("FederatedLocalPSThread: failed to execute UDF" + e.getMessage(), e);
 		}
 	}
 

--- a/src/test/config/SystemDS-MultiTenant-config.xml
+++ b/src/test/config/SystemDS-MultiTenant-config.xml
@@ -20,4 +20,6 @@
 <root>
    <!-- The timeout of the federated tests to initialize the federated matrixes -->
    <sysds.federated.initialization.timeout>30</sysds.federated.initialization.timeout>
+   <!-- The timeout of each instruction sent to federated workers -->
+   <sysds.federated.timeout>128</sysds.federated.timeout>
 </root>

--- a/src/test/config/SystemDS-config.xml
+++ b/src/test/config/SystemDS-config.xml
@@ -18,33 +18,10 @@
 -->
 
 <root>
-   <!-- local fs tmp working directory-->
-   <sysds.localtmpdir>/tmp/systemds</sysds.localtmpdir>
-
-   <!-- hdfs tmp working directory-->
-   <sysds.scratch>scratch_space</sysds.scratch>
-
-   <!-- compiler optimization level, valid values: 0 | 1 | 2 | 3 | 4, default: 2 -->
-   <sysds.optlevel>2</sysds.optlevel>
-
-   <!-- default block dim for binary block files -->
-   <sysds.defaultblocksize>1000</sysds.defaultblocksize>
-
-   <!-- enables multi-threaded matrix operations in singlenode control program -->
-   <sysds.cp.parallel.ops>true</sysds.cp.parallel.ops>
-
-   <!-- enables multi-threaded read/write in singlenode control program -->
-   <sysds.cp.parallel.io>true</sysds.cp.parallel.io>
-
-   <!-- enables native blas for matrix multiplication and convolution, experimental feature (options: auto, mkl, openblas, none) -->
-   <sysds.native.blas>none</sysds.native.blas>
-
-   <!-- custom directory where BLAS libraries are available, experimental feature (options: absolute directory path or none). If set to none, we use standard LD_LIBRARY_PATH. -->
-   <sysds.native.blas.directory>none</sysds.native.blas.directory>
-
    <!-- The number of theads for the spark instance artificially selected-->
-   <sysds.local.spark.number.threads>16</sysds.local.spark.number.threads>
-
+   <sysds.local.spark.number.threads>2</sysds.local.spark.number.threads>
    <!-- The timeout of the federated tests to initialize the federated matrixes -->
    <sysds.federated.initialization.timeout>2</sysds.federated.initialization.timeout>
+   <!-- The timeout of each instruction sent to federated workers -->
+   <sysds.federated.timeout>128</sysds.federated.timeout>
 </root>

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -1089,19 +1089,20 @@ public abstract class AutomatedTestBase {
 
 			curLocalTempDir.mkdirs();
 			TestUtils.clearDirectory(curLocalTempDir.getPath());
-
-			// Create a SystemDS config file for this test case based on default template
-			// from src/test/config or derive from custom configuration provided by test.
-			String configTemplate = FileUtils.readFileToString(getConfigTemplateFile(), "UTF-8");
-			String localTemp = curLocalTempDir.getPath();
-			String configContents = configTemplate
-				.replace(createXMLElement(DMLConfig.SCRATCH_SPACE, "scratch_space"),
-					createXMLElement(DMLConfig.SCRATCH_SPACE, localTemp + "/target/scratch_space"))
-				.replace(createXMLElement(DMLConfig.LOCAL_TMP_DIR, "/tmp/systemds"),
-					createXMLElement(DMLConfig.LOCAL_TMP_DIR, localTemp + "/localtmp"));
-
+			
 			if(!disableConfigFile){
-
+				// Create a SystemDS config file for this test case based on default template
+				// from src/test/config or derive from custom configuration provided by test.
+				String configTemplate = FileUtils.readFileToString(getConfigTemplateFile(), "UTF-8");
+				String localTemp = curLocalTempDir.getPath();
+				String testScratchSpace = "\n   "+ createXMLElement(DMLConfig.SCRATCH_SPACE, localTemp + "/target/scratch_space") + "\n   ";
+				String testTempSpace = createXMLElement(DMLConfig.LOCAL_TMP_DIR, localTemp + "/localtmp");
+				String configContents = configTemplate
+					// if the config had a tmp location remove it
+					.replace(createXMLElement(DMLConfig.SCRATCH_SPACE, "scratch_space"),"")
+					.replace(createXMLElement(DMLConfig.LOCAL_TMP_DIR, "/tmp/systemds"),"")
+					.replace("</root>", testScratchSpace + testTempSpace + "\n</root>");
+				LOG.error(configContents);
 				FileUtils.write(getCurConfigFile(), configContents, "UTF-8");
 
 				if(LOG.isDebugEnabled())

--- a/src/test/scripts/functions/federated/codegen/SystemDS-config-codegen.xml
+++ b/src/test/scripts/functions/federated/codegen/SystemDS-config-codegen.xml
@@ -18,15 +18,11 @@
 -->
 
 <root>
-   <sysds.localtmpdir>/tmp/systemds</sysds.localtmpdir>
-   <sysds.scratch>scratch_space</sysds.scratch>
    <sysds.optlevel>7</sysds.optlevel>
    <sysds.codegen.enabled>true</sysds.codegen.enabled>
    <sysds.codegen.plancache>true</sysds.codegen.plancache>
    <sysds.codegen.literals>1</sysds.codegen.literals>
-
-   <!-- The number of theads for the spark instance artificially selected-->
-   <sysds.local.spark.number.threads>16</sysds.local.spark.number.threads>
-
+   <sysds.local.spark.number.threads>2</sysds.local.spark.number.threads>
    <sysds.codegen.api>auto</sysds.codegen.api>
+   <sysds.federated.timeout>128</sysds.federated.timeout>
 </root>

--- a/src/test/scripts/functions/federated/io/SSLConfig.xml
+++ b/src/test/scripts/functions/federated/io/SSLConfig.xml
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
 -->
+
 <root>
+    <sysds.local.spark.number.threads>2</sysds.local.spark.number.threads>
     <sysds.federated.ssl>true</sysds.federated.ssl>
+    <sysds.federated.timeout>128</sysds.federated.timeout>
 </root>


### PR DESCRIPTION
This commit adds two things to the federated handler.
1. A timeout (default unlimited) that is enabled for tests to
ensure that the tests finish instead of having a controller waiting
infinitely on a crashed worker.
2. Log output of errors on the workers to enable debugging if you have
access to the worker process output. This ensures that if there is sensitive
information in the error message it is contained to the worker but still
logged.