### PR TITLE
[SYSTEMDS-3274] Disable docker login on pull_request event

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     
+    # https://github.com/docker/metadata-action
     - name: Configure Docker metadata
       id: meta
       uses: docker/metadata-action@v3
@@ -53,7 +54,12 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
+    # https://github.com/docker/login-action
+    # IMPORTANT: The credentials should not be available via the
+    # Pull request, hence this if condition here,
+    # github.event_name != 'pull_request'
     - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
           username: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/docker-testImage.yml
+++ b/.github/workflows/docker-testImage.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     
+    # https://github.com/docker/metadata-action
     - name: Configure Docker metadata
       id: meta
       uses: docker/metadata-action@v3
@@ -51,8 +52,10 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
-      
+
+    # https://github.com/docker/login-action  
     - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
           username: ${{ secrets.DOCKERHUB_USER }}


### PR DESCRIPTION
Ideally, the docker credentials should never be used in the pull_request. If the testing images are outdated, it is a good practice to build changed Dockerfile's via github actions and merge into the main and then push to Dockerhub.