### PR TITLE
[SYSTEMDS-3227] Equi-height binning in transformencode/apply

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -117,7 +117,18 @@ public class EncoderFactory {
 					int id = TfMetaUtils.parseJsonObjectID(colspec, colnames, minCol, maxCol, ids);
 					if(id <= 0)
 						continue;
-					ColumnEncoderBin bin = new ColumnEncoderBin(id, numBins);
+					String method = colspec.get("method").toString().toUpperCase();
+					ColumnEncoderBin.BinMethod binMethod;
+					if ("EQUI-WIDTH".equals(method)) {
+						binMethod = ColumnEncoderBin.BinMethod.EQUI_WIDTH;
+					}
+					else if ("EQUI-HEIGHT".equals(method)) {
+						binMethod = ColumnEncoderBin.BinMethod.EQUI_HEIGHT;
+					}
+					else {
+						throw new DMLRuntimeException("Unsupported binning method: " + method);
+					}
+					ColumnEncoderBin bin = new ColumnEncoderBin(id, numBins, binMethod);
 					addEncoderToMap(bin, colEncoders);
 				}
 			if(!dcIDs.isEmpty())

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeApplyTest.java
@@ -44,10 +44,14 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 	private final static String SPEC2b   = "homes3/homes.tfspec_dummy2.json";
 	private final static String SPEC3    = "homes3/homes.tfspec_bin.json"; //recode
 	private final static String SPEC3b   = "homes3/homes.tfspec_bin2.json"; //recode
+	private final static String SPEC3c   = "homes3/homes.tfspec_bin_height.json"; //recode
+	private final static String SPEC3d   = "homes3/homes.tfspec_bin_height2.json"; //recode
 	private final static String SPEC6    = "homes3/homes.tfspec_recode_dummy.json";
 	private final static String SPEC6b   = "homes3/homes.tfspec_recode_dummy2.json";
 	private final static String SPEC7    = "homes3/homes.tfspec_binDummy.json"; //recode+dummy
 	private final static String SPEC7b   = "homes3/homes.tfspec_binDummy2.json"; //recode+dummy
+	private final static String SPEC7c   = "homes3/homes.tfspec_binHeightDummy.json"; //recode+dummy
+	private final static String SPEC7d   = "homes3/homes.tfspec_binHeightDummy2.json"; //recode+dummy
 	private final static String SPEC8    = "homes3/homes.tfspec_hash.json";
 	private final static String SPEC8b   = "homes3/homes.tfspec_hash2.json";
 	private final static String SPEC9    = "homes3/homes.tfspec_hash_recode.json";
@@ -63,6 +67,8 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 	
 	private static final int[] BIN_col3 = new int[]{1,4,2,3,3,2,4};
 	private static final int[] BIN_col8 = new int[]{1,2,2,2,2,2,3};
+	private static final int[] BIN_HEIGHT_col3 = new int[]{1,3,1,3,3,2,3};
+	private static final int[] BIN_HEIGHT_col8 = new int[]{1,2,2,3,2,2,3};
 	
 	public enum TransformType {
 		RECODE,
@@ -70,6 +76,8 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 		RECODE_DUMMY,
 		BIN,
 		BIN_DUMMY,
+		BIN_HEIGHT,
+		BIN_HEIGHT_DUMMY,
 		IMPUTE,
 		OMIT,
 		HASH,
@@ -131,6 +139,11 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 	public void testHomesBinningIDsSingleNodeCSV() {
 		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN, false);
 	}
+
+	@Test
+	public void testHomesEqualHeightBinningIDsSingleNodeCSV() {
+		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN_HEIGHT, true);
+	}
 	
 	@Test
 	public void testHomesBinningIDsSparkCSV() {
@@ -146,6 +159,12 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 	public void testHomesBinningDummyIDsSingleNodeCSV() {
 		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN_DUMMY, false);
 	}
+
+	@Test
+	public void testHomesHeightBinningDummyIDsSingleNodeCSV() {
+		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN_HEIGHT_DUMMY, false);
+	}
+
 
 	@Test
 	public void testHomesBinningDummyIDsSparkCSV() {
@@ -250,6 +269,11 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 	@Test
 	public void testHomesBinningDummyColnamesSingleNodeCSV() {
 		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN_DUMMY, true);
+	}
+
+	@Test
+	public void testHomesHeightBinningDummyColnamesSingleNodeCSV() {
+		runTransformTest(ExecMode.SINGLE_NODE, "csv", TransformType.BIN_HEIGHT_DUMMY, true);
 	}
 	
 	@Test
@@ -369,10 +393,12 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 			case RECODE: SPEC = colnames?SPEC1b:SPEC1; DATASET = DATASET1; break;
 			case DUMMY:  SPEC = colnames?SPEC2b:SPEC2; DATASET = DATASET1; break;
 			case BIN:    SPEC = colnames?SPEC3b:SPEC3; DATASET = DATASET1; break;
+			case BIN_HEIGHT:    SPEC = colnames?SPEC3d:SPEC3c; DATASET = DATASET1; break;
 			case IMPUTE: SPEC = colnames?SPEC4b:SPEC4; DATASET = DATASET2; break;
 			case OMIT:   SPEC = colnames?SPEC5b:SPEC5; DATASET = DATASET2; break;
 			case RECODE_DUMMY: SPEC = colnames?SPEC6b:SPEC6; DATASET = DATASET1; break;
 			case BIN_DUMMY: SPEC = colnames?SPEC7b:SPEC7; DATASET = DATASET1; break;
+			case BIN_HEIGHT_DUMMY:    SPEC = colnames?SPEC7d:SPEC7c; DATASET = DATASET1; break;
 			case HASH:	 SPEC = colnames?SPEC8b:SPEC8; DATASET = DATASET1; break;
 			case HASH_RECODE: SPEC = colnames?SPEC9b:SPEC9; DATASET = DATASET1; break;
 		}
@@ -386,7 +412,7 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME1 + ".dml";
-			programArgs = new String[]{"-nvargs", 
+			programArgs = new String[]{"-nvargs",
 				"DATA=" + DATASET_DIR + DATASET,
 				"TFSPEC=" + DATASET_DIR + SPEC,
 				"TFDATA1=" + output("tfout1"),
@@ -412,13 +438,17 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 			
 			//additional checks for binning as encode-decode impossible
 			//TODO fix distributed binning as well
-			if( type == TransformType.BIN ) {
+			if (type == TransformType.BIN ) {
 				for(int i=0; i<7; i++) {
 					Assert.assertEquals(BIN_col3[i], R1[i][2], 1e-8);
 					Assert.assertEquals(BIN_col8[i], R1[i][7], 1e-8);
 				}
-			}
-			else if( type == TransformType.BIN_DUMMY ) {
+			} else if (type == TransformType.BIN_HEIGHT) {
+				for(int i=0; i<7; i++) {
+					Assert.assertEquals(BIN_HEIGHT_col3[i], R1[i][2], 1e-8);
+					Assert.assertEquals(BIN_HEIGHT_col8[i], R1[i][7], 1e-8);
+				}
+			} else if (type == TransformType.BIN_DUMMY) {
 				Assert.assertEquals(14, R1[0].length);
 				for(int i=0; i<7; i++) {
 					for(int j=0; j<4; j++) { //check dummy coded
@@ -428,6 +458,18 @@ public class TransformFrameEncodeApplyTest extends AutomatedTestBase {
 					for(int j=0; j<3; j++) { //check dummy coded
 						Assert.assertEquals((j==BIN_col8[i]-1)?
 							1:0, R1[i][10+j], 1e-8);
+					}
+				}
+			} else if (type == TransformType.BIN_HEIGHT_DUMMY) {
+				Assert.assertEquals(14, R1[0].length);
+				for(int i=0; i<7; i++) {
+					for(int j=0; j<4; j++) { //check dummy coded
+						Assert.assertEquals((j==BIN_HEIGHT_col3[i]-1)?
+								1:0, R1[i][2+j], 1e-8);
+					}
+					for(int j=0; j<3; j++) { //check dummy coded
+						Assert.assertEquals((j==BIN_HEIGHT_col8[i]-1)?
+								1:0, R1[i][10+j], 1e-8);
 					}
 				}
 			} else if (type == TransformType.IMPUTE){

--- a/src/test/resources/datasets/homes3/homes.tfspec_binHeightDummy.json
+++ b/src/test/resources/datasets/homes3/homes.tfspec_binHeightDummy.json
@@ -1,0 +1,6 @@
+{
+ "ids": true, "recode": [ 1, 2, 7 ], "bin": [
+ { "id": 8  , "method": "equi-height", "numbins": 3 },
+ { "id": 3, "method": "equi-height", "numbins": 4 }],
+ "dummycode": [ 3, 8 ]
+  }

--- a/src/test/resources/datasets/homes3/homes.tfspec_binHeightDummy2.json
+++ b/src/test/resources/datasets/homes3/homes.tfspec_binHeightDummy2.json
@@ -1,0 +1,6 @@
+{
+ "recode": [ zipcode, "district", "view" ], "bin": [
+ { "name": "saleprice"  , "method": "equi-height", "numbins": 3 },
+ { "name": "sqft", "method": "equi-height", "numbins": 4 }],
+ "dummycode": [ sqft, "saleprice" ]
+  }

--- a/src/test/resources/datasets/homes3/homes.tfspec_bin_height.json
+++ b/src/test/resources/datasets/homes3/homes.tfspec_bin_height.json
@@ -1,0 +1,5 @@
+{
+  "ids": true, "recode": [ 1, 2, 7 ], "bin": [
+  { "id": 8  , "method": "equi-height", "numbins": 3 }
+,{ "id": 3, "method": "equi-height", "numbins": 4 }]
+}

--- a/src/test/resources/datasets/homes3/homes.tfspec_bin_height2.json
+++ b/src/test/resources/datasets/homes3/homes.tfspec_bin_height2.json
@@ -1,0 +1,5 @@
+{
+  "recode": [ zipcode, "district", "view" ], "bin": [
+  { "name": "saleprice"  , "method": "equi-height", "numbins": 3 }
+,{ "name": "sqft", "method": "equi-height", "numbins": 4 }]
+}


### PR DESCRIPTION
This patch extends the built-in functions transformencode and transformapply by equi-height binning on the local runtime. For this purpose the selected column gets sorted, then the bin boundaries are calulated as quantiles which then are converted to inout indicies and applied as bin boundaries analogous to already existing equi-width binning. The bining problem for non divisible bin numbers has been adressed with spillover. This has the advantage that all but the last bin a gurantued to be equi-height. The drawback is that the last bin has equi-height + inputlength % bin number height.