### PR TITLE
[SYSTEMDS-2831] Foundation for new DeltaDDC Column Group

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -48,7 +48,7 @@ public abstract class AColGroup implements Serializable {
 
 	/** Public super types of compression ColGroups supported */
 	public enum CompressionType {
-		UNCOMPRESSED, RLE, OLE, DDC, CONST, EMPTY, SDC, PFOR,
+		UNCOMPRESSED, RLE, OLE, DDC, CONST, EMPTY, SDC, PFOR, DeltaDDC
 	}
 
 	/**
@@ -57,7 +57,7 @@ public abstract class AColGroup implements Serializable {
 	 * Protected such that outside the ColGroup package it should be unknown which specific subtype is used.
 	 */
 	protected enum ColGroupType {
-		UNCOMPRESSED, RLE, OLE, DDC, CONST, EMPTY, SDC, SDCSingle, SDCSingleZeros, SDCZeros, PFOR;
+		UNCOMPRESSED, RLE, OLE, DDC, CONST, EMPTY, SDC, SDCSingle, SDCSingleZeros, SDCZeros, PFOR, DeltaDDC;
 	}
 
 	/** The ColGroup Indexes contained in the ColGroup */

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDeltaDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDeltaDDC.java
@@ -1,0 +1,63 @@
+package org.apache.sysds.runtime.compress.colgroup;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
+import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
+
+/**
+ * Class to encapsulate information about a column group that is first delta encoded then encoded with dense
+ * dictionary encoding (DeltaDDC).
+ */
+public class ColGroupDeltaDDC extends ColGroupDDC {
+
+    /**
+     * Constructor for serialization
+     *
+     * @param numRows number of rows
+     */
+    protected ColGroupDeltaDDC(int numRows) {
+        super(numRows);
+    }
+
+    protected ColGroupDeltaDDC(int[] colIndices, int numRows, ADictionary dict, AMapToData data, int[] cachedCounts) {
+        super(colIndices, numRows, dict, data, cachedCounts);
+        _zeros = false;
+        _data = data;
+    }
+
+    public CompressionType getCompType() {
+        return CompressionType.DeltaDDC;
+    }
+
+    @Override
+    protected void decompressToDenseBlockDenseDictionary(DenseBlock db, int rl, int ru, int offR, int offC,
+                                                         double[] values) {
+        final int nCol = _colIndexes.length;
+        for(int i = rl, offT = rl + offR; i < ru; i++, offT++) {
+            final double[] c = db.values(offT);
+            final int off = db.pos(offT) + offC;
+            final int rowIndex = _data.getIndex(i) * nCol;
+            final int prevOff = (off == 0) ? off : off - nCol;
+            for(int j = 0; j < nCol; j++) {
+                // Here we use the values in the previous row to compute current values along with the delta
+                double newValue = c[prevOff + j] + values[rowIndex + j];
+                c[off + _colIndexes[j]] += newValue;
+            }
+        }
+    }
+
+    @Override
+    protected void decompressToSparseBlockDenseDictionary(SparseBlock ret, int rl, int ru, int offR, int offC,
+                                                          double[] values) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public AColGroup scalarOperation(ScalarOperator op) {
+        return new ColGroupDeltaDDC(_colIndexes, _numRows, _dict.applyScalarOp(op), _data,
+                getCachedCounts());
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupFactory.java
@@ -58,8 +58,10 @@ import org.apache.sysds.runtime.compress.utils.IntArrayList;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.Timing;
 import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
+import org.apache.sysds.runtime.util.DataConverter;
 
 /**
  * Factory class for constructing ColGroups.
@@ -335,6 +337,12 @@ public class ColGroupFactory {
 				tmp.getDblCountMap(nrUniqueEstimate), cs);
 		else if(colIndexes.length > 1 && estimatedBestCompressionType == CompressionType.DDC)
 			return directCompressDDC(colIndexes, in, cs, cg, k);
+		else if(estimatedBestCompressionType == CompressionType.DeltaDDC) {
+			if (colIndexes.length > 1)
+				return directCompressDeltaDDC(colIndexes, in, cs, cg, k);
+			else
+				return compressDeltaDDC(colIndexes, in, cs, cg);
+		}
 		else {
 			final int numRows = cs.transposed ? in.getNumColumns() : in.getNumRows();
 			final ABitmap ubm = BitmapEncoder.extractBitmap(colIndexes, in, cs.transposed, nrUniqueEstimate,
@@ -376,11 +384,25 @@ public class ColGroupFactory {
 		final int rlen = cs.transposed ? raw.getNumColumns() : raw.getNumRows();
 		// use a Map that is at least char size.
 		final int nVal = cg.getNumVals() < 16 ? 16 : Math.max(cg.getNumVals(), 257);
-		return directCompressDDC(colIndexes, raw, cs, cg, MapToFactory.create(rlen, nVal), rlen, k);
+		return directCompressDDCColGroup(colIndexes, raw, cs, cg, MapToFactory.create(rlen, nVal), rlen, k, false);
 	}
 
-	private static AColGroup directCompressDDC(int[] colIndexes, MatrixBlock raw, CompressionSettings cs,
-		CompressedSizeInfoColGroup cg, AMapToData data, int rlen, int k) {
+	private static AColGroup directCompressDeltaDDC(int[] colIndexes, MatrixBlock raw, CompressionSettings cs,
+													CompressedSizeInfoColGroup cg, int k) {
+		final int rlen = cs.transposed ? raw.getNumColumns() : raw.getNumRows();
+		// use a Map that is at least char size.
+		final int nVal = cg.getNumVals() < 16 ? 16 : Math.max(cg.getNumVals(), 257);
+		if(cs.transposed) {
+			LibMatrixReorg.transposeInPlace(raw, k);
+			cs.transposed = false;
+		}
+		// Delta encode the raw data
+		raw = deltaEncodeMatrixBlock(raw);
+		return directCompressDDCColGroup(colIndexes, raw, cs, cg, MapToFactory.create(rlen, nVal), rlen, k, true);
+	}
+
+	private static AColGroup directCompressDDCColGroup(int[] colIndexes, MatrixBlock raw, CompressionSettings cs,
+		CompressedSizeInfoColGroup cg, AMapToData data, int rlen, int k, boolean deltaEncoded) {
 		final int fill = data.getUpperBoundValue();
 		data.fill(fill);
 
@@ -396,7 +418,7 @@ public class ColGroupFactory {
 			// This is highly unlikely but could happen if forced compression of
 			// not transposed column and the estimator says use DDC.
 			return new ColGroupEmpty(colIndexes);
-		ADictionary dict = DictionaryFactory.create(map, colIndexes.length, extra);
+		ADictionary dict = DictionaryFactory.create(map, colIndexes.length, extra, deltaEncoded);
 		if(extra) {
 			data.replace(fill, map.size());
 			data.setUnique(map.size() + 1);
@@ -405,8 +427,10 @@ public class ColGroupFactory {
 			data.setUnique(map.size());
 
 		AMapToData resData = MapToFactory.resize(data, map.size() + (extra ? 1 : 0));
-		ColGroupDDC res = new ColGroupDDC(colIndexes, rlen, dict, resData, null);
-		return res;
+		if (deltaEncoded)
+			return new ColGroupDeltaDDC(colIndexes, rlen, dict, resData, null);
+		else
+			return new ColGroupDDC(colIndexes, rlen, dict, resData, null);
 	}
 
 	private static boolean readToMapDDC(final int[] colIndexes, final MatrixBlock raw, final DblArrayCountHashMap map,
@@ -458,6 +482,21 @@ public class ColGroupFactory {
 		catch(Exception e) {
 			throw new DMLRuntimeException("Failed to parallelize DDC compression");
 		}
+	}
+
+	private static MatrixBlock deltaEncodeMatrixBlock(MatrixBlock mb) {
+		int rows = mb.getNumRows();
+		int cols = mb.getNumColumns();
+		double[][] ret = new double[rows][cols];
+		double[] a = mb.getDenseBlockValues();
+		for( int i=0, ix=0; i<rows; i++ ) {
+			int prevRowOff = i > 0 ? ix-cols : 0;
+			for (int j = 0; j < cols; j++, ix++) {
+				double currentValue = a[ix];
+				ret[i][j] = i > 0 ? currentValue - a[prevRowOff+j] : currentValue;
+			}
+		}
+		return DataConverter.convertToMatrixBlock(ret);
 	}
 
 	static class readToMapDDCTask implements Callable<Boolean> {
@@ -577,6 +616,23 @@ public class ColGroupFactory {
 		ADictionary dict = DictionaryFactory.create(ubm, tupleSparsity, zeros);
 		AMapToData data = MapToFactory.create(rlen, zeros, ubm.getOffsetList());
 		return new ColGroupDDC(colIndexes, rlen, dict, data, null);
+	}
+
+	private static AColGroup compressDeltaDDC(int[] colIndexes, MatrixBlock in, CompressionSettings cs,
+											  CompressedSizeInfoColGroup cg) {
+		if(cs.transposed) {
+			LibMatrixReorg.transposeInPlace(in, 1);
+			cs.transposed = false;
+		}
+		// Delta encode the raw data
+		in = deltaEncodeMatrixBlock(in);
+		final int rlen = in.getNumRows();
+		final ABitmap ubm = BitmapEncoder.extractBitmap(colIndexes, in, cs.transposed, cg.getNumVals(),
+				cs.sortTuplesByFrequency);
+		boolean zeros = ubm.getNumOffsets() < rlen;
+		ADictionary dict = DictionaryFactory.create(ubm, cg.getTupleSparsity(), zeros);
+		AMapToData data = MapToFactory.create(rlen, zeros, ubm.getOffsetList());
+		return new ColGroupDeltaDDC(colIndexes, rlen, dict, data, null);
 	}
 
 	private static AColGroup compressOLE(int[] colIndexes, int rlen, ABitmap ubm, CompressionSettings cs,

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupIO.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupIO.java
@@ -106,6 +106,8 @@ public class ColGroupIO {
 				return new ColGroupRLE(nRows);
 			case DDC:
 				return new ColGroupDDC(nRows);
+			case DeltaDDC:
+				return new ColGroupDeltaDDC(nRows);
 			case CONST:
 				return new ColGroupConst();
 			case EMPTY:

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DeltaDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DeltaDictionary.java
@@ -1,0 +1,43 @@
+package org.apache.sysds.runtime.compress.colgroup.dictionary;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.runtime.functionobjects.Divide;
+import org.apache.sysds.runtime.functionobjects.Multiply;
+import org.apache.sysds.runtime.functionobjects.Plus;
+import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
+
+/**
+ * This dictionary class is a specialization for the DeltaDDCColgroup. Here the adjustments for operations for the delta
+ * encoded values are implemented.
+ */
+public class DeltaDictionary extends Dictionary {
+
+    private final int _numCols;
+
+    public DeltaDictionary(double[] values, int numCols) {
+        super(values);
+        _numCols = numCols;
+    }
+
+    @Override
+    public DeltaDictionary applyScalarOp(ScalarOperator op) {
+        final double[] retV = new double[_values.length];
+        if (op.fn instanceof Multiply || op.fn instanceof Divide) {
+            for(int i = 0; i < _values.length; i++)
+                retV[i] = op.executeScalar(_values[i]);
+        }
+        else if (op.fn instanceof Plus || op.fn instanceof Minus) {
+            // With Plus and Minus only the first row needs to be updated when delta encoded
+            for(int i = 0; i < _values.length; i++) {
+                if (i < _numCols)
+                    retV[i] = op.executeScalar(_values[i]);
+                else
+                    retV[i] = _values[i];
+            }
+        } else
+            throw new NotImplementedException();
+
+        return new DeltaDictionary(retV, _numCols);
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
@@ -41,7 +41,7 @@ public class Dictionary extends ADictionary {
 
 	private static final long serialVersionUID = -6517136537249507753L;
 
-	private final double[] _values;
+	protected final double[] _values;
 
 	public Dictionary(double[] values) {
 		if(values == null || values.length == 0)

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictionaryFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictionaryFactory.java
@@ -67,7 +67,7 @@ public class DictionaryFactory {
 			return Dictionary.getInMemorySize(nrValues * nrColumns);
 	}
 
-	public static ADictionary create(DblArrayCountHashMap map, int nCols, boolean addZeroTuple) {
+	public static ADictionary create(DblArrayCountHashMap map, int nCols, boolean addZeroTuple, boolean deltaEncoded) {
 		final ArrayList<DArrCounts> vals = map.extractValues();
 		final int nVals = vals.size();
 		final double[] resValues = new double[(nVals + (addZeroTuple ? 1 : 0)) * nCols];
@@ -75,7 +75,7 @@ public class DictionaryFactory {
 			final DArrCounts dac = vals.get(i);
 			System.arraycopy(dac.key.getData(), 0, resValues, dac.id * nCols, nCols);
 		}
-		return new Dictionary(resValues);
+		return deltaEncoded ? new DeltaDictionary(resValues, nCols) : new Dictionary(resValues);
 	}
 
 	public static ADictionary create(ABitmap ubm) {

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupDeltaDDCTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupDeltaDDCTest.java
@@ -1,0 +1,82 @@
+package org.apache.sysds.test.component.compress.colgroup;
+
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.compress.CompressionSettings;
+import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
+import org.apache.sysds.runtime.compress.bitmap.ABitmap;
+import org.apache.sysds.runtime.compress.bitmap.BitmapEncoder;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupFactory;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeEstimator;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
+import org.apache.sysds.runtime.compress.estim.EstimationFactors;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.util.DataConverter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.EnumSet;
+
+public class ColGroupDeltaDDCTest {
+
+    @Test
+    public void testDecompressToDenseBlockSingleColumn() {
+        testDecompressToDenseBlock(new double[][] {{1,2,3,4,5}}, true);
+    }
+
+    @Test
+    public void testDecompressToDenseBlockSingleColumnTransposed() {
+        testDecompressToDenseBlock(new double[][] {{1},{2},{3},{4},{5}}, false);
+    }
+
+    @Test
+    public void testDecompressToDenseBlockTwoColumns() {
+        testDecompressToDenseBlock(new double[][] {{1,1},{2,1},{3,1},{4,1},{5,1}}, false);
+    }
+
+    @Test
+    public void testDecompressToDenseBlockTwoColumnsTransposed() {
+        testDecompressToDenseBlock(new double[][] {{1,2,3,4,5},{1,1,1,1,1}}, true);
+    }
+
+    public void testDecompressToDenseBlock(double[][] data, boolean isTransposed) {
+        MatrixBlock mbt = DataConverter.convertToMatrixBlock(data);
+
+        final int numCols = isTransposed ? mbt.getNumRows() : mbt.getNumColumns();
+        final int numRows = isTransposed ? mbt.getNumColumns() : mbt.getNumRows();
+        int[] colIndexes = new int[numCols];
+        for(int x = 0; x < numCols; x++)
+            colIndexes[x] = x;
+
+        try {
+            CompressionSettings cs = new CompressionSettingsBuilder().setSamplingRatio(1.0)
+                    .setValidCompressions(EnumSet.of(AColGroup.CompressionType.DeltaDDC)).create();
+            cs.transposed = isTransposed;
+            ABitmap ubm = BitmapEncoder.extractBitmap(colIndexes, mbt, isTransposed, 8, false);
+
+            EstimationFactors ef = CompressedSizeEstimator.estimateCompressedColGroupSize(ubm, colIndexes,
+                    numRows, cs);
+            CompressedSizeInfoColGroup cgi = new CompressedSizeInfoColGroup(colIndexes, ef, AColGroup.CompressionType.DeltaDDC);
+            CompressedSizeInfo csi = new CompressedSizeInfo(cgi);
+            AColGroup cg = ColGroupFactory.compressColGroups(mbt, csi, cs, 1).get(0);
+
+            // Decompress to dense block
+            MatrixBlock ret = new MatrixBlock(numRows, numCols, false);
+            ret.allocateDenseBlock();
+            cg.decompressToDenseBlock(ret.getDenseBlock(), 0, numRows);
+
+            MatrixBlock expected = DataConverter.convertToMatrixBlock(data);
+            if(isTransposed)
+                LibMatrixReorg.transposeInPlace(expected, 1);
+            Assert.assertArrayEquals(expected.getDenseBlockValues(), ret.getDenseBlockValues(), 0.01);
+
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+            throw new DMLRuntimeException("Failed construction : " + this.getClass().getSimpleName());
+        }
+    }
+
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateDeltaDDCTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateDeltaDDCTest.java
@@ -1,0 +1,51 @@
+package org.apache.sysds.test.component.compress.colgroup;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.util.DataConverter;
+import org.apache.sysds.test.TestUtils;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(value = Parameterized.class)
+public class JolEstimateDeltaDDCTest extends JolEstimateTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        ArrayList<Object[]> tests = new ArrayList<>();
+
+        MatrixBlock mb;
+
+        mb = DataConverter.convertToMatrixBlock(new double[][] {{0}});
+        tests.add(new Object[] {mb});
+
+        mb = DataConverter.convertToMatrixBlock(new double[][] {{1}});
+        tests.add(new Object[] {mb});
+        mb = DataConverter.convertToMatrixBlock(new double[][] {{1, 2, 3, 4, 5}});
+        tests.add(new Object[] {mb});
+
+        mb = DataConverter.convertToMatrixBlock(new double[][] {{1,2,3},{1,1,1}});
+        tests.add(new Object[] {mb});
+
+        mb = DataConverter
+                .convertToMatrixBlock(new double[][] {{1,1},{2,1},{3,1},{4,1},{5,1}});
+        tests.add(new Object[] {mb});
+
+        mb = TestUtils.generateTestMatrixBlock(2, 5, 0, 20, 1.0, 7);
+        tests.add(new Object[] {mb});
+
+        return tests;
+    }
+
+    public JolEstimateDeltaDDCTest(MatrixBlock mb) {
+        super(mb);
+    }
+
+    @Override
+    public AColGroup.CompressionType getCT() {
+        return delta;
+    }
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/JolEstimateTest.java
@@ -53,6 +53,7 @@ public abstract class JolEstimateTest {
 	protected static final Log LOG = LogFactory.getLog(JolEstimateTest.class.getName());
 
 	protected static final CompressionType ddc = CompressionType.DDC;
+	protected static final CompressionType delta = CompressionType.DeltaDDC;
 	protected static final CompressionType ole = CompressionType.OLE;
 	protected static final CompressionType rle = CompressionType.RLE;
 	protected static final CompressionType sdc = CompressionType.SDC;

--- a/src/test/java/org/apache/sysds/test/component/compress/dictionary/DeltaDictionaryTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/dictionary/DeltaDictionaryTest.java
@@ -1,0 +1,105 @@
+package org.apache.sysds.test.component.compress.dictionary;
+
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DeltaDictionary;
+import org.apache.sysds.runtime.functionobjects.Divide;
+import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.functionobjects.Multiply;
+import org.apache.sysds.runtime.functionobjects.Plus;
+import org.apache.sysds.runtime.matrix.operators.LeftScalarOperator;
+import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
+import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeltaDictionaryTest {
+
+    @Test
+    public void testScalarOpRightMultiplySingleColumn() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2}, 1);
+        ScalarOperator sop = new RightScalarOperator(Multiply.getMultiplyFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {2, 4};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpRightMultiplyTwoColumns() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new RightScalarOperator(Multiply.getMultiplyFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {2, 4, 6, 8};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testNegScalarOpRightMultiplyTwoColumns() {
+        double scalar = -2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new RightScalarOperator(Multiply.getMultiplyFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {-2, -4, -6, -8};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpLeftMultiplyTwoColumns() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new LeftScalarOperator(Multiply.getMultiplyFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {2, 4, 6, 8};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpRightDivideTwoColumns() {
+        double scalar = 0.5;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new RightScalarOperator(Divide.getDivideFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {2, 4, 6, 8};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpRightPlusSingleColumn() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2}, 1);
+        ScalarOperator sop = new RightScalarOperator(Plus.getPlusFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {3, 2};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpRightPlusTwoColumns() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new RightScalarOperator(Plus.getPlusFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {3, 4, 3, 4};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpRightMinusTwoColumns() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new RightScalarOperator(Minus.getMinusFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {-1, 0, 3, 4};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+
+    @Test
+    public void testScalarOpLeftPlusTwoColumns() {
+        double scalar = 2;
+        DeltaDictionary d = new DeltaDictionary(new double[] {1, 2, 3, 4}, 2);
+        ScalarOperator sop = new LeftScalarOperator(Plus.getPlusFnObject(), scalar, 1);
+        d = d.applyScalarOp(sop);
+        double[] expected = new double[] {3, 4, 3, 4};
+        Assert.assertArrayEquals(expected, d.getValues(), 0.01);
+    }
+}


### PR DESCRIPTION
This commit builds a foundation for a new DeltaEncoding ColGroup as specified in the corresponding JIRA task.
The main contributions are as follows:

- New ColGroupDeltaDDC class which builds upon the existing ColGroupDDC but with delta encoded column values as discussed. Currently the implementation handles scalar operations and compress/decompress to dense block as was outlined in the task.
- New DeltaDictionary for handling internal operations on the delta encoded data and corresponding tests
- New ColGroupDeltaDDCTest to testing compress and decompress with simple matrixes. (Would preferably be integrated into the existing CompressedMatrixTests later on, but for now serves as a standalone test for the new ColGroup)
- Integration into JolEstimateTests

Please have a look @Baunsgaard