### PR TITLE
[SYSTEMDS-3281] CLA tighter bounds on distinct estimation

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
@@ -150,12 +150,8 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 
 			final int numOffs = calculateOffs(sampleFacts, _sampleSize, numRows, scalingFactor, numZerosInSample);
 
-			// final int totalCardinality = getEstimatedDistinctCount(sampleFacts.frequencies, nrUniqueUpperBound, numRows,
-			// 	sampleFacts.numOffs);
-				// private int getEstimatedDistinctCount(int[] freq, int upperBound, int numOffs, int numOffsInSample) {
-			final int totalCardinality = SampleEstimatorFactory.distinctCount(sampleFacts.frequencies, numOffs, sampleFacts.numOffs, _cs.estimationType,
-				_solveCache);
-			// return Math.min(est, upperBound);
+			final int totalCardinality = SampleEstimatorFactory.distinctCount(sampleFacts.frequencies, numOffs,
+				sampleFacts.numOffs, _cs.estimationType, _solveCache);
 
 			final int totalNumRuns = getNumRuns(map, sampleFacts.numVals, _sampleSize, numRows);
 
@@ -175,9 +171,8 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 		final int numCols = getNumColumns();
 		if(numCols == 1)
 			return (int) _data.getNonZeros();
-		else {
-			return numRows - (int)Math.floor(numZerosInSample * scalingFactor);
-		}
+		else 
+			return numRows - (int) Math.floor(numZerosInSample * scalingFactor);
 	}
 
 	private double calculateSparsity(int[] colIndexes, double scalingFactor, double sampleValue) {
@@ -208,8 +203,6 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 			// if all others aren't available use the samples value.
 			return sampleValue;
 	}
-
-
 
 	private int getNumRuns(IEncode map, int numVals, int sampleSize, int totalNumRows) {
 		// estimate number of segments and number of runs incl correction for

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
@@ -150,8 +150,12 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 
 			final int numOffs = calculateOffs(sampleFacts, _sampleSize, numRows, scalingFactor, numZerosInSample);
 
-			final int totalCardinality = getEstimatedDistinctCount(sampleFacts.frequencies, nrUniqueUpperBound, numRows,
-				sampleFacts.numOffs);
+			// final int totalCardinality = getEstimatedDistinctCount(sampleFacts.frequencies, nrUniqueUpperBound, numRows,
+			// 	sampleFacts.numOffs);
+				// private int getEstimatedDistinctCount(int[] freq, int upperBound, int numOffs, int numOffsInSample) {
+			final int totalCardinality = SampleEstimatorFactory.distinctCount(sampleFacts.frequencies, numOffs, sampleFacts.numOffs, _cs.estimationType,
+				_solveCache);
+			// return Math.min(est, upperBound);
 
 			final int totalNumRuns = getNumRuns(map, sampleFacts.numVals, _sampleSize, numRows);
 
@@ -172,8 +176,7 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 		if(numCols == 1)
 			return (int) _data.getNonZeros();
 		else {
-			final double C = Math.max(1 - (double) sampleFacts.numSingle / sampleSize, (double) sampleSize / numRows);
-			return (int) Math.ceil(numRows - scalingFactor * C * numZerosInSample);
+			return numRows - (int)Math.floor(numZerosInSample * scalingFactor);
 		}
 	}
 
@@ -206,11 +209,7 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 			return sampleValue;
 	}
 
-	private int getEstimatedDistinctCount(int[] freq, int upperBound, int numOffs, int numOffsInSample) {
-		final int est = SampleEstimatorFactory.distinctCount(freq, numOffs, numOffsInSample, _cs.estimationType,
-			_solveCache);
-		return Math.min(est, upperBound);
-	}
+
 
 	private int getNumRuns(IEncode map, int numVals, int sampleSize, int totalNumRows) {
 		// estimate number of segments and number of runs incl correction for

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/sample/HassAndStokes.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/sample/HassAndStokes.java
@@ -25,6 +25,7 @@ import org.apache.commons.math3.analysis.UnivariateFunction;
 import org.apache.commons.math3.analysis.solvers.UnivariateSolverUtils;
 
 public class HassAndStokes {
+	// protected static final Log LOG = LogFactory.getLog(HassAndStokes.class.getName());
 
 	public static final double HAAS_AND_STOKES_ALPHA1 = 0.9; // 0.9 recommended in paper
 	public static final double HAAS_AND_STOKES_ALPHA2 = 30; // 30 recommended in paper
@@ -39,18 +40,15 @@ public class HassAndStokes {
 	 * 
 	 * The hybrid estimator given by Eq. 33 in Section 6
 	 * 
-	 * @param numVals	 The number of unique values in the sample
-	 * @param freqCounts The inverse histogram of frequencies. counts extracted 
+	 * @param numVals    The number of unique values in the sample
+	 * @param freqCounts The inverse histogram of frequencies. counts extracted
 	 * @param nRows      The number of rows originally in the input
 	 * @param sampleSize The number of rows used in the sample
 	 * @param solveCache A Hashmap containing information for getDuj2aEstimate
 	 * @return An estimation of distinct elements in the population.
 	 */
-	protected static int distinctCount(int numVals, int[] freqCounts, int nRows, int sampleSize, HashMap<Integer, Double> solveCache) {
-
-		// all values in the sample are zeros.
-		if(numVals == 0)
-			return 1;
+	protected static int distinctCount(int numVals, int[] freqCounts, int nRows, int sampleSize,
+		HashMap<Integer, Double> solveCache) {
 
 		double q = ((double) sampleSize) / nRows;
 		double f1 = freqCounts[0];
@@ -71,54 +69,25 @@ public class HassAndStokes {
 			d = getSh3Estimate(q, freqCounts, numVals);
 
 		// round and ensure min value 1
-		final int est = Math.max(1, (int) Math.round(d));
-		// Number of unique is trivially bounded by the sampled number of uniques and the number of rows.
-		return Math.min(Math.max(est, numVals), nRows);
+		return  (int) Math.round(d);
+		
 	}
 
-	/**
-	 * Computes the "un-smoothed first-order jackknife estimator" (Eq 11).
-	 * 
-	 * @param q  ??
-	 * @param f1 ??
-	 * @param n  ??
-	 * @param dn ??
-	 * @return ??
-	 */
 	private static double getDuj1Estimate(double q, double f1, int n, int dn) {
+		// Computes the "un-smoothed first-order jackknife estimator" (Eq 11).
 		return dn / (1 - ((1 - q) * f1) / n);
 	}
 
-	/**
-	 * Computes the "un-smoothed second-order jackknife estimator" (Eq 18b).
-	 *
-	 * @param q         ??
-	 * @param f1        ??
-	 * @param n         ??
-	 * @param dn        ??
-	 * @param gammaDuj1 ??
-	 * @return ??
-	 */
 	private static double getDuj2Estimate(double q, double f1, int n, int dn, double gammaDuj1) {
+		// Computes the "un-smoothed second-order jackknife estimator" (Eq 18b).
 		return (dn - (1 - q) * f1 * Math.log(1 - q) * gammaDuj1 / q) / (1 - ((1 - q) * f1) / n);
 	}
 
-	/**
-	 * Computes the "un-smoothed second-order jackknife estimator" with additional stabilization procedure, which
-	 * removes the classes whose frequency exceed c, computes Duj2 over the reduced sample, and finally adds the removed
-	 * frequencies.
-	 * 
-	 * @param q          ??
-	 * @param f          ??
-	 * @param n          ??
-	 * @param dn         ??
-	 * @param gammaDuj1  ??
-	 * @param N          ??
-	 * @param solveCache ??
-	 * @return ??
-	 */
 	private static double getDuj2aEstimate(double q, int f[], int n, int dn, double gammaDuj1, int N,
 		HashMap<Integer, Double> solveCache) {
+		// Computes the "un-smoothed second-order jackknife estimator" with additional stabilization procedure, which
+		// removes the classes whose frequency exceed c, computes Duj2 over the reduced sample, and finally adds the
+		// removed frequencies.
 		int c = HAAS_AND_STOKES_UJ2A_CUT2 ? f.length / 2 + 1 : HAAS_AND_STOKES_UJ2A_C + 1;
 
 		// compute adjusted sample size after removing classes that
@@ -152,16 +121,8 @@ public class HassAndStokes {
 		return duj2 + cardB;
 	}
 
-	/**
-	 * Computes the "squared coefficient of variation" based on a given initial estimate D (Eq 16).
-	 * 
-	 * @param D ??
-	 * @param f ??
-	 * @param n ??
-	 * @param N ??
-	 * @return ??
-	 */
 	private static double getGammaSquared(double D, int[] f, int n, int N) {
+		// Computes the "squared coefficient of variation" based on a given initial estimate D (Eq 16).
 		double gamma = 0;
 		for(int i = 1; i <= f.length; i++)
 			if(f[i - 1] != 0)
@@ -171,18 +132,12 @@ public class HassAndStokes {
 		return Math.max(0, gamma);
 	}
 
-	/**
-	 * Computed the "shlosser third-order estimator". (Eq 30b)
-	 * 
-	 * Note that this estimator can show anomalies with NaN as the results due to terms such as Math.pow(1+q, i) which
-	 * exceed Double.MAX_VALUE even for moderately large i, e.g., q=0.05 at around 14K.
-	 * 
-	 * @param q  ??
-	 * @param f  ??
-	 * @param dn ??
-	 * @return ??
-	 */
 	private static double getSh3Estimate(double q, int[] f, double dn) {
+		// Computed the "shlosser third-order estimator". (Eq 30b)
+
+		// Note that this estimator can show anomalies with NaN as the results due to terms such as Math.pow(1+q, i) which
+		// exceed Double.MAX_VALUE even for moderately large i, e.g., q=0.05 at around 14K.
+
 		double fraq11 = 0, fraq12 = 0, fraq21 = 0, fraq22 = 0;
 		for(int i = 1; i <= f.length; i++)
 			if(f[i - 1] != 0) {
@@ -196,26 +151,25 @@ public class HassAndStokes {
 		return dn + f[0] * fraq11 / fraq12 * Math.pow(fraq21 / fraq22, 2);
 	}
 
-	/**
-	 * Solves the method-of-moments estimate numerically. We use a cache on the same observed instances in the sample as
-	 * q is constant and min/max are chosen conservatively.
-	 * 
-	 * @param nj         ??
-	 * @param q          ??
-	 * @param min        ??
-	 * @param max        ??
-	 * @param solveCache ??
-	 * @return ??
-	 */
 	private static double getMethodOfMomentsEstimate(int nj, double q, double min, double max,
 		HashMap<Integer, Double> solveCache) {
-		if(solveCache.containsKey(nj))
-			return solveCache.get(nj);
+		// Solves the method-of-moments estimate numerically. We use a cache on the same observed instances in the sample
+		// as q is constant and min/max are chosen conservatively.
+
+		// NOTE the cache does not work currently since the number of rows considered each call can change now
+		// This happens because the sampled estimator now considers nonzeros or offsets calculated and therefore know upper
+		// bounds of the number of offsets that are lower than the maximum number of rows.
+		// if(solveCache.containsKey(nj))
+		// 	synchronized(solveCache) {
+		// 		return solveCache.get(nj);
+		// 	}
 
 		double est = UnivariateSolverUtils.solve(new MethodOfMomentsFunction(nj, q), min, max, 1e-9);
 
-		if(solveCache.size() < MAX_SOLVE_CACHE_SIZE)
-			solveCache.put(nj, est);
+		// if(solveCache.size() < MAX_SOLVE_CACHE_SIZE)
+		// 	synchronized(solveCache) {
+		// 		solveCache.put(nj, est);
+		// 	}
 
 		return est;
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SampleEstimatorFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SampleEstimatorFactory.java
@@ -68,7 +68,7 @@ public class SampleEstimatorFactory {
 		}
 	}
 
-	public static int distinctCountWithHistogram(int numVals, int[] invHist, int[] frequencies, int nRows,
+	private static int distinctCountWithHistogram(int numVals, int[] invHist, int[] frequencies, int nRows,
 		int sampleSize, EstimationType type, HashMap<Integer, Double> solveCache) {
 		switch(type) {
 			case ShlosserEstimator:

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SampleEstimatorFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SampleEstimatorFactory.java
@@ -33,14 +33,15 @@ public class SampleEstimatorFactory {
 	}
 
 	/**
-	 * estimate a distinct count based on frequencies
+	 * Estimate a distinct number of values based on frequencies.
 	 * 
-	 * @param frequencies A list of frequencies of unique values
-	 * @param nRows       The total number of rows to consider
-	 * @param sampleSize  The size of the sample, NOTE this should ideally be scaled to match the sum(frequencies)
-	 * @param type        the Type of estimator to use
+	 * @param frequencies A list of frequencies of unique values, NOTE all values contained should be larger than zero
+	 * @param nRows       The total number of rows to consider, NOTE should always be larger or equal to sum(frequencies)
+	 * @param sampleSize  The size of the sample, NOTE this should ideally be scaled to match the sum(frequencies) and
+	 *                    should always be lower or equal to nRows
+	 * @param type        The type of estimator to use
 	 * @param solveCache  A solve cache to avoid repeated calculations
-	 * @return A bounded number of unique values.
+	 * @return A estimated number of unique values
 	 */
 	public static int distinctCount(int[] frequencies, int nRows, int sampleSize, EstimationType type,
 		HashMap<Integer, Double> solveCache) {
@@ -48,14 +49,13 @@ public class SampleEstimatorFactory {
 		if(frequencies == null || frequencies.length == 0)
 			// Frequencies for some reason is allocated as null or all values in the sample are zeros.
 			return 0;
-
 		try {
 			// Invert histogram
 			int[] invHist = getInvertedFrequencyHistogram(frequencies);
 			// estimate distinct
 			int est = distinctCountWithHistogram(frequencies.length, invHist, frequencies, nRows, sampleSize, type,
 				solveCache);
-			// Number of unique is trivially bounded by 
+			// Number of unique is trivially bounded by
 			// lower: the number of observed uniques in the sample
 			// upper: the number of rows minus the observed uniques total count, plus the observed number of uniques.
 			return Math.min(Math.max(frequencies.length, est), nRows - sampleSize + frequencies.length);
@@ -95,10 +95,8 @@ public class SampleEstimatorFactory {
 
 		// create frequency histogram
 		int[] freqCounts = new int[maxCount];
-		for(int i = 0; i < numVals; i++) {
-			if(frequencies[i] != 0)
-				freqCounts[frequencies[i] - 1]++;
-		}
+		for(int i = 0; i < numVals; i++)
+			freqCounts[frequencies[i] - 1]++;
 
 		return freqCounts;
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/sample/ShlosserEstimator.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/sample/ShlosserEstimator.java
@@ -41,7 +41,7 @@ public class ShlosserEstimator {
 			numerSum += Math.pow(oneMinusQ, iPlusOne) * freqCounts[i];
 			denomSum += iPlusOne * q * Math.pow(oneMinusQ, i) * freqCounts[i];
 		}
-		int estimate = (int) Math.round(numVals + freqCounts[0] * numerSum / denomSum);
-		return estimate < 1 ? 1 : estimate;
+		return (int) Math.round(numVals + freqCounts[0] * numerSum / denomSum);
+		
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SmoothedJackknifeEstimator.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/sample/SmoothedJackknifeEstimator.java
@@ -100,6 +100,6 @@ public class SmoothedJackknifeEstimator {
 		gamma += D0 / nRows - 1;
 
 		double estimate = (d + nRows * h * g * gamma) / (1 - (nRows - NTilde - sampleSize + 1) * f1 / Nn);
-		return estimate < 1 ? 1 : (int) Math.round(estimate);
+		return (int) Math.round(estimate);
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/estim/SampleDistinctTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/estim/SampleDistinctTest.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.test.component.compress.estim;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -152,6 +153,9 @@ public class SampleDistinctTest {
 				+ Arrays.toString(frequencies);
 			assertEquals(m, frequencies.length, c);
 		}
+		else if(c < frequencies.length)
+			fail("estimate is lower than observed elements");
+		else if(c > Math.ceil((double)total / p) - frequencies.length + total)
+			fail("estimate "+c+" is larger than theoretical max uniques " + (Math.ceil((double)total / p) - frequencies.length + total));
 	}
-
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/estim/SampleDistinctTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/estim/SampleDistinctTest.java
@@ -95,105 +95,63 @@ public class SampleDistinctTest {
 		// Sample 100%
 		int nRows = total;
 		int sampleSize = total;
-
 		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 1.0);
+	}
+
+	@Test
+	public void test20p() {
+		// Sample 20%
+		int nRows = total * 5;
+		int sampleSize = total;
+		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 0.2);
+	}
+
+	@Test
+	public void test1p() {
+		// Sample 1%
+		int nRows = total * 100;
+		int sampleSize = total;
+		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 0.01);
+	}
+
+	@Test
+	public void test01p() {
+		// Sample 0.1%
+		int nRows = total * 1000;
+		int sampleSize = total;
+		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 0.001);
+	}
+
+	@Test
+	public void test001p() {
+		// Sample 0.01%
+		int nRows = total * 10000;
+		int sampleSize = total;
+		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 0.0001);
+	}
+
+	@Test
+	public void test0001p() {
+		// Sample 0.001%
+		int nRows = total * 100000;
+		int sampleSize = total;
+		int c = SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
+		verify(c, 0.00001);
+	}
+
+	private void verify(int c, double p){
 		if(frequencies == null)
 			assertEquals(0, c);
-		else if(frequencies.length != c) {
+		else if(p == 1.0 && frequencies.length != c) {
 			String m = "incorrect estimate with type; " + type + " est: " + c + " frequencies: "
 				+ Arrays.toString(frequencies);
 			assertEquals(m, frequencies.length, c);
 		}
 	}
 
-	@Test
-	public void testDistinctCountDenseFive() {
-		// Sample 20%
-		int nRows = total * 5;
-		int sampleSize = total;
-
-		SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	}
-
-	@Test
-	public void testDistinctCountDense100() {
-		// Sample 1%
-		int nRows = total * 100;
-		int sampleSize = total;
-		SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	}
-
-	@Test
-	public void testDistinctCountDense1000() {
-		// Sample 0.1%
-		int nRows = total * 1000;
-		int sampleSize = total;
-		SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	}
-
-	@Test
-	public void testDistinctCountDense10000() {
-		// Sample 0.01%
-		int nRows = total * 10000;
-		int sampleSize = total;
-		SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	}
-
-	// @Test
-	// public void testDistinctCountSparseTwoFive() {
-	// 	int nRows = total * 5;
-	// 	int sampleSize = total * 2;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseTwo100() {
-	// 	int nRows = total * 100;
-	// 	int sampleSize = total * 2;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseTwo1000() {
-	// 	int nRows = total * 1000;
-	// 	int sampleSize = total * 2;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseTwo10000() {
-	// 	int nRows = total * 10000;
-	// 	int sampleSize = total * 2;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseFive100() {
-	// 	int nRows = total * 100;
-	// 	int sampleSize = total * 5;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseFive1000() {
-	// 	int nRows = total * 1000;
-	// 	int sampleSize = total * 5;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSparseFive10000() {
-	// 	int nRows = total * 10000;
-	// 	int sampleSize = total * 5;
-	// 	SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// }
-
-	// @Test
-	// public void testDistinctCountSpecific() {
-	// 	if(total < 604) {
-	// 		int nRows = 16000;
-	// 		int sampleSize = 604;
-	// 		SampleEstimatorFactory.distinctCount(frequencies, nRows, sampleSize, type, solveCache);
-	// 	}
-	// }
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/insertionsort/TestInsertionSorters.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/insertionsort/TestInsertionSorters.java
@@ -51,6 +51,20 @@ public class TestInsertionSorters {
 	private final IntArrayList[] offsets;
 	private final int negativeIndex;
 
+	public TestInsertionSorters(int numRows, int[][] data, SORT_TYPE st, int negativeIndex, int[] expectedIndexes,
+		int[] expectedData) {
+		this.data = data;
+		this.st = st;
+		this.expectedIndexes = expectedIndexes;
+		this.expectedData = expectedData;
+		this.numRows = numRows;
+		this.negativeIndex = negativeIndex;
+
+		offsets = new IntArrayList[data.length];
+		for(int i = 0; i < data.length; i++)
+			offsets[i] = new IntArrayList(data[i]);
+	}
+
 	@Parameters
 	public static Collection<Object[]> data() {
 		ArrayList<Object[]> tests = new ArrayList<>();
@@ -139,21 +153,6 @@ public class TestInsertionSorters {
 		}
 
 		return new Object[] {size, ar, t, 0, expectedIndexes, expectedData};
-	}
-
-	public TestInsertionSorters(int numRows, int[][] data, SORT_TYPE st, int negativeIndex, int[] expectedIndexes,
-		int[] expectedData) {
-		this.data = data;
-		this.st = st;
-		this.expectedIndexes = expectedIndexes;
-		this.expectedData = expectedData;
-		this.numRows = numRows;
-		this.negativeIndex = negativeIndex;
-
-		offsets = new IntArrayList[data.length];
-		for(int i = 0; i < data.length; i++)
-			offsets[i] = new IntArrayList(data[i]);
-
 	}
 
 	@Test


### PR DESCRIPTION
This commit change the distinct estimation to use tighter distinct bounds than n rows.
The change was encouraged by bugs showing in distinct estimation on distributed experiments.