### PR TITLE
[SYSTEMDS-2996] countDistinctApprox Builtin function

### DIFF
--- a/docs/api/java/allclasses.html
+++ b/docs/api/java/allclasses.html
@@ -293,7 +293,7 @@
 <li><a href="org/apache/sysds/runtime/controlprogram/parfor/opt/CostEstimatorRuntime.html" title="class in org.apache.sysds.runtime.controlprogram.parfor.opt">CostEstimatorRuntime</a></li>
 <li><a href="org/apache/sysds/hops/cost/CostEstimatorStaticRuntime.html" title="class in org.apache.sysds.hops.cost">CostEstimatorStaticRuntime</a></li>
 <li><a href="org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.html" title="class in org.apache.sysds.runtime.matrix.operators">CountDistinctOperator</a></li>
-<li><a href="org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.CountDistinctTypes.html" title="enum in org.apache.sysds.runtime.matrix.operators">CountDistinctOperator.CountDistinctTypes</a></li>
+<li><a href="org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.CountDistinctOperatorTypes.html" title="enum in org.apache.sysds.runtime.matrix.operators">CountDistinctOperator.CountDistinctOperatorTypes</a></li>
 <li><a href="org/apache/sysds/runtime/functionobjects/COV.html" title="class in org.apache.sysds.runtime.functionobjects">COV</a></li>
 <li><a href="org/apache/sysds/lops/CoVariance.html" title="class in org.apache.sysds.lops">CoVariance</a></li>
 <li><a href="org/apache/sysds/runtime/instructions/cp/CovarianceCPInstruction.html" title="class in org.apache.sysds.runtime.instructions.cp">CovarianceCPInstruction</a></li>

--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -93,7 +93,6 @@ public enum Builtins {
 	COS("cos", false),
 	COSH("cosh", false),
 	COUNT_DISTINCT("countDistinct",false),
-	COUNT_DISTINCT_APPROX("countDistinctApprox",false),
 	COV("cov", false),
 	COX("cox", true),
 	CSPLINE("cspline", true),
@@ -303,6 +302,7 @@ public enum Builtins {
 	//parameterized builtin functions
 	AUTODIFF("autoDiff", false, true),
 	CDF("cdf", false, true),
+	COUNT_DISTINCT_APPROX("countDistinctApprox", false, true),
 	CVLM("cvlm", true, false),
 	GROUPEDAGG("aggregate", "groupedAggregate", false, true),
 	INVCDF("icdf", false, true),

--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -153,6 +153,9 @@ public class Types
 		public boolean isCol() {
 			return this == Col;
 		}
+		public boolean isRowCol() {
+			return this == RowCol;
+		}
 		@Override
 		public String toString() {
 			switch(this) {

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -19,21 +19,6 @@
 
 package org.apache.sysds.conf;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.HashMap;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,6 +36,21 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
 
 
 public class DMLConfig
@@ -242,6 +242,7 @@ public class DMLConfig
 	private DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
 		if (_documentBuilder == null) {
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);  // Prevent XML Injection
 			factory.setIgnoringComments(true); //ignore XML comments
 			_documentBuilder = factory.newDocumentBuilder();
 		}

--- a/src/main/java/org/apache/sysds/lops/PartialAggregate.java
+++ b/src/main/java/org/apache/sysds/lops/PartialAggregate.java
@@ -217,7 +217,7 @@ public class PartialAggregate extends Lop
 	}
 
 	/**
-	 * Instruction generation for for CP and Spark
+	 * Instruction generation for CP and Spark
 	 */
 	@Override
 	public String getInstructions(String input1, String output) 

--- a/src/main/java/org/apache/sysds/lops/PartialAggregate.java
+++ b/src/main/java/org/apache/sysds/lops/PartialAggregate.java
@@ -348,8 +348,11 @@ public class PartialAggregate extends Lop
 			}
 			
 			case COUNT_DISTINCT_APPROX: {
-				if(dir == Direction.RowCol )
-					return "uacdap";
+				switch (dir) {
+					case RowCol: return "uacdap";
+					case Row: return "uacdapr";
+					case Col: return "uacdapc";
+				}
 				break;
 			}
 		}

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -19,11 +19,6 @@
 
 package org.apache.sysds.parser;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -36,6 +31,11 @@ import org.apache.sysds.parser.LanguageException.LanguageErrorCodes;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.DnnUtils;
 import org.apache.sysds.runtime.util.UtilFunctions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 
 public class BuiltinFunctionExpression extends DataIdentifier 
 {
@@ -623,10 +623,10 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		case MEAN:
 			//checkNumParameters(2, false); // mean(Y) or mean(Y,W)
 			if (getSecondExpr() != null) {
-				checkNumParameters (2);
+				checkNumParameters(2);
 			}
 			else {
-				checkNumParameters (1);
+				checkNumParameters(1);
 			}
 			
 			checkMatrixParam(getFirstExpr());
@@ -933,7 +933,6 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			output.setValueType(ValueType.INT64);
 			break;
 		case COUNT_DISTINCT:
-		case COUNT_DISTINCT_APPROX:
 			checkNumParameters(1);
 			checkDataTypeParam(getFirstExpr(), DataType.MATRIX);
 			output.setDataType(DataType.SCALAR);
@@ -941,7 +940,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			output.setBlocksize(0);
 			output.setValueType(ValueType.INT64);
 			break;
-		
+
 		case LINEAGE:
 			checkNumParameters(1);
 			checkDataTypeParam(getFirstExpr(),
@@ -1823,11 +1822,12 @@ public class BuiltinFunctionExpression extends DataIdentifier
 	}
 
 	protected void checkNumParameters(int count) { //always unconditional
+
 		if (getFirstExpr() == null && _args.length > 0) {
 			raiseValidateError("Missing argument for function " + this.getOpCode(), false,
-				LanguageErrorCodes.INVALID_PARAMETERS);
+					LanguageErrorCodes.INVALID_PARAMETERS);
 		}
-		
+
 		// Not sure the rationale for the first two if loops, but will keep them for backward compatibility
 		if (((count == 1) && (getSecondExpr() != null || getThirdExpr() != null))
 				|| ((count == 2) && (getThirdExpr() != null))) {
@@ -1843,7 +1843,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		} else if (count == 0 && (_args.length > 0
 				|| getSecondExpr() != null || getThirdExpr() != null)) {
 			raiseValidateError("Missing argument for function " + this.getOpCode()
-				+ "(). This function doesn't take any arguments.", false);
+					+ "(). This function doesn't take any arguments.", false);
 		}
 	}
 
@@ -1870,7 +1870,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 		if( !ArrayUtils.contains(dt, e.getOutput().getDataType()) )
 			raiseValidateError("Non-matching expected data type for function "+ getOpCode(), false, LanguageErrorCodes.UNSUPPORTED_PARAMETERS);
 	}
-	
+
 	protected void checkMatrixFrameParam(Expression e) { //always unconditional
 		if (e.getOutput().getDataType() != DataType.MATRIX && e.getOutput().getDataType() != DataType.FRAME) {
 			raiseValidateError("Expecting matrix or frame parameter for function "+ getOpCode(), false, LanguageErrorCodes.UNSUPPORTED_PARAMETERS);

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -19,17 +19,24 @@
 
 package org.apache.sysds.parser;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Builtins;
+import org.apache.sysds.common.Types.AggOp;
+import org.apache.sysds.common.Types.DataType;
+import org.apache.sysds.common.Types.Direction;
+import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.common.Types.OpOp1;
+import org.apache.sysds.common.Types.OpOp2;
+import org.apache.sysds.common.Types.OpOp3;
+import org.apache.sysds.common.Types.OpOpDG;
+import org.apache.sysds.common.Types.OpOpData;
+import org.apache.sysds.common.Types.OpOpDnn;
+import org.apache.sysds.common.Types.OpOpN;
+import org.apache.sysds.common.Types.ParamBuiltinOp;
+import org.apache.sysds.common.Types.ReOrgOp;
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.hops.AggBinaryOp;
@@ -62,22 +69,6 @@ import org.apache.sysds.hops.rewrite.ProgramRewriter;
 import org.apache.sysds.lops.Lop;
 import org.apache.sysds.lops.LopsException;
 import org.apache.sysds.lops.compile.Dag;
-import org.apache.sysds.api.DMLScript;
-import org.apache.sysds.common.Builtins;
-import org.apache.sysds.common.Types.AggOp;
-import org.apache.sysds.common.Types.DataType;
-import org.apache.sysds.common.Types.Direction;
-import org.apache.sysds.common.Types.FileFormat;
-import org.apache.sysds.common.Types.OpOp1;
-import org.apache.sysds.common.Types.OpOp2;
-import org.apache.sysds.common.Types.OpOp3;
-import org.apache.sysds.common.Types.OpOpDG;
-import org.apache.sysds.common.Types.OpOpData;
-import org.apache.sysds.common.Types.OpOpDnn;
-import org.apache.sysds.common.Types.OpOpN;
-import org.apache.sysds.common.Types.ParamBuiltinOp;
-import org.apache.sysds.common.Types.ReOrgOp;
-import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.parser.PrintStatement.PRINTTYPE;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.BasicProgramBlock;
@@ -91,6 +82,14 @@ import org.apache.sysds.runtime.controlprogram.WhileProgramBlock;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DMLTranslator 
 {
@@ -2035,6 +2034,29 @@ public class DMLTranslator
 					target.getValueType(), ParamBuiltinOp.LIST, paramHops);
 				break;
 
+			case COUNT_DISTINCT_APPROX:
+				// Default direction and data type
+				Direction dir = Direction.RowCol;
+				DataType dataType = DataType.SCALAR;
+
+				LiteralOp dirOp = (LiteralOp) paramHops.get("dir");
+				if (dirOp != null) {
+					String dirString = dirOp.getStringValue().toUpperCase();
+					if (dirString.equals(Direction.RowCol.toString())) {
+						dir = Direction.RowCol;
+						dataType = DataType.SCALAR;
+					} else if (dirString.equals(Direction.Row.toString())) {
+						dir = Direction.Row;
+						dataType = DataType.MATRIX;
+					} else if (dirString.equals(Direction.Col.toString())) {
+						dir = Direction.Col;
+						dataType = DataType.MATRIX;
+					}
+				}
+
+				currBuiltinOp = new AggUnaryOp(target.getName(), dataType, target.getValueType(),
+						AggOp.valueOf(source.getOpCode().name()), dir, paramHops.get("data"));
+				break;
 			default:
 				throw new ParseException(source.printErrorLocation() + 
 					"processParameterizedBuiltinFunctionExpression() -- Unknown operation: " + source.getOpCode());
@@ -2335,11 +2357,9 @@ public class DMLTranslator
 		case PROD:
 		case VAR:
 		case COUNT_DISTINCT:
-		case COUNT_DISTINCT_APPROX:
 			currBuiltinOp = new AggUnaryOp(target.getName(), DataType.SCALAR, target.getValueType(),
-				AggOp.valueOf(source.getOpCode().name()), Direction.RowCol, expr);
+					AggOp.valueOf(source.getOpCode().name()), Direction.RowCol, expr);
 			break;
-
 		case MEAN:
 			if ( expr2 == null ) {
 				// example: x = mean(Y);

--- a/src/main/java/org/apache/sysds/parser/ParameterizedBuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/ParameterizedBuiltinFunctionExpression.java
@@ -19,6 +19,16 @@
 
 package org.apache.sysds.parser;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.sysds.common.Builtins;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.DataType;
+import org.apache.sysds.common.Types.ParamBuiltinOp;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.parser.LanguageException.LanguageErrorCodes;
+import org.apache.sysds.runtime.util.CollectionUtils;
+import org.apache.wink.json4j.JSONObject;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -27,15 +37,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.apache.wink.json4j.JSONObject;
-import org.apache.sysds.common.Builtins;
-import org.apache.sysds.common.Types.DataType;
-import org.apache.sysds.common.Types.ParamBuiltinOp;
-import org.apache.sysds.common.Types.ValueType;
-import org.apache.sysds.parser.LanguageException.LanguageErrorCodes;
-import org.apache.sysds.runtime.util.CollectionUtils;
 
 
 public class ParameterizedBuiltinFunctionExpression extends DataIdentifier 
@@ -245,6 +246,10 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 			validateParamserv(output, conditional);
 			break;
 
+		case COUNT_DISTINCT_APPROX:
+			validateCountDistinctApprox(output, conditional);
+			break;
+
 		default: //always unconditional (because unsupported operation)
 			//handle common issue of transformencode
 			if( getOpCode()==Builtins.TRANSFORMENCODE )
@@ -258,7 +263,7 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 
 	private void validateAutoDiff(DataIdentifier output, boolean conditional) {
 		//validate data / metadata (recode maps)
-		checkDataType("lineage", LINEAGE_TRACE, DataType.LIST, conditional);
+		checkDataType(false, "lineage", LINEAGE_TRACE, DataType.LIST, conditional);
 
 		//validate specification
 		checkDataValueType(false, "lineage", LINEAGE_TRACE, DataType.LIST, ValueType.UNKNOWN, conditional);
@@ -266,7 +271,7 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 		// set output characteristics
 		output.setDataType(DataType.LIST);
 		output.setValueType(ValueType.UNKNOWN);
-		// TODO dimension should be set to -1 but could not set due to lineage parsing error in Spark contetx
+		// TODO dimension should be set to -1 but could not set due to lineage parsing error in Spark context
 		output.setDimensions(varParams.size(), 1);
 		// output.setDimensions(-1, 1);
 		output.setBlocksize(-1);
@@ -319,9 +324,9 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 		checkInvalidParameters(getOpCode(), getVarParams(), valid);
 
 		// check existence and correctness of parameters
-		checkDataType(fname, Statement.PS_MODEL, DataType.LIST, conditional); // check the model which is the only non-parameterized argument
-		checkDataType(fname, Statement.PS_FEATURES, DataType.MATRIX, conditional);
-		checkDataType(fname, Statement.PS_LABELS, DataType.MATRIX, conditional);
+		checkDataType(false, fname, Statement.PS_MODEL, DataType.LIST, conditional); // check the model which is the only non-parameterized argument
+		checkDataType(false, fname, Statement.PS_FEATURES, DataType.MATRIX, conditional);
+		checkDataType(false, fname, Statement.PS_LABELS, DataType.MATRIX, conditional);
 		checkDataValueType(true, fname, Statement.PS_VAL_FEATURES, DataType.MATRIX, ValueType.FP64, conditional);
 		checkDataValueType(true, fname, Statement.PS_VAL_LABELS, DataType.MATRIX, ValueType.FP64, conditional);
 		checkDataValueType(false, fname, Statement.PS_UPDATE_FUN, DataType.SCALAR, ValueType.STRING, conditional);
@@ -347,6 +352,99 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 		output.setBlocksize(-1);
 	}
 
+	private void validateCountDistinctApprox(DataIdentifier output, boolean conditional) {
+		Set<String> validTypeNames = CollectionUtils.asSet("KMV");
+		HashMap<String, Expression> varParams = getVarParams();
+
+		// "data" is the only parameter that is allowed to be unnamed
+		if (varParams.containsKey(null)) {
+			varParams.put("data", varParams.remove(null));
+		}
+
+		// Validate the number of parameters
+		String fname = getOpCode().getName();
+		String usageMessage = "function " + fname + " takes at least 1 and at most 3 parameters";
+		if (varParams.size() < 1) {
+			raiseValidateError("Too few parameters: " + usageMessage, conditional);
+		}
+
+		if (varParams.size() > 3) {
+			raiseValidateError("Too many parameters: " + usageMessage, conditional);
+		}
+
+		// Check parameter names are valid
+		Set<String> validParameterNames = CollectionUtils.asSet("data", "type", "dir");
+		checkInvalidParameters(getOpCode(), varParams, validParameterNames);
+
+		// Check parameter expression data types match expected
+		checkDataType(false, fname, "data", DataType.MATRIX, conditional);
+		checkDataValueType(false, fname, "data", DataType.MATRIX, ValueType.FP64, conditional);
+
+		// We need the dimensions of the input matrix to determine the output matrix characteristics
+		// Validate data parameter, lookup previously defined var or resolve expression
+		Identifier dataId = varParams.get("data").getOutput();
+		if (dataId == null) {
+			raiseValidateError("Cannot parse input parameter \"data\" to function " + fname, conditional);
+		}
+
+		checkStringParam(true, fname, "type", conditional);
+		// Check data value of "type" parameter
+		if (varParams.keySet().contains("type")) {
+			String typeString = varParams.get("type").toString().toUpperCase();
+			if (!validTypeNames.contains(typeString)) {
+				raiseValidateError("Unrecognized type for optional parameter " + typeString, conditional);
+			}
+		} else {
+			// default to KMV
+			addVarParam("type", new StringIdentifier("KMV", this));
+		}
+
+		checkStringParam(true, fname, "dir", conditional);
+		// Check data value of "dir" parameter
+		if (varParams.keySet().contains("dir")) {
+			String directionString = varParams.get("dir").toString().toUpperCase();
+
+			// Set output type and dimensions based on direction
+
+			// "r" -> count across all rows, resulting in a Mx1 matrix
+			if (directionString.equals(Types.Direction.Row.toString())) {
+				output.setDataType(DataType.MATRIX);
+				output.setDimensions(dataId.getDim1(), 1);
+				output.setBlocksize(dataId.getBlocksize());
+				output.setValueType(ValueType.INT64);
+				output.setNnz(dataId.getDim1());
+
+			// "c" -> count across all cols, resulting in a 1xN matrix
+			} else if (directionString.equals(Types.Direction.Col.toString())) {
+				output.setDataType(DataType.MATRIX);
+				output.setDimensions(1, dataId.getDim2());
+				output.setBlocksize(dataId.getBlocksize());
+				output.setValueType(ValueType.INT64);
+				output.setNnz(dataId.getDim2());
+
+			// "rc" -> count across all rows and cols in input matrix, resulting in a single value
+			} else if (directionString.equals(Types.Direction.RowCol.toString())) {
+				output.setDataType(DataType.SCALAR);
+				output.setDimensions(0, 0);
+				output.setBlocksize(0);
+				output.setValueType(ValueType.INT64);
+				output.setNnz(1);
+
+			// unrecognized value for "dir" parameter, should "cr" be valid?
+			} else {
+				raiseValidateError("Invalid argument: " + directionString + " is not recognized");
+			}
+
+		// default to dir="rc"
+		} else {
+			output.setDataType(DataType.SCALAR);
+			output.setDimensions(0, 0);
+			output.setBlocksize(0);
+			output.setValueType(ValueType.INT64);
+			output.setNnz(1);
+		}
+	}
+
 	private void checkStringParam(boolean optional, String fname, String pname, boolean conditional) {
 		Expression param = getVarParam(pname);
 		if (param == null) {
@@ -365,7 +463,7 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 	private void validateTokenize(DataIdentifier output, boolean conditional)
 	{
 		//validate data / metadata (recode maps)
-		checkDataType("tokenize", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
+		checkDataType(false, "tokenize", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
 
 		//validate specification
 		checkDataValueType(false, "tokenize", TF_FN_PARAM_SPEC, DataType.SCALAR, ValueType.STRING, conditional);
@@ -381,8 +479,8 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 	private void validateTransformApply(DataIdentifier output, boolean conditional) 
 	{
 		//validate data / metadata (recode maps)
-		checkDataType("transformapply", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
-		checkDataType("transformapply", TF_FN_PARAM_MTD2, DataType.FRAME, conditional);
+		checkDataType(false, "transformapply", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
+		checkDataType(false, "transformapply", TF_FN_PARAM_MTD2, DataType.FRAME, conditional);
 		
 		//validate specification
 		checkDataValueType(false, "transformapply", TF_FN_PARAM_SPEC, DataType.SCALAR, ValueType.STRING, conditional);
@@ -397,8 +495,8 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 	private void validateTransformDecode(DataIdentifier output, boolean conditional) 
 	{
 		//validate data / metadata (recode maps) 
-		checkDataType("transformdecode", TF_FN_PARAM_DATA, DataType.MATRIX, conditional);
-		checkDataType("transformdecode", TF_FN_PARAM_MTD2, DataType.FRAME, conditional);
+		checkDataType(false, "transformdecode", TF_FN_PARAM_DATA, DataType.MATRIX, conditional);
+		checkDataType(false, "transformdecode", TF_FN_PARAM_MTD2, DataType.FRAME, conditional);
 		
 		//validate specification
 		checkDataValueType(false, "transformdecode", TF_FN_PARAM_SPEC, DataType.SCALAR, ValueType.STRING, conditional);
@@ -414,7 +512,7 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 	{
 		//validate data / metadata (recode maps) 
 		Expression exprTarget = getVarParam(Statement.GAGG_TARGET);
-		checkDataType("transformcolmap", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
+		checkDataType(false, "transformcolmap", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
 		
 		//validate specification
 		checkDataValueType(false,"transformcolmap", TF_FN_PARAM_SPEC, DataType.SCALAR, ValueType.STRING, conditional);
@@ -444,7 +542,7 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 	private void validateTransformEncode(DataIdentifier output1, DataIdentifier output2, boolean conditional) 
 	{
 		//validate data / metadata (recode maps) 
-		checkDataType("transformencode", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
+		checkDataType(false, "transformencode", TF_FN_PARAM_DATA, DataType.FRAME, conditional);
 		
 		//validate specification
 		checkDataValueType(false, "transformencode", TF_FN_PARAM_SPEC, DataType.SCALAR, ValueType.STRING, conditional);
@@ -871,11 +969,15 @@ public class ParameterizedBuiltinFunctionExpression extends DataIdentifier
 		output.setBlocksize(-1);
 	}
 
-	private void checkDataType( String fname, String pname, DataType dt, boolean conditional ) {
+	private void checkDataType(boolean optional, String fname, String pname, DataType dt, boolean conditional ) {
 		Expression data = getVarParam(pname);
-		if( data==null )
+		if (data == null) {
+			if (optional) {
+				return;
+			}
 			raiseValidateError("Named parameter '" + pname + "' missing. Please specify the input.", conditional, LanguageErrorCodes.INVALID_PARAMETERS);
-		else if( data.getOutput().getDataType() != dt )
+		}
+		else if (data.getOutput().getDataType() != dt)
 			raiseValidateError("Input to "+fname+"::"+pname+" must be of type '"+dt.toString()+"'. It should not be of type '"+data.getOutput().getDataType()+"'.", conditional, LanguageErrorCodes.INVALID_PARAMETERS);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorUltraSparse.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorUltraSparse.java
@@ -26,7 +26,7 @@ import org.apache.sysds.runtime.matrix.data.LibMatrixCountDistinct;
 import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
-import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator.CountDistinctTypes;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
 
 /**
  * UltraSparse compressed size estimator (examines entire dataset).
@@ -39,7 +39,7 @@ public class CompressedSizeEstimatorUltraSparse extends CompressedSizeEstimator 
 
 	private CompressedSizeEstimatorUltraSparse(MatrixBlock data, CompressionSettings compSettings) {
 		super(data, compSettings);
-		CountDistinctOperator op = new CountDistinctOperator(CountDistinctTypes.COUNT);
+		CountDistinctOperator op = new CountDistinctOperator(CountDistinctOperatorTypes.COUNT);
 		final int _numRows = getNumRows();
 
 		if(LOG.isDebugEnabled()) {

--- a/src/main/java/org/apache/sysds/runtime/functionobjects/Builtin.java
+++ b/src/main/java/org/apache/sysds/runtime/functionobjects/Builtin.java
@@ -223,7 +223,7 @@ public class Builtin extends ValueFunction
 				// compared and performs just the value part of the comparison. We
 				// return an integer cast down to a double, since the aggregation
 				// API doesn't have any way to return anything but a double. The
-				// integer returned takes on three posssible values: //
+				// integer returned takes on three possible values: //
 				// .     0 => keep the index associated with in1 //
 				// .     1 => use the index associated with in2 //
 				// .     2 => use whichever index is higher (tie in value) //

--- a/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
@@ -96,7 +96,7 @@ public class CPInstructionParser extends InstructionParser
 		String2CPInstructionType.put( "uacvar"  , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uamax"   , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uarmax"  , CPType.AggregateUnary);
-		String2CPInstructionType.put( "uarimax", CPType.AggregateUnary);
+		String2CPInstructionType.put( "uarimax" , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uacmax"  , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uamin"   , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uarmin"  , CPType.AggregateUnary);
@@ -110,13 +110,15 @@ public class CPInstructionParser extends InstructionParser
 		String2CPInstructionType.put( "uac*"    , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uatrace" , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uaktrace", CPType.AggregateUnary);
-		String2CPInstructionType.put( "nrow"    ,CPType.AggregateUnary);
-		String2CPInstructionType.put( "ncol"    ,CPType.AggregateUnary);
-		String2CPInstructionType.put( "length"  ,CPType.AggregateUnary);
-		String2CPInstructionType.put( "exists"  ,CPType.AggregateUnary);
-		String2CPInstructionType.put( "lineage" ,CPType.AggregateUnary);
+		String2CPInstructionType.put( "nrow"    , CPType.AggregateUnary);
+		String2CPInstructionType.put( "ncol"    , CPType.AggregateUnary);
+		String2CPInstructionType.put( "length"  , CPType.AggregateUnary);
+		String2CPInstructionType.put( "exists"  , CPType.AggregateUnary);
+		String2CPInstructionType.put( "lineage" , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uacd"    , CPType.AggregateUnary);
 		String2CPInstructionType.put( "uacdap"  , CPType.AggregateUnary);
+		String2CPInstructionType.put( "uacdapr" , CPType.AggregateUnary);
+		String2CPInstructionType.put( "uacdapc" , CPType.AggregateUnary);
 
 		String2CPInstructionType.put( "uaggouterchain", CPType.UaggOuterChain);
 		

--- a/src/main/java/org/apache/sysds/runtime/instructions/InstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/InstructionUtils.java
@@ -19,15 +19,13 @@
 
 package org.apache.sysds.runtime.instructions;
 
-import java.util.Arrays;
-import java.util.StringTokenizer;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.AggOp;
 import org.apache.sysds.common.Types.CorrectionLocationType;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.Direction;
+import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.lops.Lop;
 import org.apache.sysds.lops.WeightedCrossEntropy;
@@ -40,7 +38,6 @@ import org.apache.sysds.lops.WeightedSquaredLoss;
 import org.apache.sysds.lops.WeightedSquaredLossR;
 import org.apache.sysds.lops.WeightedUnaryMM;
 import org.apache.sysds.lops.WeightedUnaryMMR;
-import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.functionobjects.And;
 import org.apache.sysds.runtime.functionobjects.BitwAnd;
@@ -49,6 +46,7 @@ import org.apache.sysds.runtime.functionobjects.BitwShiftL;
 import org.apache.sysds.runtime.functionobjects.BitwShiftR;
 import org.apache.sysds.runtime.functionobjects.BitwXor;
 import org.apache.sysds.runtime.functionobjects.Builtin;
+import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
 import org.apache.sysds.runtime.functionobjects.CM;
 import org.apache.sysds.runtime.functionobjects.Divide;
 import org.apache.sysds.runtime.functionobjects.Equals;
@@ -81,9 +79,8 @@ import org.apache.sysds.runtime.functionobjects.ReduceCol;
 import org.apache.sysds.runtime.functionobjects.ReduceDiag;
 import org.apache.sysds.runtime.functionobjects.ReduceRow;
 import org.apache.sysds.runtime.functionobjects.Xor;
-import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
-import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.CPInstruction.CPType;
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FEDType;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FederatedOutput;
 import org.apache.sysds.runtime.instructions.gpu.GPUInstruction.GPUINSTRUCTION_TYPE;
@@ -94,14 +91,17 @@ import org.apache.sysds.runtime.matrix.operators.AggregateOperator;
 import org.apache.sysds.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
+import org.apache.sysds.runtime.matrix.operators.CMOperator;
+import org.apache.sysds.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
 import org.apache.sysds.runtime.matrix.operators.LeftScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.TernaryOperator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
-import org.apache.sysds.runtime.matrix.operators.CMOperator;
-import org.apache.sysds.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
+
+import java.util.Arrays;
+import java.util.StringTokenizer;
 
 
 public class InstructionUtils 

--- a/src/main/java/org/apache/sysds/runtime/instructions/SPInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/SPInstructionParser.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.runtime.instructions;
 
-import java.util.HashMap;
-
 import org.apache.sysds.common.Types;
 import org.apache.sysds.lops.Checkpoint;
 import org.apache.sysds.lops.Compression;
@@ -42,6 +40,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.spark.AggregateTernarySPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AggregateUnarySPInstruction;
+import org.apache.sysds.runtime.instructions.spark.AggregateUnarySketchSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGAlignedSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendMSPInstruction;
@@ -62,6 +61,7 @@ import org.apache.sysds.runtime.instructions.spark.CumulativeOffsetSPInstruction
 import org.apache.sysds.runtime.instructions.spark.DeCompressionSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.DnnSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.IndexingSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.LIBSVMReblockSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.MapmmChainSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.MapmmSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.MatrixReshapeSPInstruction;
@@ -87,7 +87,9 @@ import org.apache.sysds.runtime.instructions.spark.UnaryFrameSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.UnaryMatrixSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.WriteSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.ZipmmSPInstruction;
-import org.apache.sysds.runtime.instructions.spark.LIBSVMReblockSPInstruction;
+
+import java.util.HashMap;
+
 
 public class SPInstructionParser extends InstructionParser
 {
@@ -110,7 +112,7 @@ public class SPInstructionParser extends InstructionParser
 		String2SPInstructionType.put( "uacvar"  , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uamax"   , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uarmax"  , SPType.AggregateUnary);
-		String2SPInstructionType.put( "uarimax" ,  SPType.AggregateUnary);
+		String2SPInstructionType.put( "uarimax" , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uacmax"  , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uamin"   , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uarmin"  , SPType.AggregateUnary);
@@ -124,6 +126,12 @@ public class SPInstructionParser extends InstructionParser
 		String2SPInstructionType.put( "uac*"    , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uatrace" , SPType.AggregateUnary);
 		String2SPInstructionType.put( "uaktrace", SPType.AggregateUnary);
+		String2SPInstructionType.put( "uacdap"  , SPType.AggregateUnary);
+
+		// Aggregate unary sketch operators
+		String2SPInstructionType.put( "uacdap" , SPType.AggregateUnarySketch);
+		String2SPInstructionType.put( "uacdapr", SPType.AggregateUnarySketch);
+		String2SPInstructionType.put( "uacdapc", SPType.AggregateUnarySketch);
 
 		//binary aggregate operators (matrix multiplication operators)
 		String2SPInstructionType.put( "mapmm"      , SPType.MAPMM);
@@ -387,6 +395,9 @@ public class SPInstructionParser extends InstructionParser
 
 			case AggregateUnary:
 				return AggregateUnarySPInstruction.parseInstruction(str);
+
+			case AggregateUnarySketch:
+				return AggregateUnarySketchSPInstruction.parseInstruction(str);
 
 			case AggregateTernary:
 				return AggregateTernarySPInstruction.parseInstruction(str);

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/AggregateUnaryCPInstruction.java
@@ -86,25 +86,25 @@ public class AggregateUnaryCPInstruction extends UnaryCPInstruction {
 			in1, out, AUType.COUNT_DISTINCT, opcode, str);
 		}
 		else if(opcode.equalsIgnoreCase("uacdap")){
-			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX);
-			op.setDirection(Types.Direction.RowCol);
-			op.setIndexFunction(ReduceAll.getReduceAllFnObject());
+			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX)
+					.setDirection(Types.Direction.RowCol)
+					.setIndexFunction(ReduceAll.getReduceAllFnObject());
 
 			return new AggregateUnaryCPInstruction(op, in1, out, AUType.COUNT_DISTINCT_APPROX,
 					opcode, str);
 		}
 		else if(opcode.equalsIgnoreCase("uacdapr")){
-			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX);
-			op.setDirection(Types.Direction.Row);
-			op.setIndexFunction(ReduceCol.getReduceColFnObject());
+			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX)
+					.setDirection(Types.Direction.Row)
+					.setIndexFunction(ReduceCol.getReduceColFnObject());
 
 			return new AggregateUnaryCPInstruction(op, in1, out, AUType.COUNT_DISTINCT_APPROX,
 					opcode, str);
 		}
 		else if(opcode.equalsIgnoreCase("uacdapc")){
-			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX);
-			op.setDirection(Types.Direction.Col);
-			op.setIndexFunction(ReduceRow.getReduceRowFnObject());
+			CountDistinctOperator op = new CountDistinctOperator(AUType.COUNT_DISTINCT_APPROX)
+					.setDirection(Types.Direction.Col)
+					.setIndexFunction(ReduceRow.getReduceRowFnObject());
 
 			return new AggregateUnaryCPInstruction(op, in1, out, AUType.COUNT_DISTINCT_APPROX,
 					opcode, str);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
@@ -289,7 +289,6 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 		public RDDUAggValueFunction( AggregateUnaryOperator op, int blen ) {
 			_op = op;
 			_blen = blen;
-			_blen = blen;
 			
 			_ix = new MatrixIndexes(1,1);
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySketchSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySketchSPInstruction.java
@@ -55,14 +55,14 @@ public class AggregateUnarySketchSPInstruction extends UnarySPInstruction {
         this.op = (CountDistinctOperator) super.getOperator();
 
         if (opcode.equals("uacdap")) {
-            this.op.setDirection(Types.Direction.RowCol);
-            this.op.setIndexFunction(ReduceAll.getReduceAllFnObject());
+            this.op.setDirection(Types.Direction.RowCol)
+                    .setIndexFunction(ReduceAll.getReduceAllFnObject());
         } else if (opcode.equals("uacdapr")) {
-            this.op.setDirection(Types.Direction.Row);
-            this.op.setIndexFunction(ReduceCol.getReduceColFnObject());
+            this.op.setDirection(Types.Direction.Row)
+                    .setIndexFunction(ReduceCol.getReduceColFnObject());
         } else if (opcode.equals("uacdapc")) {
-            this.op.setDirection(Types.Direction.Col);
-            this.op.setIndexFunction(ReduceRow.getReduceRowFnObject());
+            this.op.setDirection(Types.Direction.Col)
+                    .setIndexFunction(ReduceRow.getReduceRowFnObject());
         } else {
             throw new DMLException("Unrecognized opcode " + opcode);
         }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySketchSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySketchSPInstruction.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.instructions.spark;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.sysds.api.DMLException;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysds.runtime.functionobjects.ReduceAll;
+import org.apache.sysds.runtime.functionobjects.ReduceCol;
+import org.apache.sysds.runtime.functionobjects.ReduceRow;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.data.CorrMatrixBlock;
+import org.apache.sysds.runtime.matrix.data.LibMatrixCountDistinct;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+import org.apache.sysds.utils.Hash;
+import scala.Tuple2;
+
+public class AggregateUnarySketchSPInstruction extends UnarySPInstruction {
+    private AggBinaryOp.SparkAggType aggtype;
+    private CountDistinctOperator op;
+
+    protected AggregateUnarySketchSPInstruction(Operator op, CPOperand in, CPOperand out, AggBinaryOp.SparkAggType aggtype, String opcode, String instr) {
+        super(SPType.AggregateUnarySketch, op, in, out, opcode, instr);
+        this.op = (CountDistinctOperator) super.getOperator();
+
+        if (opcode.equals("uacdap")) {
+            this.op.setDirection(Types.Direction.RowCol);
+            this.op.setIndexFunction(ReduceAll.getReduceAllFnObject());
+        } else if (opcode.equals("uacdapr")) {
+            this.op.setDirection(Types.Direction.Row);
+            this.op.setIndexFunction(ReduceCol.getReduceColFnObject());
+        } else if (opcode.equals("uacdapc")) {
+            this.op.setDirection(Types.Direction.Col);
+            this.op.setIndexFunction(ReduceRow.getReduceRowFnObject());
+        } else {
+            throw new DMLException("Unrecognized opcode " + opcode);
+        }
+
+        this.aggtype = aggtype;
+    }
+
+    public static AggregateUnarySketchSPInstruction parseInstruction(String str) {
+        String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
+        InstructionUtils.checkNumFields(parts, 3);
+        String opcode = parts[0];
+
+        CPOperand in1 = new CPOperand(parts[1]);
+        CPOperand out = new CPOperand(parts[2]);
+        AggBinaryOp.SparkAggType aggtype = AggBinaryOp.SparkAggType.valueOf(parts[3]);
+
+        CountDistinctOperator cdop = new CountDistinctOperator(CountDistinctOperatorTypes.KMV, Hash.HashType.LinearHash);
+
+        return new AggregateUnarySketchSPInstruction(cdop, in1, out, aggtype, opcode, str);
+    }
+
+    @Override
+    public void processInstruction(ExecutionContext ec) {
+        if (input1.getDataType() == Types.DataType.MATRIX) {
+            processMatrixSketch(ec);
+        } else {
+            processTensorSketch(ec);
+        }
+    }
+
+    private void processMatrixSketch(ExecutionContext ec) {
+        SparkExecutionContext sec = (SparkExecutionContext)ec;
+
+        //get input
+        JavaPairRDD<MatrixIndexes, MatrixBlock> in = sec.getBinaryMatrixBlockRDDHandleForVariable(input1.getName());
+        JavaPairRDD<MatrixIndexes, MatrixBlock> out = in;
+
+        // dir = RowCol and (dim1() > 1000 || dim2() > 1000)
+        if (aggtype == AggBinaryOp.SparkAggType.SINGLE_BLOCK) {
+
+            // Create a single sketch and derive approximate count distinct from the sketch
+            JavaRDD<CorrMatrixBlock> out1 = out.map(new AggregateUnarySketchCreateFunction(this.op));
+
+            // Using fold() instead of reduce() for stable aggregation
+            // Instantiating CorrMatrixBlock mutable buffer with empty matrix block so that it can be serialized properly
+            CorrMatrixBlock out2 =
+                    out1.fold(new CorrMatrixBlock(new MatrixBlock()),
+                              new AggregateUnarySketchUnionAllFunction(this.op));
+
+            MatrixBlock out3 = LibMatrixCountDistinct.countDistinctValuesFromSketch(out2, this.op);
+
+            // put output block into symbol table (no lineage because single block)
+            // this also includes implicit maintenance of matrix characteristics
+            sec.setMatrixOutput(output.getName(), out3);
+        } else {
+
+            if (aggtype != AggBinaryOp.SparkAggType.NONE && aggtype != AggBinaryOp.SparkAggType.MULTI_BLOCK) {
+                throw new DMLRuntimeException(String.format("Unsupported aggregation type: %s", aggtype));
+            }
+
+            JavaPairRDD<MatrixIndexes, MatrixBlock> out1;
+            JavaPairRDD<MatrixIndexes, CorrMatrixBlock> out2;
+            JavaPairRDD<MatrixIndexes, MatrixBlock> out3;
+
+            // dir = Row || Col || RowCol and (dim1() <= 1000 || dim2() <= 1000)
+            if (aggtype == AggBinaryOp.SparkAggType.NONE) {
+                // Input matrix is small enough for a single index, so there is no need to execute index function.
+                // Reuse the CreateCombinerFunction(), although there is no need to merge values within the same
+                // partition, or combiners across partitions for that matter.
+                out2 = out.mapValues(new AggregateUnarySketchCreateCombinerFunction(this.op));
+
+            // aggType = MULTI_BLOCK: dir = Row || Col and (dim1() > 1000 || dim2() > 1000)
+            } else {
+                // Execute index function to group rows/columns together based on aggregation direction
+                out1 = out.mapToPair(new RowColGroupingFunction(this.op));
+
+                // Create sketch per index
+                out2 = out1.combineByKey(new AggregateUnarySketchCreateCombinerFunction(this.op),
+                        new AggregateUnarySketchMergeValueFunction(this.op),
+                        new AggregateUnarySketchMergeCombinerFunction(this.op));
+            }
+
+            out3 = out2.mapValues(new CalculateAggregateSketchFunction(this.op));
+
+            updateUnaryAggOutputDataCharacteristics(sec, this.op.getIndexFunction());
+
+            // put output RDD handle into symbol table
+            sec.setRDDHandleForVariable(output.getName(), out3);
+            sec.addLineageRDD(output.getName(), input1.getName());
+        }
+    }
+
+    private void processTensorSketch(ExecutionContext ec) {
+        throw new NotImplementedException("Aggregate sketch instruction for tensors has not been implemented yet.");
+    }
+
+    private static class AggregateUnarySketchCreateFunction implements Function<Tuple2<MatrixIndexes, MatrixBlock>, CorrMatrixBlock> {
+        private static final long serialVersionUID = 7295176181965491548L;
+        private CountDistinctOperator op;
+
+        public AggregateUnarySketchCreateFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public CorrMatrixBlock call(Tuple2<MatrixIndexes, MatrixBlock> arg0) throws Exception {
+            MatrixIndexes ixIn = arg0._1();
+            MatrixBlock blkIn = arg0._2();
+
+            MatrixIndexes ixOut = new MatrixIndexes();
+            this.op.getIndexFunction().execute(ixIn, ixOut);
+
+            return LibMatrixCountDistinct.createSketch(blkIn, this.op);
+        }
+    }
+
+    private static class AggregateUnarySketchUnionAllFunction implements Function2<CorrMatrixBlock, CorrMatrixBlock, CorrMatrixBlock> {
+        private static final long serialVersionUID = -3799519241499062936L;
+        private CountDistinctOperator op;
+
+        public AggregateUnarySketchUnionAllFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public CorrMatrixBlock call(CorrMatrixBlock arg0, CorrMatrixBlock arg1) throws Exception {
+
+            // Input matrix blocks must have corresponding sketch metadata
+            if (arg0.getCorrection() == null && arg1.getCorrection() == null) {
+                throw new DMLRuntimeException("Corrupt sketch: metadata is missing");
+            }
+
+            if ((arg0.getValue().getNumRows() == 0 && arg0.getValue().getNumColumns() == 0) || arg0.getCorrection() == null) {
+                arg0.set(arg1.getValue(), arg1.getCorrection());
+                return arg0;
+            } else if ((arg1.getValue().getNumRows() == 0 && arg1.getValue().getNumColumns() == 0) || arg1.getCorrection() == null) {
+                return arg0;
+            }
+
+            return LibMatrixCountDistinct.unionSketch(arg0, arg1, this.op);
+        }
+    }
+
+    private static class RowColGroupingFunction implements PairFunction<Tuple2<MatrixIndexes, MatrixBlock>, MatrixIndexes, MatrixBlock> {
+
+        private static final long serialVersionUID = -3456633769452405482L;
+        private CountDistinctOperator _op;
+
+        public RowColGroupingFunction(CountDistinctOperator op) {
+            this._op = op;
+        }
+
+        @Override
+        public Tuple2<MatrixIndexes, MatrixBlock> call(Tuple2<MatrixIndexes, MatrixBlock> arg0) throws Exception {
+            MatrixIndexes idxIn = arg0._1();
+            MatrixBlock blkIn = arg0._2();
+
+            MatrixIndexes idxOut = new MatrixIndexes();
+            MatrixBlock blkOut = blkIn;  // Do not create sketch yet
+            this._op.getIndexFunction().execute(idxIn, idxOut);
+
+            return new Tuple2<>(idxOut, blkOut);
+        }
+    }
+
+    private static class AggregateUnarySketchCreateCombinerFunction implements Function<MatrixBlock, CorrMatrixBlock>
+    {
+        private static final long serialVersionUID = 8997980606986435297L;
+        private final CountDistinctOperator op;
+
+        private AggregateUnarySketchCreateCombinerFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public CorrMatrixBlock call(MatrixBlock arg0)
+                throws Exception {
+
+            return LibMatrixCountDistinct.createSketch(arg0, this.op);
+        }
+    }
+
+    private static class AggregateUnarySketchMergeValueFunction implements Function2<CorrMatrixBlock, MatrixBlock, CorrMatrixBlock>
+    {
+        private static final long serialVersionUID = -7006864809860460549L;
+        private CountDistinctOperator op;
+
+        public AggregateUnarySketchMergeValueFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public CorrMatrixBlock call(CorrMatrixBlock arg0, MatrixBlock arg1) throws Exception {
+            CorrMatrixBlock arg1WithCorr = LibMatrixCountDistinct.createSketch(arg1, this.op);
+            return LibMatrixCountDistinct.unionSketch(arg0, arg1WithCorr, this.op);
+        }
+    }
+
+    private static class AggregateUnarySketchMergeCombinerFunction implements Function2<CorrMatrixBlock, CorrMatrixBlock, CorrMatrixBlock>
+    {
+        private static final long serialVersionUID = 172215143740379070L;
+        private CountDistinctOperator op;
+
+        public AggregateUnarySketchMergeCombinerFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public CorrMatrixBlock call(CorrMatrixBlock arg0, CorrMatrixBlock arg1) throws Exception {
+            return LibMatrixCountDistinct.unionSketch(arg0, arg1, this.op);
+        }
+    }
+
+    private static class CalculateAggregateSketchFunction implements Function<CorrMatrixBlock, MatrixBlock>
+    {
+        private static final long serialVersionUID = 7504873483231717138L;
+        private CountDistinctOperator op;
+
+        public CalculateAggregateSketchFunction(CountDistinctOperator op) {
+            this.op = op;
+        }
+
+        @Override
+        public MatrixBlock call(CorrMatrixBlock arg0) throws Exception {
+            return LibMatrixCountDistinct.countDistinctValuesFromSketch(arg0, this.op);
+        }
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/SPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/SPInstruction.java
@@ -37,7 +37,7 @@ public abstract class SPInstruction extends Instruction {
 		CentralMoment, Covariance, QSort, QPick,
 		ParameterizedBuiltin, MAppend, RAppend, GAppend, GAlignedAppend, Rand,
 		MatrixReshape, Ctable, Quaternary, CumsumAggregate, CumsumOffset, BinUaggChain, UaggOuterChain,
-		Write, SpoofFused, Dnn
+		Write, SpoofFused, Dnn, AggregateUnarySketch
 	}
 
 	protected final SPType _sptype;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/functions/ConvertMatrixBlockToIJVLines.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/functions/ConvertMatrixBlockToIJVLines.java
@@ -40,8 +40,11 @@ public class ConvertMatrixBlockToIJVLines implements FlatMapFunction<Tuple2<Matr
 	public Iterator<String> call(Tuple2<MatrixIndexes, MatrixBlock> kv) {
 		final BinaryBlockToTextCellConverter converter = new BinaryBlockToTextCellConverter();
 		converter.setBlockSize(blen, blen);
-		converter.convert(kv._1, kv._2);
-		
+
+		MatrixIndexes ixIn = kv._1();
+		MatrixBlock blkIn = kv._2();
+		converter.convert(ixIn, blkIn);
+
 		Iterable<String> ret = new Iterable<String>() {
 			@Override
 			public Iterator<String> iterator() {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/RDDAggregateUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/RDDAggregateUtils.java
@@ -277,7 +277,7 @@ public class RDDAggregateUtils
 							    new MergeBlocksFunction(false) );
 	}
 
-	private static class CreateCorrBlockCombinerFunction implements Function<MatrixBlock, CorrMatrixBlock> 
+	private static class CreateCorrBlockCombinerFunction implements Function<MatrixBlock, CorrMatrixBlock>
 	{
 		private static final long serialVersionUID = -3666451526776017343L;
 
@@ -286,15 +286,15 @@ public class RDDAggregateUtils
 		public CreateCorrBlockCombinerFunction(boolean deep) {
 			_deep = deep;
 		}
-		
+
 		@Override
-		public CorrMatrixBlock call(MatrixBlock arg0) 
-			throws Exception 
+		public CorrMatrixBlock call(MatrixBlock arg0)
+				throws Exception
 		{
 			//deep copy to allow update in-place
 			return new CorrMatrixBlock(
-				_deep ? new MatrixBlock(arg0) : arg0);
-		}	
+					_deep ? new MatrixBlock(arg0) : arg0);
+		}
 	}
 
 	private static class MergeSumBlockValueFunction implements Function2<CorrMatrixBlock, MatrixBlock, CorrMatrixBlock> 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/BinaryBlockToTextCellConverter.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/BinaryBlockToTextCellConverter.java
@@ -62,8 +62,11 @@ Converter<MatrixIndexes, MatrixBlock, NullWritable, Text>
 	@Override
 	public void convert(MatrixIndexes k1, MatrixBlock v1) {
 		reset();
-		startIndexes.setIndexes(UtilFunctions.computeCellIndex(k1.getRowIndex(), brow,0), 
-				UtilFunctions.computeCellIndex(k1.getColumnIndex(),bcolumn,0));
+
+		long rIndex = UtilFunctions.computeCellIndex(k1.getRowIndex(), brow,0);
+		long cIndex = UtilFunctions.computeCellIndex(k1.getColumnIndex(),bcolumn,0);
+
+		startIndexes.setIndexes(rIndex, cIndex);
 		sparse=v1.isInSparseFormat();
 		thisBlockWidth=v1.getNumColumns();
 		if(sparse)

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCountDistinct.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCountDistinct.java
@@ -19,11 +19,6 @@
 
 package org.apache.sysds.runtime.matrix.data;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.PriorityQueue;
-import java.util.Set;
-
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,10 +27,15 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.CorrMatrixBlock;
+import org.apache.sysds.runtime.matrix.data.sketch.MatrixSketch;
+import org.apache.sysds.runtime.matrix.data.sketch.countdistinctapprox.KMVSketch;
 import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
-import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator.CountDistinctTypes;
-import org.apache.sysds.utils.Hash;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
 import org.apache.sysds.utils.Hash.HashType;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class contains various methods for counting the number of distinct values inside a MatrixBlock
@@ -61,7 +61,7 @@ public class LibMatrixCountDistinct {
 	 * 
 	 * TODO: Add support for distributed spark operations
 	 * 
-	 * TODO: If the MatrixBlock type is CompressedMatrix, simply read the vaules from the ColGroups.
+	 * TODO: If the MatrixBlock type is CompressedMatrix, simply read the values from the ColGroups.
 	 * 
 	 * @param in the input matrix to count number distinct values in
 	 * @param op the selected operator to use
@@ -69,11 +69,11 @@ public class LibMatrixCountDistinct {
 	 */
 	public static int estimateDistinctValues(MatrixBlock in, CountDistinctOperator op) {
 		int res = 0;
-		if(op.operatorType == CountDistinctTypes.KMV &&
-			(op.hashType == HashType.ExpHash || op.hashType == HashType.StandardJava)) {
-			throw new DMLException("Invalid hashing configuration using " + op.hashType + " and " + op.operatorType);
+		if(op.getOperatorType() == CountDistinctOperatorTypes.KMV &&
+			(op.getHashType() == HashType.ExpHash || op.getHashType() == HashType.StandardJava)) {
+			throw new DMLException("Invalid hashing configuration using " + op.getHashType() + " and " + op.getOperatorType());
 		}
-		else if(op.operatorType == CountDistinctTypes.HLL) {
+		else if(op.getOperatorType() == CountDistinctOperatorTypes.HLL) {
 			throw new NotImplementedException("HyperLogLog not implemented");
 		}
 		// shortcut in simplest case.
@@ -84,12 +84,13 @@ public class LibMatrixCountDistinct {
 			res = countDistinctValuesNaive(in);
 		}
 		else {
-			switch(op.operatorType) {
+			switch(op.getOperatorType()) {
 				case COUNT:
 					res = countDistinctValuesNaive(in);
 					break;
 				case KMV:
-					res = countDistinctValuesKVM(in, op);
+					KMVSketch sketch = new KMVSketch(op);
+					res = sketch.getScalarValue(in);
 					break;
 				default:
 					throw new DMLException("Invalid or not implemented Estimator Type");
@@ -157,149 +158,44 @@ public class LibMatrixCountDistinct {
 		return distinct;
 	}
 
-	/**
-	 * KMV synopsis(for k minimum values) Distinct-Value Estimation
-	 * 
-	 * Kevin S. Beyer, Peter J. Haas, Berthold Reinwald, Yannis Sismanis, Rainer Gemulla:
-	 * 
-	 * On synopses for distinct‐value estimation under multiset operations. SIGMOD 2007
-	 * 
-	 * TODO: Add multi-threaded version
-	 * 
-	 * @param in The Matrix Block to estimate the number of distinct values in
-	 * @return The distinct count estimate
-	 */
-	private static int countDistinctValuesKVM(MatrixBlock in, CountDistinctOperator op) {
-
-		// D is the number of possible distinct values in the MatrixBlock.
-		// plus 1 to take account of 0 input.
-		long D = in.getNonZeros() + 1;
-
-		/**
-		 * To ensure that the likelihood to hash to the same value we need O(D^2) positions to hash to assign. If the
-		 * value is higher than int (which is the area we hash to) then use Integer Max value as largest hashing space.
-		 */
-		long tmp = D * D;
-		int M = (tmp > (long) Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) tmp;
-		LOG.debug("M not forced to int size: " + tmp);
-		LOG.debug("M: " + M);
-		/**
-		 * The estimator is asymptotically unbiased as k becomes large, but memory usage also scales with k. Furthermore k
-		 * value must be within range: D >> k >> 0
-		 */
-		int k = D > 64 ? 64 : (int) D;
-		SmallestPriorityQueue spq = new SmallestPriorityQueue(k);
-
-		countDistinctValuesKVM(in, op.hashType, k, spq, M);
-
-		LOG.debug("M: " + M);
-		LOG.debug("smallest hash:" + spq.peek());
-		LOG.debug("spq: " + spq.toString());
-
-		if(spq.size() < k) {
-			return spq.size();
+	public static MatrixBlock countDistinctValuesFromSketch(CorrMatrixBlock arg0, CountDistinctOperator op) {
+		MatrixSketch sketch;
+		if (op.getOperatorType() == CountDistinctOperatorTypes.KMV) {
+			sketch = new KMVSketch(op);
+		} else if (op.getOperatorType() == CountDistinctOperatorTypes.HLL) {
+			throw new NotImplementedException("Not implemented yet");
+		} else {
+			throw new NotImplementedException("Not implemented yet");
 		}
-		else {
-			double U_k = (double) spq.poll() / (double) M;
-			LOG.debug("U_k : " + U_k);
-			double estimate = (double) (k - 1) / U_k;
-			LOG.debug("Estimate: " + estimate);
-			double ceilEstimate = Math.min(estimate, (double) D);
-			LOG.debug("Ceil worst case: " + D);
-			return (int) ceilEstimate;
-		}
+
+		return sketch.getMatrixValue(arg0);
 	}
 
-	private static void countDistinctValuesKVM(MatrixBlock in, HashType hashType, int k, SmallestPriorityQueue spq,
-		int m) {
-		double[] data;
-		if(in.isEmpty())
-			spq.add(0);
-		else if(in instanceof CompressedMatrixBlock)
-			throw new NotImplementedException();
-		else if(in.sparseBlock != null) {
-			SparseBlock sb = in.sparseBlock;
-			if(in.sparseBlock.isContiguous()) {
-				data = sb.values(0);
-				countDistinctValuesKVM(data, hashType, k, spq, m);
-			}
-			else {
-				for(int i = 0; i < in.getNumRows(); i++) {
-					if(!sb.isEmpty(i)) {
-						data = in.sparseBlock.values(i);
-						countDistinctValuesKVM(data, hashType, k, spq, m);
-					}
-				}
-			}
+	public static CorrMatrixBlock createSketch(MatrixBlock blkIn, CountDistinctOperator op) {
+
+		MatrixSketch sketch;
+		if (op.getOperatorType() == CountDistinctOperatorTypes.KMV) {
+			sketch = new KMVSketch(op);
+		} else if (op.getOperatorType() == CountDistinctOperatorTypes.HLL) {
+			throw new NotImplementedException("Not implemented yet");
+		} else {
+			throw new NotImplementedException("Not implemented yet");
 		}
-		else {
-			DenseBlock db = in.denseBlock;
-			final int bil = db.index(0);
-			final int biu = db.index(in.rlen);
-			for(int i = bil; i <= biu; i++) {
-				data = db.valuesAt(i);
-				countDistinctValuesKVM(data, hashType, k, spq, m);
-			}
-		}
+
+		return sketch.create(blkIn);
 	}
 
-	private static void countDistinctValuesKVM(double[] data, HashType hashType, int k, SmallestPriorityQueue spq,
-		int m) {
-		for(double fullValue : data) {
-			int hash = Hash.hash(fullValue, hashType);
-			int v = (Math.abs(hash)) % (m - 1) + 1;
-			spq.add(v);
+	public static CorrMatrixBlock unionSketch(CorrMatrixBlock arg0, CorrMatrixBlock arg1, CountDistinctOperator op) {
+		MatrixSketch sketch;
+		if (op.getOperatorType() == CountDistinctOperatorTypes.KMV) {
+			sketch = new KMVSketch(op);
+		} else if (op.getOperatorType() == CountDistinctOperatorTypes.HLL) {
+			throw new NotImplementedException("Not implemented yet");
+		} else {
+			throw new NotImplementedException("Not implemented yet");
 		}
+
+		return sketch.union(arg0, arg1);
 	}
 
-	/**
-	 * Deceiving name, but is used to contain the k smallest values inserted.
-	 * 
-	 * TODO: add utility method to join two partitions
-	 * 
-	 * TODO: Replace Standard Java Set and Priority Queue with optimized versions.
-	 */
-	private static class SmallestPriorityQueue {
-		private Set<Integer> containedSet;
-		private PriorityQueue<Integer> smallestHashes;
-		private int k;
-
-		public SmallestPriorityQueue(int k) {
-			smallestHashes = new PriorityQueue<>(k, Collections.reverseOrder());
-			containedSet = new HashSet<>(1);
-			this.k = k;
-		}
-
-		public void add(int v) {
-			if(!containedSet.contains(v)) {
-				if(smallestHashes.size() < k) {
-					smallestHashes.add(v);
-					containedSet.add(v);
-				}
-				else if(v < smallestHashes.peek()) {
-					LOG.trace(smallestHashes.peek() + " -- " + v);
-					smallestHashes.add(v);
-					containedSet.add(v);
-					containedSet.remove(smallestHashes.poll());
-				}
-			}
-		}
-
-		public int size() {
-			return smallestHashes.size();
-		}
-
-		public int peek() {
-			return smallestHashes.peek();
-		}
-
-		public int poll() {
-			return smallestHashes.poll();
-		}
-
-		@Override
-		public String toString() {
-			return smallestHashes.toString();
-		}
-	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -5770,7 +5770,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 				+ block.getClass().getSimpleName());
 		return (MatrixBlock) block;
 	}
-	
+
 	/**
 	 * Indicates if concurrent modifications of disjoint rows are thread-safe.
 	 * 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/OperationsOnMatrixValues.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/OperationsOnMatrixValues.java
@@ -216,7 +216,7 @@ public class OperationsOnMatrixValues
 			MatrixValue valueOut, AggregateUnaryOperator op,int blen) {
 		//operate on the value indexes first
 		op.indexFn.execute(indexesIn, indexesOut);
-		
+
 		//perform on the value
 		valueIn.aggregateUnaryOperations(op, valueOut, blen, indexesIn);
 	}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/MatrixSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/MatrixSketch.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data.sketch;
+
+import org.apache.sysds.runtime.instructions.spark.data.CorrMatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public interface MatrixSketch <T> {
+    T getScalarValue(MatrixBlock blkIn);
+    MatrixBlock getMatrixValue(CorrMatrixBlock blkIn);
+    CorrMatrixBlock create(MatrixBlock blkIn);
+    CorrMatrixBlock union(CorrMatrixBlock arg0, CorrMatrixBlock arg1);
+    CorrMatrixBlock intersection(CorrMatrixBlock arg0, CorrMatrixBlock arg1);
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data.sketch.countdistinctapprox;
+
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.sketch.MatrixSketch;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+
+// Package private
+abstract class CountDistinctApproxSketch implements MatrixSketch<Integer> {
+    CountDistinctOperator op;
+
+    CountDistinctApproxSketch(Operator op) {
+        if (!(op instanceof CountDistinctOperator)) {
+            throw new DMLRuntimeException(String.format("Cannot create %s with given operator", CountDistinctApproxSketch.class.getSimpleName()));
+        }
+
+        this.op = (CountDistinctOperator) op;
+
+        if (!this.op.getDirection().isRow() && !this.op.getDirection().isCol() && !this.op.getDirection().isRowCol()) {
+            throw new DMLRuntimeException(String.format("Unexpected direction: %s", this.op.getDirection()));
+        }
+    }
+
+    protected void validateSketchMetadata(MatrixBlock corrBlock) {
+        // (nHashes, k, D) row vector
+        if (corrBlock.getNumColumns() < 3 || corrBlock.getValue(0, 0) < 0 || corrBlock.getValue(0, 1) < 0
+                || corrBlock.getValue(0, 2) < 0) {
+            throw new DMLRuntimeException("Sketch metadata is corrupt");
+        }
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
@@ -36,12 +36,12 @@ abstract class CountDistinctApproxSketch implements MatrixSketch<Integer> {
 
         this.op = (CountDistinctOperator) op;
 
-        if (this.op.getDirection() == null || (!this.op.getDirection().isRow() && !this.op.getDirection().isCol() && !this.op.getDirection().isRowCol())) {
-            String message = "No direction was set for the operator";
-            if (this.op.getDirection() != null) {
-                message = String.format("Unexpected direction: %s", this.op.getDirection());
-            }
-            throw new DMLRuntimeException(message);
+        if (this.op.getDirection() == null) {
+            throw new DMLRuntimeException("No direction was set for the operator");
+        }
+
+        if (!this.op.getDirection().isRow() && !this.op.getDirection().isCol() && !this.op.getDirection().isRowCol()) {
+            throw new DMLRuntimeException(String.format("Unexpected direction: %s", this.op.getDirection()));
         }
     }
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/CountDistinctApproxSketch.java
@@ -36,8 +36,12 @@ abstract class CountDistinctApproxSketch implements MatrixSketch<Integer> {
 
         this.op = (CountDistinctOperator) op;
 
-        if (!this.op.getDirection().isRow() && !this.op.getDirection().isCol() && !this.op.getDirection().isRowCol()) {
-            throw new DMLRuntimeException(String.format("Unexpected direction: %s", this.op.getDirection()));
+        if (this.op.getDirection() == null || (!this.op.getDirection().isRow() && !this.op.getDirection().isCol() && !this.op.getDirection().isRowCol())) {
+            String message = "No direction was set for the operator";
+            if (this.op.getDirection() != null) {
+                message = String.format("Unexpected direction: %s", this.op.getDirection());
+            }
+            throw new DMLRuntimeException(message);
         }
     }
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/KMVSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/KMVSketch.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data.sketch.countdistinctapprox;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.CorrMatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+import org.apache.sysds.utils.Hash;
+
+public class KMVSketch extends CountDistinctApproxSketch {
+
+    private static final Log LOGGER = LogFactory.getLog(KMVSketch.class.getName());
+
+    public KMVSketch(Operator op) {
+        super(op);
+    }
+
+    // 1. Methods to obtain scalar distinct count value from input matrix block
+    //
+    /**
+     * KMV synopsis(for k minimum values) Distinct-Value Estimation
+     *
+     * Kevin S. Beyer, Peter J. Haas, Berthold Reinwald, Yannis Sismanis, Rainer Gemulla:
+     *
+     * On synopses for distinct‐value estimation under multiset operations. SIGMOD 2007
+     *
+     * TODO: Add multi-threaded version
+     *
+     * @param in The Matrix Block to estimate the number of distinct values in
+     * @return The distinct count estimate
+     */
+    @Override
+    public Integer getScalarValue(MatrixBlock in) {
+
+        // D is the number of possible distinct values in the MatrixBlock.
+        // plus 1 to take account of 0 input.
+        long D = in.getNonZeros() + 1;
+
+        /**
+         * To ensure that the likelihood to hash to the same value we need O(D^2) positions to hash to assign. If the
+         * value is higher than int (which is the area we hash to) then use Integer Max value as largest hashing space.
+         */
+        long tmp = D * D;
+        int M = (tmp > (long) Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) tmp;
+        LOGGER.debug("M not forced to int size: " + tmp);
+        LOGGER.debug("M: " + M);
+        /**
+         * The estimator is asymptotically unbiased as k becomes large, but memory usage also scales with k. Furthermore
+         * k value must be within range: D >> k >> 0
+         */
+        int k = D > 64 ? 64 : (int) D;
+
+        SmallestPriorityQueue spq = getKSmallestHashes(in, k, M);
+
+        LOGGER.debug("M: " + M);
+        LOGGER.debug("kth smallest hash:" + spq.peek());
+        LOGGER.debug("spq: " + spq.toString());
+
+        if(spq.size() < k) {
+            return spq.size();
+        }
+        else {
+            double kthSmallestHash = spq.poll();
+            double U_k = kthSmallestHash / (double) M;
+            LOGGER.debug("U_k : " + U_k);
+            double estimate = (double) (k - 1) / U_k;
+            LOGGER.debug("Estimate: " + estimate);
+            double ceilEstimate = Math.min(estimate, (double) D);
+            LOGGER.debug("Ceil worst case: " + D);
+            return (int) ceilEstimate;
+        }
+    }
+
+    private SmallestPriorityQueue getKSmallestHashes(MatrixBlock in, int k, int M) {
+        SmallestPriorityQueue spq = new SmallestPriorityQueue(k);
+        countDistinctValuesKMV(in, op.getHashType(), k, spq, M);
+
+        return spq;
+    }
+
+    private void countDistinctValuesKMV(MatrixBlock in, Hash.HashType hashType, int k, SmallestPriorityQueue spq,
+                                        int m) {
+        double[] data;
+        if(in.isEmpty())
+            spq.add(0);
+        else if(in instanceof CompressedMatrixBlock)
+            throw new NotImplementedException("Cannot approximate distinct count for compressed matrices");
+        else if(in.getSparseBlock() != null) {
+            SparseBlock sb = in.getSparseBlock();
+            if(sb.isContiguous()) {
+                data = sb.values(0);
+                countDistinctValuesKMV(data, hashType, k, spq, m);
+            }
+            else {
+                for(int i = 0; i < in.getNumRows(); i++) {
+                    if(!sb.isEmpty(i)) {
+                        data = sb.values(i);
+                        countDistinctValuesKMV(data, hashType, k, spq, m);
+                    }
+                }
+            }
+        }
+        else {
+            DenseBlock db = in.getDenseBlock();
+            final int bil = db.index(0);
+            final int biu = db.index(in.getNumRows());
+            for(int i = bil; i <= biu; i++) {
+                data = db.valuesAt(i);
+                countDistinctValuesKMV(data, hashType, k, spq, m);
+            }
+        }
+    }
+
+    private void countDistinctValuesKMV(double[] data, Hash.HashType hashType, int k, SmallestPriorityQueue spq,
+                                        int m) {
+        for(double fullValue : data) {
+            int hash = Hash.hash(fullValue, hashType);
+            int v = (Math.abs(hash)) % (m - 1) + 1;
+            spq.add(v);
+        }
+    }
+
+    // 2. Methods to obtain matrix distinct count value from input sketch
+    //
+    @Override
+    public MatrixBlock getMatrixValue(CorrMatrixBlock arg0) {
+        MatrixBlock blkIn = arg0.getValue();
+        if (op.getDirection() == Types.Direction.Row) {
+            // 1000 x 1 blkOut -> slice out the first column of the matrix
+            MatrixBlock blkOut = blkIn.slice(0, blkIn.getNumRows()-1, 0, 0);
+            for (int i = 0; i < blkIn.getNumRows(); ++i) {
+                getDistinctCountFromSketchByIndex(arg0, i, blkOut);
+            }
+
+            return blkOut;
+        } else if (op.getDirection() == Types.Direction.Col) {
+            // 1 x 1000 blkOut -> slice out the first row of the matrix
+            MatrixBlock blkOut = blkIn.slice(0, 0, 0, blkIn.getNumColumns()-1);
+            for (int j = 0; j < blkIn.getNumColumns(); ++j) {
+                getDistinctCountFromSketchByIndex(arg0, j, blkOut);
+            }
+
+            return blkOut;
+        } else {  // op.getDirection().isRowCol()
+
+            // 1 x 1 blkOut -> slice out the first row and column of the matrix
+            MatrixBlock blkOut = blkIn.slice(0, 0, 0, 0);
+            getDistinctCountFromSketchByIndex(arg0, 0, blkOut);
+
+            return blkOut;
+        }
+    }
+
+    private void getDistinctCountFromSketchByIndex(CorrMatrixBlock arg0, int idx, MatrixBlock blkOut) {
+        MatrixBlock blkIn = arg0.getValue();
+        MatrixBlock blkInCorr = arg0.getCorrection();
+
+        if (op.getOperatorType() == CountDistinctOperatorTypes.KMV) {
+            double kthSmallestHash;
+            if (op.getDirection().isRow() || op.getDirection().isRowCol()) {
+                kthSmallestHash = blkIn.getValue(idx, 0);
+            } else {  // op.getDirection().isCol()
+                kthSmallestHash = blkIn.getValue(0, idx);
+            }
+
+            double nHashes = blkInCorr.getValue(idx, 0);
+            double k = blkInCorr.getValue(idx, 1);
+            double D = blkInCorr.getValue(idx, 2);
+
+            double D2 = D * D;
+            double M = (D2 > (long) Integer.MAX_VALUE) ? Integer.MAX_VALUE : D2;
+
+            double ceilEstimate;
+            if (nHashes != 0 && nHashes < k) {
+                ceilEstimate = nHashes;
+            } else if (nHashes == 0) {
+                ceilEstimate = 1;
+            } else {
+                double U_k = kthSmallestHash / M;
+                double estimate = (k - 1) / U_k;
+                ceilEstimate = Math.min(estimate, D);
+            }
+
+            if (op.getDirection().isRow() || op.getDirection().isRowCol()) {
+                blkOut.setValue(idx, 0, ceilEstimate);
+            } else {  // op.getDirection().isCol()
+                blkOut.setValue(0, idx, ceilEstimate);
+            }
+        }
+    }
+
+    // Create sketch
+    @Override
+    public CorrMatrixBlock create(MatrixBlock blkIn) {
+
+        // We need a matrix containing sketch metadata per block
+        // N x 3 row vector: (nHashes, k, D)
+        // O(N) extra space
+
+        if (op.getDirection().isRowCol()) {
+            // (nHashes, k, D) row matrix
+            MatrixBlock blkOut = new MatrixBlock(blkIn);
+            MatrixBlock blkOutCorr = new MatrixBlock(1, 3, false);
+
+            createSketchByIndex(blkIn, blkOutCorr, 0, blkOut);
+            return new CorrMatrixBlock(blkOut, blkOutCorr);
+
+        } else if (op.getDirection().isRow()) {
+            MatrixBlock blkOut = blkIn;
+            MatrixBlock blkOutCorr = new MatrixBlock(blkIn.getNumRows(), 3, false);
+            // (nHashes, k, D) row matrix
+            for (int i = 0; i < blkIn.getNumRows(); ++i) {
+                createSketchByIndex(blkOut, blkOutCorr, i);
+            }
+            return new CorrMatrixBlock(blkOut, blkOutCorr);
+
+        } else if (op.getDirection().isCol()) {
+            MatrixBlock blkOut = blkIn;
+            // (nHashes, k, D) row matrix
+            MatrixBlock blkOutCorr = new MatrixBlock(blkIn.getNumColumns(), 3, false);
+            for (int j = 0; j < blkIn.getNumColumns(); ++j) {
+                createSketchByIndex(blkOut, blkOutCorr, j);
+            }
+            return new CorrMatrixBlock(blkOut, blkOutCorr);
+
+        } else {
+            throw new DMLRuntimeException(String.format("Unexpected direction: %s", op.getDirection()));
+        }
+    }
+
+    private MatrixBlock sliceMatrixBlockByIndexDirection(MatrixBlock blkIn, int idx) {
+        MatrixBlock blkInSlice;
+        if (op.getDirection().isRow()) {
+            blkInSlice = blkIn.slice(idx, idx);
+        } else if (op.getDirection().isCol()) {
+            blkInSlice = blkIn.slice(0, blkIn.getNumRows() - 1, idx, idx);
+        } else {
+            blkInSlice = blkIn;
+        }
+
+        return blkInSlice;
+    }
+
+    private void createSketchByIndex(MatrixBlock blkIn, MatrixBlock sketchMetaMB, int idx) {
+        createSketchByIndex(blkIn, sketchMetaMB, idx, null);
+    }
+
+    private void createSketchByIndex(MatrixBlock blkIn, MatrixBlock sketchMetaMB, int idx, MatrixBlock blkOut) {
+
+        MatrixBlock sketchMB = (blkOut == null)? blkIn : blkOut;
+
+        MatrixBlock blkInSlice = sliceMatrixBlockByIndexDirection(blkIn, idx);
+        long D = blkInSlice.getNonZeros() + 1;
+
+        long D2 = D * D;
+        int M = (D2 > (long) Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) D2;
+        int k = D > 64 ? 64 : (int) D;
+
+        // blkOut is only passed as parameter in case dir == RowCol
+        // This means that the entire block will produce a single 1xK sketch-
+        // The output matrix block must be resized and filled with 0 accordingly
+        if (blkOut != null) {
+            sketchMB.reset(1, k);
+        }
+
+        if (blkInSlice.getLength() == 1 || blkInSlice.isEmpty()) {
+
+            // There can only be 1 distinct value for a 1x1 or empty matrix
+            // getMatrixValue() will short circuit and return 1 if nHashes = 0
+
+            // (nHashes, k, D) row matrix
+            sketchMetaMB.setValue(idx, 0, 0);
+            sketchMetaMB.setValue(idx, 1, k);
+            sketchMetaMB.setValue(idx, 2, D);
+
+            return;
+        }
+
+        SmallestPriorityQueue spq = getKSmallestHashes(blkInSlice, k, M);
+        int nHashes = spq.size();
+        assert(nHashes > 0);
+
+        // nHashes != k always
+
+        int i = 0;
+        while (!spq.isEmpty()) {
+            double toInsert = spq.poll();
+            if (op.getDirection().isRow()) {
+                sketchMB.setValue(idx, i, toInsert);
+            } else if (op.getDirection().isCol()) {
+                sketchMB.setValue(i, idx, toInsert);
+            } else {
+                sketchMB.setValue(idx, i, toInsert);
+            }
+            ++i;
+        }
+
+        // Last column contains the correction
+        sketchMetaMB.setValue(idx, 0, nHashes);
+        sketchMetaMB.setValue(idx, 1, k);
+        sketchMetaMB.setValue(idx, 2, D);
+    }
+
+    // Union sketch
+    @Override
+    public CorrMatrixBlock union(CorrMatrixBlock arg0, CorrMatrixBlock arg1) {
+
+        // Both matrices are guaranteed to be row-/column-aligned
+        MatrixBlock matrix0 = arg0.getValue();
+        MatrixBlock matrix1 = arg1.getValue();
+
+        if (op.getDirection().isRow()) {
+            // Use the wider of the 2 inputs for stable aggregation.
+            // The number of rows is always guaranteed to match due to col index function execution.
+            // Therefore, checking the number of columns is sufficient.
+            MatrixBlock combined;
+            if (matrix0.getNumColumns() > matrix1.getNumColumns()) {
+                combined = matrix0;
+            } else {
+                combined = matrix1;
+            }
+            // (nHashes, k, D)
+            MatrixBlock combinedCorr = new MatrixBlock(matrix0.getNumRows(), 3, false);
+
+            CorrMatrixBlock blkout = new CorrMatrixBlock(combined, combinedCorr);
+            for (int i = 0; i < matrix0.getNumRows(); ++i) {
+                unionSketchByIndex(arg0, arg1, i, blkout);
+            }
+
+            return blkout;
+
+        } else if (op.getDirection().isCol()) {
+            // Use the taller of the 2 inputs for stable aggregation.
+            // The number of columns is always guaranteed to match due to col index function execution.
+            // Therefore, checking the number of rows is sufficient.
+            MatrixBlock combined;
+            if (matrix0.getNumRows() > matrix1.getNumRows()) {
+                combined = matrix0;
+            } else {
+                combined = matrix1;
+            }
+            // (nHashes, k, D) row vector
+            MatrixBlock combinedCorr = new MatrixBlock(matrix0.getNumColumns(), 3, false);
+
+            CorrMatrixBlock blkOut = new CorrMatrixBlock(combined, combinedCorr);
+            for (int j = 0; j < matrix0.getNumColumns(); ++j) {
+                unionSketchByIndex(arg0, arg1, j, blkOut);
+            }
+
+            return blkOut;
+
+        } else {  // op.getDirection().isRowCol()
+
+            // Use the wider of the 2 inputs for stable aggregation.
+            // The number of rows is always guaranteed to match due to col index function execution.
+            // Therefore, checking the number of columns is sufficient.
+            MatrixBlock combined;
+            if (matrix0.getNumColumns() > matrix1.getNumColumns()) {
+                combined = matrix0;
+            } else {
+                combined = matrix1;
+            }
+            // (nHashes, k, D)
+            MatrixBlock combinedCorr = new MatrixBlock(1, 3, false);
+
+            CorrMatrixBlock blkOut = new CorrMatrixBlock(combined, combinedCorr);
+            unionSketchByIndex(arg0, arg1, 0, blkOut);
+
+            return blkOut;
+        }
+    }
+
+    public void unionSketchByIndex(CorrMatrixBlock arg0, CorrMatrixBlock arg1, int idx, CorrMatrixBlock blkOut) {
+        MatrixBlock corr0 = arg0.getCorrection();
+        MatrixBlock corr1 = arg1.getCorrection();
+
+        validateSketchMetadata(corr0);
+        validateSketchMetadata(corr1);
+
+        // Both matrices are guaranteed to be row-/column-aligned
+        MatrixBlock matrix0 = arg0.getValue();
+        MatrixBlock matrix1 = arg1.getValue();
+
+        if ((op.getDirection().isRow() && matrix0.getNumRows() != matrix1.getNumRows()) ||
+                (op.getDirection().isCol() && matrix0.getNumColumns() != matrix1.getNumColumns())) {
+            throw new DMLRuntimeException("Cannot take the union of sketches: rows/columns are not aligned");
+        }
+
+        MatrixBlock combined = blkOut.getValue();
+        MatrixBlock combinedCorr = blkOut.getCorrection();
+
+        double nHashes0 = corr0.getValue(idx, 0);
+        double k0 = corr0.getValue(idx, 1);
+        double D0 = corr0.getValue(idx, 2);
+
+        double nHashes1 = corr1.getValue(idx, 0);
+        double k1 = corr1.getValue(idx, 1);
+        double D1 = corr1.getValue(idx, 2);
+
+        double nHashes = Math.max(nHashes0, nHashes1);
+        double k = Math.max(k0, k1);
+        double D = D0 + D1 - 1;
+
+        SmallestPriorityQueue hashUnion = new SmallestPriorityQueue((int) nHashes);
+
+        for (int i = 0; i < nHashes0; ++i) {
+            double val;
+            if (op.getDirection().isRow() || op.getDirection().isRowCol()) {
+                val = matrix0.getValue(idx, i);
+            } else {  // op.getDirection().isCol()
+                val = matrix0.getValue(i, idx);
+            }
+            hashUnion.add(val);
+        }
+
+        for (int i = 0; i < nHashes1; ++i) {
+            double val;
+            if (op.getDirection().isRow() || op.getDirection().isRowCol()) {
+                val = matrix1.getValue(idx, i);
+            } else {  // op.getDirection().isCol()
+                val = matrix1.getValue(i, idx);
+            }
+            hashUnion.add(val);
+        }
+
+        int i = 0;
+        while (!hashUnion.isEmpty()) {
+            double val = hashUnion.poll();
+            if (op.getDirection().isRow() || op.getDirection().isRowCol()) {
+                combined.setValue(idx, i, val);
+            } else {  // op.getDirection().isCol()
+                combined.setValue(i, idx, val);
+            }
+            i++;
+        }
+
+        combinedCorr.setValue(idx, 0, nHashes);
+        combinedCorr.setValue(idx, 1, k);
+        combinedCorr.setValue(idx, 2, D);
+    }
+
+    // Intersect sketch
+    @Override
+    public CorrMatrixBlock intersection(CorrMatrixBlock arg0, CorrMatrixBlock arg1) {
+        throw new NotImplementedException(String.format("%s intersection has not been implemented yet",
+                KMVSketch.class.getSimpleName()));
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/SmallestPriorityQueue.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/SmallestPriorityQueue.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data.sketch.countdistinctapprox;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+/**
+ * Deceiving name, but is used to contain the k smallest values inserted.
+ *
+ * TODO: Replace Standard Java Set and Priority Queue with optimized versions.
+ */
+public class SmallestPriorityQueue {
+    private static final Log LOG = LogFactory.getLog(SmallestPriorityQueue.class.getName());
+
+    private Set<Double> containedSet;
+    private PriorityQueue<Double> smallestHashes;
+    private int k;
+
+    public SmallestPriorityQueue(int k) {
+        smallestHashes = new PriorityQueue<>(k, Collections.reverseOrder());
+        containedSet = new HashSet<>(1);
+        this.k = k;
+    }
+
+    public void add(double v) {
+        if(!containedSet.contains(v)) {
+            if(smallestHashes.size() < k) {
+                smallestHashes.add(v);
+                containedSet.add(v);
+            }
+            else if(v < smallestHashes.peek()) {
+                LOG.trace(smallestHashes.peek() + " -- " + v);
+                smallestHashes.add(v);
+                containedSet.add(v);
+                double largest = smallestHashes.poll();
+                containedSet.remove(largest);
+            }
+        }
+    }
+
+    public int size() {
+        return smallestHashes.size();
+    }
+
+    public double peek() {
+        return smallestHashes.peek();
+    }
+
+    public double poll() {
+        return smallestHashes.poll();
+    }
+
+    public boolean isEmpty() {
+        return this.size() == 0;
+    }
+
+    @Override
+    public String toString() {
+        return smallestHashes.toString();
+    }
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.java
@@ -71,23 +71,25 @@ public class CountDistinctOperator extends Operator {
 		return operatorType;
 	}
 
+	public HashType getHashType() {
+		return hashType;
+	}
+
 	public IndexFunction getIndexFunction() {
 		return indexFunction;
 	}
 
-	public HashType getHashType() {
-		return hashType;
+	public CountDistinctOperator setIndexFunction(IndexFunction indexFunction) {
+		this.indexFunction = indexFunction;
+		return this;
 	}
 
 	public Types.Direction getDirection() {
 		return direction;
 	}
 
-	public void setDirection(Types.Direction direction) {
+	public CountDistinctOperator setDirection(Types.Direction direction) {
 		this.direction = direction;
-	}
-
-	public void setIndexFunction(IndexFunction indexFunction) {
-		this.indexFunction = indexFunction;
+		return this;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperator.java
@@ -19,30 +19,28 @@
 
 package org.apache.sysds.runtime.matrix.operators;
 
+import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.functionobjects.IndexFunction;
 import org.apache.sysds.runtime.instructions.cp.AggregateUnaryCPInstruction.AUType;
 import org.apache.sysds.utils.Hash.HashType;
 
 public class CountDistinctOperator extends Operator {
 	private static final long serialVersionUID = 7615123453265129670L;
 
-	public final CountDistinctTypes operatorType;
-	public final HashType hashType;
-
-	public enum CountDistinctTypes { // The different supported types of counting.
-		COUNT, // Baseline naive implementation, iterate though, add to hashMap.
-		KMV, // K-Minimum Values algorithm.
-		HLL // HyperLogLog algorithm.
-	}
+	private final CountDistinctOperatorTypes operatorType;
+	private final HashType hashType;
+	private Types.Direction direction;
+	private IndexFunction indexFunction;
 
 	public CountDistinctOperator(AUType opType) {
 		super(true);
 		switch (opType) {
 			case COUNT_DISTINCT:
-				this.operatorType = CountDistinctTypes.COUNT;
+				this.operatorType = CountDistinctOperatorTypes.COUNT;
 				break;
 			case COUNT_DISTINCT_APPROX:
-				this.operatorType = CountDistinctTypes.KMV;
+				this.operatorType = CountDistinctOperatorTypes.KMV;
 				break;
 			default:
 				throw new DMLRuntimeException(opType + " not supported for CountDistinct Operator");
@@ -50,15 +48,46 @@ public class CountDistinctOperator extends Operator {
 		this.hashType = HashType.LinearHash;
 	}
 
-	public CountDistinctOperator(CountDistinctTypes operatorType) {
+	public CountDistinctOperator(CountDistinctOperatorTypes operatorType) {
 		super(true);
 		this.operatorType = operatorType;
 		this.hashType = HashType.StandardJava;
 	}
 
-	public CountDistinctOperator(CountDistinctTypes operatorType, HashType hashType) {
+	public CountDistinctOperator(CountDistinctOperatorTypes operatorType, HashType hashType) {
 		super(true);
 		this.operatorType = operatorType;
 		this.hashType = hashType;
+	}
+
+	public CountDistinctOperator(CountDistinctOperatorTypes operatorType, IndexFunction indexFunction, HashType hashType) {
+		super(true);
+		this.operatorType = operatorType;
+		this.indexFunction = indexFunction;
+		this.hashType = hashType;
+	}
+
+	public CountDistinctOperatorTypes getOperatorType() {
+		return operatorType;
+	}
+
+	public IndexFunction getIndexFunction() {
+		return indexFunction;
+	}
+
+	public HashType getHashType() {
+		return hashType;
+	}
+
+	public Types.Direction getDirection() {
+		return direction;
+	}
+
+	public void setDirection(Types.Direction direction) {
+		this.direction = direction;
+	}
+
+	public void setIndexFunction(IndexFunction indexFunction) {
+		this.indexFunction = indexFunction;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperatorTypes.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperatorTypes.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysds.runtime.matrix.operators;
 
 public enum CountDistinctOperatorTypes { // The different supported types of counting.

--- a/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperatorTypes.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/operators/CountDistinctOperatorTypes.java
@@ -1,0 +1,7 @@
+package org.apache.sysds.runtime.matrix.operators;
+
+public enum CountDistinctOperatorTypes { // The different supported types of counting.
+    COUNT, // Baseline naive implementation, iterate through, add to hashMap.
+    KMV, // K-Minimum Values algorithm.
+    HLL // HyperLogLog algorithm.
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedMatrixTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedMatrixTest.java
@@ -19,17 +19,6 @@
 
 package org.apache.sysds.test.component.compress;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.util.Collection;
-import java.util.Random;
-
 import org.apache.sysds.common.Types.CorrectionLocationType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
@@ -52,7 +41,7 @@ import org.apache.sysds.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
-import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator.CountDistinctTypes;
+import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
 import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.TernaryOperator;
@@ -70,6 +59,17 @@ import org.openjdk.jol.datamodel.X86_64_DataModel;
 import org.openjdk.jol.info.ClassLayout;
 import org.openjdk.jol.layouters.HotSpotLayouter;
 import org.openjdk.jol.layouters.Layouter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Collection;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(value = Parameterized.class)
 public class CompressedMatrixTest extends AbstractCompressedUnaryTests {
@@ -142,7 +142,7 @@ public class CompressedMatrixTest extends AbstractCompressedUnaryTests {
 			if(!(cmb instanceof CompressedMatrixBlock) || (overlappingType == OverLapping.MATRIX_MULT_NEGATIVE))
 				return; // Input was not compressed then just pass test
 
-			CountDistinctOperator op = new CountDistinctOperator(CountDistinctTypes.COUNT);
+			CountDistinctOperator op = new CountDistinctOperator(CountDistinctOperatorTypes.COUNT);
 			int ret1 = LibMatrixCountDistinct.estimateDistinctValues(mb, op);
 			int ret2 = LibMatrixCountDistinct.estimateDistinctValues(cmb, op);
 

--- a/src/test/java/org/apache/sysds/test/component/matrix/CountDistinctTest.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/CountDistinctTest.java
@@ -19,11 +19,9 @@
 
 package org.apache.sysds.test.component.matrix;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.api.DMLException;
+import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.matrix.data.LibMatrixCountDistinct;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.CountDistinctOperator;
@@ -38,6 +36,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
 public class CountDistinctTest {
@@ -146,7 +147,8 @@ public class CountDistinctTest {
 		}
 
 		Integer out = 0;
-		CountDistinctOperator op = new CountDistinctOperator(et, ht);
+		CountDistinctOperator op = new CountDistinctOperator(et, ht)
+				.setDirection(Types.Direction.RowCol);
 		try {
 			out = LibMatrixCountDistinct.estimateDistinctValues(in, op);
 		}

--- a/src/test/java/org/apache/sysds/test/functions/aggregate/FullAggregateTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/aggregate/FullAggregateTest.java
@@ -19,12 +19,6 @@
 
 package org.apache.sysds.test.functions.aggregate;
 
-import java.util.HashMap;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
@@ -33,6 +27,12 @@ import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.apache.sysds.utils.Statistics;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
 
 /**
  * 
@@ -244,7 +244,7 @@ public class FullAggregateTest extends AutomatedTestBase
 	{
 		runColAggregateOperationTest(OpType.SUM, false, false, ExecType.SPARK);
 	}
-	
+
 	@Test
 	public void testMeanDenseMatrixSP() 
 	{
@@ -262,13 +262,13 @@ public class FullAggregateTest extends AutomatedTestBase
 	{
 		runColAggregateOperationTest(OpType.MIN, false, false, ExecType.SPARK);
 	}
-	
+
 	@Test
 	public void testProdDenseMatrixSP() 
 	{
 		runColAggregateOperationTest(OpType.PROD, false, false, ExecType.SPARK);
 	}
-	
+
 	@Test
 	public void testTraceDenseMatrixSP() 
 	{

--- a/src/test/java/org/apache/sysds/test/functions/aggregate/FullRowAggregateTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/aggregate/FullRowAggregateTest.java
@@ -19,19 +19,19 @@
 
 package org.apache.sysds.test.functions.aggregate;
 
-import java.util.HashMap;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
-import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.common.Types.ExecType;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
 
 /**
  * NOTES:
@@ -555,7 +555,7 @@ public class FullRowAggregateTest extends AutomatedTestBase
 	{
 		runRowAggregateOperationTest(OpType.ROW_INDEXMAX, true, false, ExecType.SPARK, false, false);
 	}
-	
+
 	@Test
 	public void testRowIndexMinSparseMatrixNoRewritesSP() 
 	{

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxCol.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxCol.java
@@ -23,7 +23,7 @@ import org.apache.sysds.common.Types;
 
 public class CountDistinctApproxCol extends CountDistinctRowOrColBase {
 
-    private final static String TEST_NAME = "CountDistinctApproxCol";
+    private final static String TEST_NAME = "countDistinctApproxCol";
     private final static String TEST_DIR = "functions/countDistinct/";
     private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApproxCol.class.getSimpleName() + "/";
 

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxCol.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxCol.java
@@ -19,31 +19,36 @@
 
 package org.apache.sysds.test.functions.countDistinct;
 
-import org.apache.sysds.common.Types.ExecType;
-import org.junit.Test;
+import org.apache.sysds.common.Types;
 
-public class CountDistinct extends CountDistinctBase {
+public class CountDistinctApproxCol extends CountDistinctRowOrColBase {
 
-	public String TEST_NAME = "countDistinct";
-	public String TEST_DIR = "functions/countDistinct/";
-	public String TEST_CLASS_DIR = TEST_DIR + CountDistinct.class.getSimpleName() + "/";
+    private final static String TEST_NAME = "CountDistinctApproxCol";
+    private final static String TEST_DIR = "functions/countDistinct/";
+    private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApproxCol.class.getSimpleName() + "/";
 
-	protected String getTestClassDir() {
-		return TEST_CLASS_DIR;
-	}
+    @Override
+    protected String getTestClassDir() {
+        return TEST_CLASS_DIR;
+    }
 
-	protected String getTestName() {
-		return TEST_NAME;
-	}
+    @Override
+    protected String getTestName() {
+        return TEST_NAME;
+    }
 
-	protected String getTestDir() {
-		return TEST_DIR;
-	}
+    @Override
+    protected String getTestDir() {
+        return TEST_DIR;
+    }
 
-	@Test
-	public void testSimple1by1() {
-		// test simple 1 by 1.
-		ExecType ex = ExecType.CP;
-		countDistinctTest(1, 1, 1, 1.0, ex, 0.00001);
-	}
+    @Override
+    protected Types.Direction getDirection() {
+        return Types.Direction.Col;
+    }
+
+    @Override
+    public void setUp() {
+        super.addTestConfiguration();
+    }
 }

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRow.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRow.java
@@ -23,7 +23,7 @@ import org.apache.sysds.common.Types;
 
 public class CountDistinctApproxRow extends CountDistinctRowOrColBase {
 
-    private final static String TEST_NAME = "CountDistinctApproxRow";
+    private final static String TEST_NAME = "countDistinctApproxRow";
     private final static String TEST_DIR = "functions/countDistinct/";
     private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApproxRow.class.getSimpleName() + "/";
 

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRow.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRow.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.countDistinct;
+
+import org.apache.sysds.common.Types;
+
+public class CountDistinctApproxRow extends CountDistinctRowOrColBase {
+
+    private final static String TEST_NAME = "CountDistinctApproxRow";
+    private final static String TEST_DIR = "functions/countDistinct/";
+    private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApproxRow.class.getSimpleName() + "/";
+
+    @Override
+    protected String getTestClassDir() {
+        return TEST_CLASS_DIR;
+    }
+
+    @Override
+    protected String getTestName() {
+        return TEST_NAME;
+    }
+
+    @Override
+    protected String getTestDir() {
+        return TEST_DIR;
+    }
+
+    @Override
+    protected Types.Direction getDirection() {
+        return Types.Direction.Row;
+    }
+
+    @Override
+    public void setUp() {
+        super.addTestConfiguration();
+    }
+}

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRowCol.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctApproxRowCol.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.countDistinct;
+
+import org.apache.sysds.common.Types.ExecType;
+import org.junit.Test;
+
+public class CountDistinctApproxRowCol extends CountDistinctRowColBase {
+
+	private final static String TEST_NAME = "countDistinctApproxRowCol";
+	private final static String TEST_DIR = "functions/countDistinct/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApproxRowCol.class.getSimpleName() + "/";
+
+	@Override
+	public void setUp() {
+		super.addTestConfiguration();
+		super.percentTolerance = 0.2;
+	}
+
+	@Test
+	public void testCPSparseLarge() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 9000 * percentTolerance;
+		countDistinctScalarTest(9000, 10000, 5000, 0.1, ex, tolerance);
+	}
+
+	@Test
+	public void testSparkSparseLarge() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 9000 * percentTolerance;
+		countDistinctScalarTest(9000, 10000, 5000, 0.1, ex, tolerance);
+	}
+
+	@Test
+	public void testCPSparseSmall() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 9000 * percentTolerance;
+		countDistinctScalarTest(9000, 999, 999, 0.1, ex, tolerance);
+	}
+
+	@Test
+	public void testSparkSparseSmall() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 9000 * percentTolerance;
+		countDistinctScalarTest(9000, 999, 999, 0.1, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDenseXSmall() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 5 * percentTolerance;
+		countDistinctScalarTest(5, 5, 10, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testSparkDenseXSmall() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 5 * percentTolerance;
+		countDistinctScalarTest(5, 10, 5, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPEmpty() {
+		ExecType ex = ExecType.CP;
+		countDistinctScalarTest(1, 0, 0, 0.1, ex, 0);
+	}
+
+	@Test
+	public void testSparkEmpty() {
+		ExecType ex = ExecType.SPARK;
+		countDistinctScalarTest(1, 0, 0, 0.1, ex, 0);
+	}
+
+	@Test
+	public void testCPSingleValue() {
+		ExecType ex = ExecType.CP;
+		countDistinctScalarTest(1, 1, 1, 1.0, ex, 0);
+	}
+
+	@Test
+	public void testSparkSingleValue() {
+		ExecType ex = ExecType.SPARK;
+		countDistinctScalarTest(1, 1, 1, 1.0, ex, 0);
+	}
+
+	// Corresponding execType=SPARK tests for CP tests in base class
+	//
+	@Test
+	public void testSparkDense1Unique() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 0.00001;
+		countDistinctScalarTest(1, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testSparkDense2Unique() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 0.00001;
+		countDistinctScalarTest(2, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testSparkDense120Unique() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = 0.00001 + 120 * percentTolerance;
+		countDistinctScalarTest(120, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Override
+	protected String getTestClassDir() {
+		return TEST_CLASS_DIR;
+	}
+
+	@Override
+	protected String getTestName() {
+		return TEST_NAME;
+	}
+
+	@Override
+	protected String getTestDir() {
+		return TEST_DIR;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowCol.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowCol.java
@@ -22,42 +22,34 @@ package org.apache.sysds.test.functions.countDistinct;
 import org.apache.sysds.common.Types.ExecType;
 import org.junit.Test;
 
-public class CountDistinctApprox extends CountDistinctBase {
+public class CountDistinctRowCol extends CountDistinctRowColBase {
 
-	private final static String TEST_NAME = "countDistinctApprox";
-	private final static String TEST_DIR = "functions/countDistinct/";
-	private final static String TEST_CLASS_DIR = TEST_DIR + CountDistinctApprox.class.getSimpleName() + "/";
+	public String TEST_NAME = "countDistinct";
+	public String TEST_DIR = "functions/countDistinct/";
+	public String TEST_CLASS_DIR = TEST_DIR + CountDistinctRowCol.class.getSimpleName() + "/";
 
-	public CountDistinctApprox() {
-		percentTolerance = 0.1;
-	}
-
-	@Test
-	public void testXXLarge() {
-		ExecType ex = ExecType.CP;
-		double tolerance = 9000 * percentTolerance;
-		countDistinctTest(9000, 10000, 5000, 0.1, ex, tolerance);
-	}
-
-	@Test
-	public void testSparse500Unique(){
-		ExecType ex = ExecType.CP;
-		double tolerance = 0.00001 + 120 * percentTolerance;
-		countDistinctTest(500, 100, 100000, 0.1, ex, tolerance);
-	}
-
-	@Override
 	protected String getTestClassDir() {
 		return TEST_CLASS_DIR;
 	}
 
-	@Override
 	protected String getTestName() {
 		return TEST_NAME;
 	}
 
-	@Override
 	protected String getTestDir() {
 		return TEST_DIR;
+	}
+
+	@Override
+	public void setUp() {
+		super.addTestConfiguration();
+		super.percentTolerance = 0.0;
+	}
+
+	@Test
+	public void testSimple1by1() {
+		// test simple 1 by 1.
+		ExecType ex = ExecType.CP;
+		countDistinctScalarTest(1, 1, 1, 1.0, ex, 0.00001);
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowColBase.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowColBase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.countDistinct;
+
+import org.apache.sysds.common.Types.ExecType;
+import org.junit.Test;
+
+public abstract class CountDistinctRowColBase extends CountDistinctBase {
+	@Test
+	public void testCPDenseSmall() {
+		ExecType ex = ExecType.CP;
+		double tolerance = baseTolerance + 50 * percentTolerance;
+		countDistinctScalarTest(50, 50, 50, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDenseLarge() {
+		ExecType ex = ExecType.CP;
+		double tolerance = baseTolerance + 800 * percentTolerance;
+		countDistinctScalarTest(800, 1000, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDenseXLarge() {
+		ExecType ex = ExecType.CP;
+		double tolerance = baseTolerance + 1723 * percentTolerance;
+		countDistinctScalarTest(1723, 5000, 2000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDense1Unique() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 0.00001;
+		countDistinctScalarTest(1, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDense2Unique() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 0.00001;
+		countDistinctScalarTest(2, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPDense120Unique() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 0.00001 + 120 * percentTolerance;
+		countDistinctScalarTest(120, 100, 1000, 1.0, ex, tolerance);
+	}
+
+	@Test
+	public void testCPSparse500Unique() {
+		ExecType ex = ExecType.CP;
+		double tolerance = 0.00001 + 500 * percentTolerance;
+		countDistinctScalarTest(500, 100, 640000, 0.1, ex, tolerance);
+	}
+
+	@Test
+	public void testCPSparse120Unique(){
+		ExecType ex = ExecType.CP;
+		double tolerance = 0.00001 + 120 * percentTolerance;
+		countDistinctScalarTest(120, 100, 64000, 0.1, ex, tolerance);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowOrColBase.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowOrColBase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.countDistinct;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+public abstract class CountDistinctRowOrColBase extends CountDistinctBase {
+
+    @Override
+    protected abstract String getTestClassDir();
+
+    @Override
+    protected abstract String getTestName();
+
+    @Override
+    protected abstract String getTestDir();
+
+    protected abstract Types.Direction getDirection();
+
+    protected void addTestConfiguration() {
+        TestUtils.clearAssertionInformation();
+        addTestConfiguration(getTestName(),
+                new TestConfiguration(getTestClassDir(), getTestName(), new String[] {"A"}));
+
+        this.percentTolerance = 0.2;
+    }
+
+    @Test
+    public void testCPSparseLarge() {
+        Types.ExecType ex = Types.ExecType.CP;
+
+        int actualDistinctCount = 10;
+        int rows = 10000, cols = 1000;
+        double sparsity = 0.1;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, ex, tolerance);
+    }
+
+    @Test
+    public void testCPDenseLarge() {
+        Types.ExecType ex = Types.ExecType.CP;
+
+        int actualDistinctCount = 100;
+        int rows = 10000, cols = 1000;
+        double sparsity = 0.9;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, ex, tolerance);
+    }
+
+    @Test
+    public void testCPSparseSmall() {
+        Types.ExecType execType = Types.ExecType.CP;
+
+        int actualDistinctCount = 10;
+        int rows = 1000, cols = 1000;
+        double sparsity = 0.1;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+
+    @Test
+    public void testCPDenseSmall() {
+        Types.ExecType execType = Types.ExecType.CP;
+
+        int actualDistinctCount = 10;
+        int rows = 1000, cols = 1000;
+        double sparsity = 0.9;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+
+
+    @Test
+    public void testSparkSparseLargeMultiBlockAggregation() {
+        Types.ExecType execType = Types.ExecType.SPARK;
+
+        int actualDistinctCount = 10;
+        int rows = 10000, cols = 1001;
+        double sparsity = 0.1;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+
+    @Test
+    public void testSparkDenseLargeMultiBlockAggregation() {
+        Types.ExecType execType = Types.ExecType.SPARK;
+
+        int actualDistinctCount = 10;
+        int rows = 10000, cols = 1001;
+        double sparsity = 0.9;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+
+
+    @Test
+    public void testSparkSparseLargeNoneAggregation() {
+        Types.ExecType execType = Types.ExecType.SPARK;
+
+        int actualDistinctCount = 10;
+        int rows = 10000, cols = 1000;
+        double sparsity = 0.1;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+
+    @Test
+    public void testSparkDenseLargeNoneAggregation() {
+        Types.ExecType execType = Types.ExecType.SPARK;
+
+        int actualDistinctCount = 10;
+        int rows = 10000, cols = 1000;
+        double sparsity = 0.9;
+        double tolerance = actualDistinctCount * this.percentTolerance;
+
+        countDistinctMatrixTest(getDirection(), actualDistinctCount, cols, rows, sparsity, execType, tolerance);
+    }
+}

--- a/src/test/scripts/functions/countDistinct/countDistinctApproxCol.dml
+++ b/src/test/scripts/functions/countDistinct/countDistinctApproxCol.dml
@@ -19,6 +19,6 @@
 #
 #-------------------------------------------------------------
 
-input = round(rand(rows = $2, cols = $3, min = 0, max = $1 -1, sparsity= $4,  seed = 7))
-res = countDistinct(input)
+input = round(rand(rows = $2, cols = $3, min = 0, max = $1 -1, sparsity= $4, seed = 7))
+res = countDistinctApprox(input, dir="c", type="KMV")
 write(res, $5, format="text")

--- a/src/test/scripts/functions/countDistinct/countDistinctApproxRow.dml
+++ b/src/test/scripts/functions/countDistinct/countDistinctApproxRow.dml
@@ -19,6 +19,6 @@
 #
 #-------------------------------------------------------------
 
-input = round(rand(rows = $2, cols = $3, min = 0, max = $1 -1, sparsity= $4,  seed = 7))
-res = countDistinct(input)
+input = round(rand(rows = $2, cols = $3, min = 0, max = $1 -1, sparsity= $4, seed = 7))
+res = countDistinctApprox(input, dir="r", type="KMV")
 write(res, $5, format="text")

--- a/src/test/scripts/functions/countDistinct/countDistinctApproxRowCol.dml
+++ b/src/test/scripts/functions/countDistinct/countDistinctApproxRowCol.dml
@@ -20,5 +20,5 @@
 #-------------------------------------------------------------
 
 input = round(rand(rows = $2, cols = $3, min = 0, max = $1 -1, sparsity= $4, seed = 7))
-res = countDistinctApprox(input)
+res = countDistinctApprox(input, dir="rc", type="KMV")
 write(res, $5, format="text")


### PR DESCRIPTION
Added `countDistinctApprox()` to Spark runtime by extending existing KMV implementation for CP. Also added `dir` parameter for `countDistinctApprox()` for both CP and Spark runtimes.

[Here is a design note for the implementation](https://docs.google.com/document/d/1jKnVjHXWjo6u2Ij1lPhgQAiyMj9QPcioeCMI3UwqnNw/edit?usp=sharing)

Fixes [this JIRA issue](https://issues.apache.org/jira/browse/SYSTEMDS-2996?jql=project%20%3D%20SYSTEMDS%20AND%20text%20~%20%22count%20distinct%22).

Coming up next in this PR
1. The `type="KMV"` parameter is currently being ignored. It is being validated, but ignored. 
2. Use builder pattern for sketch initialization.
3. I tested `countDistinctApprox()` parameters manually. It would be nice to have a parameterized builtin test for it.
4. Minor refactoring
5. [DONE] Fix count distinct tests in matrix component: `org.apache.sysds.test.component.matrix.CountDistinctTest.testEstimation`
6. [DONE] Fix CI test failure:
```
Exception : class java.io.FileNotFoundException
Message   : ./src/test/scripts/functions/countDistinct/CountDistinctApproxCol.dml (No 
```
7. Add javadocs to classes to eliminate warnings