### PR TITLE
[SYSTEMDS-2837] Operator Linearization Algorithms

### DIFF
--- a/.github/workflows/functionsTests.yml
+++ b/.github/workflows/functionsTests.yml
@@ -65,7 +65,7 @@ jobs:
           "**.functions.parfor.**,**.functions.pipelines.**,**.functions.privacy.**",
           "**.functions.unary.scalar.**,**.functions.updateinplace.**,**.functions.vect.**",
           "**.functions.reorg.**,**.functions.rewrite.**,**.functions.ternary.**,**.functions.transform.**",
-          "**.functions.unary.matrix.**"
+          "**.functions.unary.matrix.**,**.functions.linearization.**"
           ]
         os: [ubuntu-latest]
     name: ${{ matrix.tests }}

--- a/conf/SystemDS-config.xml.template
+++ b/conf/SystemDS-config.xml.template
@@ -38,7 +38,7 @@
     
     <!-- enables compressed linear algebra, experimental feature -->
     <sysds.compressed.linalg>false</sysds.compressed.linalg>
-    
+
     <!-- enables operator fusion via code generation, experimental feature -->
     <sysds.codegen.enabled>false</sysds.codegen.enabled>
 

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -43,6 +43,7 @@ import org.apache.sysds.hops.codegen.SpoofCompiler.CompilerType;
 import org.apache.sysds.hops.codegen.SpoofCompiler.GeneratorAPI;
 import org.apache.sysds.hops.codegen.SpoofCompiler.PlanSelector;
 import org.apache.sysds.lops.Compression;
+import org.apache.sysds.lops.compile.linearization.ILinearize.DagLinearization;
 import org.apache.sysds.parser.ParseException;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
@@ -82,6 +83,7 @@ public class DMLConfig
 	public static final String COMPRESSED_TRANSPOSE = "sysds.compressed.transpose";
 	public static final String NATIVE_BLAS          = "sysds.native.blas";
 	public static final String NATIVE_BLAS_DIR      = "sysds.native.blas.directory";
+	public static final String DAG_LINEARIZATION    = "sysds.compile.linearization";
 	public static final String CODEGEN              = "sysds.codegen.enabled"; //boolean
 	public static final String CODEGEN_API          = "sysds.codegen.api"; // see SpoofCompiler.API
 	public static final String CODEGEN_COMPILER     = "sysds.codegen.compiler"; //see SpoofCompiler.CompilerType
@@ -145,6 +147,7 @@ public class DMLConfig
 		_defaultVals.put(COMPRESSED_COCODE,      "AUTO");
 		_defaultVals.put(COMPRESSED_COST_MODEL,  "AUTO");
 		_defaultVals.put(COMPRESSED_TRANSPOSE,   "auto");
+		_defaultVals.put(DAG_LINEARIZATION,      DagLinearization.DEPTH_FIRST.name());
 		_defaultVals.put(CODEGEN,                "false" );
 		_defaultVals.put(CODEGEN_API,            GeneratorAPI.JAVA.name() );
 		_defaultVals.put(CODEGEN_COMPILER,       CompilerType.AUTO.name() );
@@ -414,7 +417,7 @@ public class DMLConfig
 			LOCAL_TMP_DIR,SCRATCH_SPACE,OPTIMIZATION_LEVEL, DEFAULT_BLOCK_SIZE,
 			CP_PARALLEL_OPS, CP_PARALLEL_IO, PARALLEL_ENCODE, NATIVE_BLAS, NATIVE_BLAS_DIR,
 			COMPRESSED_LINALG, COMPRESSED_LOSSY, COMPRESSED_VALID_COMPRESSIONS, COMPRESSED_OVERLAPPING,
-			COMPRESSED_SAMPLING_RATIO, COMPRESSED_COCODE, COMPRESSED_TRANSPOSE,
+			COMPRESSED_SAMPLING_RATIO, COMPRESSED_COCODE, COMPRESSED_TRANSPOSE, DAG_LINEARIZATION,
 			CODEGEN, CODEGEN_API, CODEGEN_COMPILER, CODEGEN_OPTIMIZER, CODEGEN_PLANCACHE, CODEGEN_LITERALS,
 			STATS_MAX_WRAP_LEN, LINEAGECACHESPILL, COMPILERASSISTED_RW, PRINT_GPU_MEMORY_INFO,
 			AVAILABLE_GPUS, SYNCHRONIZE_GPU, EAGER_CUDA_FREE, FLOATING_POINT_PRECISION, GPU_EVICTION_POLICY, 

--- a/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
+++ b/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.compile.linearization;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.lops.Lop;
+
+/**
+ * A interface for the linearization algorithms that order the DAG nodes into a sequence of instructions to execute.
+ * 
+ * https://en.wikipedia.org/wiki/Linearizability#Linearization_points
+ */
+public interface ILinearize {
+	public static Log LOG = LogFactory.getLog(ILinearize.class.getName());
+
+	public enum DagLinearization {
+		DEPTH_FIRST, BREADTH_FIRST, MIN_INTERMEDIATE
+	}
+
+	public static List<Lop> linearize(List<Lop> v) {
+		try {
+			DMLConfig dmlConfig = ConfigurationManager.getDMLConfig();
+			DagLinearization linearization = DagLinearization
+				.valueOf(dmlConfig.getTextValue(DMLConfig.DAG_LINEARIZATION).toUpperCase());
+
+			switch(linearization) {
+				case MIN_INTERMEDIATE:
+					return doMinIntermediateSort(v);
+				case BREADTH_FIRST:
+					return doBreadthFirstSort(v);
+				case DEPTH_FIRST:
+				default:
+					return depthFirst(v);
+			}
+		}
+		catch(Exception e) {
+			LOG.warn("Invalid or failed DAG_LINEARIZATION, fallback to DEPTH_FIRST ordering");
+			return depthFirst(v);
+		}
+	}
+
+	/**
+	 * Sort lops depth-first
+	 * 
+	 * previously called doTopologicalSortTwoLevelOrder
+	 * 
+	 * @param v List of lops to sort
+	 * @return Sorted list of lops
+	 */
+	private static List<Lop> depthFirst(List<Lop> v) {
+		// partition nodes into leaf/inner nodes and dag root nodes,
+		// + sort leaf/inner nodes by ID to force depth-first scheduling
+		// + append root nodes in order of their original definition
+		// (which also preserves the original order of prints)
+		List<Lop> nodes = Stream
+			.concat(v.stream().filter(l -> !l.getOutputs().isEmpty()).sorted(Comparator.comparing(l -> l.getID())),
+				v.stream().filter(l -> l.getOutputs().isEmpty()))
+			.collect(Collectors.toList());
+
+		// NOTE: in contrast to hadoop execution modes, we avoid computing the transitive
+		// closure here to ensure linear time complexity because its unnecessary for CP and Spark
+		return nodes;
+	}
+
+	private static List<Lop> doBreadthFirstSort(List<Lop> v) {
+		List<Lop> nodes = v.stream().sorted(Comparator.comparing(Lop::getLevel)).collect(Collectors.toList());
+
+		return nodes;
+	}
+
+	/**
+	 * Sort lops to execute them in an order that minimizes the memory requirements of intermediates
+	 * 
+	 * @param v List of lops to sort
+	 * @return Sorted list of lops
+	 */
+	private static List<Lop> doMinIntermediateSort(List<Lop> v) {
+		List<Lop> nodes = new ArrayList<>(v.size());
+		// Get the lowest level in the tree to move upwards from
+		List<Lop> lowestLevel = v.stream().filter(l -> l.getOutputs().isEmpty()).collect(Collectors.toList());
+
+		// Traverse the tree bottom up, choose nodes with higher memory requirements, then reverse the list
+		List<Lop> remaining = new LinkedList<>(v);
+		sortRecursive(nodes, lowestLevel, remaining);
+
+		// In some cases (function calls) some output lops are not in the list of nodes to be sorted.
+		// With the next layer up having output lops, they are not added to the initial list of lops and are
+		// subsequently never reached by the recursive sort.
+		// We work around this issue by checking for remaining lops after the initial sort.
+		while(!remaining.isEmpty()) {
+			// Start with the lowest level lops, this time by level instead of no outputs
+			int maxLevel = remaining.stream().mapToInt(Lop::getLevel).max().orElse(-1);
+			List<Lop> lowestNodes = remaining.stream().filter(l -> l.getLevel() == maxLevel).collect(Collectors.toList());
+			sortRecursive(nodes, lowestNodes, remaining);
+		}
+
+		// All lops were added bottom up, from highest to lowest memory consumption, now reverse this
+		Collections.reverse(nodes);
+
+		return nodes;
+	}
+
+	private static void sortRecursive(List<Lop> result, List<Lop> input, List<Lop> remaining) {
+		// Sort input lops by memory estimate
+		// Lowest level nodes (those with no outputs) receive a memory estimate of 0 to preserve order
+		// This affects prints, writes, ...
+		List<Map.Entry<Lop, Long>> memEst = input.stream().distinct().map(l -> new AbstractMap.SimpleEntry<>(l,
+			l.getOutputs().isEmpty() ? 0 : OptimizerUtils.estimateSizeExactSparsity(l.getOutputParameters().getNumRows(),
+				l.getOutputParameters().getNumCols(), l.getOutputParameters().getNnz())))
+			.sorted(Comparator.comparing(e -> ((Map.Entry<Lop, Long>) e).getValue())).collect(Collectors.toList());
+
+		// Start with the highest memory estimate because the entire list is reversed later
+		Collections.reverse(memEst);
+		for(Map.Entry<Lop, Long> e : memEst) {
+			// Skip if the node is already in the result list
+			// Skip if one of the lop's outputs is not in the result list yet (will be added once the output lop is
+			// traversed), but only if any of the output lops is bound to be added to the result at a later stage
+			if(result.contains(e.getKey()) || (!result.containsAll(e.getKey().getOutputs()) &&
+				remaining.stream().anyMatch(l -> e.getKey().getOutputs().contains(l))))
+				continue;
+			result.add(e.getKey());
+			remaining.remove(e.getKey());
+			// Add input lops recursively
+			sortRecursive(result, e.getKey().getInputs(), remaining);
+		}
+	}
+
+}

--- a/src/test/java/org/apache/sysds/test/functions/linearization/DagLinearizationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/linearization/DagLinearizationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.test.functions.linearization;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+public class DagLinearizationTest extends AutomatedTestBase {
+
+	private static final Log LOG = LogFactory.getLog(DagLinearizationTest.class.getName());
+
+	private final String testNames[] = {"matrixmult_dag_linearization", "csplineCG_dag_linearization",
+		"linear_regression_dag_linearization"};
+
+	private final String testConfigs[] = {"breadth-first", "depth-first", "incorrect", "min-intermediate"};
+
+	private final String testDir = "functions/linearization/";
+
+	@Override
+	public void setUp() {
+		setOutputBuffering(true);
+		disableConfigFile = true;
+		TestUtils.clearAssertionInformation();
+		for(String testname : testNames) {
+			addTestConfiguration(testname, new TestConfiguration(testDir, testname));
+		}
+	}
+
+	private String getPath(String filename) {
+		return SCRIPT_DIR + "/" + testDir + filename;
+	}
+
+	@Test
+	public void testMatrixMultSameOutput() {
+		try {
+			fullDMLScriptName = getPath("MatrixMult.dml");
+			loadTestConfiguration(getTestConfiguration(testNames[0]));
+
+			// Default arguments
+			programArgs = new String[] {"-config", "", "-args", output("totalResult")};
+
+			run(0, "totalResult");
+		}
+		catch(Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testCSplineCGSameOutput() {
+		try {
+			int rows = 10;
+			int cols = 1;
+			int numIter = rows;
+
+			loadTestConfiguration(getTestConfiguration(testNames[1]));
+
+			List<String> proArgs = new ArrayList<>();
+			proArgs.add("-config");
+			proArgs.add("");
+			proArgs.add("-nvargs");
+			proArgs.add("X=" + input("X"));
+			proArgs.add("Y=" + input("Y"));
+			proArgs.add("K=" + output("K"));
+			proArgs.add("O=" + output("pred_y"));
+			proArgs.add("maxi=" + numIter);
+			proArgs.add("inp_x=" + 4.5);
+
+			fullDMLScriptName = SCRIPT_DIR + "applications/cspline/CsplineCG.dml";
+
+			double[][] X = new double[rows][cols];
+
+			// X axis is given in the increasing order
+			for(int rid = 0; rid < rows; rid++)
+				for(int cid = 0; cid < cols; cid++)
+					X[rid][cid] = rid + 1;
+
+			double[][] Y = getRandomMatrix(rows, cols, 0, 5, 1.0, -1);
+
+			writeInputMatrixWithMTD("X", X, true);
+			writeInputMatrixWithMTD("Y", Y, true);
+
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			run(Math.pow(10, -5), "pred_y");
+
+		}
+		catch(Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testLinearRegressionSameOutput() {
+		try {
+			int rows = 100;
+			int cols = 50;
+
+			loadTestConfiguration(getTestConfiguration(testNames[2]));
+
+			List<String> proArgs = new ArrayList<>();
+			proArgs.add("-config");
+			proArgs.add("");
+			proArgs.add("-args");
+			proArgs.add(input("v"));
+			proArgs.add(input("y"));
+			proArgs.add(Double.toString(Math.pow(10, -8)));
+			proArgs.add(output("w"));
+
+			fullDMLScriptName = SCRIPT_DIR + "applications/linear_regression/LinearRegression.dml";
+
+			double[][] v = getRandomMatrix(rows, cols, 0, 1, 0.01, -1);
+			double[][] y = getRandomMatrix(rows, 1, 1, 10, 1, -1);
+			writeInputMatrixWithMTD("v", v, true);
+			writeInputMatrixWithMTD("y", y, true);
+
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+			run(Math.pow(10, -10), "w");
+
+		}
+		catch(Exception ex) {
+			ex.printStackTrace();
+			fail("Exception in execution: " + ex.getMessage());
+		}
+	}
+
+	private void run(double eps, String out) {
+		programArgs[1] = getPath("SystemDS-config-default.xml");
+		LOG.debug(runTest(null));
+		HashMap<MatrixValue.CellIndex, Double> retDefault = readDMLMatrixFromOutputDir(out);
+
+		for(String conf : testConfigs) {
+			programArgs[1] = getPath("SystemDS-config-" + conf + ".xml");
+			LOG.debug(runTest(null));
+			HashMap<MatrixValue.CellIndex, Double> ret2 = readDMLMatrixFromOutputDir(out);
+			TestUtils.compareMatrices(retDefault, ret2, eps, "default", conf);
+		}
+	}
+}

--- a/src/test/scripts/functions/linearization/MatrixMult.dml
+++ b/src/test/scripts/functions/linearization/MatrixMult.dml
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+totalResult = matrix(0, rows=1000, cols=1)
+for (i in 1:2) {
+    A = matrix(1.0 * i, rows=1000, cols=1000)
+    B = matrix(1.0 * (i + 1), rows=1000, cols=1000)
+    C = matrix(1.0 * (i + 2), rows=1000, cols=1000)
+    D = matrix(1.0 * (i + 3), rows=1000, cols=1000)
+    result = (A + B) %*% (rowMaxs(C + D))
+    totalResult = totalResult + result
+}
+
+print(toString(totalResult))
+write(totalResult, $1, format="text")

--- a/src/test/scripts/functions/linearization/SystemDS-config-breadth-first.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-breadth-first.xml
@@ -1,0 +1,22 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+    <sysds.compile.linearization>breadth_first</sysds.compile.linearization>
+</root>

--- a/src/test/scripts/functions/linearization/SystemDS-config-default.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-default.xml
@@ -1,0 +1,21 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+</root>

--- a/src/test/scripts/functions/linearization/SystemDS-config-depth-first.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-depth-first.xml
@@ -1,0 +1,22 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+    <sysds.compile.linearization>depth_first</sysds.compile.linearization>
+</root>

--- a/src/test/scripts/functions/linearization/SystemDS-config-incorrect.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-incorrect.xml
@@ -1,0 +1,22 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+    <sysds.compile.linearization>something_incorrect</sysds.compile.linearization>
+</root>

--- a/src/test/scripts/functions/linearization/SystemDS-config-min-intermediate.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-min-intermediate.xml
@@ -1,0 +1,22 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<root>
+    <sysds.compile.linearization>min_intermediate</sysds.compile.linearization>
+</root>


### PR DESCRIPTION
This commit adds a new setting to the system to switch between different
operator linearization algorithms "DAG_LINEARIZATION".
The settings allow a user to control the order of the operations based
on different ordering algorithms.
While adding the feature a min_intermediate setting is added to order
dag elements to reduce the intermediate memory footprint of the operations.

Co-authored-by: Paul Mirtl <38892504+past12am@users.noreply.github.com>
Co-authored-by: Jonathan Haberl <95644983+jhaberl@users.noreply.github.com>

Closes #1505