### PR TITLE
[SYSTEMDS-3185] Federated Read Reuse - fix computetime and robustness

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedReadCache.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedReadCache.java
@@ -39,10 +39,12 @@ public class FederatedReadCache {
 	 * to indicate that the data is not cached yet.
 	 *
 	 * @param fname the filename of the read data
+	 * @param putPlaceholder whether to put a placeholder if there is no mapping for the filename
 	 * @return the CacheableData object if it is cached, otherwise null
 	 */
-	public CacheableData<?> get(String fname) {
-		ReadCacheEntry tmp = _rmap.putIfAbsent(fname, new ReadCacheEntry());
+	public CacheableData<?> get(String fname, boolean putPlaceholder) {
+		ReadCacheEntry tmp = putPlaceholder ?
+			_rmap.putIfAbsent(fname, new ReadCacheEntry()) : _rmap.get(fname);
 		return (tmp != null) ? tmp.get() : null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -260,15 +260,10 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 				cd = _frc.get(filename);
 			try {
 				if(cd == null) { // data is neither in lineage cache nor in read cache
-					long t0 = !ReuseCacheType.isNone() ? System.nanoTime() : 0;
 					cd = readDataNoReuse(filename, dataType, mc); // actual read of the data
-					long t1 = !ReuseCacheType.isNone() ? System.nanoTime() : 0;
 					if(!ReuseCacheType.isNone() && dataType == DataType.MATRIX)
 						// put the object into the lineage cache
-						// FIXME: As we lazily read the actual data, this computetime
-						//  only records the metadata read. A small computetime wrongly
-						//  dictates the cache eviction logic to remove this entry early.
-						LineageCache.putFedReadObject(cd, linItem, ec, t1 - t0);
+						LineageCache.putFedReadObject(cd, linItem, ec);
 					else
 						_frc.setData(filename, cd); // set the data into the read cache entry
 				}
@@ -276,7 +271,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 
 			} catch(Exception ex) {
 				if(!ReuseCacheType.isNone() && dataType == DataType.MATRIX)
-					LineageCache.putFedReadObject(null, linItem, ec, 0); // removing the placeholder
+					LineageCache.putFedReadObject(null, linItem, ec); // removing the placeholder
 				else
 					_frc.setInvalid(filename);
 				throw ex;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -663,13 +663,15 @@ public class LineageCache
 		}
 	}
 
-	public static void putFedReadObject(Data data, LineageItem li, ExecutionContext ec, long computetime) {
+	public static void putFedReadObject(Data data, LineageItem li, ExecutionContext ec) {
 		if(ReuseCacheType.isNone())
 			return;
 
 		LineageCacheEntry entry = _cache.get(li);
 		if(entry != null && data instanceof MatrixObject) {
+			long t0 = System.nanoTime();
 			MatrixBlock mb = ((MatrixObject)data).acquireRead();
+			long t1 = System.nanoTime();
 			synchronized(_cache) {
 				long size = mb != null ? mb.getInMemorySize() : 0;
 
@@ -683,7 +685,7 @@ public class LineageCache
 					LineageCacheEviction.makeSpace(_cache, size);
 				LineageCacheEviction.updateSize(size, true);
 
-				entry.setValue(mb, computetime);
+				entry.setValue(mb, t1 - t0);
 			}
 		}
 		else {


### PR DESCRIPTION
Hi,
This PR addresses the two issues mentioned in #1522, namely (1) obtaining the wrong computation time from a lazy read, and (2) allowing to change the lineage reuse type on the worker during runtime.

Thanks for review :)