### PR TITLE
[SYSTEMDS-3334] Code-gen rewrite ROWMAXS_VECTMULT

### DIFF
--- a/src/main/java/org/apache/sysds/hops/codegen/SpoofCompiler.java
+++ b/src/main/java/org/apache/sysds/hops/codegen/SpoofCompiler.java
@@ -38,6 +38,7 @@ import org.apache.sysds.hops.Hop;
 import org.apache.sysds.hops.LiteralOp;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.codegen.cplan.CNode;
+import org.apache.sysds.hops.codegen.cplan.CNodeBinary;
 import org.apache.sysds.hops.codegen.cplan.CNodeCell;
 import org.apache.sysds.hops.codegen.cplan.CNodeData;
 import org.apache.sysds.hops.codegen.cplan.CNodeMultiAgg;
@@ -945,7 +946,8 @@ public class SpoofCompiler {
 					&& TemplateUtils.hasSingleOperation(tpl) )
 				|| (tpl instanceof CNodeRow && (((CNodeRow)tpl).getRowType()==RowType.NO_AGG
 					|| ((CNodeRow)tpl).getRowType()==RowType.NO_AGG_B1
-					|| ((CNodeRow)tpl).getRowType()==RowType.ROW_AGG )
+					|| (((CNodeRow)tpl).getRowType()==RowType.ROW_AGG  && !TemplateUtils.isBinary(tpl.getOutput(),
+							CNodeBinary.BinType.AGGMAX_ROWMAXS_VECTMULT)))
 					&& TemplateUtils.hasSingleOperation(tpl))
 				|| TemplateUtils.hasNoOperation(tpl) ) 
 			{

--- a/src/main/java/org/apache/sysds/hops/codegen/cplan/CNodeBinary.java
+++ b/src/main/java/org/apache/sysds/hops/codegen/cplan/CNodeBinary.java
@@ -30,6 +30,7 @@ import org.apache.sysds.hops.codegen.SpoofCompiler.GeneratorAPI;
 public class CNodeBinary extends CNode {
 
 	public enum BinType {
+		AGGMAX_ROWMAXS_VECTMULT,
 		//matrix multiplication operations
 		DOT_PRODUCT, VECT_MATRIXMULT, VECT_OUTERMULT_ADD,
 		//vector-scalar-add operations

--- a/src/main/java/org/apache/sysds/hops/codegen/cplan/java/Binary.java
+++ b/src/main/java/org/apache/sysds/hops/codegen/cplan/java/Binary.java
@@ -28,6 +28,9 @@ public class Binary extends CodeTemplate {
 		boolean scalarVector, boolean scalarInput, boolean vectorVector)
 	{
 		switch (type) {
+			case AGGMAX_ROWMAXS_VECTMULT:
+				return sparseLhs ? "\tdouble %TMP% = LibSpoofPrimitives.aggMaxRowMaxsVectMult(%IN1v%, %IN2%, %IN1i%, %POS1%, %POS2%, alen);\n" :
+						"\tdouble %TMP% = LibSpoofPrimitives.aggMaxRowMaxsVectMult(%IN1%, %IN2%, %POS1%, %POS2%, %LEN%);\n";
 			case DOT_PRODUCT:
 				return sparseLhs ? "    double %TMP% = LibSpoofPrimitives.dotProduct(%IN1v%, %IN2%, %IN1i%, %POS1%, %POS2%, alen);\n" :
 						"    double %TMP% = LibSpoofPrimitives.dotProduct(%IN1%, %IN2%, %POS1%, %POS2%, %LEN%);\n";

--- a/src/main/java/org/apache/sysds/hops/codegen/template/TemplateUtils.java
+++ b/src/main/java/org/apache/sysds/hops/codegen/template/TemplateUtils.java
@@ -391,7 +391,8 @@ public class TemplateUtils
 				&& !TemplateUtils.isUnary(output, 
 					UnaryType.EXP, UnaryType.LOG, UnaryType.ROW_COUNTNNZS)) 
 			|| (output instanceof CNodeBinary
-				&& !TemplateUtils.isBinary(output, BinType.VECT_OUTERMULT_ADD))
+				&& (!TemplateUtils.isBinary(output, BinType.VECT_OUTERMULT_ADD) ||
+				    !TemplateUtils.isBinary(output, BinType.AGGMAX_ROWMAXS_VECTMULT)))
 			|| output instanceof CNodeTernary 
 				&& ((CNodeTernary)output).getType() == TernaryType.IFELSE)
 			&& hasOnlyDataNodeOrLookupInputs(output);

--- a/src/main/java/org/apache/sysds/runtime/codegen/LibSpoofPrimitives.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/LibSpoofPrimitives.java
@@ -50,9 +50,23 @@ public class LibSpoofPrimitives
 	private static ThreadLocal<VectorBuffer> memPool = new ThreadLocal<VectorBuffer>() {
 		@Override protected VectorBuffer initialValue() { return new VectorBuffer(0,0,0); }
 	};
-	
+
+	public static double aggMaxRowMaxsVectMult(double[] a, double[] b, int ai, int bi, int len) {
+		double val = Double.NEGATIVE_INFINITY;
+		int j=0;
+		for( int i = ai; i < ai+len; i++ )
+			val = Math.max(a[i]*b[j++], val);
+		return Math.max(val, b[bi]);
+	}
+
+	public static double aggMaxRowMaxsVectMult(double[] a, double[] b, int[] aix, int ai, int bi, int len) {
+		double val = Double.NEGATIVE_INFINITY;
+		for( int i = ai; i < ai+len; i++ )
+			val = Math.max(a[i]*b[aix[i]], val);
+		return Math.max(val, b[bi]);
+	}
+
 	// forwarded calls to LibMatrixMult
-	
 	public static double dotProduct(double[] a, double[] b, int ai, int bi, int len) {
 		if( a == null || b == null ) return 0;
 		return LibMatrixMult.dotProduct(a, b, ai, bi, len);


### PR DESCRIPTION
This patch adds a rewrite to avoid vector intermediates in the generated row template of connected components by doing the elementwise multiplication, row_maxs and max in one pass.

Works only for a certain small input size. Then other rewrites seem to get to modify the DAG before this pattern can be tested. E.g., tested with 1000 nodes -> works, tested with 100000 nodes -> pattern not applied because DAG is already different.

This is for java codegen only. The CUDA version works analogously and will be pushed with other pending CUDA codegen changes (and after the input size issue is fixed)