### PR TITLE
[SYSTEMDS-3022] Avoid cudaMemset() where possible

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDACellwise.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDACellwise.java
@@ -93,8 +93,8 @@ public class SpoofCUDACellwise extends SpoofCellwise implements SpoofCUDAOperato
 		long nnz = in_obj.getNnz("spoofCUDA" + getSpoofType(), false);
 		MatrixObject out_obj = sparseOut ?
 				(ec.getSparseMatrixOutputForGPUInstruction(outputName, out_rows, out_cols, (isSparseSafe() && nnz > 0) ?
-						nnz : out_rows * out_cols).getKey()) :
-				(ec.getDenseMatrixOutputForGPUInstruction(outputName, out_rows, out_cols).getKey());
+						nnz : out_rows * out_cols, false).getKey()) :
+				(ec.getDenseMatrixOutputForGPUInstruction(outputName, out_rows, out_cols, false).getKey());
 
 		packDataForTransfer(ec, inputs, scalarObjects, out_obj, 1, ID, 0,false, null);
 		if(NotEmpty(in_obj) || !sparseSafe) {

--- a/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDAOperator.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDAOperator.java
@@ -72,7 +72,7 @@ public interface SpoofCUDAOperator  {
 				int rows = (int)mo.getNumRows();
 				int cols = (int)mo.getNumColumns();
 				Pointer b1 = mo.getGPUObject(ec.getGPUContext(0)).getDensePointer();
-				Pointer ptr = ec.getGPUContext(0).allocate(getName(), (long) rows * cols * sizeOfDataType);
+				Pointer ptr = ec.getGPUContext(0).allocate(getName(), (long) rows * cols * sizeOfDataType, false);
 				LibMatrixCUDA.denseTranspose(ec, ec.getGPUContext(0), getName(), b1, ptr, rows, cols);
 				writeMatrixDescriptorToBuffer(buf, rows, cols, 0, 0, GPUObject.getPointerAddress(ptr), mo.getNnz());
 			} else {
@@ -115,8 +115,10 @@ public interface SpoofCUDAOperator  {
 				int NT = 256;
 				long N = inputs.get(0).getNumRows() * inputs.get(0).getNumColumns();
 				num_blocks = ((N + NT * 2 - 1) / (NT * 2));
+				ptr[0] = ec.getGPUContext(0).allocate(getName(), LibMatrixCUDA.sizeOfDataType * num_blocks, false);
 			}
-			ptr[0] = ec.getGPUContext(0).allocate(getName(), LibMatrixCUDA.sizeOfDataType * num_blocks);
+			else
+				ptr[0] = ec.getGPUContext(0).allocate(getName(), LibMatrixCUDA.sizeOfDataType * num_blocks, true);
 			writeMatrixDescriptorToBuffer(buf, 1, 1, 0, 0, GPUObject.getPointerAddress(ptr[0]), 1);
 		}
  		else {

--- a/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDARowwise.java
+++ b/src/main/java/org/apache/sysds/runtime/codegen/SpoofCUDARowwise.java
@@ -77,7 +77,7 @@ public class SpoofCUDARowwise extends SpoofRowwise implements SpoofCUDAOperator 
 				hasMatrixObjectSideInput(inputs) ? getMinColsMatrixObjectSideInputs(inputs) : -1;
 		OutputDimensions out_dims = new OutputDimensions(m, n, n2);
 		ec.setMetaData(outputName, out_dims.rows, out_dims.cols);
-		MatrixObject out_obj = ec.getDenseMatrixOutputForGPUInstruction(outputName, out_dims.rows, out_dims.cols).getKey();
+		MatrixObject out_obj = ec.getDenseMatrixOutputForGPUInstruction(outputName, out_dims.rows, out_dims.cols, false).getKey();
 
 		packDataForTransfer(ec, inputs, scalarObjects, out_obj, 1, ID, 0,_tB1, null);
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -373,8 +373,14 @@ public class ExecutionContext {
 	 * @return a pair containing the wrapping {@link MatrixObject} and a boolean indicating whether a cuda memory allocation took place (as opposed to the space already being allocated)
 	 */
 	public Pair<MatrixObject, Boolean> getDenseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols) {
+		return 	getDenseMatrixOutputForGPUInstruction(varName, numRows, numCols, true);
+	}
+
+	public Pair<MatrixObject, Boolean> getDenseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols,
+		boolean initialize)
+	{
 		MatrixObject mo = allocateGPUMatrixObject(varName, numRows, numCols);
-		boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifyDense();
+		boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifyDense(initialize);
 		mo.getDataCharacteristics().setNonZeros(-1);
 		return new Pair<>(mo, allocated);
 	}
@@ -390,9 +396,15 @@ public class ExecutionContext {
 	 * @return matrix object
 	 */
 	public Pair<MatrixObject, Boolean> getSparseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols, long nnz) {
+		return getSparseMatrixOutputForGPUInstruction(varName, numRows, numCols, nnz, true);
+	}
+
+	public Pair<MatrixObject, Boolean> getSparseMatrixOutputForGPUInstruction(String varName, long numRows, long numCols,
+		long nnz, boolean initialize)
+	{
 		MatrixObject mo = allocateGPUMatrixObject(varName, numRows, numCols);
 		mo.getDataCharacteristics().setNonZeros(nnz);
-		boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifySparse();
+		boolean allocated = mo.getGPUObject(getGPUContext(0)).acquireDeviceModifySparse(initialize);
 		return new Pair<>(mo, allocated);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/DnnGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/DnnGPUInstruction.java
@@ -637,7 +637,8 @@ public class DnnGPUInstruction extends GPUInstruction {
 		int D = toInt(numRowsW) - M; // since W:(D+M, 4M) ... numFeatures 
 		Pointer sysdsWPointer = LibMatrixCuDNN.getDensePointerForCuDNN(gCtx, W, instructionName, D+M, 4*M);
 		Pointer sysdsBiasPointer = LibMatrixCuDNN.getDensePointerForCuDNN(gCtx, bias, instructionName, 1, 4*M);
-		Pointer cudnnWPointer = gCtx.allocate(instructionName, (D+M+2)*(4*M)*LibMatrixCUDA.sizeOfDataType);
+		// TODO: find out if memset is necessary
+		Pointer cudnnWPointer = gCtx.allocate(instructionName, (D+M+2)*(4*M)*LibMatrixCUDA.sizeOfDataType, true);
 		LibMatrixCUDA.getCudaKernels(gCtx).launchKernel("prepare_lstm_weight",
 				ExecutionConfig.getConfigForSimpleVectorOperations((D+M+2)*(4*M)),
 				sysdsWPointer, sysdsBiasPointer, cudnnWPointer, D, M);
@@ -650,7 +651,7 @@ public class DnnGPUInstruction extends GPUInstruction {
 		int N = toInt(X.getNumRows()); // batchSize .. since X:(N, T*D)
 		long numColsX = X.getNumColumns();
 		int T = toInt(numColsX/ D); // since X:(N, T*D) ... seqLength
-		Pointer cudnnInput = gCtx.allocate(instructionName, (N*T*D)*LibMatrixCUDA.sizeOfDataType);
+		Pointer cudnnInput = gCtx.allocate(instructionName, (N*T*D)*LibMatrixCUDA.sizeOfDataType, false);
 		LibMatrixCUDA.getCudaKernels(gCtx).launchKernel("prepare_lstm_input",
 				ExecutionConfig.getConfigForSimpleVectorOperations(N*T*D),
 				xPointer, cudnnInput, N, D, T*D, N*T*D);
@@ -702,7 +703,7 @@ public class DnnGPUInstruction extends GPUInstruction {
 		int D = toInt(numRowsW) - M; // since W:(D+M, 4M) ... numFeatures 
 		Pointer sysdsWPointer = LibMatrixCuDNN.getDensePointerForCuDNN(gCtx, W, instructionName, D+M, 4*M);
 		Pointer sysdsBiasPointer = LibMatrixCuDNN.getDensePointerForCuDNN(gCtx, bias, instructionName, 1, 4*M);
-		Pointer cudnnWPointer = gCtx.allocate(instructionName, (D+M+2)*(4*M)*LibMatrixCUDA.sizeOfDataType);
+		Pointer cudnnWPointer = gCtx.allocate(instructionName, (D+M+2)*(4*M)*LibMatrixCUDA.sizeOfDataType, false);
 		LibMatrixCUDA.getCudaKernels(gCtx).launchKernel("prepare_lstm_weight",
 				ExecutionConfig.getConfigForSimpleVectorOperations((D+M+2)*(4*M)),
 				sysdsWPointer, sysdsBiasPointer, cudnnWPointer, D, M);
@@ -717,7 +718,7 @@ public class DnnGPUInstruction extends GPUInstruction {
 		int N = toInt(X.getNumRows()); // batchSize .. since X:(N, T*D)
 		long numColsX = X.getNumColumns();
 		int T = toInt(numColsX/ D); // since X:(N, T*D) ... seqLength
-		Pointer cudnnInput = gCtx.allocate(instructionName, (N*T*D)*LibMatrixCUDA.sizeOfDataType);
+		Pointer cudnnInput = gCtx.allocate(instructionName, (N*T*D)*LibMatrixCUDA.sizeOfDataType, false);
 		LibMatrixCUDA.getCudaKernels(gCtx).launchKernel("prepare_lstm_input",
 				ExecutionConfig.getConfigForSimpleVectorOperations(N*T*D),
 				xPointer, cudnnInput, N, D, T*D, N*T*D);

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/GPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/GPUInstruction.java
@@ -252,7 +252,13 @@ public abstract class GPUInstruction extends Instruction implements LineageTrace
 	 * @return	the matrix object
 	 */
 	protected MatrixObject getDenseMatrixOutputForGPUInstruction(ExecutionContext ec, String name, long numRows, long numCols) {
-		return ec.getDenseMatrixOutputForGPUInstruction(name, numRows, numCols).getKey();
+		return getDenseMatrixOutputForGPUInstruction(ec, name, numRows, numCols, true);
+	}
+
+	protected MatrixObject getDenseMatrixOutputForGPUInstruction(ExecutionContext ec, String name, long numRows, long numCols,
+		boolean initialize)
+	{
+		return ec.getDenseMatrixOutputForGPUInstruction(name, numRows, numCols, initialize).getKey();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/MatrixReshapeGPUInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/MatrixReshapeGPUInstruction.java
@@ -85,7 +85,8 @@ public class MatrixReshapeGPUInstruction extends GPUInstruction {
 		}
 		// We currently support only dense rshape
 		Pointer inPtr = LibMatrixCUDA.getDensePointer(gCtx, mat, instName);
-		MatrixObject out = LibMatrixCUDA.getDenseMatrixOutputForGPUInstruction(ec, instName, _output.getName(), rows, cols);
+		MatrixObject out = LibMatrixCUDA.getDenseMatrixOutputForGPUInstruction(ec, instName, _output.getName(), rows,
+			cols, false);
 		Pointer outPtr = LibMatrixCUDA.getDensePointer(gCtx, out, instName);
 		if(byRow.getBooleanValue()) {
 			// byrow = TRUE is simple memcpy and metadata update

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
@@ -245,9 +245,10 @@ public class GPUMemoryManager {
 	 * 
 	 * @param opcode instruction name
 	 * @param size size in bytes
+	 * @param initialize if cudaMemset() should be called
 	 * @return allocated pointer
 	 */
-	public Pointer malloc(String opcode, long size) {
+	public Pointer malloc(String opcode, long size, boolean initialize) {
 		if(size < 0) {
 			throw new DMLRuntimeException("Cannot allocate memory of size " + byteCountToDisplaySize(size));
 		}
@@ -432,7 +433,6 @@ public class GPUMemoryManager {
 			}
 		}
 		
-		
 		// Step 8: Handle defragmentation
 		if(A == null) {
 			LOG.warn("Potential fragmentation of the GPU memory. Forcibly evicting all ...");
@@ -448,11 +448,12 @@ public class GPUMemoryManager {
 		}
 		
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		cudaMemset(A, 0, size);
+		if(initialize)
+			cudaMemset(A, 0, size);
 		addMiscTime(opcode, GPUStatistics.cudaMemSet0Time, GPUStatistics.cudaMemSet0Count, GPUInstruction.MISC_TIMER_SET_ZERO, t0);
 		return A;
 	}
-	
+
 	private int worstCaseContiguousMemorySizeCompare(GPUObject o1, GPUObject o2) {
 		long ret = matrixMemoryManager.getWorstCaseContiguousMemorySize(o1) - matrixMemoryManager.getWorstCaseContiguousMemorySize(o2);
 		return ret < 0 ? -1 : (ret == 0 ? 0 : 1);

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
@@ -202,7 +202,7 @@ public class GPUObject {
 				long rows = me.mat.getNumRows();
 				long cols = me.mat.getNumColumns();
 				long size = rows * cols * LibMatrixCUDA.sizeOfDataType;
-				that.setDensePointer(allocate(size));
+				that.setDensePointer(allocate(size, false));
 				cudaMemcpy(that.getDensePointer(), me.getDensePointer(), size, cudaMemcpyDeviceToDevice);
 			}
 
@@ -218,17 +218,15 @@ public class GPUObject {
 		return that;
 	}
 
-	private Pointer allocate(long size) {
-		return getGPUContext().allocate(null, size);
+	private Pointer allocate(long size, boolean initialize) {
+		return getGPUContext().allocate(null, size, initialize);
 	}
 
 	private void cudaFreeHelper(Pointer toFree) throws DMLRuntimeException {
 		getGPUContext().cudaFreeHelper(null, toFree, DMLScript.EAGER_CUDA_FREE);
 	}
 
-	GPUContext getGPUContext() {
-		return gpuContext;
-	}
+	GPUContext getGPUContext() { return gpuContext; }
 
 	/**
 	 * Transposes a dense matrix on the GPU by calling the cublasDgeam operation
@@ -248,7 +246,7 @@ public class GPUObject {
 		Pointer alpha = LibMatrixCUDA.one();
 		Pointer beta = LibMatrixCUDA.zero();
 		Pointer A = densePtr;
-		Pointer C = gCtx.allocate(null, m * getDatatypeSizeOf(n));
+		Pointer C = gCtx.allocate(null, m * getDatatypeSizeOf(n), false);
 
 		// Transpose the matrix to get a dense matrix
 		LibMatrixCUDA.cudaSupportFunctions.cublasgeam(gCtx.getCublasHandle(), CUBLAS_OP_T, CUBLAS_OP_T, m, n, alpha, A, lda, beta, new Pointer(),
@@ -276,8 +274,8 @@ public class GPUObject {
 		Pointer nnzPerRowPtr = null;
 		Pointer nnzTotalDevHostPtr = null;
 
-		nnzPerRowPtr = gCtx.allocate(null, getIntSizeOf(rows));
-		nnzTotalDevHostPtr = gCtx.allocate(null, getIntSizeOf(1));
+		nnzPerRowPtr = gCtx.allocate(null, getIntSizeOf(rows), false);
+		nnzTotalDevHostPtr = gCtx.allocate(null, getIntSizeOf(1), false);
 
 		// Output is in dense vector format, convert it to CSR
 		LibMatrixCUDA.cudaSupportFunctions.cusparsennz(cusparseHandle, cusparseDirection.CUSPARSE_DIRECTION_ROW, rows, cols, matDescr, densePtr, rows,
@@ -526,13 +524,9 @@ public class GPUObject {
 		long cols = mat.getNumColumns();
 		int numElems = toIntExact(rows * cols);
 		long size = getDatatypeSizeOf(numElems);
-		setDensePointer(allocate(size));
-		// The "fill" kernel is called which treats the matrix "jcudaDensePtr" like a vector and fills it with value "v"
-		// If the fill value is 0, no need to call the special kernel, the allocate memsets the allocated region to 0
-		if (v != 0)
-			getGPUContext().getKernels()
-			.launchKernel("fill", ExecutionConfig.getConfigForSimpleVectorOperations(numElems),
-					getDensePointer(), v, numElems);
+		setDensePointer(allocate(size,false));
+		getGPUContext().getKernels().launchKernel("fill", ExecutionConfig.getConfigForSimpleVectorOperations
+				(numElems), getDensePointer(), v, numElems);
 	}
 
 	/**
@@ -574,8 +568,8 @@ public class GPUObject {
 				int cols = toIntExact(mat.getNumColumns());
 				Pointer nnzPerRowPtr = null;
 				Pointer nnzTotalDevHostPtr = null;
-				nnzPerRowPtr = gCtx.allocate(instName, getIntSizeOf(rows));
-				nnzTotalDevHostPtr = gCtx.allocate(instName, getIntSizeOf(1));
+				nnzPerRowPtr = gCtx.allocate(instName, getIntSizeOf(rows), false);
+				nnzTotalDevHostPtr = gCtx.allocate(instName, getIntSizeOf(1), false);
 				LibMatrixCUDA.cudaSupportFunctions.cusparsennz(cusparseHandle, cusparseDirection.CUSPARSE_DIRECTION_ROW, rows, cols, matDescr, getDensePointer(), rows,
 						nnzPerRowPtr, nnzTotalDevHostPtr);
 				int[] nnzC = { -1 };
@@ -613,6 +607,10 @@ public class GPUObject {
 	}
 
 	public boolean acquireDeviceModifyDense() {
+		return acquireDeviceModifyDense(true);
+	}
+
+	public boolean acquireDeviceModifyDense(boolean initialize) {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : acquireDeviceModifyDense on " + this + ", GPUContext=" + getGPUContext());
 		}
@@ -623,7 +621,7 @@ public class GPUObject {
 				LOG.trace("GPU : data is not allocated, allocating a dense block, on " + this);
 			}
 			// Dense block, size = numRows * numCols
-			allocateDenseMatrixOnDevice();
+			allocateDenseMatrixOnDevice(initialize);
 			allocated = true;
 		}
 		dirty = true;
@@ -633,6 +631,10 @@ public class GPUObject {
 	}
 
 	public boolean acquireDeviceModifySparse() {
+ 		return acquireDeviceModifySparse(true);
+	}
+
+	public boolean acquireDeviceModifySparse(boolean initialize) {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : acquireDeviceModifySparse on " + this + ", GPUContext=" + getGPUContext());
 		}
@@ -643,7 +645,7 @@ public class GPUObject {
 				LOG.trace("GPU : data is not allocated, allocating a sparse block, on " + this);
 			}
 			mat.setDirty(true);
-			allocateSparseMatrixOnDevice();
+			allocateSparseMatrixOnDevice(initialize);
 			allocated = true;
 		}
 		dirty = true;
@@ -753,7 +755,7 @@ public class GPUObject {
 			throw new DMLRuntimeException("Attempting to release an output before allocating it");
 	}
 
-	void allocateDenseMatrixOnDevice() {
+	void allocateDenseMatrixOnDevice(boolean initialize) {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : allocateDenseMatrixOnDevice, on " + this + ", GPUContext=" + getGPUContext());
 		}
@@ -766,11 +768,11 @@ public class GPUObject {
 		if(cols <= 0)
 			throw new DMLRuntimeException("Internal error - invalid number of columns when allocating dense matrix:" + cols);
 		long size = getDatatypeSizeOf(rows * cols);
-		Pointer tmp = allocate(size);
+		Pointer tmp = allocate(size, initialize);
 		setDensePointer(tmp);
 	}
 
-	void allocateSparseMatrixOnDevice() {
+	void allocateSparseMatrixOnDevice(boolean initialize) {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : allocateSparseMatrixOnDevice, on " + this + ", GPUContext=" + getGPUContext());
 		}
@@ -782,16 +784,16 @@ public class GPUObject {
 			throw new DMLRuntimeException("Internal error - invalid number of rows when allocating sparse matrix");
 		if(nnz < 0)
 			throw new DMLRuntimeException("Internal error - invalid number of non zeroes when allocating a sparse matrix");
-		CSRPointer tmp = CSRPointer.allocateEmpty(getGPUContext(), nnz, rows);
+		CSRPointer tmp = CSRPointer.allocateEmpty(getGPUContext(), nnz, rows, initialize);
 		setSparseMatrixCudaPointer(tmp);
 	}
 
-	void allocateSparseMatrixOnDevice(long numVals) {
+	void allocateSparseMatrixOnDevice(long numVals, boolean initialize) {
 		// This method is called when #values > nnz
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : allocateSparseMatrixOnDevice, on " + this + ", GPUContext=" + getGPUContext());
 		}
-		if(isAllocated()) 
+		if(isAllocated())
 			throw new DMLRuntimeException("Internal error - trying to allocated sparse matrix to a GPUObject that is already allocated");
 		long rows = mat.getNumRows();
 		long nnz = mat.getNnz();
@@ -799,7 +801,7 @@ public class GPUObject {
 			throw new DMLRuntimeException("Internal error - invalid number of rows when allocating sparse matrix");
 		if(nnz < 0)
 			throw new DMLRuntimeException("Internal error - invalid number of non zeroes when allocating a sparse matrix");
-		CSRPointer tmp = CSRPointer.allocateEmpty(getGPUContext(), numVals, rows);
+		CSRPointer tmp = CSRPointer.allocateEmpty(getGPUContext(), numVals, rows, initialize);
 		setSparseMatrixCudaPointer(tmp);
 	}
 
@@ -883,11 +885,11 @@ public class GPUObject {
 
 			if (values != null)
 				if(values.length > tmp.getNonZeros())
-					allocateSparseMatrixOnDevice(values.length);
+					allocateSparseMatrixOnDevice(values.length, false);
 				else
-					allocateSparseMatrixOnDevice();
+					allocateSparseMatrixOnDevice(false);
 			else
-				allocateSparseMatrixOnDevice();
+				allocateSparseMatrixOnDevice(false);
 
 			if (copyToDevice) {
 				CSRPointer.copyToDevice(getGPUContext(), getJcudaSparseMatrixPtr(),
@@ -901,7 +903,7 @@ public class GPUObject {
 			else if (data == null && tmp.getNonZeros() != 0)
 				throw new DMLRuntimeException("MatrixBlock is not allocated");
 			
-			allocateDenseMatrixOnDevice();
+			allocateDenseMatrixOnDevice(false);
 			
 			if (tmp.getNonZeros() == 0) {
 				// Minor optimization: No need to allocate empty error for CPU 

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/ShadowBuffer.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/ShadowBuffer.java
@@ -103,7 +103,7 @@ public class ShadowBuffer {
 	public void moveToDevice() {
 		long start = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		long numBytes = shadowPointer.length*LibMatrixCUDA.sizeOfDataType;
-		gpuObj.jcudaDenseMatrixPtr = gpuObj.getGPUContext().allocate(null, numBytes);
+		gpuObj.jcudaDenseMatrixPtr = gpuObj.getGPUContext().allocate(null, numBytes, false);
 		cudaMemcpy(gpuObj.jcudaDenseMatrixPtr, Pointer.to(shadowPointer), numBytes, jcuda.runtime.cudaMemcpyKind.cudaMemcpyHostToDevice);
 		clearShadowPointer();
 		if (DMLScript.STATISTICS) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNConvolutionAlgorithm.java
@@ -134,7 +134,7 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		jcuda.jcudnn.JCudnn.cudnnGetConvolutionForwardWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
 				ret.nchwTensorDesc, ret.filterDesc, ret.convDesc, ret.nkpqTensorDesc, algos[0], sizeInBytesArray);
 		if (sizeInBytesArray[0] != 0)
-			ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0]);
+			ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0], false);
 		ret.sizeInBytes = sizeInBytesArray[0];
 		ret.algo = algos[0];
 		return ret;
@@ -168,7 +168,7 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 				pad_h, pad_w, stride_h, stride_w, P, Q);
 		
 		int[] algos = {-1};
-		long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+		long[] sizeInBytesArray = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
 		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterAlgorithm(
 				LibMatrixCuDNN.getCudnnHandle(gCtx), 
 				ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, 
@@ -176,7 +176,7 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardFilterWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
 				ret.nchwTensorDesc, ret.nkpqTensorDesc, ret.convDesc, ret.filterDesc, algos[0], sizeInBytesArray);
 		if (sizeInBytesArray[0] != 0)
-			ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0]);
+			ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0], false);
 		ret.sizeInBytes = sizeInBytesArray[0];
 		ret.algo = algos[0];
 		
@@ -218,7 +218,7 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 		}
 		else {
 			int[] algos = {-1};
-			long sizeInBytesArray[] = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
+			long[] sizeInBytesArray = {Math.min(workspaceLimit, MAX_WORKSPACE_LIMIT_BYTES)};
 			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataAlgorithm(
 					LibMatrixCuDNN.getCudnnHandle(gCtx), 
 					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc,
@@ -226,7 +226,7 @@ public class LibMatrixCuDNNConvolutionAlgorithm implements java.lang.AutoCloseab
 			jcuda.jcudnn.JCudnn.cudnnGetConvolutionBackwardDataWorkspaceSize(LibMatrixCuDNN.getCudnnHandle(gCtx), 
 					ret.filterDesc, ret.nkpqTensorDesc, ret.convDesc, ret.nchwTensorDesc, algos[0], sizeInBytesArray);
 			if (sizeInBytesArray[0] != 0)
-				ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0]);
+				ret.workSpace = gCtx.allocate(instName, sizeInBytesArray[0], false);
 			ret.sizeInBytes = sizeInBytesArray[0];
 			ret.algo = algos[0];
 		}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNInputRowFetcher.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNInputRowFetcher.java
@@ -47,7 +47,7 @@ public class LibMatrixCuDNNInputRowFetcher extends LibMatrixCUDA implements java
 		numColumns = LibMatrixCUDA.toInt(image.getNumColumns());
 		isInputInSparseFormat = LibMatrixCUDA.isInSparseFormat(gCtx, image);
 		inPointer = isInputInSparseFormat ? LibMatrixCUDA.getSparsePointer(gCtx, image, instName) : LibMatrixCuDNN.getDensePointerForCuDNN(gCtx, image, instName);
-		outPointer = gCtx.allocate(instName, numColumns*sizeOfDataType);
+		outPointer = gCtx.allocate(instName, (long) numColumns *sizeOfDataType, false);
 	}
 	/**
 	 * Copy the nth row and return the dense pointer
@@ -57,7 +57,7 @@ public class LibMatrixCuDNNInputRowFetcher extends LibMatrixCUDA implements java
 	public Pointer getNthRow(int n) {
 		if(isInputInSparseFormat) {
 			jcuda.runtime.JCuda.cudaDeviceSynchronize();
-			cudaMemset(outPointer, 0, numColumns*sizeOfDataType);
+			cudaMemset(outPointer, 0, (long) numColumns *sizeOfDataType);
 			jcuda.runtime.JCuda.cudaDeviceSynchronize();
 			LibMatrixCUDA.sliceSparseDense(gCtx, instName, (CSRPointer)inPointer, outPointer, n, n, 0, LibMatrixCUDA.toInt(numColumns-1), numColumns);
 		}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNRnnAlgorithm.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuDNNRnnAlgorithm.java
@@ -90,7 +90,7 @@ public class LibMatrixCuDNNRnnAlgorithm implements java.lang.AutoCloseable {
 		dropOutSizeInBytes = _dropOutSizeInBytes[0];
 		dropOutStateSpace = new Pointer();
 		if (dropOutSizeInBytes != 0)
-			dropOutStateSpace = gCtx.allocate(instName, dropOutSizeInBytes);
+			dropOutStateSpace = gCtx.allocate(instName, dropOutSizeInBytes, false);
 		JCudnn.cudnnSetDropoutDescriptor(dropoutDesc, gCtx.getCudnnHandle(), 0, dropOutStateSpace, dropOutSizeInBytes, 12345);
 		
 		// Initialize RNN descriptor
@@ -112,12 +112,12 @@ public class LibMatrixCuDNNRnnAlgorithm implements java.lang.AutoCloseable {
 		workSpace = new Pointer(); reserveSpace = new Pointer();
 		sizeInBytes = getWorkspaceSize(T);
 		if(sizeInBytes != 0)
-			workSpace = gCtx.allocate(instName, sizeInBytes);
+			workSpace = gCtx.allocate(instName, sizeInBytes, false);
 		reserveSpaceSizeInBytes = 0;
 		if(isTraining) {
 			reserveSpaceSizeInBytes = getReservespaceSize(T);
 			if (reserveSpaceSizeInBytes != 0) {
-				reserveSpace = gCtx.allocate(instName, reserveSpaceSizeInBytes);
+				reserveSpace = gCtx.allocate(instName, reserveSpaceSizeInBytes, false);
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuMatMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixCuMatMult.java
@@ -259,7 +259,7 @@ public class LibMatrixCuMatMult extends LibMatrixCUDA {
 		// t(C) = t(B) %*% t(A)
 		Pointer output = null;
 		if (outRLen != 1 && outCLen != 1) {
-			output = gCtx.allocate(instName, outRLen * outCLen * sizeOfDataType);
+			output = gCtx.allocate(instName, outRLen * outCLen * sizeOfDataType, false);
 		} else {
 			// no transpose required for vector output
 			output = C;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/SinglePrecisionCudaSupportFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/SinglePrecisionCudaSupportFunctions.java
@@ -178,7 +178,7 @@ public class SinglePrecisionCudaSupportFunctions implements CudaSupportFunctions
 		// during eviction: `evict -> devictToHost -> float2double -> allocate -> ensureFreeSpace -> evict`. 
 		// To avoid this recursion, it is necessary to perform this conversion in host.
 		if(PERFORM_CONVERSION_ON_DEVICE && !isEviction) {
-			Pointer deviceDoubleData = gCtx.allocate(instName, ((long)dest.length)*Sizeof.DOUBLE);
+			Pointer deviceDoubleData = gCtx.allocate(instName, ((long)dest.length)*Sizeof.DOUBLE, false);
 			LibMatrixCUDA.float2double(gCtx, src, deviceDoubleData, dest.length);
 			cudaMemcpy(Pointer.to(dest), deviceDoubleData, ((long)dest.length)*Sizeof.DOUBLE, cudaMemcpyDeviceToHost);
 			gCtx.cudaFreeHelper(instName, deviceDoubleData, DMLScript.EAGER_CUDA_FREE);
@@ -202,7 +202,7 @@ public class SinglePrecisionCudaSupportFunctions implements CudaSupportFunctions
 		// TODO: Perform conversion on GPU using double2float and float2double kernels
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		if(PERFORM_CONVERSION_ON_DEVICE) {
-			Pointer deviceDoubleData = gCtx.allocate(instName, ((long)src.length)*Sizeof.DOUBLE);
+			Pointer deviceDoubleData = gCtx.allocate(instName, ((long)src.length)*Sizeof.DOUBLE, false);
 			cudaMemcpy(deviceDoubleData, Pointer.to(src), ((long)src.length)*Sizeof.DOUBLE, cudaMemcpyHostToDevice);
 			LibMatrixCUDA.double2float(gCtx, deviceDoubleData, dest, src.length);
 			gCtx.cudaFreeHelper(instName, deviceDoubleData, DMLScript.EAGER_CUDA_FREE);


### PR DESCRIPTION
This improvement tries to avoid calling cudaMemset() after allocating memory if there is a subsequent write to the whole buffer happening.