### PR TITLE
[SYSTEMDS-3018] Federated Planner Extended 3

### DIFF
--- a/src/main/java/org/apache/sysds/hops/fedplanner/AFederatedPlanner.java
+++ b/src/main/java/org/apache/sysds/hops/fedplanner/AFederatedPlanner.java
@@ -78,6 +78,10 @@ public abstract class AFederatedPlanner {
 		else if ( HopRewriteUtils.isReorg(hop, ReOrgOp.TRANS) ){
 			return ft[0] == FType.COL || ft[0] == FType.ROW;
 		}
+		else if (HopRewriteUtils.isData(hop, Types.OpOpData.FEDERATED)
+			|| HopRewriteUtils.isData(hop, Types.OpOpData.TRANSIENTWRITE)
+			|| HopRewriteUtils.isData(hop, Types.OpOpData.TRANSIENTREAD))
+			return true;
 		else if(ft.length==1 && ft[0] != null) {
 			return HopRewriteUtils.isReorg(hop, ReOrgOp.TRANS)
 				|| HopRewriteUtils.isAggUnaryOp(hop, AggOp.SUM, AggOp.MIN, AggOp.MAX);
@@ -135,6 +139,9 @@ public abstract class AFederatedPlanner {
 		}
 		else if ( HopRewriteUtils.isData(hop, Types.OpOpData.FEDERATED) )
 			return deriveFType((DataOp)hop);
+		else if ( HopRewriteUtils.isData(hop, Types.OpOpData.TRANSIENTWRITE)
+			|| HopRewriteUtils.isData(hop, Types.OpOpData.TRANSIENTREAD) )
+			return ft[0];
 		return null;
 	}
 	

--- a/src/main/java/org/apache/sysds/hops/fedplanner/FederatedPlannerCostbased.java
+++ b/src/main/java/org/apache/sysds/hops/fedplanner/FederatedPlannerCostbased.java
@@ -327,14 +327,12 @@ public class FederatedPlannerCostbased extends AFederatedPlanner {
 		}
 		if ( HopRewriteUtils.isData(currentHop, Types.OpOpData.TRANSIENTWRITE) )
 			transientWrites.put(currentHop.getName(), currentHop);
-		else {
-			if ( HopRewriteUtils.isData(currentHop, Types.OpOpData.FEDERATED) )
-				hopRels.add(new HopRel(currentHop, FederatedOutput.FOUT, deriveFType((DataOp)currentHop), hopRelMemo, inputHops));
-			else
-				hopRels.addAll(generateHopRels(currentHop, inputHops));
-			if ( isLOUTSupported(currentHop) )
-				hopRels.add(new HopRel(currentHop, FederatedOutput.LOUT, hopRelMemo, inputHops));
-		}
+		if ( HopRewriteUtils.isData(currentHop, Types.OpOpData.FEDERATED) )
+			hopRels.add(new HopRel(currentHop, FederatedOutput.FOUT, deriveFType((DataOp)currentHop), hopRelMemo, inputHops));
+		else
+			hopRels.addAll(generateHopRels(currentHop, inputHops));
+		if ( isLOUTSupported(currentHop) )
+			hopRels.add(new HopRel(currentHop, FederatedOutput.LOUT, hopRelMemo, inputHops));
 		return hopRels;
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
-import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint;
 import org.apache.sysds.test.AutomatedTestBase;
@@ -127,8 +126,6 @@ public class FederatedL2SVMPlanningTest extends AutomatedTestBase {
 		Thread t1 = null, t2 = null;
 
 		try {
-			OptimizerUtils.FEDERATED_COMPILATION = true;
-
 			getAndLoadTestConfiguration(TEST_NAME);
 			String HOME = SCRIPT_DIR + TEST_DIR;
 
@@ -146,8 +143,6 @@ public class FederatedL2SVMPlanningTest extends AutomatedTestBase {
 				"Y=" + input("Y"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
 			runTest(true, false, null, -1);
 
-			OptimizerUtils.FEDERATED_COMPILATION = false;
-
 			// Run reference dml script with normal matrix
 			fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
 			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"),
@@ -161,7 +156,6 @@ public class FederatedL2SVMPlanningTest extends AutomatedTestBase {
 					+ Arrays.toString(missingHeavyHitters(expectedHeavyHitters)));
 		}
 		finally {
-			OptimizerUtils.FEDERATED_COMPILATION = false;
 			TestUtils.shutdownThreads(t1, t2);
 			rtplatform = platformOld;
 			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
@@ -74,7 +74,8 @@ public class FederatedL2SVMPlanningTest extends AutomatedTestBase {
 	public void runL2SVMCostBasedTest(){
 		//String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
 		//	"fed_max", "fed_1-*", "fed_tsmm", "fed_>"};
-		String[] expectedHeavyHitters = new String[]{ "fed_fedinit"};
+		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
+			"fed_max", "fed_1-*", "fed_>"};
 		setTestConf("SystemDS-config-cost-based.xml");
 		loadAndRunTest(expectedHeavyHitters);
 	}


### PR DESCRIPTION
This PR adds DataOps to allowsFederated and getFederatedOut methods to ensure that transient reads and writes are allowed to be FOUT. 