### PR TITLE
[SYSTEMDS-3359] Sample-based recode map size estimation

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/CompressedSizeEstimatorSample.java
@@ -226,7 +226,7 @@ public class CompressedSizeEstimatorSample extends CompressedSizeEstimator {
 			return _sample.getNonZeros();
 	}
 
-	private static int[] getSortedSample(int range, int sampleSize, long seed, int k) {
+	public static int[] getSortedSample(int range, int sampleSize, long seed, int k) {
 		// set meta data and allocate dense block
 		final int[] a = new int[sampleSize];
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoder.java
@@ -60,6 +60,7 @@ public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder
 	private static final long serialVersionUID = 2299156350718979064L;
 	protected int _colID;
 	protected ArrayList<Integer> _sparseRowsWZeros = null;
+	protected long _estMetaSize = 0;
 
 	protected enum TransformType{
 		BIN, RECODE, DUMMYCODE, FEATURE_HASH, PASS_THROUGH, N_A
@@ -279,6 +280,14 @@ public abstract class ColumnEncoder implements Encoder, Comparable<ColumnEncoder
 
 	public void shiftCol(int columnOffset) {
 		_colID += columnOffset;
+	}
+
+	public void setEstMetaSize(long estSize) {
+		_estMetaSize = estSize;
+	}
+
+	public long getEstMetaSize() {
+		return _estMetaSize;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
@@ -360,6 +360,14 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 		return false;
 	}
 
+	public void computeRCDMapSizeEstimate(CacheBlock in, int[] sampleIndices) {
+		for (ColumnEncoder e : _columnEncoders)
+			if (e.getClass().equals(ColumnEncoderRecode.class))
+				((ColumnEncoderRecode) e).computeRCDMapSizeEstimate(in, sampleIndices);
+		long totEstSize = _columnEncoders.stream().mapToLong(ColumnEncoder::getEstMetaSize).sum();
+		setEstMetaSize(totEstSize);
+	}
+
 	@Override
 	public void shiftCol(int columnOffset) {
 		super.shiftCol(columnOffset);

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Callable;
 
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.lops.Lop;
+import org.apache.sysds.runtime.compress.estim.sample.SampleEstimatorFactory;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -126,6 +127,41 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	private long lookupRCDMap(String key) {
 		Long tmp = _rcdMap.get(key);
 		return (tmp != null) ? tmp : -1;
+	}
+
+	public void computeRCDMapSizeEstimate(CacheBlock in, int[] sampleIndices) {
+		if (getEstMetaSize() != 0)
+			return;
+
+		// Find the frequencies of distinct values in the sample
+		HashMap<String, Integer> distinctFreq = new HashMap<>();
+		long totSize = 0;
+		for (int sind : sampleIndices) {
+			String key = in.getString(sind, _colID-1);
+			if (key == null)
+				continue;
+			//distinctFreq.put(key, distinctFreq.getOrDefault(key, (long)0) + 1);
+			if (distinctFreq.containsKey(key))
+				distinctFreq.put(key, distinctFreq.get(key) + 1);
+			else {
+				distinctFreq.put(key, 1);
+				// Maintain total size of the keys
+				totSize += (key.length() * 2L + 16); //sizeof(String) = len(chars) + header
+			}
+		}
+
+		// Estimate total #distincts using Hass and Stokes estimator
+		int[] freq = distinctFreq.values().stream().mapToInt(v -> v).toArray();
+		int estDistCount = SampleEstimatorFactory.distinctCount(freq, in.getNumRows(),
+			sampleIndices.length, SampleEstimatorFactory.EstimationType.HassAndStokes);
+
+		// Compute total size estimates for each partial recode map
+		// We assume each partial map contains all distinct values and have the same size
+		long avgKeySize = totSize / distinctFreq.size();
+		long valSize = 16L; //sizeof(Long) = 8 + header
+		long estMapSize = estDistCount * (avgKeySize + valSize);
+		setEstMetaSize(estMapSize);
+		//System.out.println("Estimated map size for col "+(_colID-1)+" = "+getEstMetaSize());
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/utils/stats/TransformStatistics.java
+++ b/src/main/java/org/apache/sysds/utils/stats/TransformStatistics.java
@@ -40,6 +40,7 @@ public class TransformStatistics {
 
 	private static final LongAdder outMatrixPreProcessingTime = new LongAdder();
 	private static final LongAdder outMatrixPostProcessingTime = new LongAdder();
+	private static final LongAdder mapSizeEstimationTime = new LongAdder();
 
 	public static void incEncoderCount(long encoders) {
 		encoderCount.add(encoders);
@@ -93,6 +94,10 @@ public class TransformStatistics {
 		outMatrixPostProcessingTime.add(t);
 	}
 
+	public static void incMapSizeEstimationTime(long t) {
+		mapSizeEstimationTime.add(t);
+	}
+
 	public static long getEncodeBuildTime() {
 		return binningBuildTime.longValue() + imputeBuildTime.longValue() +
 				recodeBuildTime.longValue();
@@ -121,6 +126,7 @@ public class TransformStatistics {
 		imputeApplyTime.reset();
 		outMatrixPreProcessingTime.reset();
 		outMatrixPostProcessingTime.reset();
+		mapSizeEstimationTime.reset();
 	}
 
 	public static String displayStatistics() {
@@ -168,6 +174,8 @@ public class TransformStatistics {
 				outMatrixPreProcessingTime.longValue()*1e-9)).append(" sec.\n");
 			sb.append("TransformEncode PostProc. time:\t").append(String.format("%.3f",
 				outMatrixPostProcessingTime.longValue()*1e-9)).append(" sec.\n");
+			sb.append("TransformEncode SizeEst. time:\t").append(String.format("%.3f",
+				mapSizeEstimationTime.longValue()*1e-9)).append(" sec.\n");
 			return sb.toString();
 		}
 		return "";


### PR DESCRIPTION
This patch improves the transformencode optimizer by adding
a sample-based estimation of the recode/partial recode map sizes.
We fallback to full column recode build tasks if the partial
maps do not fit in the memory. Future commits will fine tune
the task graph with 1) column-specific build blocks counts
and 2) serialized column-build tasks -- both based on the
memory estimates.