### PR TITLE
[SYSTEMDS-3363] Netty Encoding - Buffer Allocation Size

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.controlprogram.federated;
 
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -33,11 +34,13 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
-import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
+import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.meta.MetaData;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -184,7 +187,7 @@ public class FederatedData {
 					cp.addLast("ObjectDecoder", new ObjectDecoder(Integer.MAX_VALUE,
 						ClassResolvers.weakCachingResolver(ClassLoader.getSystemClassLoader())));
 					cp.addLast("FederatedOperationHandler", handler);
-					cp.addLast("ObjectEncoder", new ObjectEncoder());
+					cp.addLast("FederatedRequestEncoder", new FederatedRequestEncoder());
 				}
 			});
 
@@ -283,5 +286,32 @@ public class FederatedData {
 		sb.append(" " + _address.toString());
 		sb.append(":" + _filepath);
 		return sb.toString();
+	}
+
+	public static class FederatedRequestEncoder extends ObjectEncoder {
+		@Override
+		protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, Serializable msg,
+		boolean preferDirect) throws Exception {
+			int initCapacity = 256; // default initial capacity
+			if(msg instanceof FederatedRequest[]) {
+				try {
+					for(FederatedRequest fr : (FederatedRequest[])msg) {
+						if(fr.getType() == RequestType.PUT_VAR && fr.getNumParams() > 0
+							&& fr.getParam(0) instanceof CacheBlock) {
+							int cbSize = Math.toIntExact(((CacheBlock)fr.getParam(0)).getInMemorySize());
+							if(Integer.MAX_VALUE - initCapacity < cbSize) // summed cache block sizes exceed integer limits
+								throw new ArithmeticException("Overflow.");
+							initCapacity += cbSize;
+						}
+					}
+				} catch(ArithmeticException ae) { // in memory size of cache block exceeds integer limits
+					initCapacity = Integer.MAX_VALUE;
+				}
+			}
+			if(preferDirect)
+				return ctx.alloc().ioBuffer(initCapacity);
+			else
+				return ctx.alloc().heapBuffer(initCapacity);
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
@@ -195,6 +195,19 @@ public class FederatedRequest implements Serializable {
 		return _lineageTrace;
 	}
 
+	public long estimateSerializationBufferSize() {
+		long minBufferSize = 512; // general offset for the FederatedRequest object
+		if(_data != null) {
+			for(Object obj : _data) {
+				if(obj instanceof CacheBlock)
+					minBufferSize += ((CacheBlock)obj).getExactSerializedSize();
+			}
+		}
+		if(_lineageTrace != null)
+			minBufferSize += _lineageTrace.length();
+		return minBufferSize;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("FederatedRequest[");

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.privacy.CheckedConstraintsLog;
 import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
@@ -77,6 +78,17 @@ public class FederatedResponse implements Serializable {
 		if ( !isSuccessful() )
 			throwExceptionFromResponse(); 
 		return _data;
+	}
+
+	public long estimateSerializationBufferSize() {
+		long minBufferSize = 312; // general offset for the FederatedResponse object
+		if(_data != null) {
+			for(Object obj : _data) {
+				if(obj instanceof CacheBlock)
+					minBufferSize += ((CacheBlock)obj).getExactSerializedSize();
+			}
+		}
+		return minBufferSize;
 	}
 
 	/**


### PR DESCRIPTION
Hi,
this PR replaces the ObjectEncoders for encoding federated communication messages (i.e., FederatedRequest and FederatedResponse) with a respective FederatedRequestEncoder and FederatedResponseEncoder. These two new classes extent from ObjectEncoder and override the allocateBuffer method in order to allocate the buffer with an initial capacity corresponding to the FederatedRequest/FederatedResponse instead of the default value of 256.
I've tried estimating the entire serialized size of the requests and responses to allocate the exact size needed, but haven't found a good solution for it because of the many cases to consider. Hence, the initial capacity in this PR only results from taking into consideration a static offset (FederatedRequest: 512, FederatedResponse: 312), the size of the CacheBlock parameters, and the length of the lineage trace (only for FederatedRequests).
In my experiments with a matrix of dimensions 600.000x200, it reduces the encoding time from 50 seconds to 1.9 seconds. :tada: 

Thanks for review :)