### PR TITLE
[MINOR] Add `protobuf` parameter for consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		<hadoop.version>3.3.1</hadoop.version>
 		<!-- Consistant with spark -->
 		<antlr.version>4.8</antlr.version>
+		<protobuf.version>3.20.1</protobuf.version>
 		<spark.version>3.2.0</spark.version>
 		<scala.version>2.12.0</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
@@ -304,7 +305,7 @@
 						<configuration>
 							<!-- protoc binaries to be picked up from
 							  https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/ -->
-							<protocVersion>3.20.1</protocVersion>
+							<protocVersion>${protobuf.version}</protocVersion>
 							<inputDirectories>
 								<include>src/main/resources/protobuf</include>
 							</inputDirectories>
@@ -1166,13 +1167,13 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.20.1</version>
+			<version>${protobuf.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java-util</artifactId>
-			<version>3.20.1</version>
+			<version>${protobuf.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Use a `protobuf.version` consistent naming across the pom definition.