### PR TITLE
[SYSTEMDS-3367] Integrate UDF encoders in task graph

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
@@ -269,6 +269,9 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 		ColumnEncoderDummycode dc = getEncoder(ColumnEncoderDummycode.class);
 		if(dc != null)
 			dc.updateDomainSizes(_columnEncoders);
+		ColumnEncoderUDF udf = getEncoder(ColumnEncoderUDF.class);
+		if (udf != null && dc != null)
+			udf.updateDomainSizes(_columnEncoders);
 	}
 
 	public void addEncoder(ColumnEncoder other) {
@@ -385,7 +388,10 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	public void setNumPartitions(int nBuild, int nApply) {
 			_columnEncoders.forEach(e -> {
 				e.setBuildRowBlocksPerColumn(nBuild);
-				e.setApplyRowBlocksPerColumn(nApply);
+				if (e.getClass().equals(ColumnEncoderUDF.class))
+					e.setApplyRowBlocksPerColumn(1);
+				else
+					e.setApplyRowBlocksPerColumn(nApply);
 			});
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
@@ -83,8 +83,11 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 				codes[i-startInd] = Double.NaN;
 			else {
 				// Calculate non-negative modulo
-				double mod = key.hashCode() % _K > 0 ? key.hashCode() % _K : _K + key.hashCode() % _K;
-				codes[i - startInd] = mod + 1;
+				//double mod = key.hashCode() % _K > 0 ? key.hashCode() % _K : _K + key.hashCode() % _K;
+				double mod = (key.hashCode() % _K) + 1;
+				if (mod < 0)
+					mod += _K;
+				codes[i - startInd] = mod;
 			}
 		}
 		return codes;

--- a/src/main/java/org/apache/sysds/utils/stats/TransformStatistics.java
+++ b/src/main/java/org/apache/sysds/utils/stats/TransformStatistics.java
@@ -35,6 +35,7 @@ public class TransformStatistics {
 	private static final LongAdder passThroughApplyTime = new LongAdder();
 	private static final LongAdder featureHashingApplyTime = new LongAdder();
 	private static final LongAdder binningApplyTime = new LongAdder();
+	private static final LongAdder UDFApplyTime = new LongAdder();
 	private static final LongAdder omitApplyTime = new LongAdder();
 	private static final LongAdder imputeApplyTime = new LongAdder();
 
@@ -56,6 +57,10 @@ public class TransformStatistics {
 
 	public static void incBinningApplyTime(long t) {
 		binningApplyTime.add(t);
+	}
+
+	public static void incUDFApplyTime(long t) {
+		UDFApplyTime.add(t);
 	}
 
 	public static void incPassThroughApplyTime(long t) {
@@ -106,8 +111,8 @@ public class TransformStatistics {
 	public static long getEncodeApplyTime() {
 		return dummyCodeApplyTime.longValue() + binningApplyTime.longValue() +
 				featureHashingApplyTime.longValue() + passThroughApplyTime.longValue() +
-				recodeApplyTime.longValue() + omitApplyTime.longValue() +
-				imputeApplyTime.longValue();
+				recodeApplyTime.longValue() + UDFApplyTime.longValue() +
+				omitApplyTime.longValue() + imputeApplyTime.longValue();
 	}
 
 	public static void reset() {
@@ -122,6 +127,7 @@ public class TransformStatistics {
 		passThroughApplyTime.reset();
 		featureHashingApplyTime.reset();
 		binningApplyTime.reset();
+		UDFApplyTime.reset();
 		omitApplyTime.reset();
 		imputeApplyTime.reset();
 		outMatrixPreProcessingTime.reset();
@@ -163,6 +169,9 @@ public class TransformStatistics {
 			if(passThroughApplyTime.longValue() > 0)
 				sb.append("\tPassThrough apply time:\t").append(String.format("%.3f",
 					passThroughApplyTime.longValue()*1e-9)).append(" sec.\n");
+			if(UDFApplyTime.longValue() > 0)
+				sb.append("\tUDF apply time:\t").append(String.format("%.3f",
+					UDFApplyTime.longValue()*1e-9)).append(" sec.\n");
 			if(omitApplyTime.longValue() > 0)
 				sb.append("\tOmit apply time:\t").append(String.format("%.3f",
 					omitApplyTime.longValue()*1e-9)).append(" sec.\n");


### PR DESCRIPTION
This patch integrates UDF-based transformencoders into the
task graph to allow concurrent execution. As we cannot estimate
the sparsity of an arbitrary UDF output, we always allocate
dense output matrix if at least one UDF is present. If an UDF
comes after a dummycode, we slice the expanded columns and
apply the UDF. Moreover, we disable row partitioning for UDFs.