### PR TITLE
[SYSTEMDS-3386] Refactor replacement of CP instructions

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
@@ -152,6 +152,7 @@ public class FederationUtils {
 	}
 
 	public static FederatedRequest callInstruction(String inst, CPOperand varOldOut, long outputId, CPOperand[] varOldIn, long[] varNewIn, ExecType type, boolean rmFedOutputFlag) {
+		boolean isFedInstr = inst.startsWith(ExecType.FED.name() + Lop.OPERAND_DELIMITOR);
 		String linst = InstructionUtils.replaceOperand(inst, 0, type.name());
 		linst = linst.replace(Lop.OPERAND_DELIMITOR+varOldOut.getName()+Lop.DATATYPE_PREFIX, Lop.OPERAND_DELIMITOR+outputId+Lop.DATATYPE_PREFIX);
 		for(int i=0; i<varOldIn.length; i++)
@@ -161,7 +162,7 @@ public class FederationUtils {
 					Lop.OPERAND_DELIMITOR+(varNewIn[i])+Lop.DATATYPE_PREFIX);
 				linst = linst.replace("="+varOldIn[i].getName(), "="+(varNewIn[i])); //parameterized
 			}
-		if(rmFedOutputFlag)
+		if(rmFedOutputFlag && isFedInstr)
 			linst = InstructionUtils.removeFEDOutputFlag(linst);
 		return new FederatedRequest(RequestType.EXEC_INST, outputId, linst);
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/InstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/InstructionUtils.java
@@ -1135,10 +1135,11 @@ public class InstructionUtils
 	 * @return instruction string prepared for federated request
 	 */
 	public static String instructionStringFEDPrepare(String inst, CPOperand varOldOut, long id, CPOperand[] varOldIn, long[] varNewIn, boolean rmFederatedOutput){
+		boolean isFedInstr = inst.startsWith(ExecType.FED.name() + Lop.OPERAND_DELIMITOR);
 		String linst = replaceExecTypeWithCP(inst);
 		linst = replaceOutputOperand(linst, varOldOut, id);
 		linst = replaceInputOperand(linst, varOldIn, varNewIn);
-		if(rmFederatedOutput)
+		if(rmFederatedOutput && isFedInstr)
 			linst = removeFEDOutputFlag(linst);
 		return linst;
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/CtableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/CtableCPInstruction.java
@@ -185,4 +185,20 @@ public class CtableCPInstruction extends ComputationCPInstruction {
 			LineageItemUtils.getLineage(ec, input1, input2, input3);
 		return Pair.of(output.getName(), new LineageItem(getOpcode(), linputs));
 	}
+
+	public CPOperand getOutDim1() {
+		return _outDim1;
+	}
+
+	public CPOperand getOutDim2() {
+		return _outDim2;
+	}
+
+	public boolean getIsExpand() {
+		return _isExpand;
+	}
+
+	public boolean getIgnoreZeros() {
+		return _ignoreZeros;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/IndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/IndexingCPInstruction.java
@@ -56,6 +56,22 @@ public abstract class IndexingCPInstruction extends UnaryCPInstruction {
 			(int)(ec.getScalarInput(colUpper).getLongValue()-1));
 	}
 
+	public CPOperand getRowLower() {
+		return rowLower;
+	}
+
+	public CPOperand getRowUpper() {
+		return rowUpper;
+	}
+
+	public CPOperand getColLower() {
+		return colLower;
+	}
+
+	public CPOperand getColUpper() {
+		return colUpper;
+	}
+
 	public static IndexingCPInstruction parseInstruction ( String str ) {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		String opcode = parts[0];

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/MMChainCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/MMChainCPInstruction.java
@@ -41,6 +41,10 @@ public class MMChainCPInstruction extends UnaryCPInstruction {
 		return _type;
 	}
 
+	public int getNumThreads() {
+		return _numThreads;
+	}
+
 	public static MMChainCPInstruction parseInstruction ( String str ) {
 		//parse instruction parts (without exec type)
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType( str );

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/MMTSJCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/MMTSJCPInstruction.java
@@ -70,4 +70,8 @@ public class MMTSJCPInstruction extends UnaryCPInstruction {
 	{
 		return _type;
 	}
+
+	public int getNumThreads() {
+		return _numThreads;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/QuantilePickCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/QuantilePickCPInstruction.java
@@ -65,7 +65,7 @@ public class QuantilePickCPInstruction extends BinaryCPInstruction {
 			CPOperand out = new CPOperand(parts[2]);
 			OperationTypes ptype = OperationTypes.valueOf(parts[3]);
 			boolean inmem = Boolean.parseBoolean(parts[4]);
-			return new QuantilePickCPInstruction(null, in1, new CPOperand(), out, ptype, inmem, opcode, str);
+			return new QuantilePickCPInstruction(null, in1, out, ptype, inmem, opcode, str);
 		}
 		else if( parts.length == 6 ) {
 			CPOperand in1 = new CPOperand(parts[1]);
@@ -126,5 +126,13 @@ public class QuantilePickCPInstruction extends BinaryCPInstruction {
 			default:
 				throw new DMLRuntimeException("Unsupported qpick operation type: "+_type);
 		}
+	}
+
+	public OperationTypes getOperationType() {
+		return _type;
+	}
+
+	public boolean isInMem() {
+		return _inmem;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/QuantileSortCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/QuantileSortCPInstruction.java
@@ -119,4 +119,8 @@ public class QuantileSortCPInstruction extends UnaryCPInstruction {
 		//set and release output
 		ec.setMatrixOutput(output.getName(), resultBlock);
 	}
+
+	public int getNumThreads() {
+		return _numThreads;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/QuaternaryCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/QuaternaryCPInstruction.java
@@ -135,5 +135,5 @@ public class QuaternaryCPInstruction extends ComputationCPInstruction {
 				}
 			ec.setMatrixOutput(output.getName(), out);
 		}
-	}	
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ReshapeCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ReshapeCPInstruction.java
@@ -113,4 +113,20 @@ public class ReshapeCPInstruction extends UnaryCPInstruction {
 		return Pair.of(output.getName(), new LineageItem(getOpcode(),
 			LineageItemUtils.getLineage(ec, input1, _opRows, _opCols, _opDims, _opByRow)));
 	}
+
+	public CPOperand getOpRows() {
+		return _opRows;
+	}
+
+	public CPOperand getOpCols() {
+		return _opCols;
+	}
+
+	public CPOperand getOpDims() {
+		return _opDims;
+	}
+
+	public CPOperand getOpByRow() {
+		return _opByRow;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/SpoofCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/SpoofCPInstruction.java
@@ -54,6 +54,10 @@ public class SpoofCPInstruction extends ComputationCPInstruction {
 		_in = in;
 	}
 
+	public SpoofOperator getSpoofOperator() {
+		return _op;
+	}
+
 	public Class<?> getOperatorClass() {
 		return _class;
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryScalarCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryScalarCPInstruction.java
@@ -26,10 +26,10 @@ import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 
-public class UnaryScalarCPInstruction extends UnaryMatrixCPInstruction {
+public class UnaryScalarCPInstruction extends UnaryCPInstruction {
 
 	protected UnaryScalarCPInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String instr) {
-		super(op, in, out, opcode, instr);
+		super(CPType.Unary, op, in, out, opcode, instr);
 	}
 
 	@Override 

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateBinaryFEDInstruction.java
@@ -36,7 +36,9 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.AggregateBinaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.AggregateBinarySPInstruction;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
@@ -52,7 +54,17 @@ public class AggregateBinaryFEDInstruction extends BinaryFEDInstruction {
 		String opcode, String istr, FederatedOutput fedOut) {
 		super(FEDType.AggregateBinary, op, in1, in2, out, opcode, istr, fedOut);
 	}
-	
+
+	public static AggregateBinaryFEDInstruction parseInstruction(AggregateBinaryCPInstruction instr) {
+		return new AggregateBinaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static AggregateBinaryFEDInstruction parseInstruction(AggregateBinarySPInstruction instr) {
+		return new AggregateBinaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+				instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
 	public static AggregateBinaryFEDInstruction parseInstruction(String str) {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		String opcode = parts[0];

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateTernaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateTernaryFEDInstruction.java
@@ -31,9 +31,11 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.AggregateTernaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.instructions.spark.AggregateTernarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.AggregateTernaryOperator;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -44,6 +46,16 @@ public class AggregateTernaryFEDInstruction extends ComputationFEDInstruction {
 	private AggregateTernaryFEDInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
 		String opcode, String istr, FederatedOutput fedOut) {
 		super(FEDType.AggregateTernary, op, in1, in2, in3, out, opcode, istr, fedOut);
+	}
+
+	public static AggregateTernaryFEDInstruction parseInstruction(AggregateTernaryCPInstruction instr) {
+		return new AggregateTernaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static AggregateTernaryFEDInstruction parseInstruction(AggregateTernarySPInstruction instr) {
+		return new AggregateTernaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
 	}
 
 	public static AggregateTernaryFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AggregateUnaryFEDInstruction.java
@@ -33,8 +33,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.AggregateUnaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.instructions.spark.AggregateUnarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
@@ -64,6 +66,17 @@ public class AggregateUnaryFEDInstruction extends UnaryFEDInstruction {
 		CPOperand in2, CPOperand in3, CPOperand out, String opcode, String istr)
 	{
 		super(FEDType.AggregateUnary, op, in1, in2, in3, out, opcode, istr);
+	}
+
+	public static AggregateUnaryFEDInstruction parseInstruction(AggregateUnaryCPInstruction instr) {
+		return new AggregateUnaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static AggregateUnaryFEDInstruction parseInstruction(AggregateUnarySPInstruction instr) {
+		// TODO: during processing the NONE-flag of AggregateUnarySPInstruction (SparkAggType) will be removed, making the instruction unparseable
+		return new AggregateUnaryFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static AggregateUnaryFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/AppendFEDInstruction.java
@@ -30,11 +30,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.functionobjects.OffsetColumnIndex;
-import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
-import org.apache.sysds.runtime.instructions.cp.CPInstruction;
+import org.apache.sysds.runtime.instructions.cp.AppendCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
-import org.apache.sysds.runtime.instructions.spark.SPInstruction;
+import org.apache.sysds.runtime.instructions.spark.AppendSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
@@ -56,22 +55,15 @@ public class AppendFEDInstruction extends BinaryFEDInstruction {
 		_cbind = cbind;
 	}
 
-	public static AppendFEDInstruction parseInstruction(Instruction inst){
-		if ( inst instanceof CPInstruction || inst instanceof SPInstruction ){
-			String instStr = inst.getInstructionString();
-			String[] parts = InstructionUtils.getInstructionPartsWithValueType(instStr);
-			InstructionUtils.checkNumFields(parts, 6, 5, 4);
+	public static AppendFEDInstruction parseInstruction(AppendCPInstruction instr) {
+		return new AppendFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getAppendType().equals(AppendCPInstruction.AppendType.CBIND), instr.getOpcode(),
+			instr.getInstructionString(), FederatedOutput.NONE);
+	}
 
-			String opcode = parts[0];
-			CPOperand in1 = new CPOperand(parts[1]);
-			CPOperand in2 = new CPOperand(parts[2]);
-			CPOperand out = new CPOperand(parts[parts.length - 2]);
-			boolean cbind = Boolean.parseBoolean(parts[parts.length - 1]);
-
-			Operator op = new ReorgOperator(OffsetColumnIndex.getOffsetColumnIndexFnObject(-1));
-			return new AppendFEDInstruction(op, in1, in2, out, cbind, opcode, instStr);
-		}
-		else return parseInstruction(inst.getInstructionString());
+	public static AppendFEDInstruction parseInstruction(AppendSPInstruction instr) {
+		return new AppendFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output, instr.getCBind(),
+			instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
 	}
 
 	public static AppendFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryFEDInstruction.java
@@ -104,7 +104,7 @@ public abstract class BinaryFEDInstruction extends ComputationFEDInstruction {
 				" and " + in2.getName() + " must produce a matrix, which " + out.getName() + " is not");
 	}
 
-	private static String rewriteSparkInstructionToCP(String inst_str) {
+	protected static String rewriteSparkInstructionToCP(String inst_str) {
 		// rewrite the spark instruction to a cp instruction
 		inst_str = inst_str.replace(ExecType.SPARK.name(), ExecType.CP.name());
 		inst_str = inst_str.replace(Lop.OPERAND_DELIMITOR + "map", Lop.OPERAND_DELIMITOR);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixMatrixFEDInstruction.java
@@ -28,7 +28,11 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.BinaryMatrixMatrixCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.BinaryMatrixBVectorSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.BinaryMatrixMatrixSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
@@ -37,6 +41,18 @@ public class BinaryMatrixMatrixFEDInstruction extends BinaryFEDInstruction
 	protected BinaryMatrixMatrixFEDInstruction(Operator op,
 		CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr, FederatedOutput fedOut) {
 		super(FEDType.Binary, op, in1, in2, out, opcode, istr, fedOut);
+	}
+
+	public static BinaryMatrixMatrixFEDInstruction parseInstruction(BinaryMatrixMatrixCPInstruction instr) {
+		return new BinaryMatrixMatrixFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static BinaryMatrixMatrixFEDInstruction parseInstruction(BinaryMatrixMatrixSPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new BinaryMatrixMatrixFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			opcode, instrStr, FederatedOutput.NONE);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixScalarFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/BinaryMatrixScalarFEDInstruction.java
@@ -23,7 +23,10 @@ import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.BinaryMatrixScalarCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.BinaryMatrixScalarSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
 public class BinaryMatrixScalarFEDInstruction extends BinaryFEDInstruction
@@ -31,6 +34,18 @@ public class BinaryMatrixScalarFEDInstruction extends BinaryFEDInstruction
 	protected BinaryMatrixScalarFEDInstruction(Operator op,
 		CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr, FederatedOutput fedOut) {
 		super(FEDType.Binary, op, in1, in2, out, opcode, istr, fedOut);
+	}
+
+	public static BinaryMatrixScalarFEDInstruction parseInstruction(BinaryMatrixScalarCPInstruction instr) {
+		return new BinaryMatrixScalarFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static BinaryMatrixScalarFEDInstruction parseInstruction(BinaryMatrixScalarSPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new BinaryMatrixScalarFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			opcode, instrStr, FederatedOutput.NONE);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CastFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CastFEDInstruction.java
@@ -39,6 +39,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.CastSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 
@@ -46,6 +47,11 @@ public class CastFEDInstruction extends UnaryFEDInstruction {
 
 	private CastFEDInstruction(Operator op, CPOperand in, CPOperand out, String opcode, String istr) {
 		super(FEDInstruction.FEDType.Cast, op, in, out, opcode, istr);
+	}
+
+	public static CastFEDInstruction parseInstruction(CastSPInstruction spInstruction) {
+		return new CastFEDInstruction(spInstruction.getOperator(), spInstruction.input1, spInstruction.output,
+			spInstruction.getOpcode(), spInstruction.getInstructionString());
 	}
 
 	public static CastFEDInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CentralMomentFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CentralMomentFEDInstruction.java
@@ -32,7 +32,6 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
-import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CM_COV_Object;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
@@ -40,7 +39,7 @@ import org.apache.sysds.runtime.instructions.cp.CentralMomentCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
-import org.apache.sysds.runtime.instructions.spark.SPInstruction;
+import org.apache.sysds.runtime.instructions.spark.CentralMomentSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.CMOperator;
@@ -64,18 +63,13 @@ public class CentralMomentFEDInstruction extends AggregateUnaryFEDInstruction {
 		return fedInst;
 	}
 
-	public static CentralMomentFEDInstruction parseInstruction(Instruction inst){
-		if ( inst instanceof CentralMomentCPInstruction)
-			return parseInstruction((CentralMomentCPInstruction) inst);
-		else if ( inst instanceof SPInstruction )
-			return parseInstruction(CentralMomentCPInstruction.parseInstruction(inst.getInstructionString()));
-		else
-			return parseInstruction(inst.getInstructionString());
+	public static CentralMomentFEDInstruction parseInstruction(CentralMomentCPInstruction inst) {
+		return new CentralMomentFEDInstruction(inst.getOperator(), inst.input1, inst.input2, inst.input3, inst.output,
+			inst.getOpcode(), inst.getInstructionString());
 	}
 
-	public static CentralMomentFEDInstruction parseInstruction(CentralMomentCPInstruction inst) { 
-		return new CentralMomentFEDInstruction(inst.getOperator(),
-			inst.input1, inst.input2, inst.input3, inst.output,
+	public static CentralMomentFEDInstruction parseInstruction(CentralMomentSPInstruction inst) {
+		return new CentralMomentFEDInstruction(inst.getOperator(), inst.input1, inst.input2, inst.input3, inst.output,
 			inst.getOpcode(), inst.getInstructionString());
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CovarianceFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CovarianceFEDInstruction.java
@@ -37,7 +37,6 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
-import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CM_COV_Object;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
@@ -45,7 +44,7 @@ import org.apache.sysds.runtime.instructions.cp.CovarianceCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
-import org.apache.sysds.runtime.instructions.spark.SPInstruction;
+import org.apache.sysds.runtime.instructions.spark.CovarianceSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.COVOperator;
@@ -68,21 +67,16 @@ public class CovarianceFEDInstruction extends BinaryFEDInstruction {
 		return fedInst;
 	}
 
-	public static CovarianceFEDInstruction parseInstruction(Instruction inst){
-		if ( inst instanceof CovarianceCPInstruction )
-			return parseInstruction((CovarianceCPInstruction) inst);
-		else if ( inst instanceof SPInstruction )
-			return parseInstruction(CovarianceCPInstruction.parseInstruction(inst.getInstructionString()));
-		else
-			return parseInstruction(inst.getInstructionString());
-	}
-
-	public static CovarianceFEDInstruction parseInstruction(CovarianceCPInstruction inst) { 
-		return new CovarianceFEDInstruction(inst.getOperator(),
-			inst.input1, inst.input2, inst.input3, inst.output,
+	public static CovarianceFEDInstruction parseInstruction(CovarianceCPInstruction inst) {
+		return new CovarianceFEDInstruction(inst.getOperator(), inst.input1, inst.input2, inst.input3, inst.output,
 			inst.getOpcode(), inst.getInstructionString());
 	}
-	
+
+	public static CovarianceFEDInstruction parseInstruction(CovarianceSPInstruction inst) {
+		return new CovarianceFEDInstruction(inst.getOperator(), inst.input1, inst.input2, inst.input3, inst.output,
+			inst.getOpcode(), inst.getInstructionString());
+	}
+
 	@Override
 	public void processInstruction(ExecutionContext ec) {
 		MatrixObject mo1 = ec.getMatrixObject(input1);

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/CumulativeOffsetFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/CumulativeOffsetFEDInstruction.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.CumulativeOffsetSPInstruction;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
@@ -57,6 +58,11 @@ public class CumulativeOffsetFEDInstruction extends BinaryFEDInstruction
 			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummin"));
 		else if ("bcumoffmax".equals(opcode))
 			_uop = new UnaryOperator(Builtin.getBuiltinFnObject("ucummax"));
+	}
+
+	public static CumulativeOffsetFEDInstruction parseInstruction(CumulativeOffsetSPInstruction instr) {
+		return new CumulativeOffsetFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getInitValue(), instr.getBroadcast(), instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static CumulativeOffsetFEDInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/FEDInstructionUtils.java
@@ -29,15 +29,18 @@ import org.apache.sysds.runtime.codegen.SpoofRowwise;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
-import org.apache.sysds.runtime.controlprogram.caching.TensorObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.AggregateBinaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.AggregateTernaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.AggregateUnaryCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.AppendCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.BinaryCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.BinaryMatrixMatrixCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.BinaryMatrixScalarCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CentralMomentCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.CovarianceCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.CtableCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.IndexingCPInstruction;
@@ -45,8 +48,11 @@ import org.apache.sysds.runtime.instructions.cp.MMChainCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.MMTSJCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.MultiReturnParameterizedBuiltinCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ParameterizedBuiltinCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.QuantilePickCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.QuantileSortCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ReorgCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.ReshapeCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.SpoofCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.TernaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.TernaryFrameScalarCPInstruction;
@@ -54,21 +60,20 @@ import org.apache.sysds.runtime.instructions.cp.UnaryCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.UnaryMatrixCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction.VariableOperationCode;
-import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FederatedOutput;
+import org.apache.sysds.runtime.instructions.spark.AggregateBinarySPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AggregateTernarySPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AggregateUnarySPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGAlignedSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendGSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendMSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.AppendRSPInstruction;
-import org.apache.sysds.runtime.instructions.spark.BinaryMatrixBVectorSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.AppendSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinaryMatrixMatrixSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinaryMatrixScalarSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.BinarySPInstruction;
-import org.apache.sysds.runtime.instructions.spark.BinaryTensorTensorBroadcastSPInstruction;
-import org.apache.sysds.runtime.instructions.spark.BinaryTensorTensorSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.CastSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.CentralMomentSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.CovarianceSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.CpmmSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.CtableSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.CumulativeOffsetSPInstruction;
@@ -91,7 +96,7 @@ import org.apache.sysds.runtime.instructions.spark.WriteSPInstruction;
 
 public class FEDInstructionUtils {
 	
-	private static String[] PARAM_BUILTINS = new String[]{
+	private static final String[] PARAM_BUILTINS = new String[]{
 		"replace", "rmempty", "lowertri", "uppertri", "transformdecode", "transformapply", "tokenize"};
 
 	public static boolean noFedRuntimeConversion = false;
@@ -120,8 +125,7 @@ public class FEDInstructionUtils {
 					if ( (mo1.isFederated(FType.ROW) && mo1.isFederatedExcept(FType.BROADCAST))
 						|| (mo2.isFederated(FType.ROW) && mo2.isFederatedExcept(FType.BROADCAST))
 						|| (mo1.isFederated(FType.COL) && mo1.isFederatedExcept(FType.BROADCAST))) {
-						fedinst = AggregateBinaryFEDInstruction.parseInstruction(
-							InstructionUtils.concatOperands(inst.getInstructionString(), FederatedOutput.NONE.name()));
+						fedinst = AggregateBinaryFEDInstruction.parseInstruction(instruction);
 					}
 				}
 			}
@@ -129,14 +133,14 @@ public class FEDInstructionUtils {
 				MMChainCPInstruction linst = (MMChainCPInstruction) inst;
 				MatrixObject mo = ec.getMatrixObject(linst.input1);
 				if( mo.isFederated(FType.ROW) )
-					fedinst = MMChainFEDInstruction.parseInstruction(linst.getInstructionString());
+					fedinst = MMChainFEDInstruction.parseInstruction(linst);
 			}
 			else if( inst instanceof MMTSJCPInstruction ) {
 				MMTSJCPInstruction linst = (MMTSJCPInstruction) inst;
 				MatrixObject mo = ec.getMatrixObject(linst.input1);
 				if( (mo.isFederated(FType.ROW) && mo.isFederatedExcept(FType.BROADCAST) && linst.getMMTSJType().isLeft()) ||
 					(mo.isFederated(FType.COL) && mo.isFederatedExcept(FType.BROADCAST) && linst.getMMTSJType().isRight()))
-					fedinst = TsmmFEDInstruction.parseInstruction(linst.getInstructionString());
+					fedinst = TsmmFEDInstruction.parseInstruction(linst);
 			}
 			else if (inst instanceof UnaryCPInstruction && ! (inst instanceof IndexingCPInstruction)) {
 				UnaryCPInstruction instruction = (UnaryCPInstruction) inst;
@@ -147,62 +151,65 @@ public class FEDInstructionUtils {
 
 					if((mo instanceof MatrixObject || mo instanceof FrameObject)
 						&& mo.isFederatedExcept(FType.BROADCAST) )
-						fedinst = ReorgFEDInstruction.parseInstruction(
-							InstructionUtils.concatOperands(rinst.getInstructionString(),FederatedOutput.NONE.name()));
+						fedinst = ReorgFEDInstruction.parseInstruction(rinst);
 				}
 				else if(instruction.input1 != null && instruction.input1.isMatrix()
 					&& ec.containsVariable(instruction.input1)) {
 
 					MatrixObject mo1 = ec.getMatrixObject(instruction.input1);
 					if( mo1.isFederatedExcept(FType.BROADCAST) ) {
-						if(instruction.getOpcode().equalsIgnoreCase("cm"))
-							fedinst = CentralMomentFEDInstruction.parseInstruction(inst);
-						else if(inst.getOpcode().equalsIgnoreCase("qsort")) {
+						if(instruction instanceof CentralMomentCPInstruction)
+							fedinst = CentralMomentFEDInstruction.parseInstruction((CentralMomentCPInstruction) inst);
+						else if(inst instanceof QuantileSortCPInstruction) {
 							if(mo1.isFederated(FType.ROW) || mo1.getFedMapping().getFederatedRanges().length == 1 && mo1.isFederated(FType.COL))
-								fedinst = QuantileSortFEDInstruction.parseInstruction(inst.getInstructionString(), false);
+								fedinst = QuantileSortFEDInstruction.parseInstruction((QuantileSortCPInstruction) inst);
 						}
-						else if(inst.getOpcode().equalsIgnoreCase("rshape"))
-							fedinst = ReshapeFEDInstruction.parseInstruction(inst.getInstructionString());
+						else if(inst instanceof ReshapeCPInstruction)
+							fedinst = ReshapeFEDInstruction.parseInstruction((ReshapeCPInstruction) inst);
 						else if(inst instanceof AggregateUnaryCPInstruction &&
 							((AggregateUnaryCPInstruction) instruction).getAUType() == AggregateUnaryCPInstruction.AUType.DEFAULT)
-							fedinst = AggregateUnaryFEDInstruction.parseInstruction(
-								InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+							fedinst = AggregateUnaryFEDInstruction.parseInstruction((AggregateUnaryCPInstruction) inst);
 						else if(inst instanceof UnaryMatrixCPInstruction) {
 							if(UnaryMatrixFEDInstruction.isValidOpcode(inst.getOpcode()) &&
 								!(inst.getOpcode().equalsIgnoreCase("ucumk+*") && mo1.isFederated(FType.COL)))
-								fedinst = UnaryMatrixFEDInstruction.parseInstruction(inst.getInstructionString());
+								fedinst = UnaryMatrixFEDInstruction.parseInstruction((UnaryMatrixCPInstruction) inst);
 						}
 					}
 				}
 			}
 			else if (inst instanceof BinaryCPInstruction) {
 				BinaryCPInstruction instruction = (BinaryCPInstruction) inst;
-				if( (instruction.input1.isMatrix() && ec.getMatrixObject(instruction.input1).isFederatedExcept(FType.BROADCAST))
-					|| (instruction.input2.isMatrix() && ec.getMatrixObject(instruction.input2).isFederatedExcept(FType.BROADCAST))) {
-					if(instruction.getOpcode().equals("append") )
-						fedinst = AppendFEDInstruction.parseInstruction(inst);
-					else if(instruction.getOpcode().equals("qpick"))
-						fedinst = QuantilePickFEDInstruction.parseInstruction(inst);
-					else if("cov".equals(instruction.getOpcode()) && (ec.getMatrixObject(instruction.input1).isFederated(FType.ROW) ||
-						ec.getMatrixObject(instruction.input2).isFederated(FType.ROW)))
-						fedinst = CovarianceFEDInstruction.parseInstruction(inst);
-					else
-						fedinst = BinaryFEDInstruction.parseInstruction(
-							InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+				if((instruction.input1.isMatrix() &&
+					ec.getMatrixObject(instruction.input1).isFederatedExcept(FType.BROADCAST)) ||
+					(instruction.input2 != null && instruction.input2.isMatrix() &&
+						ec.getMatrixObject(instruction.input2).isFederatedExcept(FType.BROADCAST))) {
+					if(instruction instanceof AppendCPInstruction)
+						fedinst = AppendFEDInstruction.parseInstruction((AppendCPInstruction) inst);
+					else if(instruction instanceof QuantilePickCPInstruction)
+						fedinst = QuantilePickFEDInstruction.parseInstruction((QuantilePickCPInstruction) inst);
+					else if(instruction instanceof CovarianceCPInstruction &&
+						(ec.getMatrixObject(instruction.input1).isFederated(FType.ROW) ||
+							ec.getMatrixObject(instruction.input2).isFederated(FType.ROW)))
+						fedinst = CovarianceFEDInstruction.parseInstruction((CovarianceCPInstruction) inst);
+					else if(instruction instanceof BinaryMatrixMatrixCPInstruction)
+						fedinst = BinaryMatrixMatrixFEDInstruction
+							.parseInstruction((BinaryMatrixMatrixCPInstruction) inst);
+					else if(instruction instanceof BinaryMatrixScalarCPInstruction)
+						fedinst = BinaryMatrixScalarFEDInstruction
+							.parseInstruction((BinaryMatrixScalarCPInstruction) inst);
 				}
 			}
 			else if( inst instanceof ParameterizedBuiltinCPInstruction ) {
 				ParameterizedBuiltinCPInstruction pinst = (ParameterizedBuiltinCPInstruction) inst;
 				if( ArrayUtils.contains(PARAM_BUILTINS, pinst.getOpcode()) && pinst.getTarget(ec).isFederatedExcept(FType.BROADCAST) )
-					fedinst = ParameterizedBuiltinFEDInstruction.parseInstruction(pinst.getInstructionString());
+					fedinst = ParameterizedBuiltinFEDInstruction.parseInstruction(pinst);
 			}
 			else if (inst instanceof MultiReturnParameterizedBuiltinCPInstruction) {
 				MultiReturnParameterizedBuiltinCPInstruction minst = (MultiReturnParameterizedBuiltinCPInstruction) inst;
 				if(minst.getOpcode().equals("transformencode") && minst.input1.isFrame()) {
 					CacheableData<?> fo = ec.getCacheableData(minst.input1);
 					if(fo.isFederatedExcept(FType.BROADCAST)) {
-						fedinst = MultiReturnParameterizedBuiltinFEDInstruction
-							.parseInstruction(minst.getInstructionString());
+						fedinst = MultiReturnParameterizedBuiltinFEDInstruction.parseInstruction(minst);
 					}
 				}
 			}
@@ -211,7 +218,7 @@ public class FEDInstructionUtils {
 				IndexingCPInstruction minst = (IndexingCPInstruction) inst;
 				if((minst.input1.isMatrix() || minst.input1.isFrame())
 					&& ec.getCacheableData(minst.input1).isFederatedExcept(FType.BROADCAST)) {
-					fedinst = IndexingFEDInstruction.parseInstruction(minst.getInstructionString());
+					fedinst = IndexingFEDInstruction.parseInstruction(minst);
 				}
 			}
 			else if(inst instanceof TernaryCPInstruction) {
@@ -221,13 +228,12 @@ public class FEDInstructionUtils {
 					long margin = ec.getScalarInput(tinst.input3).getLongValue();
 					FrameObject fo = ec.getFrameObject(tinst.input1);
 					if(margin == 0 || (fo.isFederated(FType.ROW) && margin == 1) || (fo.isFederated(FType.COL) && margin == 2))
-						fedinst = TernaryFrameScalarFEDInstruction
-							.parseInstruction(InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+						fedinst = TernaryFrameScalarFEDInstruction.parseInstruction((TernaryFrameScalarCPInstruction) inst);
 				}
 				else if((tinst.input1.isMatrix() && ec.getCacheableData(tinst.input1).isFederatedExcept(FType.BROADCAST))
 					|| (tinst.input2.isMatrix() && ec.getCacheableData(tinst.input2).isFederatedExcept(FType.BROADCAST))
 					|| (tinst.input3.isMatrix() && ec.getCacheableData(tinst.input3).isFederatedExcept(FType.BROADCAST))) {
-					fedinst = TernaryFEDInstruction.parseInstruction(tinst.getInstructionString());
+					fedinst = TernaryFEDInstruction.parseInstruction(tinst);
 				}
 			}
 			else if(inst instanceof VariableCPInstruction ){
@@ -252,14 +258,14 @@ public class FEDInstructionUtils {
 				AggregateTernaryCPInstruction ins = (AggregateTernaryCPInstruction) inst;
 				if(ins.input1.isMatrix() && ec.getCacheableData(ins.input1).isFederatedExcept(FType.BROADCAST)
 					&& ins.input2.isMatrix() && ec.getCacheableData(ins.input2).isFederatedExcept(FType.BROADCAST)) {
-					fedinst = AggregateTernaryFEDInstruction.parseInstruction(ins.getInstructionString());
+					fedinst = AggregateTernaryFEDInstruction.parseInstruction(ins);
 				}
 			}
 			else if(inst instanceof QuaternaryCPInstruction) {
 				QuaternaryCPInstruction instruction = (QuaternaryCPInstruction) inst;
 				Data data = ec.getVariable(instruction.input1);
 				if(data instanceof MatrixObject && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST))
-					fedinst = QuaternaryFEDInstruction.parseInstruction(instruction.getInstructionString());
+					fedinst = QuaternaryFEDInstruction.parseInstruction(instruction);
 			}
 			else if(inst instanceof SpoofCPInstruction) {
 				SpoofCPInstruction ins = (SpoofCPInstruction) inst;
@@ -267,7 +273,7 @@ public class FEDInstructionUtils {
 				if(((scla == SpoofCellwise.class || scla == SpoofMultiAggregate.class || scla == SpoofOuterProduct.class)
 					&& SpoofFEDInstruction.isFederated(ec, ins.getInputs(), scla))
 					|| (scla == SpoofRowwise.class && SpoofFEDInstruction.isFederated(ec, FType.ROW, ins.getInputs(), scla))) {
-					fedinst = SpoofFEDInstruction.parseInstruction(ins.getInstructionString());
+					fedinst = SpoofFEDInstruction.parseInstruction(ins);
 				}
 			}
 			else if(inst instanceof CtableCPInstruction) {
@@ -276,7 +282,7 @@ public class FEDInstructionUtils {
 					&& ( ec.getCacheableData(cinst.input1).isFederated(FType.ROW)
 					|| (cinst.input2.isMatrix() && ec.getCacheableData(cinst.input2).isFederated(FType.ROW))
 					|| (cinst.input3.isMatrix() && ec.getCacheableData(cinst.input3).isFederated(FType.ROW))))
-					fedinst = CtableFEDInstruction.parseInstruction(cinst.getInstructionString());
+					fedinst = CtableFEDInstruction.parseInstruction(cinst);
 			}
 
 			//set thread id for federated context management
@@ -296,7 +302,7 @@ public class FEDInstructionUtils {
 			if((ins.getOpcode().equalsIgnoreCase(OpOp1.CAST_AS_FRAME.toString())
 					|| ins.getOpcode().equalsIgnoreCase(OpOp1.CAST_AS_MATRIX.toString()))
 				&& ins.input1.isMatrix() && ec.getCacheableData(ins.input1).isFederatedExcept(FType.BROADCAST)){
-				fedinst = CastFEDInstruction.parseInstruction(ins.getInstructionString());
+				fedinst = CastFEDInstruction.parseInstruction(ins);
 			}
 		}
 		else if (inst instanceof WriteSPInstruction) {
@@ -312,7 +318,7 @@ public class FEDInstructionUtils {
 			QuaternarySPInstruction instruction = (QuaternarySPInstruction) inst;
 			Data data = ec.getVariable(instruction.input1);
 			if(data instanceof MatrixObject && ((MatrixObject) data).isFederated())
-				fedinst = QuaternaryFEDInstruction.parseInstruction(instruction.getInstructionString());
+				fedinst = QuaternaryFEDInstruction.parseInstruction(instruction);
 		}
 		else if(inst instanceof SpoofSPInstruction) {
 			SpoofSPInstruction ins = (SpoofSPInstruction) inst;
@@ -320,7 +326,7 @@ public class FEDInstructionUtils {
 			if(((scla == SpoofCellwise.class || scla == SpoofMultiAggregate.class || scla == SpoofOuterProduct.class)
 					&& SpoofFEDInstruction.isFederated(ec, ins.getInputs(), scla))
 				|| (scla == SpoofRowwise.class && SpoofFEDInstruction.isFederated(ec, FType.ROW, ins.getInputs(), scla))) {
-				fedinst = SpoofFEDInstruction.parseInstruction(inst.getInstructionString());
+				fedinst = SpoofFEDInstruction.parseInstruction(ins);
 			}
 		}
 		else if (inst instanceof UnarySPInstruction && ! (inst instanceof IndexingSPInstruction)) {
@@ -329,12 +335,12 @@ public class FEDInstructionUtils {
 				CentralMomentSPInstruction cinstruction = (CentralMomentSPInstruction) inst;
 				Data data = ec.getVariable(cinstruction.input1);
 				if (data instanceof MatrixObject && ((MatrixObject) data).isFederated() && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST))
-					fedinst = CentralMomentFEDInstruction.parseInstruction(inst);
+					fedinst = CentralMomentFEDInstruction.parseInstruction(cinstruction);
 			} else if (inst instanceof QuantileSortSPInstruction) {
 				QuantileSortSPInstruction qinstruction = (QuantileSortSPInstruction) inst;
 				Data data = ec.getVariable(qinstruction.input1);
 				if (data instanceof MatrixObject && ((MatrixObject) data).isFederated() && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST))
-					fedinst = QuantileSortFEDInstruction.parseInstruction(inst.getInstructionString(), false);
+					fedinst = QuantileSortFEDInstruction.parseInstruction(qinstruction);
 			}
 			else if (inst instanceof AggregateUnarySPInstruction) {
 				AggregateUnarySPInstruction auinstruction = (AggregateUnarySPInstruction) inst;
@@ -342,25 +348,23 @@ public class FEDInstructionUtils {
 				if(data instanceof MatrixObject && ((MatrixObject) data).isFederated() && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST))
 					if(ArrayUtils.contains(new String[]{"uarimin", "uarimax"}, auinstruction.getOpcode())) {
 						if(((MatrixObject) data).getFedMapping().getType() == FType.ROW)
-							fedinst = AggregateUnaryFEDInstruction.parseInstruction(
-								InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+							fedinst = AggregateUnaryFEDInstruction.parseInstruction(auinstruction);
 					}
 					else
-						fedinst = AggregateUnaryFEDInstruction.parseInstruction(InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+						fedinst = AggregateUnaryFEDInstruction.parseInstruction(auinstruction);
 			}
 			else if(inst instanceof ReorgSPInstruction && (inst.getOpcode().equals("r'") || inst.getOpcode().equals("rdiag")
 				|| inst.getOpcode().equals("rev"))) {
 				ReorgSPInstruction rinst = (ReorgSPInstruction) inst;
 				CacheableData<?> mo = ec.getCacheableData(rinst.input1);
-				if((mo instanceof MatrixObject || mo instanceof FrameObject) && mo.isFederated()  && ((MatrixObject) mo).isFederatedExcept(FType.BROADCAST))
-					fedinst = ReorgFEDInstruction.parseInstruction(
-						InstructionUtils.concatOperands(rinst.getInstructionString(), FederatedOutput.NONE.name()));
+				if((mo instanceof MatrixObject || mo instanceof FrameObject) && mo.isFederated() && mo.isFederatedExcept(FType.BROADCAST))
+					fedinst = ReorgFEDInstruction.parseInstruction(rinst);
 			}
 			else if(inst instanceof ReblockSPInstruction && instruction.input1 != null && (instruction.input1.isFrame() || instruction.input1.isMatrix())) {
 				ReblockSPInstruction rinst = (ReblockSPInstruction)  instruction;
 				CacheableData<?> data = ec.getCacheableData(rinst.input1);
 				if(data.isFederatedExcept(FType.BROADCAST))
-					fedinst = ReblockFEDInstruction.parseInstruction(inst.getInstructionString());
+					fedinst = ReblockFEDInstruction.parseInstruction((ReblockSPInstruction) inst);
 			}
 			else if(instruction.input1 != null && instruction.input1.isMatrix() && ec.containsVariable(instruction.input1)) {
 				MatrixObject mo1 = ec.getMatrixObject(instruction.input1);
@@ -376,7 +380,7 @@ public class FEDInstructionUtils {
 					}
 					else if(inst instanceof UnaryMatrixSPInstruction) {
 						if(UnaryMatrixFEDInstruction.isValidOpcode(inst.getOpcode()))
-							fedinst = UnaryMatrixFEDInstruction.parseInstruction(inst.getInstructionString());
+							fedinst = UnaryMatrixFEDInstruction.parseInstruction((UnaryMatrixSPInstruction) inst);
 					}
 				}
 			}
@@ -386,7 +390,7 @@ public class FEDInstructionUtils {
 			if (inst instanceof MapmmSPInstruction || inst instanceof CpmmSPInstruction || inst instanceof RmmSPInstruction) {
 				Data data = ec.getVariable(instruction.input1);
 				if (data instanceof MatrixObject && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST)) {
-					fedinst = MMFEDInstruction.parseInstruction(instruction.getInstructionString());
+					fedinst = MMFEDInstruction.parseInstruction((AggregateBinarySPInstruction) instruction);
 				}
 			}
 			else
@@ -394,7 +398,7 @@ public class FEDInstructionUtils {
 				QuantilePickSPInstruction qinstruction = (QuantilePickSPInstruction) inst;
 				Data data = ec.getVariable(qinstruction.input1);
 				if(data instanceof MatrixObject && ((MatrixObject) data).isFederatedExcept(FType.BROADCAST))
-					fedinst = QuantilePickFEDInstruction.parseInstruction(inst);
+					fedinst = QuantilePickFEDInstruction.parseInstruction(qinstruction);
 			}
 			else if (inst instanceof AppendGAlignedSPInstruction || inst instanceof AppendGSPInstruction
 				|| inst instanceof AppendMSPInstruction || inst instanceof AppendRSPInstruction) {
@@ -403,44 +407,45 @@ public class FEDInstructionUtils {
 				Data data2 = ec.getVariable(ainstruction.input2);
 				if ((data1 instanceof MatrixObject && ((MatrixObject) data1).isFederatedExcept(FType.BROADCAST))
 					|| (data2 instanceof MatrixObject && ((MatrixObject) data2).isFederatedExcept(FType.BROADCAST))) {
-					fedinst = AppendFEDInstruction.parseInstruction(instruction);
+					fedinst = AppendFEDInstruction.parseInstruction((AppendSPInstruction) instruction);
 				}
 			}
-			else if (inst instanceof BinaryMatrixScalarSPInstruction
-				|| inst instanceof BinaryMatrixMatrixSPInstruction
-				|| inst instanceof BinaryMatrixBVectorSPInstruction
-				|| inst instanceof BinaryTensorTensorSPInstruction
-				|| inst instanceof BinaryTensorTensorBroadcastSPInstruction) {
+			else if (inst instanceof BinaryMatrixScalarSPInstruction) {
 				Data data = ec.getVariable(instruction.input1);
-				if((data instanceof MatrixObject && ((MatrixObject)data).isFederatedExcept(FType.BROADCAST))
-					|| (data instanceof TensorObject && ((TensorObject)data).isFederatedExcept(FType.BROADCAST))) {
-					fedinst = BinaryFEDInstruction.parseInstruction(
-						InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+				if(data instanceof MatrixObject && ((MatrixObject)data).isFederatedExcept(FType.BROADCAST)) {
+					fedinst = BinaryMatrixScalarFEDInstruction.parseInstruction((BinaryMatrixScalarSPInstruction) inst);
+				}
+			}
+			else if (inst instanceof BinaryMatrixMatrixSPInstruction) {
+				Data data = ec.getVariable(instruction.input1);
+				if(data instanceof MatrixObject && ((MatrixObject)data).isFederatedExcept(FType.BROADCAST)) {
+					fedinst = BinaryMatrixMatrixFEDInstruction.parseInstruction((BinaryMatrixMatrixSPInstruction) inst);
 				}
 			}
 			else if( (instruction.input1.isMatrix() && ec.getCacheableData(instruction.input1).isFederatedExcept(FType.BROADCAST))
 				|| (instruction.input2.isMatrix() && ec.getMatrixObject(instruction.input2).isFederatedExcept(FType.BROADCAST))) {
-				if("cov".equals(instruction.getOpcode()) && (ec.getMatrixObject(instruction.input1)
+				if(inst instanceof CovarianceSPInstruction && (ec.getMatrixObject(instruction.input1)
 					.isFederated(FType.ROW) || ec.getMatrixObject(instruction.input2).isFederated(FType.ROW)))
-					fedinst = CovarianceFEDInstruction.parseInstruction(inst);
+					fedinst = CovarianceFEDInstruction.parseInstruction((CovarianceSPInstruction) inst);
 				else if(inst instanceof CumulativeOffsetSPInstruction) {
-					fedinst = CumulativeOffsetFEDInstruction.parseInstruction(inst.getInstructionString());
+					fedinst = CumulativeOffsetFEDInstruction.parseInstruction((CumulativeOffsetSPInstruction) inst);
 				}
 				else
-					fedinst = BinaryFEDInstruction.parseInstruction(InstructionUtils.concatOperands(inst.getInstructionString(), FederatedOutput.NONE.name()));
+					fedinst = BinaryFEDInstruction.parseInstruction(InstructionUtils
+						.concatOperands(inst.getInstructionString(), FEDInstruction.FederatedOutput.NONE.name()));
 			}
 		}
 		else if( inst instanceof ParameterizedBuiltinSPInstruction) {
 			ParameterizedBuiltinSPInstruction pinst = (ParameterizedBuiltinSPInstruction) inst;
 			if( pinst.getOpcode().equalsIgnoreCase("replace") && pinst.getTarget(ec).isFederatedExcept(FType.BROADCAST) )
-				fedinst = ParameterizedBuiltinFEDInstruction.parseInstruction(pinst.getInstructionString());
+				fedinst = ParameterizedBuiltinFEDInstruction.parseInstruction(pinst);
 		}
 		else if (inst instanceof MultiReturnParameterizedBuiltinSPInstruction) {
 			MultiReturnParameterizedBuiltinSPInstruction minst = (MultiReturnParameterizedBuiltinSPInstruction) inst;
 			if(minst.getOpcode().equals("transformencode") && minst.input1.isFrame()) {
 				CacheableData<?> fo = ec.getCacheableData(minst.input1);
 				if(fo.isFederatedExcept(FType.BROADCAST)) {
-					fedinst = MultiReturnParameterizedBuiltinFEDInstruction.parseInstruction(minst.getInstructionString());
+					fedinst = MultiReturnParameterizedBuiltinFEDInstruction.parseInstruction(minst);
 				}
 			}
 		}
@@ -449,7 +454,7 @@ public class FEDInstructionUtils {
 			IndexingSPInstruction minst = (IndexingSPInstruction) inst;
 			if((minst.input1.isMatrix() || minst.input1.isFrame())
 				&& ec.getCacheableData(minst.input1).isFederatedExcept(FType.BROADCAST)) {
-				fedinst = IndexingFEDInstruction.parseInstruction(minst.getInstructionString());
+				fedinst = IndexingFEDInstruction.parseInstruction(minst);
 			}
 		}
 		else if(inst instanceof TernarySPInstruction) {
@@ -459,19 +464,18 @@ public class FEDInstructionUtils {
 				long margin = ec.getScalarInput(tinst.input3).getLongValue();
 				FrameObject fo = ec.getFrameObject(tinst.input1);
 				if(margin == 0 || (fo.isFederated(FType.ROW) && margin == 1) || (fo.isFederated(FType.COL) && margin == 2))
-					fedinst = TernaryFrameScalarFEDInstruction
-						.parseInstruction(InstructionUtils.concatOperands(inst.getInstructionString(),FederatedOutput.NONE.name()));
+					fedinst = TernaryFrameScalarFEDInstruction.parseInstruction((TernaryFrameScalarSPInstruction) tinst);
 			} else if((tinst.input1.isMatrix() && ec.getCacheableData(tinst.input1).isFederatedExcept(FType.BROADCAST))
 				|| (tinst.input2.isMatrix() && ec.getCacheableData(tinst.input2).isFederatedExcept(FType.BROADCAST))
 				|| (tinst.input3.isMatrix() && ec.getCacheableData(tinst.input3).isFederatedExcept(FType.BROADCAST))) {
-				fedinst = TernaryFEDInstruction.parseInstruction(tinst.getInstructionString());
+				fedinst = TernaryFEDInstruction.parseInstruction(tinst);
 			}
 		}
 		else if(inst instanceof AggregateTernarySPInstruction){
 			AggregateTernarySPInstruction ins = (AggregateTernarySPInstruction) inst;
 			if(ins.input1.isMatrix() && ec.getCacheableData(ins.input1).isFederatedExcept(FType.BROADCAST) && ins.input2.isMatrix() &&
 				ec.getCacheableData(ins.input2).isFederatedExcept(FType.BROADCAST)) {
-				fedinst = AggregateTernaryFEDInstruction.parseInstruction(ins.getInstructionString());
+				fedinst = AggregateTernaryFEDInstruction.parseInstruction(ins);
 			}
 		}
 		else if(inst instanceof CtableSPInstruction) {
@@ -480,7 +484,7 @@ public class FEDInstructionUtils {
 				&& ( ec.getCacheableData(cinst.input1).isFederated(FType.ROW)
 				|| (cinst.input2.isMatrix() && ec.getCacheableData(cinst.input2).isFederated(FType.ROW))
 				|| (cinst.input3.isMatrix() && ec.getCacheableData(cinst.input3).isFederated(FType.ROW))))
-				fedinst = CtableFEDInstruction.parseInstruction(cinst.getInstructionString());
+				fedinst = CtableFEDInstruction.parseInstruction(cinst);
 		}
 
 		//set thread id for federated context management

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/IndexingFEDInstruction.java
@@ -46,8 +46,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.IndexingCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.IndexingSPInstruction;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.IndexRange;
 
@@ -78,6 +80,16 @@ public final class IndexingFEDInstruction extends UnaryFEDInstruction {
 			(int) (ec.getScalarInput(rowUpper).getLongValue() - 1),
 			(int) (ec.getScalarInput(colLower).getLongValue() - 1),
 			(int) (ec.getScalarInput(colUpper).getLongValue() - 1));
+	}
+
+	public static IndexingFEDInstruction parseInstruction(IndexingCPInstruction instr) {
+		return new IndexingFEDInstruction(instr.input1, instr.input2, instr.getRowLower(), instr.getRowUpper(),
+			instr.getColLower(), instr.getColUpper(), instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static IndexingFEDInstruction parseInstruction(IndexingSPInstruction instr) {
+		return new IndexingFEDInstruction(instr.input1, instr.input2, instr.getRowLower(), instr.getRowUpper(),
+			instr.getColLower(), instr.getColUpper(), instr.output, instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static IndexingFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MMChainFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MMChainFEDInstruction.java
@@ -31,6 +31,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.Reques
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.MMChainCPInstruction;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 import java.util.concurrent.Future;
@@ -47,6 +48,11 @@ public class MMChainFEDInstruction extends UnaryFEDInstruction {
 
 	public ChainType getMMChainType() {
 		return _type;
+	}
+
+	public static MMChainFEDInstruction parseInstruction(MMChainCPInstruction instr) {
+		return new MMChainFEDInstruction(instr.input1, instr.input2, instr.input3, instr.output, instr.getMMChainType(),
+			instr.getNumThreads(), instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static MMChainFEDInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -50,6 +50,8 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.instructions.cp.MultiReturnParameterizedBuiltinCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.MultiReturnParameterizedBuiltinSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
@@ -64,16 +66,28 @@ import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
 import org.apache.sysds.runtime.util.IndexRange;
 
 public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFEDInstruction {
-	protected final ArrayList<CPOperand> _outputs;
+	protected final List<CPOperand> _outputs;
 
 	private MultiReturnParameterizedBuiltinFEDInstruction(Operator op, CPOperand input1, CPOperand input2,
-		ArrayList<CPOperand> outputs, String opcode, String istr) {
+		List<CPOperand> outputs, String opcode, String istr) {
 		super(FEDType.MultiReturnParameterizedBuiltin, op, input1, input2, null, opcode, istr);
 		_outputs = outputs;
 	}
 
 	public CPOperand getOutput(int i) {
 		return _outputs.get(i);
+	}
+
+	public static MultiReturnParameterizedBuiltinFEDInstruction parseInstruction(
+		MultiReturnParameterizedBuiltinCPInstruction instr) {
+		return new MultiReturnParameterizedBuiltinFEDInstruction(instr.getOperator(), instr.input1, instr.input2,
+			instr.getOutputs(), instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static MultiReturnParameterizedBuiltinFEDInstruction parseInstruction(
+			MultiReturnParameterizedBuiltinSPInstruction instr) {
+		return new MultiReturnParameterizedBuiltinFEDInstruction(instr.getOperator(), instr.input1, instr.input2,
+				instr.getOutputs(), instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static MultiReturnParameterizedBuiltinFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ParameterizedBuiltinFEDInstruction.java
@@ -62,7 +62,9 @@ import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.instructions.cp.ParameterizedBuiltinCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.instructions.spark.ParameterizedBuiltinSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
@@ -80,9 +82,9 @@ import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstruction {
-	protected final LinkedHashMap<String, String> params;
+	protected final HashMap<String, String> params;
 
-	protected ParameterizedBuiltinFEDInstruction(Operator op, LinkedHashMap<String, String> paramsMap, CPOperand out,
+	protected ParameterizedBuiltinFEDInstruction(Operator op, HashMap<String, String> paramsMap, CPOperand out,
 		String opcode, String istr) {
 		super(FEDType.ParameterizedBuiltin, op, null, null, out, opcode, istr);
 		params = paramsMap;
@@ -108,6 +110,16 @@ public class ParameterizedBuiltinFEDInstruction extends ComputationFEDInstructio
 		}
 
 		return paramMap;
+	}
+
+	public static ParameterizedBuiltinFEDInstruction parseInstruction(ParameterizedBuiltinCPInstruction instr) {
+		return new ParameterizedBuiltinFEDInstruction(instr.getOperator(), instr.getParameterMap(), instr.output,
+			instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static ParameterizedBuiltinFEDInstruction parseInstruction(ParameterizedBuiltinSPInstruction instr) {
+		return new ParameterizedBuiltinFEDInstruction(instr.getOperator(), instr.getParameterMap(), instr.output,
+			instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static ParameterizedBuiltinFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.hops.fedplanner.FTypes.FType;
-import org.apache.sysds.lops.Lop;
 import org.apache.sysds.lops.PickByCount.OperationTypes;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
@@ -48,12 +47,13 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
-import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.DoubleObject;
+import org.apache.sysds.runtime.instructions.cp.QuantilePickCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.instructions.spark.QuantilePickSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -80,8 +80,14 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 		this(op, in, in2, out, type, inmem, opcode, istr, FederatedOutput.NONE);
 	}
 
-	public static QuantilePickFEDInstruction parseInstruction( Instruction inst ){
-		return parseInstruction(inst.getInstructionString() + Lop.OPERAND_DELIMITOR + FederatedOutput.NONE);
+	public static QuantilePickFEDInstruction parseInstruction(QuantilePickCPInstruction instr) {
+		return new QuantilePickFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+			instr.getOperationType(), instr.isInMem(), instr.getOpcode(), instr.getInstructionString());
+	}
+	
+	public static QuantilePickFEDInstruction parseInstruction(QuantilePickSPInstruction instr) {
+		return new QuantilePickFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.output,
+				instr.getOperationType(), false, instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static QuantilePickFEDInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantileSortFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantileSortFEDInstruction.java
@@ -35,6 +35,8 @@ import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.instructions.cp.QuantileSortCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuantileSortSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
@@ -49,6 +51,16 @@ public class QuantileSortFEDInstruction extends UnaryFEDInstruction {
 		String istr, int k) {
 		super(FEDInstruction.FEDType.QSort, null, in1, in2, out, opcode, istr);
 		_numThreads = k;
+	}
+
+	public static QuantileSortFEDInstruction parseInstruction(QuantileSortCPInstruction instr) {
+		return new QuantileSortFEDInstruction(instr.input1, instr.input2, instr.output, instr.getOpcode(),
+			instr.getInstructionString(), instr.getNumThreads());
+	}
+
+	public static QuantileSortFEDInstruction parseInstruction(QuantileSortSPInstruction instr) {
+		return new QuantileSortFEDInstruction(instr.input1, instr.input2, instr.output, instr.getOpcode(),
+				instr.getInstructionString(), 1);
 	}
 
 	private static void parseInstruction(String instr, CPOperand in1, CPOperand in2, CPOperand out) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryFEDInstruction.java
@@ -39,6 +39,8 @@ import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.QuaternaryOperator;
 
@@ -54,6 +56,38 @@ public abstract class QuaternaryFEDInstruction extends ComputationFEDInstruction
 		CPOperand in3, CPOperand in4, CPOperand out, String opcode, String instruction_str) {
 		super(type, operator, in1, in2, in3, out, opcode, instruction_str);
 		_input4 = in4;
+	}
+
+	public static QuaternaryFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		QuaternaryOperator qop = (QuaternaryOperator) instr.getOperator();
+		if(qop.wtype1 != null)
+			return QuaternaryWSLossFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype2 != null)
+			return QuaternaryWSigmoidFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype3 != null)
+			return QuaternaryWDivMMFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype4 != null)
+			return QuaternaryWCeMMFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype5 != null)
+			return QuaternaryWUMMFEDInstruction.parseInstruction(instr);
+		// unreachable
+		return null;
+	}
+
+	public static QuaternaryFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		QuaternaryOperator qop = (QuaternaryOperator) instr.getOperator();
+		if(qop.wtype1 != null)
+			return QuaternaryWSLossFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype2 != null)
+			return QuaternaryWSigmoidFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype3 != null)
+			return QuaternaryWDivMMFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype4 != null)
+			return QuaternaryWCeMMFEDInstruction.parseInstruction(instr);
+		else if(qop.wtype5 != null)
+			return QuaternaryWUMMFEDInstruction.parseInstruction(instr);
+		// unreachable
+		return null;
 	}
 
 	public static QuaternaryFEDInstruction parseInstruction(String str) {
@@ -143,7 +177,9 @@ public abstract class QuaternaryFEDInstruction extends ComputationFEDInstruction
 		return false;
 	}
 
-	private static String rewriteSparkInstructionToCP(String inst_str) {
+	protected static String rewriteSparkInstructionToCP(String inst_str) {
+		// TODO: don't perform replacement over the whole instruction string, possibly changing string literals,
+		//  instead only at positions of ExecType and Opcode
 		// rewrite the spark instruction to a cp instruction
 		inst_str = inst_str.replace(ExecType.SPARK.name(), ExecType.CP.name());
 		if(inst_str.contains(WeightedCrossEntropy.OPCODE))

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWCeMMFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWCeMMFEDInstruction.java
@@ -21,6 +21,8 @@ package org.apache.sysds.runtime.instructions.fed;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.common.Types.DataType;
@@ -54,6 +56,18 @@ public class QuaternaryWCeMMFEDInstruction extends QuaternaryFEDInstruction
 		CPOperand out, String opcode, String instruction_str)
 	{
 		super(FEDType.Quaternary, operator, in1, in2, in3, in4, out, opcode, instruction_str);
+	}
+
+	public static QuaternaryWCeMMFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		return new QuaternaryWCeMMFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.getInput4(), instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static QuaternaryWCeMMFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new QuaternaryWCeMMFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+				instr.getInput4(), instr.output, opcode, instrStr);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWDivMMFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWDivMMFEDInstruction.java
@@ -21,6 +21,8 @@ package org.apache.sysds.runtime.instructions.fed;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.hops.fedplanner.FTypes.AlignType;
@@ -69,6 +71,18 @@ public class QuaternaryWDivMMFEDInstruction extends QuaternaryFEDInstruction
 	{
 		super(FEDType.Quaternary, operator, in1, in2, in3, in4, out, opcode, instruction_str);
 		_qop = operator;
+	}
+
+	public static QuaternaryWDivMMFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		return new QuaternaryWDivMMFEDInstruction((QuaternaryOperator) instr.getOperator(), instr.input1, instr.input2,
+			instr.input3, instr.getInput4(), instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static QuaternaryWDivMMFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new QuaternaryWDivMMFEDInstruction((QuaternaryOperator) instr.getOperator(), instr.input1, instr.input2,
+			instr.input3, instr.getInput4(), instr.output, opcode, instrStr);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWSLossFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWSLossFEDInstruction.java
@@ -33,6 +33,8 @@ import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.QuaternaryOperator;
@@ -59,6 +61,18 @@ public class QuaternaryWSLossFEDInstruction extends QuaternaryFEDInstruction {
 	protected QuaternaryWSLossFEDInstruction(Operator operator, CPOperand in1, CPOperand in2, CPOperand in3,
 		CPOperand in4, CPOperand out, String opcode, String instruction_str) {
 		super(FEDType.Quaternary, operator, in1, in2, in3, in4, out, opcode, instruction_str);
+	}
+
+	public static QuaternaryWSLossFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		return new QuaternaryWSLossFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.getInput4(), instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static QuaternaryWSLossFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new QuaternaryWSLossFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+				instr.getInput4(), instr.output, opcode, instrStr);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWSigmoidFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWSigmoidFEDInstruction.java
@@ -31,7 +31,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
 public class QuaternaryWSigmoidFEDInstruction extends QuaternaryFEDInstruction {
@@ -52,6 +55,18 @@ public class QuaternaryWSigmoidFEDInstruction extends QuaternaryFEDInstruction {
 	protected QuaternaryWSigmoidFEDInstruction(Operator operator, CPOperand in1, CPOperand in2, CPOperand in3,
 		CPOperand out, String opcode, String instruction_str) {
 		super(FEDType.Quaternary, operator, in1, in2, in3, out, opcode, instruction_str);
+	}
+
+	public static QuaternaryWSigmoidFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		return new QuaternaryWSigmoidFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.getOutput(), instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static QuaternaryWSigmoidFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new QuaternaryWSigmoidFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, opcode, instrStr);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWUMMFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuaternaryWUMMFEDInstruction.java
@@ -31,7 +31,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.QuaternaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.QuaternarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
 public class QuaternaryWUMMFEDInstruction extends QuaternaryFEDInstruction {
@@ -53,6 +56,18 @@ public class QuaternaryWUMMFEDInstruction extends QuaternaryFEDInstruction {
 	protected QuaternaryWUMMFEDInstruction(Operator operator, CPOperand in1, CPOperand in2, CPOperand in3,
 		CPOperand out, String opcode, String instruction_str) {
 		super(FEDType.Quaternary, operator, in1, in2, in3, out, opcode, instruction_str);
+	}
+
+	public static QuaternaryWUMMFEDInstruction parseInstruction(QuaternaryCPInstruction instr) {
+		return new QuaternaryWUMMFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static QuaternaryWUMMFEDInstruction parseInstruction(QuaternarySPInstruction instr) {
+		String instrStr = rewriteSparkInstructionToCP(instr.getInstructionString());
+		String opcode = InstructionUtils.getInstructionPartsWithValueType(instrStr)[0];
+		return new QuaternaryWUMMFEDInstruction(instr.getOperator(), instr.input1, instr.input2, instr.input3,
+			instr.output, opcode, instrStr);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReblockFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReblockFEDInstruction.java
@@ -28,6 +28,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.ReblockSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
@@ -36,11 +37,15 @@ import org.apache.sysds.runtime.meta.MetaDataFormat;
 public class ReblockFEDInstruction extends UnaryFEDInstruction {
 	private int blen;
 
-	private ReblockFEDInstruction(Operator op, CPOperand in, CPOperand out, int br, int bc, boolean emptyBlocks,
+	private ReblockFEDInstruction(Operator op, CPOperand in, CPOperand out, int blen, boolean emptyBlocks,
 		String opcode, String instr) {
 		super(FEDInstruction.FEDType.Reblock, op, in, out, opcode, instr);
-		blen = br;
-		blen = bc;
+		this.blen = blen;
+	}
+
+	public static ReblockFEDInstruction parseInstruction(ReblockSPInstruction instr) {
+		return new ReblockFEDInstruction(instr.getOperator(), instr.input1, instr.output, instr.getBlockLength(),
+			instr.getOutputEmptyBlocks(), instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static ReblockFEDInstruction parseInstruction(String str) {
@@ -57,7 +62,7 @@ public class ReblockFEDInstruction extends UnaryFEDInstruction {
 		boolean outputEmptyBlocks = Boolean.parseBoolean(parts[4]);
 
 		Operator op = null; // no operator for ReblockFEDInstruction
-		return new ReblockFEDInstruction(op, in, out, blen, blen, outputEmptyBlocks, opcode, str);
+		return new ReblockFEDInstruction(op, in, out, blen, outputEmptyBlocks, opcode, str);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
@@ -47,6 +47,8 @@ import org.apache.sysds.runtime.functionobjects.SwapIndex;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
+import org.apache.sysds.runtime.instructions.cp.ReorgCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.ReorgSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -62,6 +64,16 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 
 	public ReorgFEDInstruction(Operator op, CPOperand in1, CPOperand out, String opcode, String istr) {
 		super(FEDType.Reorg, op, in1, out, opcode, istr);
+	}
+
+	public static ReorgFEDInstruction parseInstruction(ReorgCPInstruction rinst) {
+		return new ReorgFEDInstruction(rinst.getOperator(), rinst.input1, rinst.output, rinst.getOpcode(),
+			rinst.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static ReorgFEDInstruction parseInstruction(ReorgSPInstruction rinst) {
+		return new ReorgFEDInstruction(rinst.getOperator(), rinst.input1, rinst.output, rinst.getOpcode(),
+			rinst.getInstructionString(), FederatedOutput.NONE);
 	}
 
 	public static ReorgFEDInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReshapeFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReshapeFEDInstruction.java
@@ -35,6 +35,8 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.BooleanObject;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.ReshapeCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.MatrixReshapeSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -52,6 +54,17 @@ public class ReshapeFEDInstruction extends UnaryFEDInstruction {
 		_opCols = in3;
 		_opDims = in4;
 		_opByRow = in5;
+	}
+
+	public static ReshapeFEDInstruction parseInstruction(ReshapeCPInstruction instr) {
+		return new ReshapeFEDInstruction(instr.getOperator(), instr.input1, instr.getOpRows(), instr.getOpCols(),
+			instr.getOpDims(), instr.getOpByRow(), instr.output, instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static ReshapeFEDInstruction parseInstruction(MatrixReshapeSPInstruction instr) {
+		// TODO: add dims argument (for tensors) to MatrixReshapeSPInstruction
+		return new ReshapeFEDInstruction(instr.getOperator(), instr.input1, instr.getOpRows(), instr.getOpCols(), null,
+			instr.getOpByRow(), instr.output, instr.getOpcode(), instr.getInstructionString());
 	}
 
 	public static ReshapeFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/SpoofFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/SpoofFEDInstruction.java
@@ -50,6 +50,8 @@ import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.cp.Data;
 import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+import org.apache.sysds.runtime.instructions.cp.SpoofCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.SpoofSPInstruction;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 
@@ -65,6 +67,17 @@ public class SpoofFEDInstruction extends FEDInstruction
 		_op = op;
 		_inputs = in;
 		_output = out;
+	}
+
+	public static SpoofFEDInstruction parseInstruction(SpoofCPInstruction instr) {
+		return new SpoofFEDInstruction(instr.getSpoofOperator(), instr.getInputs(), instr.getOutput(),
+			instr.getOpcode(), instr.getInstructionString());
+	}
+
+	public static SpoofFEDInstruction parseInstruction(SpoofSPInstruction instr) {
+		SpoofOperator op = CodegenUtils.createInstance(instr.getOperatorClass());
+		return new SpoofFEDInstruction(op, instr.getInputs(), instr.getOutput(), instr.getOpcode(),
+			instr.getInstructionString());
 	}
 
 	public static SpoofFEDInstruction parseInstruction(String str) {
@@ -482,6 +495,7 @@ public class SpoofFEDInstruction extends FEDInstruction
 	}
 
 	public static boolean isFederated(ExecutionContext ec, CPOperand[] inputs, Class<?> scla) {
+		// TODO: use the `SpoofOperator` instead of the `Class<?>`, as it is more robust to inheritance hierarchy change
 		return isFederated(ec, null, inputs, scla);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/TernaryFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/TernaryFEDInstruction.java
@@ -33,6 +33,8 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.controlprogram.federated.MatrixLineagePair;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.TernaryCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.TernarySPInstruction;
 import org.apache.sysds.runtime.matrix.operators.TernaryOperator;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 
@@ -42,6 +44,16 @@ public class TernaryFEDInstruction extends ComputationFEDInstruction {
 	protected TernaryFEDInstruction(TernaryOperator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
 		String opcode, String str, FederatedOutput fedOut) {
 		super(FEDInstruction.FEDType.Ternary, op, in1, in2, in3, out, opcode, str, fedOut);
+	}
+
+	public static TernaryFEDInstruction parseInstruction(TernaryCPInstruction instr) {
+		return new TernaryFEDInstruction((TernaryOperator) instr.getOperator(), instr.input1, instr.input2,
+			instr.input3, instr.output, instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
+	}
+
+	public static TernaryFEDInstruction parseInstruction(TernarySPInstruction instr) {
+		return new TernaryFEDInstruction((TernaryOperator) instr.getOperator(), instr.input1, instr.input2,
+				instr.input3, instr.output, instr.getOpcode(), instr.getInstructionString(), FederatedOutput.NONE);
 	}
 
 	public static TernaryFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/TernaryFrameScalarFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/TernaryFrameScalarFEDInstruction.java
@@ -25,6 +25,8 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
 import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.TernaryFrameScalarCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.TernaryFrameScalarSPInstruction;
 import org.apache.sysds.runtime.matrix.operators.TernaryOperator;
 
 public class TernaryFrameScalarFEDInstruction extends TernaryFEDInstruction
@@ -32,6 +34,18 @@ public class TernaryFrameScalarFEDInstruction extends TernaryFEDInstruction
 	protected TernaryFrameScalarFEDInstruction(TernaryOperator op, CPOperand in1,
 			CPOperand in2, CPOperand in3, CPOperand out, String opcode, String istr, FederatedOutput fedOut) {
 		super(op, in1, in2, in3, out, opcode, istr, fedOut);
+	}
+
+	public static TernaryFrameScalarFEDInstruction parseInstruction(TernaryFrameScalarCPInstruction instr) {
+		return new TernaryFrameScalarFEDInstruction((TernaryOperator) instr.getOperator(), instr.input1, instr.input2,
+			instr.input3, instr.output, instr.getOpcode(), instr.getInstructionString(),
+			FEDInstruction.FederatedOutput.NONE);
+	}
+
+	public static TernaryFrameScalarFEDInstruction parseInstruction(TernaryFrameScalarSPInstruction instr) {
+		return new TernaryFrameScalarFEDInstruction((TernaryOperator) instr.getOperator(), instr.input1, instr.input2,
+			instr.input3, instr.output, instr.getOpcode(), instr.getInstructionString(),
+			FEDInstruction.FederatedOutput.NONE);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/TsmmFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/TsmmFEDInstruction.java
@@ -33,6 +33,7 @@ import org.apache.sysds.runtime.controlprogram.federated.FederationMap;
 import org.apache.sysds.runtime.controlprogram.federated.FederationUtils;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.MMTSJCPInstruction;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 public class TsmmFEDInstruction extends BinaryFEDInstruction {
@@ -49,7 +50,12 @@ public class TsmmFEDInstruction extends BinaryFEDInstruction {
 	public TsmmFEDInstruction(CPOperand in, CPOperand out, MMTSJType type, int k, String opcode, String istr) {
 		this(in, out, type, k, opcode, istr, FederatedOutput.NONE);
 	}
-	
+
+	public static TsmmFEDInstruction parseInstruction(MMTSJCPInstruction instr) {
+		return new TsmmFEDInstruction(instr.input1, instr.getOutput(), instr.getMMTSJType(), instr.getNumThreads(),
+			instr.getOpcode(), instr.getInstructionString());
+	}
+
 	public static TsmmFEDInstruction parseInstruction(String str) {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
 		String opcode = parts[0];

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/UnaryMatrixFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/UnaryMatrixFEDInstruction.java
@@ -36,6 +36,8 @@ import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.cp.UnaryMatrixCPInstruction;
+import org.apache.sysds.runtime.instructions.spark.UnaryMatrixSPInstruction;
 import org.apache.sysds.runtime.matrix.data.LibCommonsMath;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -49,6 +51,16 @@ public class UnaryMatrixFEDInstruction extends UnaryFEDInstruction {
 
 	public static boolean isValidOpcode(String opcode) {
 		return !LibCommonsMath.isSupportedUnaryOperation(opcode);
+	}
+
+	public static UnaryMatrixFEDInstruction parseInstruction(UnaryMatrixCPInstruction instr) {
+		return new UnaryMatrixFEDInstruction(instr.getOperator(), instr.input1, instr.output, instr.getOpcode(),
+			instr.getInstructionString());
+	}
+
+	public static UnaryMatrixFEDInstruction parseInstruction(UnaryMatrixSPInstruction instr) {
+		return new UnaryMatrixFEDInstruction(instr.getOperator(), instr.input1, instr.output, instr.getOpcode(),
+			instr.getInstructionString());
 	}
 
 	public static UnaryMatrixFEDInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/VariableFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/VariableFEDInstruction.java
@@ -44,6 +44,7 @@ import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction.VariableOp
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageTraceable;
 
+// TODO: merge with `CastFEDInstruction`
 public class VariableFEDInstruction extends FEDInstruction implements LineageTraceable {
 	private static final Log LOG = LogFactory.getLog(VariableFEDInstruction.class.getName());
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateBinarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateBinarySPInstruction.java
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.sysds.runtime.instructions.spark;
+
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+
+/**
+ * Class to group the different MM <code>SPInstruction</code>s together.
+ */
+public abstract class AggregateBinarySPInstruction extends BinarySPInstruction {
+	protected AggregateBinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+			String opcode, String istr) {
+		super(type, op, in1, in2, out, opcode, istr);
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendGAlignedSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendGAlignedSPInstruction.java
@@ -34,13 +34,10 @@ import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import scala.Tuple2;
 
-public class AppendGAlignedSPInstruction extends BinarySPInstruction {
-	private boolean _cbind = true;
-
+public class AppendGAlignedSPInstruction extends AppendSPInstruction {
 	private AppendGAlignedSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand in3, CPOperand out,
-			boolean cbind, String opcode, String istr) {
-		super(SPType.GAppend, op, in1, in2, out, opcode, istr);
-		_cbind = cbind;
+		boolean cbind, String opcode, String istr) {
+		super(SPType.GAppend, op, in1, in2, out, cbind, opcode, istr);
 	}
 
 	public static AppendGAlignedSPInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendGSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendGSPInstruction.java
@@ -40,13 +40,10 @@ import scala.Tuple2;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class AppendGSPInstruction extends BinarySPInstruction {
-	private boolean _cbind = true;
-
+public class AppendGSPInstruction extends AppendSPInstruction {
 	private AppendGSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand offset2,
-			CPOperand out, boolean cbind, String opcode, String istr) {
-		super(SPType.GAppend, op, in1, in2, out, opcode, istr);
-		_cbind = cbind;
+		CPOperand out, boolean cbind, String opcode, String istr) {
+		super(SPType.GAppend, op, in1, in2, out, cbind, opcode, istr);
 	}
 
 	public static AppendGSPInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendMSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendMSPInstruction.java
@@ -27,15 +27,13 @@ import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 
-public abstract class AppendMSPInstruction extends BinarySPInstruction {
+public abstract class AppendMSPInstruction extends AppendSPInstruction {
 	protected CPOperand _offset = null;
-	protected boolean _cbind = true;
 
 	protected AppendMSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand offset, CPOperand out,
-			boolean cbind, String opcode, String istr) {
-		super(SPType.MAppend, op, in1, in2, out, opcode, istr);
+		boolean cbind, String opcode, String istr) {
+		super(SPType.MAppend, op, in1, in2, out, cbind, opcode, istr);
 		_offset = offset;
-		_cbind = cbind;
 	}
 
 	public static AppendMSPInstruction parseInstruction( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendRSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendRSPInstruction.java
@@ -26,12 +26,10 @@ import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 
-public abstract class AppendRSPInstruction extends BinarySPInstruction {
-	protected boolean _cbind = true;
-
-	protected AppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind, String opcode, String istr) {
-		super(SPType.RAppend, op, in1, in2, out, opcode, istr);
-		_cbind = cbind;
+public abstract class AppendRSPInstruction extends AppendSPInstruction {
+	protected AppendRSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean cbind,
+		String opcode, String istr) {
+		super(SPType.RAppend, op, in1, in2, out, cbind, opcode, istr);
 	}
 
 	public static AppendRSPInstruction parseInstruction ( String str ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AppendSPInstruction.java
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.sysds.runtime.instructions.spark;
+
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+
+/**
+ * Class to group the different append <code>SPInstruction</code>s together.
+ */
+public abstract class AppendSPInstruction extends BinarySPInstruction {
+	protected boolean _cbind;
+
+	protected AppendSPInstruction(SPType type, Operator op, CPOperand input1, CPOperand input2, CPOperand output,
+		boolean cbind, String opcode, String instructionString) {
+		super(type, op, input1, input2, output, opcode, instructionString);
+		_cbind = cbind;
+	}
+
+	public boolean getCBind() {
+		return _cbind;
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/BinaryMatrixBVectorSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/BinaryMatrixBVectorSPInstruction.java
@@ -24,12 +24,12 @@ import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
-public class BinaryMatrixBVectorSPInstruction extends BinarySPInstruction {
+public class BinaryMatrixBVectorSPInstruction extends BinaryMatrixMatrixSPInstruction {
 	private VectorType _vtype = null;
 
 	protected BinaryMatrixBVectorSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
 			VectorType vtype, String opcode, String istr) {
-		super(SPType.Binary, op, in1, in2, out, opcode, istr);
+		super(op, in1, in2, out, opcode, istr);
 		_vtype = vtype;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
@@ -54,7 +54,7 @@ import scala.Tuple2;
  * this would result in a degree of parallelism of 1.
  * 
  */
-public class CpmmSPInstruction extends BinarySPInstruction {
+public class CpmmSPInstruction extends AggregateBinarySPInstruction {
 	private final boolean _outputEmptyBlocks;
 	private final SparkAggType _aggtype;
 	

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CtableSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CtableSPInstruction.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.sysds.common.Types;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.lops.Ctable;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -193,6 +194,22 @@ public class CtableSPInstruction extends ComputationSPInstruction {
 		
 		//post-processing to obtain sparsity of ultra-sparse outputs
 		SparkUtils.postprocessUltraSparseOutput(sec.getMatrixObject(output), mcOut);
+	}
+
+	public CPOperand getOutDim1() {
+		return new CPOperand(_outDim1, ValueType.FP64, Types.DataType.SCALAR, _dim1Literal);
+	}
+
+	public CPOperand getOutDim2() {
+		return new CPOperand(_outDim1, ValueType.FP64, Types.DataType.SCALAR, _dim1Literal);
+	}
+
+	public boolean getIsExpand() {
+		return _isExpand;
+	}
+
+	public boolean getIgnoreZeros() {
+		return _ignoreZeros;
 	}
 
 	private static class CTableFunction implements PairFlatMapFunction<Iterator<Tuple2<MatrixIndexes, MatrixBlock[]>>, MatrixIndexes, MatrixBlock> 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CumulativeOffsetSPInstruction.java
@@ -122,6 +122,14 @@ public class CumulativeOffsetSPInstruction extends BinarySPInstruction {
 		sec.addLineage(output.getName(), input2.getName(), broadcast);
 	}
 
+	public double getInitValue() {
+		return _initValue;
+	}
+
+	public boolean getBroadcast() {
+		return _broadcast;
+	}
+
 	private static class RDDCumSplitFunction implements PairFlatMapFunction<Tuple2<MatrixIndexes, MatrixBlock>, MatrixIndexes, MatrixBlock> 
 	{
 		private static final long serialVersionUID = -8407407527406576965L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/IndexingSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/IndexingSPInstruction.java
@@ -53,6 +53,22 @@ public abstract class IndexingSPInstruction extends UnarySPInstruction {
 		colLower = cl;
 		colUpper = cu;
 	}
+	
+	public CPOperand getRowLower() {
+		return rowLower;
+	}
+	
+	public CPOperand getRowUpper() {
+		return rowUpper;
+	}
+	
+	public CPOperand getColLower() {
+		return colLower;
+	}
+	
+	public CPOperand getColUpper() {
+		return colUpper;
+	}
 
 	public static IndexingSPInstruction parseInstruction ( String str ) {
 		String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/MapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/MapmmSPInstruction.java
@@ -56,7 +56,7 @@ import org.apache.sysds.runtime.meta.DataCharacteristics;
 
 import scala.Tuple2;
 
-public class MapmmSPInstruction extends BinarySPInstruction {
+public class MapmmSPInstruction extends AggregateBinarySPInstruction {
 	private static final Log LOG = LogFactory.getLog(MapmmSPInstruction.class.getName());
 	
 	private CacheType _type = null;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/MatrixReshapeSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/MatrixReshapeSPInstruction.java
@@ -127,7 +127,19 @@ public class MatrixReshapeSPInstruction extends UnarySPInstruction
 			sec.addLineageRDD(output.getName(), input1.getName());
 		}
 	}
-	
+
+	public CPOperand getOpRows() {
+		return _opRows;
+	}
+
+	public CPOperand getOpCols() {
+		return _opCols;
+	}
+
+	public CPOperand getOpByRow() {
+		return _opByRow;
+	}
+
 	private static class RDDReshapeFunction implements PairFlatMapFunction<Tuple2<MatrixIndexes, MatrixBlock>, MatrixIndexes, MatrixBlock>
 	{
 		private static final long serialVersionUID = 2819309412002224478L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/MultiReturnParameterizedBuiltinSPInstruction.java
@@ -180,6 +180,10 @@ public class MultiReturnParameterizedBuiltinSPInstruction extends ComputationSPI
 		return acc;
 	}
 
+	public List<CPOperand> getOutputs() {
+		return _outputs;
+	}
+
 	private static class MaxLongAccumulator extends AccumulatorV2<Long, Long> {
 		private static final long serialVersionUID = -3739727823287550826L;
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/ParameterizedBuiltinSPInstruction.java
@@ -547,6 +547,10 @@ public class ParameterizedBuiltinSPInstruction extends ComputationSPInstruction 
 		}
 	}
 
+	public HashMap<String, String> getParameterMap() {
+		return params;
+	}
+
 	public static class RDDReplaceFunction implements Function<MatrixBlock, MatrixBlock> {
 		private static final long serialVersionUID = 6576713401901671659L;
 		private final double _pattern;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
@@ -235,7 +235,11 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 				pos + " in block of size " + tmp.getNumRows()+"x"+tmp.getNumColumns());
 		return val.get(0).quickGetValue((int)pos, 0);
 	}
-	
+
+	public OperationTypes getOperationType() {
+		return _type;
+	}
+
 	private static class FilterFunction implements Function<Tuple2<MatrixIndexes,MatrixBlock>, Boolean> 
 	{
 		private static final long serialVersionUID = -8249102381116157388L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/QuaternarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/QuaternarySPInstruction.java
@@ -323,6 +323,10 @@ public class QuaternarySPInstruction extends ComputationSPInstruction {
 		}
 	}
 
+	public CPOperand getInput4() {
+		return _input4;
+	}
+
 	private abstract static class RDDQuaternaryBaseFunction implements Serializable
 	{
 		private static final long serialVersionUID = -3175397651350954930L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/ReblockSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/ReblockSPInstruction.java
@@ -272,4 +272,12 @@ public class ReblockSPInstruction extends UnarySPInstruction {
 		//default reblock w/ active lineage tracing
 		return super.getLineageItem(ec);
 	}
+
+	public int getBlockLength() {
+		return blen;
+	}
+
+	public boolean getOutputEmptyBlocks() {
+		return outputEmptyBlocks;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/RmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/RmmSPInstruction.java
@@ -47,7 +47,7 @@ import scala.Tuple2;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-public class RmmSPInstruction extends BinarySPInstruction {
+public class RmmSPInstruction extends AggregateBinarySPInstruction {
 
 	private RmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(SPType.RMM, op, in1, in2, out, opcode, istr);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/SpoofSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/SpoofSPInstruction.java
@@ -354,6 +354,10 @@ public class SpoofSPInstruction extends SPInstruction {
 		}
 	}
 
+	public CPOperand getOutput() {
+		return _out;
+	}
+
 	private static class SpoofFunction implements Serializable
 	{
 		private static final long serialVersionUID = 2953479427746463003L;


### PR DESCRIPTION
This reworks our runtime replacement of CP instructions with FED versions when appropriate. 
SP replacement will be done in another PR.

This implementation was my second approach, the first one consisted of static methods in the FED instructions. I much prefer this one as it is quite clear which instructions are replaced, which constraints the CP imposes and we don't have to lead every check with an `instanceof` check. The downside of this approach is that it can get a bit confusing with inheritance, but it is---and will probably stay---manageable.

Note that not everything is replaced yet, I will work on it while the general approach can already be reviewed.

During the testing I found myself requiring to check if actual FED instructions are executed, is there a way to ensure this in the test framework, or is this already ensured in some way via privacy? Tests checking the heavy hitters do it implicitly.

NOTE: I deleted a fix in `QuantilePickCPInstruction` (bf19244c909ae8354bc8b3da0985eaf448aa5f0c), as the common layout is no longer necessary and null is cleaner. This is intentional and the fix is no longer necessary.