### PR TITLE
[MINOR] Dense&SparseBlock internal toString improvement

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/data/DenseBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/data/DenseBlock.java
@@ -650,7 +650,11 @@ public abstract class DenseBlock implements Serializable
 			double[] data = values(i);
 			int ix = pos(i);
 			for(int j=0; j<_odims[0]; j++) {
-				sb.append(data[ix+j]);
+				double v = data[ix+j];
+				if(v == (long) v)
+					sb.append((long)v);
+				else
+					sb.append(data[ix+j]);
 				sb.append("\t");
 			}
 			sb.append("\n");

--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
@@ -882,21 +882,20 @@ public class SparseBlockCSR extends SparseBlock
 		sb.append(", nnz=");
 		sb.append(size());
 		sb.append("\n");
+		final int rowDigits = (int)Math.max(Math.ceil(Math.log10(numRows())),1) ;
 		for(int i = 0; i < numRows(); i++) {
 			// append row
 			final int pos = pos(i);
 			final int len = size(i);
 			if(pos < pos + len) {
-
-				sb.append("row +");
-				sb.append(i);
-				sb.append(": ");
-
+				sb.append(String.format("row %0"+rowDigits+"d -- ", i));
 				for(int j = pos; j < pos + len; j++) {
-					sb.append(_indexes[j]);
-					sb.append(": ");
-					sb.append(_values[j]);
-					sb.append("\t");
+					if(_values[j] == (long) _values[j])
+						sb.append(String.format("%"+rowDigits+"d:%d", _indexes[j], (long)_values[j]));
+					else
+						sb.append(String.format("%"+rowDigits+"d:%s", _indexes[j], Double.toString(_values[j])));
+					if(j + 1 < pos + len)
+						sb.append(", ");
 				}
 				sb.append("\n");
 			}

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
@@ -124,16 +124,33 @@ public abstract class SparseRow implements Serializable
 	 * and shifts non-zero entries to the left if necessary.
 	 */
 	public abstract void compact();
+
+	/**
+	 * In-place compaction of values over eps away from zero;
+	 * and shifts non-zero entries to the left if necessary.
+	 * @param eps epsilon value
+	 */
+	public abstract void compact(double eps);
 	
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		for(int i=0; i<size(); i++) {
-			sb.append(indexes()[i]);
-			sb.append(": ");
-			sb.append(values()[i]);
-			sb.append("\t");
+		final int s = size();
+		if(s == 0)
+			return "";
+		final int[] indexes = indexes();
+		final double[] values = values();
+
+		final int rowDigits = (int) Math.max(Math.ceil(Math.log10(indexes[s-1])),1);
+		for(int i=0; i<s; i++){
+			if(values[i] == (long) values[i])
+				sb.append(String.format("%"+rowDigits+"d:%d", indexes[i], (long)values[i]));
+			else
+				sb.append(String.format("%"+rowDigits+"d:%s", indexes[i], Double.toString(values[i])));
+			if(i + 1 < s)
+				sb.append(", ");
 		}
+		
 		return sb.toString();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRowScalar.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRowScalar.java
@@ -103,6 +103,11 @@ public final class SparseRowScalar extends SparseRow{
 		index = (value!=0) ? index : -1;
 	}
 
+	@Override
+	public void compact(double eps) {
+		index = (Math.abs(value) < eps) ? -1: index;
+	}
+
 	public int getIndex(){
 		return index;
 	}

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRowVector.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRowVector.java
@@ -58,6 +58,27 @@ public final class SparseRowVector extends SparseRow{
 			}
 		size = nnz;
 	}
+
+	/**
+	 * Sparse row vector constructor that take a dense array, and allocate sparsely by ignoring zero values
+	 * @param v The dense row
+	 */
+	public SparseRowVector(double[] v){
+		int nnz = 0;
+		for(double vv: v)
+			if(vv != 0)
+				nnz++;
+
+		values = new double[nnz];
+		indexes = new int[nnz];
+		for(int i=0, pos=0; i<v.length; i++)
+			if( v[i] != 0 ) {
+				values[pos] = v[i];
+				indexes[pos] = i;
+				pos++;
+			}
+		size = nnz;
+	}
 	
 	public SparseRowVector(int estnnz, int maxnnz) {
 		if( estnnz > initialCapacity )
@@ -71,7 +92,7 @@ public final class SparseRowVector extends SparseRow{
 	
 	public SparseRowVector(SparseRow that) {
 		size = that.size();
-		int cap = Math.max(initialCapacity, that.size());
+		int cap = Math.max(initialCapacity, size);
 		
 		//allocate arrays and copy new values
 		values = Arrays.copyOf(that.values(), cap);
@@ -427,7 +448,19 @@ public final class SparseRowVector extends SparseRow{
 	public void compact() {
 		int nnz = 0;
 		for( int i=0; i<size; i++ ) 
-			if( values[i] != 0 ){
+			if( values[i] != 0.0 ){
+				values[nnz] = values[i];
+				indexes[nnz] = indexes[i];
+				nnz++;
+			}
+		size = nnz; //adjust row size
+	}
+
+	@Override
+	public void compact(double eps) {
+		int nnz = 0;
+		for( int i=0; i<size; i++ ) 
+			if( Math.abs(values[i]) > eps ){
 				values[nnz] = values[i];
 				indexes[nnz] = indexes[i];
 				nnz++;


### PR DESCRIPTION
This commit change the internal toString to make it more readable
when we internally in systemds change a matrix block into a string.
This makes it more easy for us to debug a given matrix when printing.

This commit also contain a minor fix to "compact(int r)" for sparse
blocks that did not handle the transition between SparseRowScalar to
SparseRowVector well. There are more of these instances inside MCSR that
are not addressed in this commit.