### PR TITLE
[SYSTEMDS-3396] LocalVarMap Concurrency in Federated Execution

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/LocalVariableMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/LocalVariableMap.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.controlprogram;
 
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -44,19 +45,19 @@ public class LocalVariableMap implements Cloneable
 	private static final IDSequence _seq = new IDSequence();
 	
 	//variable map data and id
-	private final HashMap<String, Data> localMap;
+	private final ConcurrentHashMap<String, Data> localMap;
 	private final long localID;
 	
 	//optional set of registered outputs
 	private HashSet<String> outputs = null;
 	
 	public LocalVariableMap() {
-		localMap = new HashMap<>();
+		localMap = new ConcurrentHashMap<>();
 		localID = _seq.getNextID();
 	}
 	
 	public LocalVariableMap(LocalVariableMap vars) {
-		localMap = new HashMap<>(vars.localMap);
+		localMap = new ConcurrentHashMap<>(vars.localMap);
 		localID = _seq.getNextID();
 	}
 


### PR DESCRIPTION
Hi,
This PR changes the local variable map back to a _ConcurrentHashMap_ in order to allow for simultaneously modification and iteration of the map.
Without a _ConcurrentHashMap_, some algorithms might throw a _ConcurrentModificationException_ because the coordinator does not wait for the worker's result and triggers a new federated instruction in the meanwhile. Therefore, the worker iterates the local variable map when performing an '_rmvar_' instruction, and creates new entries in the local variable map at the same time, resulting in a _ConcurrentModificationException_. Thanks to @kev-inn for finding this issue.
Another approach to resolve this problem would be to create a queue of federated requests for every coordinator+threadid pair and process the requests of the queue sequentially.

Thanks for review :)