### PR TITLE
[MINOR] Fix federation for Python API

### DIFF
--- a/src/main/java/org/apache/sysds/api/PythonDMLScript.java
+++ b/src/main/java/org/apache/sysds/api/PythonDMLScript.java
@@ -55,14 +55,7 @@ public class PythonDMLScript {
 		// we enable multi-threaded I/O and operations for a single JMLC
 		// connection because the calling Python process is unlikely to run
 		// multi-threaded streams of operations on the same shared context
-		_connection = new Connection(
-			CompilerConfig.ConfigType.PARALLEL_CP_READ_TEXTFORMATS,
-			CompilerConfig.ConfigType.PARALLEL_CP_WRITE_TEXTFORMATS,
-			CompilerConfig.ConfigType.PARALLEL_CP_READ_BINARYFORMATS,
-			CompilerConfig.ConfigType.PARALLEL_CP_WRITE_BINARYFORMATS,
-			CompilerConfig.ConfigType.PARALLEL_CP_MATRIX_OPERATIONS,
-			CompilerConfig.ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR,
-			CompilerConfig.ConfigType.ALLOW_DYN_RECOMPILATION);
+		_connection = new Connection();
 	}
 
 	public Connection getConnection() {

--- a/src/main/java/org/apache/sysds/api/jmlc/Connection.java
+++ b/src/main/java/org/apache/sysds/api/jmlc/Connection.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.meta.MetaDataAll;
 import org.apache.sysds.api.DMLException;
 import org.apache.sysds.api.DMLScript;
@@ -145,23 +146,15 @@ public class Connection implements Closeable
 		
 		//setup basic parameters for embedded execution
 		//(parser, compiler, and runtime parameters)
-		CompilerConfig cconf = new CompilerConfig();
-		cconf.set(ConfigType.IGNORE_UNSPECIFIED_ARGS, true);
-		cconf.set(ConfigType.IGNORE_READ_WRITE_METADATA, true);
-		cconf.set(ConfigType.IGNORE_TEMPORARY_FILENAMES, true);
-		cconf.set(ConfigType.REJECT_READ_WRITE_UNKNOWNS, false);
-		cconf.set(ConfigType.PARALLEL_CP_READ_TEXTFORMATS, false);
-		cconf.set(ConfigType.PARALLEL_CP_WRITE_TEXTFORMATS, false);
-		cconf.set(ConfigType.PARALLEL_CP_READ_BINARYFORMATS, false);
-		cconf.set(ConfigType.PARALLEL_CP_WRITE_BINARYFORMATS, false);
-		cconf.set(ConfigType.PARALLEL_CP_MATRIX_OPERATIONS, false);
-		cconf.set(ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR, false);
-		cconf.set(ConfigType.ALLOW_DYN_RECOMPILATION, false);
-		cconf.set(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS, false);
-		cconf.set(ConfigType.ALLOW_CSE_PERSISTENT_READS, false);
-		cconf.set(ConfigType.CODEGEN_ENABLED, false);
-		_cconf = cconf;
-		
+		_cconf = OptimizerUtils.constructCompilerConfig(dmlconfig);
+		_cconf.set(ConfigType.IGNORE_UNSPECIFIED_ARGS, true);
+		_cconf.set(ConfigType.IGNORE_READ_WRITE_METADATA, true);
+		_cconf.set(ConfigType.IGNORE_TEMPORARY_FILENAMES, true);
+		_cconf.set(ConfigType.REJECT_READ_WRITE_UNKNOWNS, false);
+		_cconf.set(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS, false);
+		_cconf.set(ConfigType.ALLOW_CSE_PERSISTENT_READS, false);
+		_cconf.set(ConfigType.CODEGEN_ENABLED, false);
+
 		//disable caching globally 
 		CacheableData.disableCaching();
 		

--- a/src/main/java/org/apache/sysds/api/jmlc/Connection.java
+++ b/src/main/java/org/apache/sysds/api/jmlc/Connection.java
@@ -112,8 +112,7 @@ public class Connection implements Closeable
 		this(new DMLConfig()); //with default dml configuration
 		
 		//set optional compiler configurations in current config
-		for( ConfigType configType : cconfigs )
-			_cconf.set(configType, true);
+		setConfigTypes(true, cconfigs);
 		setLocalConfigs();
 	}
 	
@@ -130,8 +129,7 @@ public class Connection implements Closeable
 		this(dmlconfig); 
 		
 		//set optional compiler configurations in current config
-		for( ConfigType configType : cconfigs )
-			_cconf.set(configType, true);
+		setConfigTypes(true, cconfigs);
 		setLocalConfigs();
 	}
 	
@@ -151,9 +149,7 @@ public class Connection implements Closeable
 		_cconf.set(ConfigType.IGNORE_READ_WRITE_METADATA, true);
 		_cconf.set(ConfigType.IGNORE_TEMPORARY_FILENAMES, true);
 		_cconf.set(ConfigType.REJECT_READ_WRITE_UNKNOWNS, false);
-		_cconf.set(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS, false);
 		_cconf.set(ConfigType.ALLOW_CSE_PERSISTENT_READS, false);
-		_cconf.set(ConfigType.CODEGEN_ENABLED, false);
 
 		//disable caching globally 
 		CacheableData.disableCaching();
@@ -162,6 +158,16 @@ public class Connection implements Closeable
 		_dmlconf = dmlconfig;
 		
 		setLocalConfigs();
+	}
+
+	/**
+	 * Sets compiler configs.
+	 * @param activate activate or disable
+	 * @param cconfigs the configs to set
+	 */
+	public void setConfigTypes(boolean activate, CompilerConfig.ConfigType... cconfigs) {
+		for( ConfigType configType : cconfigs )
+			_cconf.set(configType, activate);
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/jmlc/JMLCClonedPreparedScriptTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/jmlc/JMLCClonedPreparedScriptTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.sysds.conf.CompilerConfig;
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysds.api.DMLException;
@@ -94,6 +95,7 @@ public class JMLCClonedPreparedScriptTest extends AutomatedTestBase
 		
 		boolean failed = false;
 		try( Connection conn = new Connection() ) {
+			conn.setConfigTypes(false, CompilerConfig.ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR);
 			DMLScript.STATISTICS = true;
 			Statistics.reset();
 			PreparedScript pscript = conn.prepareScript(

--- a/src/test/java/org/apache/sysds/test/functions/jmlc/JMLCParfor2ForCompileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/jmlc/JMLCParfor2ForCompileTest.java
@@ -48,8 +48,8 @@ public class JMLCParfor2ForCompileTest extends AutomatedTestBase
 
 	private static void runJMLCParFor2ForTest(boolean par) {
 		try {
-			Connection conn = !par ? new Connection() :
-				new Connection(ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR);
+			Connection conn = new Connection();
+			conn.setConfigTypes(par, ConfigType.PARALLEL_LOCAL_OR_REMOTE_PARFOR);
 			String script =
 				"  X = rand(rows=10, cols=10);"
 				+ "R = matrix(0, rows=10, cols=1)"


### PR DESCRIPTION
Fixes a bug where instructions were not replaced by FED equivalent instructions, because the correct `CompilerConfig` option was not set.
In the future we want to check the statistics report in our federated testcases to check if execution was performed on federated workers.