### PR TITLE
[SYSTEMDS-3432] Evaluate Sparse/Dense in FedUtils.bindResponses

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
@@ -145,7 +145,7 @@ public class FederationUtils {
 					Lop.OPERAND_DELIMITOR + varOldOut.getName() + Lop.DATATYPE_PREFIX,
 					Lop.OPERAND_DELIMITOR + String.valueOf(outputId) + Lop.DATATYPE_PREFIX);
 			}
-			
+
 			fr[j] = new FederatedRequest(RequestType.EXEC_INST, outputId, (Object) linst[j]);
 		}
 		return fr;
@@ -539,7 +539,13 @@ public class FederationUtils {
 	public static MatrixBlock bindResponses(List<Pair<FederatedRange, Future<FederatedResponse>>> readResponses, long[] dims)
 		throws Exception
 	{
-		MatrixBlock ret = new MatrixBlock((int) dims[0], (int) dims[1], false);
+        long totalNNZ = 0;
+        for(Pair<FederatedRange, Future<FederatedResponse>> readResponse :readResponses) {
+            FederatedResponse response = readResponse.getRight().get();
+            MatrixBlock multRes = (MatrixBlock) response.getData()[0];
+            totalNNZ += multRes.getNonZeros();
+        }
+		MatrixBlock ret = new MatrixBlock((int) dims[0], (int) dims[1], MatrixBlock.evalSparseFormatInMemory(dims[0], dims[1], totalNNZ));
 		for(Pair<FederatedRange, Future<FederatedResponse>> readResponse : readResponses) {
 			FederatedRange range = readResponse.getLeft();
 			FederatedResponse response = readResponse.getRight().get();


### PR DESCRIPTION
Evaluate if the 'complete' matrix should be sparse/dense before creating the matrix.
I encountered this when running FTBench T15. Since we always create the matrix as dense we can run out of memory when we get sparse matrices from the worker nodes.