### PR TITLE
[SYSTEMDS-3437] CLA Invalid Unique estimate DDC

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -68,10 +68,6 @@ public abstract class AColGroup implements Serializable {
 	/** The ColGroup Indexes contained in the ColGroup */
 	protected int[] _colIndexes;
 
-	/** Empty constructor, used for serializing into an empty new object of ColGroup. */
-	protected AColGroup() {
-		// empty
-	}
 
 	/**
 	 * Main constructor.
@@ -174,18 +170,12 @@ public abstract class AColGroup implements Serializable {
 			out.writeInt(_colIndexes[i]);
 	}
 
-	/**
-	 * Deserialize column group from data input.
-	 * 
-	 * @param in data input
-	 * @throws IOException if IOException occurs
-	 */
-	protected void readFields(DataInput in) throws IOException {
-		// column group type is read in ColGroupIO
+	protected static int[] readCols(DataInput in) throws IOException {
 		final int numCols = in.readInt();
-		_colIndexes = new int[numCols];
+		int[] cols = new int[numCols];
 		for(int i = 0; i < numCols; i++)
-			_colIndexes[i] = in.readInt();
+			cols[i] = in.readInt();
+		return cols;
 	}
 
 	/**
@@ -358,7 +348,7 @@ public abstract class AColGroup implements Serializable {
 	 * @param right The MatrixBlock on the right of this matrix multiplication
 	 * @return The new Column Group or null that is the result of the matrix multiplication.
 	 */
-	public final AColGroup rightMultByMatrix(MatrixBlock right){
+	public final AColGroup rightMultByMatrix(MatrixBlock right) {
 		return rightMultByMatrix(right, null);
 	}
 
@@ -367,8 +357,9 @@ public abstract class AColGroup implements Serializable {
 	 * 
 	 * This method can return null, meaning that the output overlapping group would have been empty.
 	 * 
-	 * @param right The MatrixBlock on the right of this matrix multiplication
-	 * @param allCols A pre-materialized list of all col indexes, that can be shared across all column groups if use full, can be set to null.
+	 * @param right   The MatrixBlock on the right of this matrix multiplication
+	 * @param allCols A pre-materialized list of all col indexes, that can be shared across all column groups if use
+	 *                full, can be set to null.
 	 * @return The new Column Group or null that is the result of the matrix multiplication.
 	 */
 	public abstract AColGroup rightMultByMatrix(MatrixBlock right, int[] allCols);
@@ -406,7 +397,7 @@ public abstract class AColGroup implements Serializable {
 	 * @param lhs    The left hand side Column group to multiply with, the left hand side should be considered
 	 *               transposed. Also it should be guaranteed that this column group is not empty.
 	 * @param result The result matrix to insert the result of the multiplication into
-	 * @param nRows   Number of rows in the lhs colGroup
+	 * @param nRows  Number of rows in the lhs colGroup
 	 */
 	public abstract void leftMultByAColGroup(AColGroup lhs, MatrixBlock result, int nRows);
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupCompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupCompressed.java
@@ -45,10 +45,6 @@ public abstract class AColGroupCompressed extends AColGroup {
 
 	private static final long serialVersionUID = 6219835795420081223L;
 
-	protected AColGroupCompressed() {
-		super();
-	}
-
 	protected AColGroupCompressed(int[] colIndices) {
 		super(colIndices);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupCompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupCompressed.java
@@ -201,19 +201,13 @@ public abstract class AColGroupCompressed extends AColGroup {
 
 	protected static void tsmm(double[] result, int numColumns, int[] counts, ADictionary dict, int[] colIndexes) {
 		dict = dict.getMBDict(colIndexes.length);
-		if(dict != null) {
-			if(dict instanceof MatrixBlockDictionary) {
-				MatrixBlockDictionary mbd = (MatrixBlockDictionary) dict;
-				MatrixBlock mb = mbd.getMatrixBlock();
-				// Guaranteed not to be empty
-				if(mb.isInSparseFormat())
-					tsmmSparse(result, numColumns, mb.getSparseBlock(), counts, colIndexes);
-				else
-					tsmmDense(result, numColumns, mb.getDenseBlockValues(), counts, colIndexes);
-			}
-			else
-				tsmmDense(result, numColumns, dict.getValues(), counts, colIndexes);
-		}
+		if(dict == null) // null if empty
+			return;
+		MatrixBlock mb = ((MatrixBlockDictionary) dict).getMatrixBlock();
+		if(mb.isInSparseFormat())
+			tsmmSparse(result, numColumns, mb.getSparseBlock(), counts, colIndexes);
+		else
+			tsmmDense(result, numColumns, mb.getDenseBlockValues(), counts, colIndexes);
 
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupOffset.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupOffset.java
@@ -45,16 +45,6 @@ public abstract class AColGroupOffset extends APreAgg {
 
 	protected boolean _zeros;
 
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected AColGroupOffset(int numRows) {
-		super();
-		_numRows = numRows;
-	}
-
 	protected AColGroupOffset(int[] colIndices, int numRows, boolean zeros, ADictionary dict, int[] cachedCounts) {
 		super(colIndices, dict, cachedCounts);
 		_numRows = numRows;
@@ -104,20 +94,18 @@ public abstract class AColGroupOffset extends APreAgg {
 		return ret;
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
+	public static int[] readPointers(DataInput in) throws IOException {
+		int[] ptr = new int[in.readInt()];
+		for(int i = 0; i < ptr.length; i++)
+			ptr[i] = in.readInt();
+		return ptr;
+	}
 
-		// read bitmaps
-		_ptr = new int[in.readInt()];
-		for(int i = 0; i < _ptr.length; i++)
-			_ptr[i] = in.readInt();
-
-		_data = new char[in.readInt()];
-		for(int i = 0; i < _data.length; i++)
-			_data[i] = in.readChar();
-
-		_zeros = in.readBoolean();
+	public static char[] readData(DataInput in) throws IOException {
+		char[] data = new char[in.readInt()];
+		for(int i = 0; i < data.length; i++)
+			data[i] = in.readChar();
+		return data;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupValue.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroupValue.java
@@ -37,10 +37,6 @@ public abstract class AColGroupValue extends ADictBasedColGroup implements Clone
 	/** The count of each distinct value contained in the dictionary */
 	private SoftReference<int[]> counts = null;
 
-	protected AColGroupValue() {
-		super();
-	}
-
 	/**
 	 * A abstract class for column groups that contain ADictionary for values.
 	 * 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ADictBasedColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ADictBasedColGroup.java
@@ -18,7 +18,6 @@
  */
 package org.apache.sysds.runtime.compress.colgroup;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import java.util.Set;
 
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
-import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.data.DenseBlock;
@@ -38,10 +36,6 @@ public abstract class ADictBasedColGroup extends AColGroupCompressed {
 	private static final long serialVersionUID = -3737025296618703668L;
 	/** Distinct value tuples associated with individual bitmaps. */
 	protected ADictionary _dict;
-
-	protected ADictBasedColGroup() {
-		super();
-	}
 
 	/**
 	 * A Abstract class for column groups that contain ADictionary for values.
@@ -142,12 +136,6 @@ public abstract class ADictBasedColGroup extends AColGroupCompressed {
 	 */
 	protected abstract void decompressToSparseBlockDenseDictionary(SparseBlock ret, int rl, int ru, int offR, int offC,
 		double[] values);
-
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_dict = DictionaryFactory.read(in);
-	}
 
 	@Override
 	public void write(DataOutput out) throws IOException {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AMorphingMMColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AMorphingMMColGroup.java
@@ -36,13 +36,6 @@ public abstract class AMorphingMMColGroup extends AColGroupValue {
 	private static final long serialVersionUID = -4265713396790607199L;
 
 	/**
-	 * Constructor for serialization
-	 */
-	protected AMorphingMMColGroup() {
-		super();
-	}
-
-	/**
 	 * A Abstract class for column groups that contain ADictionary for values.
 	 * 
 	 * @param colIndices   The Column indexes

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
@@ -40,14 +40,6 @@ public abstract class APreAgg extends AColGroupValue {
 	private static boolean loggedWarningForDirect = false;
 
 	/**
-	 * Constructor for serialization
-	 * 
-	 */
-	protected APreAgg() {
-		super();
-	}
-
-	/**
 	 * A Abstract class for column groups that contain ADictionary for values.
 	 * 
 	 * @param colIndices   The Column indexes

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDC.java
@@ -34,34 +34,23 @@ public abstract class ASDC extends AMorphingMMColGroup {
 
 	/** Sparse row indexes for the data */
 	protected AOffset _indexes;
-	
+
 	final protected int _numRows;
 
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ASDC(int numRows) {
-		super();
-		_numRows = numRows;
-	}
-
-	protected ASDC(int[] colIndices, int numRows, ADictionary dict,  AOffset offsets,
-		int[] cachedCounts) {
+	protected ASDC(int[] colIndices, int numRows, ADictionary dict, AOffset offsets, int[] cachedCounts) {
 		super(colIndices, dict, cachedCounts);
 
 		_indexes = offsets;
 		_numRows = numRows;
 	}
 
-	public int getNumRows(){
+	public int getNumRows() {
 		return _numRows;
 	}
 
 	public abstract double[] getDefaultTuple();
 
-	public AOffset getOffsets(){
+	public AOffset getOffsets() {
 		return _indexes;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDCZero.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDCZero.java
@@ -34,11 +34,6 @@ public abstract class ASDCZero extends APreAgg {
 	protected AOffset _indexes;
 	final protected int _numRows;
 
-	protected ASDCZero(int numRows) {
-		super();
-		_numRows = numRows;
-	}
-
 	protected ASDCZero(int[] colIndices, int numRows, ADictionary dict, AOffset offsets, int[] cachedCounts) {
 		super(colIndices, dict, cachedCounts);
 		_indexes = offsets;

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
@@ -19,9 +19,13 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import java.io.DataInput;
+import java.io.IOException;
+
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.lib.CLALibLeftMultBy;
@@ -39,11 +43,6 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 public class ColGroupConst extends ADictBasedColGroup {
 
 	private static final long serialVersionUID = -7387793538322386611L;
-
-	/** Constructor for serialization */
-	protected ColGroupConst() {
-		super();
-	}
 
 	/**
 	 * Constructs an Constant Colum Group, that contains only one tuple, with the given value.
@@ -512,6 +511,12 @@ public class ColGroupConst extends ADictBasedColGroup {
 			return create(colIndexes, preAgg);
 		else
 			return null;
+	}
+
+	public static ColGroupConst read(DataInput in) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		return new ColGroupConst(cols, dict);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
@@ -48,11 +49,6 @@ public class ColGroupDDC extends APreAgg {
 	private static final long serialVersionUID = -5769772089913918987L;
 
 	protected AMapToData _data;
-
-	/** Constructor for serialization */
-	protected ColGroupDDC() {
-		super();
-	}
 
 	private ColGroupDDC(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {
 		super(colIndexes, dict, cachedCounts);
@@ -427,10 +423,11 @@ public class ColGroupDDC extends APreAgg {
 		_data.write(out);
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_data = MapToFactory.readIn(in);
+	public static ColGroupDDC read(DataInput in) throws IOException {
+		int[] cols = AColGroup.readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		AMapToData data = MapToFactory.readIn(in);
+		return new ColGroupDDC(cols, dict, data, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -24,7 +24,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
@@ -57,10 +56,11 @@ public class ColGroupDDC extends APreAgg {
 
 	private ColGroupDDC(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {
 		super(colIndexes, dict, cachedCounts);
-		if(data.getUnique() != dict.getNumberOfValues(colIndexes.length))
-			throw new DMLCompressionException("Invalid construction of DDC group " + data.getUnique() + " vs. "
-				+ dict.getNumberOfValues(colIndexes.length));
 		_data = data;
+		getCounts();
+		// if(data.getUnique() != dict.getNumberOfValues(colIndexes.length))
+		// 	throw new DMLCompressionException("Invalid construction of DDC group " + data.getUnique() + " vs. "
+		// 		+ dict.getNumberOfValues(colIndexes.length));
 	}
 
 	public static AColGroup create(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -57,10 +57,6 @@ public class ColGroupDDC extends APreAgg {
 	private ColGroupDDC(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {
 		super(colIndexes, dict, cachedCounts);
 		_data = data;
-		getCounts();
-		// if(data.getUnique() != dict.getNumberOfValues(colIndexes.length))
-		// 	throw new DMLCompressionException("Invalid construction of DDC group " + data.getUnique() + " vs. "
-		// 		+ dict.getNumberOfValues(colIndexes.length));
 	}
 
 	public static AColGroup create(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDeltaDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDeltaDDC.java
@@ -19,69 +19,62 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
-import org.apache.commons.lang.NotImplementedException;
-import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
-import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
-import org.apache.sysds.runtime.data.DenseBlock;
-import org.apache.sysds.runtime.data.SparseBlock;
-import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
-
 /**
  * Class to encapsulate information about a column group that is first delta encoded then encoded with dense dictionary
  * encoding (DeltaDDC).
  */
-public class ColGroupDeltaDDC extends ColGroupDDC {
+// public class ColGroupDeltaDDC extends ColGroupDDC {
 
-	private static final long serialVersionUID = -1045556313148564147L;
+// 	private static final long serialVersionUID = -1045556313148564147L;
 
-	/** Constructor for serialization */
-	protected ColGroupDeltaDDC() {
-	}
+// 	/** Constructor for serialization */
+// 	protected ColGroupDeltaDDC() {
+// 	}
 
-	private ColGroupDeltaDDC(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {
-		super();
-		LOG.info("Carefully use of DeltaDDC since implementation is not finished.");
-		_colIndexes = colIndexes;
-		_dict = dict;
-		_data = data;
-	}
+// 	private ColGroupDeltaDDC(int[] colIndexes, ADictionary dict, AMapToData data, int[] cachedCounts) {
+// 		super();
+// 		LOG.info("Carefully use of DeltaDDC since implementation is not finished.");
+// 		_colIndexes = colIndexes;
+// 		_dict = dict;
+// 		_data = data;
+// 	}
 
-	public static AColGroup create(int[] colIndices, ADictionary dict, AMapToData data, int[] cachedCounts) {
-		if(dict == null)
-			throw new NotImplementedException("Not implemented constant delta group");
-		else
-			return new ColGroupDeltaDDC(colIndices, dict, data, cachedCounts);
-	}
+// 	public static AColGroup create(int[] colIndices, ADictionary dict, AMapToData data, int[] cachedCounts) {
+// 		if(dict == null)
+// 			throw new NotImplementedException("Not implemented constant delta group");
+// 		else
+// 			return new ColGroupDeltaDDC(colIndices, dict, data, cachedCounts);
+// 	}
 
-	public CompressionType getCompType() {
-		return CompressionType.DeltaDDC;
-	}
+// 	public CompressionType getCompType() {
+// 		return CompressionType.DeltaDDC;
+// 	}
 
-	@Override
-	protected void decompressToDenseBlockDenseDictionary(DenseBlock db, int rl, int ru, int offR, int offC,
-		double[] values) {
-		final int nCol = _colIndexes.length;
-		for(int i = rl, offT = rl + offR; i < ru; i++, offT++) {
-			final double[] c = db.values(offT);
-			final int off = db.pos(offT) + offC;
-			final int rowIndex = _data.getIndex(i) * nCol;
-			final int prevOff = (off == 0) ? off : off - nCol;
-			for(int j = 0; j < nCol; j++) {
-				// Here we use the values in the previous row to compute current values along with the delta
-				double newValue = c[prevOff + j] + values[rowIndex + j];
-				c[off + _colIndexes[j]] += newValue;
-			}
-		}
-	}
+// 	@Override
+// 	protected void decompressToDenseBlockDenseDictionary(DenseBlock db, int rl, int ru, int offR, int offC,
+// 		double[] values) {
+// 		final int nCol = _colIndexes.length;
+// 		for(int i = rl, offT = rl + offR; i < ru; i++, offT++) {
+// 			final double[] c = db.values(offT);
+// 			final int off = db.pos(offT) + offC;
+// 			final int rowIndex = _data.getIndex(i) * nCol;
+// 			final int prevOff = (off == 0) ? off : off - nCol;
+// 			for(int j = 0; j < nCol; j++) {
+// 				// Here we use the values in the previous row to compute current values along with the delta
+// 				double newValue = c[prevOff + j] + values[rowIndex + j];
+// 				c[off + _colIndexes[j]] += newValue;
+// 			}
+// 		}
+// 	}
 
-	@Override
-	protected void decompressToSparseBlockDenseDictionary(SparseBlock ret, int rl, int ru, int offR, int offC,
-		double[] values) {
-		throw new NotImplementedException();
-	}
+// 	@Override
+// 	protected void decompressToSparseBlockDenseDictionary(SparseBlock ret, int rl, int ru, int offR, int offC,
+// 		double[] values) {
+// 		throw new NotImplementedException();
+// 	}
 
-	@Override
-	public AColGroup scalarOperation(ScalarOperator op) {
-		return new ColGroupDeltaDDC(_colIndexes, _dict.applyScalarOp(op), _data, getCachedCounts());
-	}
-}
+// 	@Override
+// 	public AColGroup scalarOperation(ScalarOperator op) {
+// 		return new ColGroupDeltaDDC(_colIndexes, _dict.applyScalarOp(op), _data, getCachedCounts());
+// 	}
+// }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -38,11 +40,6 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 
 public class ColGroupEmpty extends AColGroupCompressed {
 	private static final long serialVersionUID = -2307677253622099958L;
-
-	/** Constructor for serialization */
-	protected ColGroupEmpty() {
-		super();
-	}
 
 	/**
 	 * Constructs an Constant Colum Group, that contains only one tuple, with the given value.
@@ -303,5 +300,10 @@ public class ColGroupEmpty extends AColGroupCompressed {
 	@Override
 	public boolean isEmpty() {
 		return true;
+	}
+
+	public static ColGroupEmpty read(DataInput in) throws IOException {
+		int[] cols = readCols(in);
+		return new ColGroupEmpty(cols);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupIO.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupIO.java
@@ -48,20 +48,13 @@ public interface ColGroupIO {
 
 		// Read in how many colGroups there are
 		final int nColGroups = in.readInt();
-		final boolean trace = LOG.isTraceEnabled();
 
 		// Allocate that amount into an ArrayList
 		final List<AColGroup> _colGroups = new ArrayList<>(nColGroups);
 
 		// Read each ColGroup one at a time.
-		for(int i = 0; i < nColGroups; i++) {
-			ColGroupType ctype = ColGroupType.values()[in.readByte()];
-			if(trace)
-				LOG.trace("Reading in : " + ctype);
-			final AColGroup grp = constructColGroup(ctype, nRows);
-			grp.readFields(in);
-			_colGroups.add(grp);
-		}
+		for(int i = 0; i < nColGroups; i++)
+			_colGroups.add(readColGroup(in, nRows));
 
 		return _colGroups;
 	}
@@ -93,36 +86,44 @@ public interface ColGroupIO {
 		return ret;
 	}
 
-	private static AColGroup constructColGroup(ColGroupType ctype, int nRows) {
+	public static AColGroup readColGroup(DataInput in, int nRows) throws IOException {
+		final ColGroupType ctype = ColGroupType.values()[in.readByte()];
 		switch(ctype) {
-			case UNCOMPRESSED:
-				return new ColGroupUncompressed();
-			case OLE:
-				return new ColGroupOLE(nRows);
-			case RLE:
-				return new ColGroupRLE(nRows);
 			case DDC:
-				return new ColGroupDDC();
-			case DeltaDDC:
-				return new ColGroupDeltaDDC();
-			case CONST:
-				return new ColGroupConst();
-			case EMPTY:
-				return new ColGroupEmpty();
-			case SDC:
-				return new ColGroupSDC(nRows);
-			case SDCSingle:
-				return new ColGroupSDCSingle(nRows);
-			case SDCSingleZeros:
-				return new ColGroupSDCSingleZeros(nRows);
-			case SDCZeros:
-				return new ColGroupSDCZeros(nRows);
-			case SDCFOR:
-				return new ColGroupSDCFOR(nRows);
+				return ColGroupDDC.read(in);
 			case DDCFOR:
-				return new ColGroupDDCFOR();
+				return ColGroupDDCFOR.read(in);
+			case OLE:
+				return ColGroupOLE.read(in, nRows);
+			case RLE:
+				return ColGroupRLE.read(in, nRows);
+			case CONST:
+				return ColGroupConst.read(in);
+			case EMPTY:
+				return ColGroupEmpty.read(in);
+			case UNCOMPRESSED:
+				return ColGroupUncompressed.read(in);
+			case SDC:
+				return ColGroupSDC.read(in, nRows);
+			case SDCSingle:
+				return ColGroupSDCSingle.read(in, nRows);
+			case SDCSingleZeros:
+				return ColGroupSDCSingleZeros.read(in, nRows);
+			case SDCZeros:
+				return ColGroupSDCZeros.read(in, nRows);
+			case SDCFOR:
+				return ColGroupSDCFOR.read(in, nRows);
+			case LinearFunctional:
+				return ColGroupLinearFunctional.read(in, nRows);
 			default:
-				throw new DMLRuntimeException("Unsupported ColGroup Type used:  " + ctype);
+				throw new DMLRuntimeException("Unsupported ColGroup Type used: " + ctype);
 		}
+	}
+
+	public static double[] readDoubleArray(int length, DataInput in) throws IOException {
+		double[] ret = new double[length];
+		for(int i = 0; i < length; i++)
+			ret[i] = in.readDouble();
+		return ret;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
@@ -57,11 +57,6 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 
 	protected int _numRows;
 
-	/** Constructor for serialization */
-	protected ColGroupLinearFunctional() {
-		super();
-	}
-
 	/**
 	 * Constructs a Linear Functional Column Group that compresses its content using a linear functional.
 	 *
@@ -417,12 +412,10 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 		throw new DMLCompressionException("This method should never be called");
 	}
 
-
 	@Override
 	public void leftMultByAColGroup(AColGroup lhs, MatrixBlock result, int nRows) {
-		if(lhs instanceof ColGroupEmpty) 
+		if(lhs instanceof ColGroupEmpty)
 			return;
-		
 
 		MatrixBlock tmpRet = new MatrixBlock(lhs.getNumCols(), _colIndexes.length, 0);
 
@@ -526,14 +519,17 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 		throw new NotImplementedException();
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		throw new NotImplementedException();
+	public static ColGroupLinearFunctional read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		double[] coefficients = ColGroupIO.readDoubleArray(2 * cols.length, in);
+		return new ColGroupLinearFunctional(cols, coefficients, nRows);
 	}
 
 	@Override
 	public void write(DataOutput out) throws IOException {
-		throw new NotImplementedException();
+		super.write(out);
+		for(double d : _coefficents)
+			out.writeDouble(d);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.lang.NotImplementedException;
@@ -42,15 +44,6 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
  */
 public class ColGroupOLE extends AColGroupOffset {
 	private static final long serialVersionUID = 5723227906925121066L;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupOLE(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupOLE(int[] colIndices, int numRows, boolean zero, ADictionary dict, char[] bitmaps, int[] bitmapOffs,
 		int[] counts) {
@@ -644,4 +637,14 @@ public class ColGroupOLE extends AColGroupOffset {
 	public double getCost(ComputationCostEstimator e, int nRows) {
 		throw new NotImplementedException();
 	}
+
+	public static ColGroupOLE read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		int[] ptr = readPointers(in);
+		char[] data = readData(in);
+		boolean zeros = in.readBoolean();
+		return new ColGroupOLE(cols, nRows, zeros, dict, data, ptr, null);
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.runtime.compress.colgroup;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,15 +44,6 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 /** A group of columns compressed with a single run-length encoded bitmap. */
 public class ColGroupRLE extends AColGroupOffset {
 	private static final long serialVersionUID = -1560710477952862791L;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupRLE(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupRLE(int[] colIndexes, int numRows, boolean zeros, ADictionary dict, char[] bitmaps, int[] bitmapOffs,
 		int[] cachedCounts) {
@@ -974,6 +967,15 @@ public class ColGroupRLE extends AColGroupOffset {
 		final int nVals = getNumValues();
 		final int nCols = getNumCols();
 		return e.getCost(_numRows, _data.length, nCols, nVals, _dict.getSparsity());
+	}
+
+	public static ColGroupRLE read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		int[] ptr = readPointers(in);
+		char[] data = readData(in);
+		boolean zeros = in.readBoolean();
+		return new ColGroupRLE(cols, nRows, zeros, dict, data, ptr,null);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -941,8 +941,6 @@ public class ColGroupRLE extends AColGroupOffset {
 			for(int apos = _ptr[k], rs = 0, re = 0; apos < blen; apos += 2) {
 				rs = re + _data[apos];
 				re = rs + _data[apos + 1];
-				if(rs == re)// empty run
-					continue;
 				for(int tk = 0; tk < tnv; tk++) {
 					final int tblen = that._ptr[tk + 1];
 					int tapos = skip[tk];

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
@@ -62,15 +63,6 @@ public class ColGroupSDCFOR extends ASDC {
 
 	/** Reference values in this column group */
 	protected double[] _reference;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupSDCFOR(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupSDCFOR(int[] colIndices, int numRows, ADictionary dict, AOffset indexes, AMapToData data,
 		int[] cachedCounts, double[] reference) {
@@ -113,7 +105,7 @@ public class ColGroupSDCFOR extends ASDC {
 	}
 
 	@Override
-	public  double[] getDefaultTuple(){
+	public double[] getDefaultTuple() {
 		return _reference;
 	}
 
@@ -211,14 +203,13 @@ public class ColGroupSDCFOR extends ASDC {
 			out.writeDouble(d);
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_indexes = OffsetFactory.readIn(in);
-		_data = MapToFactory.readIn(in);
-		_reference = new double[_colIndexes.length];
-		for(int i = 0; i < _colIndexes.length; i++)
-			_reference[i] = in.readDouble();
+	public static ColGroupSDCFOR read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		AOffset indexes = OffsetFactory.readIn(in);
+		AMapToData data = MapToFactory.readIn(in);
+		double[] reference = ColGroupIO.readDoubleArray(cols.length, in);
+		return new ColGroupSDCFOR(cols, nRows, dict, indexes, data, null, reference);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
@@ -54,15 +55,6 @@ public class ColGroupSDCSingle extends ASDC {
 
 	/** The default value stored in this column group */
 	protected double[] _defaultTuple;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupSDCSingle(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupSDCSingle(int[] colIndices, int numRows, ADictionary dict, double[] defaultTuple, AOffset offsets,
 		int[] cachedCounts) {
@@ -434,13 +426,12 @@ public class ColGroupSDCSingle extends ASDC {
 			out.writeDouble(d);
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_indexes = OffsetFactory.readIn(in);
-		_defaultTuple = new double[_colIndexes.length];
-		for(int i = 0; i < _colIndexes.length; i++)
-			_defaultTuple[i] = in.readDouble();
+	public static ColGroupSDCSingle read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		AOffset indexes = OffsetFactory.readIn(in);
+		double[] defaultTuple = ColGroupIO.readDoubleArray(cols.length, in);
+		return new ColGroupSDCSingle(cols, nRows, dict, defaultTuple, indexes, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
@@ -51,15 +52,6 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
  */
 public class ColGroupSDCSingleZeros extends ASDCZero {
 	private static final long serialVersionUID = 8033235615964315078L;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupSDCSingleZeros(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupSDCSingleZeros(int[] colIndices, int numRows, ADictionary dict, AOffset offsets,
 		int[] cachedCounts) {
@@ -95,7 +87,7 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 			return;
 		else if(it.value() >= ru)
 			_indexes.cacheIterator(it, ru);
-		else{
+		else {
 			decompressToDenseBlockDenseDictionaryWithProvidedIterator(db, rl, ru, offR, offC, values, it);
 			_indexes.cacheIterator(it, ru);
 		}
@@ -563,10 +555,11 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 		_indexes.write(out);
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_indexes = OffsetFactory.readIn(in);
+	public static ColGroupSDCSingleZeros read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		AOffset indexes = OffsetFactory.readIn(in);
+		return new ColGroupSDCSingleZeros(cols, nRows, dict, indexes, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
@@ -58,15 +59,6 @@ public class ColGroupSDCZeros extends ASDCZero {
 
 	/** Pointers to row indexes in the dictionary. Note the dictionary has one extra entry. */
 	protected AMapToData _data;
-
-	/**
-	 * Constructor for serialization
-	 * 
-	 * @param numRows Number of rows contained
-	 */
-	protected ColGroupSDCZeros(int numRows) {
-		super(numRows);
-	}
 
 	private ColGroupSDCZeros(int[] colIndices, int numRows, ADictionary dict, AOffset indexes, AMapToData data,
 		int[] cachedCounts) {
@@ -549,11 +541,12 @@ public class ColGroupSDCZeros extends ASDCZero {
 		_data.write(out);
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_indexes = OffsetFactory.readIn(in);
-		_data = MapToFactory.readIn(in);
+	public static ColGroupSDCZeros read(DataInput in, int nRows) throws IOException {
+		int[] cols = readCols(in);
+		ADictionary dict = DictionaryFactory.read(in);
+		AOffset indexes = OffsetFactory.readIn(in);
+		AMapToData data = MapToFactory.readIn(in);
+		return new ColGroupSDCZeros(cols, nRows, dict, indexes, data, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -528,17 +528,17 @@ public class ColGroupUncompressed extends AColGroup {
 	}
 
 	private void leftMultByAPreAggColGroup(APreAgg paCG, MatrixBlock result) {
+		final int nCols = paCG.getNumCols();
+		final MatrixBlock dictM = paCG._dict.getMBDict(nCols).getMatrixBlock();
+		if(dictM == null)
+			return;
 		LOG.warn("\nInefficient transpose of uncompressed to fit to"
 			+ " t(AColGroup) %*% UncompressedColGroup mult by colGroup uncompressed column"
 			+ "\nCurrently solved by t(t(Uncompressed) %*% AColGroup)");
 		final int k = InfrastructureAnalyzer.getLocalParallelism();
 		final MatrixBlock ucCGT = LibMatrixReorg.transpose(getData(), k);
-		final int nCols = paCG.getNumCols();
 		final MatrixBlock preAgg = new MatrixBlock(1, paCG.getNumValues(), false);
 		final MatrixBlock tmpRes = new MatrixBlock(1, nCols, false);
-		final MatrixBlock dictM = paCG._dict.getMBDict(nCols).getMatrixBlock();
-		if(dictM == null)
-			return;
 		preAgg.allocateDenseBlock();
 		tmpRes.allocateDenseBlock();
 		final int nRowsTransposed = ucCGT.getNumRows();

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -65,11 +65,6 @@ public class ColGroupUncompressed extends AColGroup {
 	 */
 	private MatrixBlock _data;
 
-	/** Constructor for serialization */
-	protected ColGroupUncompressed() {
-		super();
-	}
-
 	private ColGroupUncompressed(MatrixBlock mb, int[] colIndexes) {
 		super(colIndexes);
 		_data = mb;
@@ -454,11 +449,11 @@ public class ColGroupUncompressed extends AColGroup {
 		}
 	}
 
-	@Override
-	public void readFields(DataInput in) throws IOException {
-		super.readFields(in);
-		_data = new MatrixBlock();
-		_data.readFields(in);
+	public static ColGroupUncompressed read(DataInput in) throws IOException {
+		int[] cols = readCols(in);
+		MatrixBlock data = new MatrixBlock();
+		data.readFields(in);
+		return new ColGroupUncompressed(data, cols);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
@@ -347,6 +347,8 @@ public abstract class AOffset implements Serializable {
 
 		while(i < last) { // while we are not done iterating
 			for(int r = rl; r < ru; r++) {
+				if(sb.isEmpty(r))
+					continue;
 				final int off = r - rl;
 				int apos = aOffs[off]; // current offset
 				final int alen = sb.size(r) + sb.pos(r);
@@ -363,6 +365,8 @@ public abstract class AOffset implements Serializable {
 
 		// process final element
 		for(int r = rl; r < ru; r++) {
+			if(sb.isEmpty(r))
+				continue;
 			final int off = r - rl;
 			int apos = aOffs[off];
 			final int alen = sb.size(r) + sb.pos(r);

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/EstimationFactors.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/EstimationFactors.java
@@ -60,6 +60,10 @@ public class EstimationFactors {
 		this(numVals, numRows, -1, null, -1, numRows, false, false, 1.0, tupleSparsity);
 	}
 
+	public EstimationFactors(int numVals, int numRows, int numOffs, double tupleSparsity) {
+		this(numVals, numOffs, -1, null, -1, numRows, false, false, 1.0, tupleSparsity);
+	}
+
 	public EstimationFactors(int numVals, int numOffs, int largestOff, int[] frequencies, int numSingle, int numRows,
 		boolean lossy, boolean zeroIsMostFrequent, double overAllSparsity, double tupleSparsity) {
 		this(numVals, numOffs, largestOff, frequencies, numSingle, numRows, numOffs, lossy, zeroIsMostFrequent,
@@ -90,7 +94,7 @@ public class EstimationFactors {
 				"Invalid number of instance of most common element should be lower than number of rows. " + largestOff
 					+ " > numRows: " + numRows);
 		else if(numVals > numOffs)
-			throw new DMLCompressionException("Num vals cannot be greater than num offs");
+			throw new DMLCompressionException("Num vals cannot be greater than num offs: vals: "+ numVals + " offs: " + numOffs);
 	}
 
 	public int[] getFrequencies(){

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedTestBase.java
@@ -92,7 +92,7 @@ public abstract class CompressedTestBase extends TestBase {
 
 	protected static SparsityType[] usedSparsityTypes = new SparsityType[] { //
 		SparsityType.FULL, //
-		SparsityType.SPARSE, //
+		// SparsityType.SPARSE, //
 		SparsityType.ULTRA_SPARSE //
 	};
 

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupBase.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupBase.java
@@ -49,6 +49,7 @@ import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
 import org.apache.sysds.runtime.compress.estim.EstimationFactors;
 import org.apache.sysds.runtime.compress.utils.Util;
+import org.apache.sysds.runtime.data.DenseBlockFP64;
 import org.apache.sysds.runtime.functionobjects.Modulus;
 import org.apache.sysds.runtime.functionobjects.Plus;
 import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
@@ -106,6 +107,7 @@ public abstract class ColGroupBase {
 		this.maxCol = Arrays.stream(base.getColIndices()).max().getAsInt() + 1;
 	}
 
+
 	protected AColGroup serializeAndBack(AColGroup g) {
 		try {
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -141,6 +143,35 @@ public abstract class ColGroupBase {
 		MatrixBlock t = new MatrixBlock(nRow, nCol, false);
 		t.allocateDenseBlock();
 		return t;
+	}
+
+	protected MatrixBlock multiBlockDenseMB(int nCol){
+
+		MatrixBlock t = new MatrixBlock(nRow, nCol, false);
+		t.allocateDenseBlock();
+
+		double[] values = t.getDenseBlockValues();
+		DenseBlockFP64Mock m = new DenseBlockFP64Mock(new int[]{nRow, nCol}, values);
+
+		return new MatrixBlock(nRow, nCol, m);
+	}
+
+	private class DenseBlockFP64Mock extends DenseBlockFP64 {
+		private static final long serialVersionUID = -3601232958390554672L;
+
+		public DenseBlockFP64Mock(int[] dims, double[] data) {
+			super(dims, data);
+		}
+
+		@Override
+		public boolean isContiguous() {
+			return false;
+		}
+
+		@Override
+		public int numBlocks() {
+			return 2;
+		}
 	}
 
 	protected static void compare(MatrixBlock m1, MatrixBlock m2) {

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupFactoryTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupFactoryTest.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.sysds.runtime.compress.CompressionSettings;
+import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupFactory;
+import org.apache.sysds.runtime.compress.cost.ACostEstimate;
+import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
+import org.apache.sysds.runtime.compress.cost.DistinctCostEstimator;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
+import org.apache.sysds.runtime.compress.estim.EstimationFactors;
+import org.apache.sysds.runtime.compress.utils.Util;
+import org.apache.sysds.runtime.data.DenseBlockFP64;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class ColGroupFactoryTest {
+
+	private final MatrixBlock mb;
+	private final MatrixBlock mbt;
+	private final ACostEstimate ce;
+	private final CompressionSettingsBuilder csb;
+	private final int nRow;
+	private final int nCol;
+	private final CompressionType ct;
+	private final List<AColGroup> g;
+
+	private final int[] cols;
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		ArrayList<Object[]> tests = new ArrayList<>();
+		add(tests, 100, 5, 2, 5, 0.7, 234);
+		add(tests, 100, 5, 1, 1, 0.7, 234);
+		add(tests, 100, 1, 2, 5, 0.7, 234);
+		add(tests, 100, 1, 1, 1, 0.7, 234);
+		add(tests, 100, 5, 2, 5, 0.2, 234);
+		add(tests, 100, 5, 2, 5, 0.1, 234);
+		add(tests, 100, 1, 2, 5, 0.1, 234);
+		add(tests, 100, 1, 1, 1, 0.8, 234);
+		add(tests, 100, 1, 1, 1, 0.1, 234);
+		add(tests, 100, 5, 2, 5, 0.0, 234);
+		add(tests, 100, 1, 1, 3, 1.0, 234);
+		add(tests, 100, 1, 1, 3, 1.0, 234);
+
+		addWithEmpty(tests, 100, 1, 2, 5, 0.1, 234);
+		addWithEmpty(tests, 100, 1, 1, 1, 0.1, 234);
+		addWithEmpty(tests, 100, 1, 1, 1, 0.8, 234);
+		addWithEmpty(tests, 100, 3, 2, 5, 0.1, 234);
+
+		addWithEmptyReverse(tests, 100, 1, 2, 5, 0.1, 234);
+		addWithEmptyReverse(tests, 100, 1, 2, 5, 0.7, 234);
+		addWithEmptyReverse(tests, 100, 1, 1, 1, 0.7, 234);
+		addWithEmptyReverse(tests, 100, 3, 2, 5, 0.1, 234);
+
+		addDenseMultiBlock(tests, 100, 3, 2, 5, 0.7, 234);
+		addDenseMultiBlock(tests, 100, 1, 2, 5, 0.7, 234);
+
+		return tests;
+	}
+
+	private static void addDenseMultiBlock(ArrayList<Object[]> tests, int nRows, int nCols, int min, int max,
+		double sparsity, int seed) {
+		MatrixBlock mb = TestUtils.generateTestMatrixBlock(nRows, nCols, min, max, sparsity, seed);
+		mb = TestUtils.ceil(mb);
+
+		MatrixBlock mbt = LibMatrixReorg.transpose(mb);
+
+		mb = new MatrixBlock(mb.getNumRows(), mb.getNumColumns(),
+			new DenseBlockFP64Mock(new int[] {mb.getNumRows(), mb.getNumColumns()}, mb.getDenseBlockValues()));
+		mbt = new MatrixBlock(mbt.getNumRows(), mbt.getNumColumns(),
+			new DenseBlockFP64Mock(new int[] {mbt.getNumRows(), mbt.getNumColumns()}, mbt.getDenseBlockValues()));
+
+		add(tests, nCols + 3, mb, mbt);
+	}
+
+	private static void addWithEmpty(ArrayList<Object[]> tests, int nRows, int nCols, int min, int max, double sparsity,
+		int seed) {
+		MatrixBlock mb = TestUtils.generateTestMatrixBlock(nRows, nCols, min, max, sparsity, seed);
+		mb = TestUtils.ceil(mb);
+
+		mb = mb.append(new MatrixBlock(nRows, 3, false), null);
+
+		MatrixBlock mbt = LibMatrixReorg.transpose(mb);
+
+		mb.denseToSparse(true);
+		mbt.denseToSparse(true);
+
+		add(tests, nCols + 3, mb, mbt);
+	}
+
+	private static void addWithEmptyReverse(ArrayList<Object[]> tests, int nRows, int nCols, int min, int max,
+		double sparsity, int seed) {
+		MatrixBlock mb = TestUtils.generateTestMatrixBlock(nRows, nCols, min, max, sparsity, seed);
+		mb = TestUtils.ceil(mb);
+
+		mb = new MatrixBlock(nRows, 3, false).append(mb, null);
+
+		MatrixBlock mbt = LibMatrixReorg.transpose(mb);
+
+		mb.denseToSparse(true);
+		mbt.denseToSparse(true);
+
+		add(tests, nCols + 3, mb, mbt);
+	}
+
+	private static void add(ArrayList<Object[]> tests, int nRows, int nCols, int min, int max, double sparsity,
+		int seed) {
+
+		MatrixBlock mb = TestUtils.generateTestMatrixBlock(nRows, nCols, min, max, sparsity, seed);
+		mb = TestUtils.ceil(mb);
+		MatrixBlock mbt = LibMatrixReorg.transpose(mb);
+
+		if(sparsity < 0.4) {
+			mb.denseToSparse(true);
+			mbt.denseToSparse(true);
+		}
+		add(tests, nCols, mb, mbt);
+	}
+
+	private static void add(ArrayList<Object[]> tests, int nCols, MatrixBlock mb, MatrixBlock mbt) {
+		final CompressionSettingsBuilder csb = new CompressionSettingsBuilder();
+
+		ACostEstimate cce = new ComputationCostEstimator(2, 2, 2, 2, 2, 2, 2, 2, true);
+		ACostEstimate dce = new DistinctCostEstimator(mb.getNumRows(), csb.create(), mb.getSparsity());
+
+		int[] cols = Util.genColsIndices(nCols);
+		int[] cols2 = Util.genColsIndices(1, nCols);
+		int[] cols3 = new int[] {nCols - 1};
+		try {
+			for(CompressionType ct : CompressionType.values()) {
+				if(ct == CompressionType.DeltaDDC)
+					continue;
+				for(ACostEstimate ce : new ACostEstimate[] {null, cce, dce}) {
+
+					tests.add(new Object[] {mb, mbt, ce, csb, ct, cols});
+					if(nCols > 1) {
+						tests.add(new Object[] {mb, mbt, ce, csb, ct, cols2});
+						tests.add(new Object[] {mb, mbt, ce, csb, ct, cols3});
+					}
+				}
+
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("failed constructing tests");
+		}
+	}
+
+	public ColGroupFactoryTest(MatrixBlock mb, MatrixBlock mbt, ACostEstimate ce, CompressionSettingsBuilder csb,
+		CompressionType ct, int[] cols) {
+		this.mb = mb;
+		this.nRow = mb.getNumRows();
+		this.nCol = mb.getNumColumns();
+		this.ce = ce;
+		this.csb = csb;
+		this.mbt = mbt;
+		this.ct = ct;
+		this.cols = cols;
+		g = compST();
+	}
+
+	@Test
+	public void testCompressTransposedSingleThread() {
+		compare(compTransposedST());
+	}
+
+	@Test
+	public void testCompressTransposedMultiThread() {
+		compare(compTransposedMT());
+	}
+
+	@Test
+	public void testCompressMultiThread() {
+		compare(compMT());
+	}
+
+	@Test
+	public void testCompressMultiThreadDDC() {
+		if(ct == CompressionType.DDC) {
+			CompressionSettings.PAR_DDC_THRESHOLD = 1;
+			compare(compMT());
+			compare(compST());
+			CompressionSettings.PAR_DDC_THRESHOLD = 13425;
+		}
+	}
+
+	@Test
+	public void testCompressMultipleTimes() {
+		final int offs = Math.min((int) (mbt.getSparsity() * nRow * nCol), nRow);
+		final EstimationFactors f = new EstimationFactors(Math.min(nRow, offs), nRow, offs, mbt.getSparsity());
+		final List<CompressedSizeInfoColGroup> es = new ArrayList<>();
+		es.add(new CompressedSizeInfoColGroup(cols, f, 312152, ct));
+		es.add(new CompressedSizeInfoColGroup(cols, f, 312152, ct));// second time.
+		final CompressedSizeInfo csi = new CompressedSizeInfo(es);
+		CompressionSettings cs = csb.create();
+
+		cs.transposed = true;
+		if(ce != null)
+			ColGroupFactory.compressColGroups(mbt, csi, cs, ce, 6);
+		else
+			ColGroupFactory.compressColGroups(mbt, csi, cs, 6);
+	}
+
+	private void compare(List<AColGroup> gt) {
+		for(int i = 0; i < g.size(); i++)
+			compare(gt.get(i), g.get(i));
+	}
+
+	private void compare(AColGroup gtt, AColGroup gg) {
+		assertArrayEquals(gtt.getColIndices(), gg.getColIndices());
+	}
+
+	private List<AColGroup> compST() {
+		return comp(1, false);
+	}
+
+	private List<AColGroup> compMT() {
+		return comp(6, false);
+	}
+
+	private List<AColGroup> compTransposedST() {
+		return comp(1, true);
+	}
+
+	private List<AColGroup> compTransposedMT() {
+		return comp(6, true);
+	}
+
+	private List<AColGroup> comp(int k, boolean transposed) {
+		try {
+			final int offs = Math.min((int) (mbt.getSparsity() * nRow * nCol), nRow);
+			final EstimationFactors f = new EstimationFactors(Math.min(nRow, offs), nRow, offs, mbt.getSparsity());
+			final List<CompressedSizeInfoColGroup> es = new ArrayList<>();
+			es.add(new CompressedSizeInfoColGroup(cols, f, 312152, ct));
+			final CompressedSizeInfo csi = new CompressedSizeInfo(es);
+			CompressionSettings cs = csb.create();
+
+			if(transposed) {
+				cs.transposed = true;
+				if(ce != null)
+					return ColGroupFactory.compressColGroups(mbt, csi, cs, ce, 1);
+				else
+					return ColGroupFactory.compressColGroups(mbt, csi, cs, 1);
+			}
+			else {
+				if(ce != null)
+					return ColGroupFactory.compressColGroups(mb, csi, cs, ce, k);
+				else if(k == 1)
+					return ColGroupFactory.compressColGroups(mb, csi, cs);
+				else
+					return ColGroupFactory.compressColGroups(mb, csi, cs, k);
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("Failed to compress");
+			return null;
+		}
+	}
+
+	private static class DenseBlockFP64Mock extends DenseBlockFP64 {
+		private static final long serialVersionUID = -3601232958390554672L;
+
+		public DenseBlockFP64Mock(int[] dims, double[] data) {
+			super(dims, data);
+		}
+
+		@Override
+		public boolean isContiguous() {
+			return false;
+		}
+
+		@Override
+		public int numBlocks() {
+			return 2;
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupFactoryTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupFactoryTest.java
@@ -64,31 +64,31 @@ public class ColGroupFactoryTest {
 	@Parameters
 	public static Collection<Object[]> data() {
 		ArrayList<Object[]> tests = new ArrayList<>();
-		add(tests, 100, 5, 2, 5, 0.7, 234);
-		add(tests, 100, 5, 1, 1, 0.7, 234);
-		add(tests, 100, 1, 2, 5, 0.7, 234);
-		add(tests, 100, 1, 1, 1, 0.7, 234);
-		add(tests, 100, 5, 2, 5, 0.2, 234);
-		add(tests, 100, 5, 2, 5, 0.1, 234);
-		add(tests, 100, 1, 2, 5, 0.1, 234);
-		add(tests, 100, 1, 1, 1, 0.8, 234);
-		add(tests, 100, 1, 1, 1, 0.1, 234);
-		add(tests, 100, 5, 2, 5, 0.0, 234);
-		add(tests, 100, 1, 1, 3, 1.0, 234);
-		add(tests, 100, 1, 1, 3, 1.0, 234);
+		// add(tests, 40, 5, 2, 5, 0.7, 234);
+		// add(tests, 40, 5, 1, 1, 0.7, 234);
+		add(tests, 40, 1, 2, 5, 0.7, 234);
+		add(tests, 40, 1, 1, 1, 0.7, 234);
+		add(tests, 40, 5, 2, 5, 0.2, 234);
+		add(tests, 40, 5, 2, 5, 0.1, 234);
+		add(tests, 40, 1, 2, 5, 0.1, 234);
+		add(tests, 40, 1, 1, 1, 0.8, 234);
+		add(tests, 40, 1, 1, 1, 0.1, 234);
+		add(tests, 40, 5, 2, 5, 0.0, 234);
+		add(tests, 40, 1, 1, 3, 1.0, 234);
+		add(tests, 40, 1, 1, 3, 1.0, 234);
 
-		addWithEmpty(tests, 100, 1, 2, 5, 0.1, 234);
-		addWithEmpty(tests, 100, 1, 1, 1, 0.1, 234);
-		addWithEmpty(tests, 100, 1, 1, 1, 0.8, 234);
-		addWithEmpty(tests, 100, 3, 2, 5, 0.1, 234);
+		addWithEmpty(tests, 40, 1, 2, 5, 0.1, 234);
+		addWithEmpty(tests, 40, 1, 1, 1, 0.1, 234);
+		addWithEmpty(tests, 40, 1, 1, 1, 0.8, 234);
+		addWithEmpty(tests, 40, 3, 2, 5, 0.1, 234);
 
-		addWithEmptyReverse(tests, 100, 1, 2, 5, 0.1, 234);
-		addWithEmptyReverse(tests, 100, 1, 2, 5, 0.7, 234);
-		addWithEmptyReverse(tests, 100, 1, 1, 1, 0.7, 234);
-		addWithEmptyReverse(tests, 100, 3, 2, 5, 0.1, 234);
+		addWithEmptyReverse(tests, 40, 1, 2, 5, 0.1, 234);
+		addWithEmptyReverse(tests, 40, 1, 2, 5, 0.7, 234);
+		addWithEmptyReverse(tests, 40, 1, 1, 1, 0.7, 234);
+		addWithEmptyReverse(tests, 40, 3, 2, 5, 0.1, 234);
 
-		addDenseMultiBlock(tests, 100, 3, 2, 5, 0.7, 234);
-		addDenseMultiBlock(tests, 100, 1, 2, 5, 0.7, 234);
+		addDenseMultiBlock(tests, 40, 3, 2, 5, 0.7, 234);
+		addDenseMultiBlock(tests, 40, 1, 2, 5, 0.7, 234);
 
 		return tests;
 	}
@@ -232,9 +232,9 @@ public class ColGroupFactoryTest {
 
 		cs.transposed = true;
 		if(ce != null)
-			ColGroupFactory.compressColGroups(mbt, csi, cs, ce, 6);
+			ColGroupFactory.compressColGroups(mbt, csi, cs, ce, 4);
 		else
-			ColGroupFactory.compressColGroups(mbt, csi, cs, 6);
+			ColGroupFactory.compressColGroups(mbt, csi, cs, 4);
 	}
 
 	private void compare(List<AColGroup> gt) {
@@ -251,7 +251,7 @@ public class ColGroupFactoryTest {
 	}
 
 	private List<AColGroup> compMT() {
-		return comp(6, false);
+		return comp(4, false);
 	}
 
 	private List<AColGroup> compTransposedST() {
@@ -259,7 +259,7 @@ public class ColGroupFactoryTest {
 	}
 
 	private List<AColGroup> compTransposedMT() {
-		return comp(6, true);
+		return comp(4, true);
 	}
 
 	private List<AColGroup> comp(int k, boolean transposed) {
@@ -267,7 +267,7 @@ public class ColGroupFactoryTest {
 			final int offs = Math.min((int) (mbt.getSparsity() * nRow * nCol), nRow);
 			final EstimationFactors f = new EstimationFactors(Math.min(nRow, offs), nRow, offs, mbt.getSparsity());
 			final List<CompressedSizeInfoColGroup> es = new ArrayList<>();
-			es.add(new CompressedSizeInfoColGroup(cols, f, 312152, ct));
+			es.add(new CompressedSizeInfoColGroup(cols, f, 314152, ct));
 			final CompressedSizeInfo csi = new CompressedSizeInfo(es);
 			CompressionSettings cs = csb.create();
 

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupMorphingPerformanceCompare.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupMorphingPerformanceCompare.java
@@ -153,11 +153,6 @@ public class ColGroupMorphingPerformanceCompare {
 		private static final long serialVersionUID = -7157464508602251065L;
 		private final MatrixBlock mbDict;
 
-		protected SDCNoMorph(int numRows) {
-			super(numRows);
-			mbDict = null;
-		}
-
 		public SDCNoMorph(ColGroupSDC g) {
 			this(g.getColIndices(), g.getNumRows(), g.getDictionary(), g.getDefaultTuple(), g.getOffsets(), g.getMapping(),
 				null);

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/GenOffsetOLETest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/GenOffsetOLETest.java
@@ -26,7 +26,7 @@ import org.apache.sysds.runtime.compress.CompressionSettings;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupOLE;
 import org.junit.Test;
 
-public class genOffsetOLETest {
+public class GenOffsetOLETest {
 
 	@Test
 	public void testEmpty() {


### PR DESCRIPTION
This commit fixes another edge case in DDC compression.
If the row of a sparse matrix is full, then a zero entry was added to DDC anyway.
This commit fixes this to not add unnecessary dictionary entries.