### PR TITLE
[SYSTEMDS-3454] CLA Sheme primitive 

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -638,6 +639,13 @@ public abstract class AColGroup implements Serializable {
 	 * @return A combined column group or null
 	 */
 	protected abstract AColGroup appendNInternal(AColGroup[] groups);
+
+	/**
+	 * Get the compression scheme for this column group to enable compression of other data.
+	 * 
+	 * @return The compression scheme of this column group
+	 */
+	public abstract ICLAScheme getCompressionScheme();
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AOffsetsGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AOffsetsGroup.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup;
+
+import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
+
+public interface AOffsetsGroup {
+
+	public AOffset getOffsets();
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDC.java
@@ -29,7 +29,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
  * This column group is handy in cases where sparse unsafe operations is executed on very sparse columns. Then the zeros
  * would be materialized in the group without any overhead.
  */
-public abstract class ASDC extends AMorphingMMColGroup {
+public abstract class ASDC extends AMorphingMMColGroup implements AOffsetsGroup {
 	private static final long serialVersionUID = 769993538831949086L;
 
 	/** Sparse row indexes for the data */
@@ -49,6 +49,7 @@ public abstract class ASDC extends AMorphingMMColGroup {
 
 	public abstract double[] getDefaultTuple();
 
+	@Override
 	public AOffset getOffsets() {
 		return _indexes;
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDCZero.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ASDCZero.java
@@ -27,7 +27,7 @@ import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
-public abstract class ASDCZero extends APreAgg {
+public abstract class ASDCZero extends APreAgg implements AOffsetsGroup {
 	private static final long serialVersionUID = -69266306137398807L;
 
 	/** Sparse row indexes for the data */
@@ -39,6 +39,10 @@ public abstract class ASDCZero extends APreAgg {
 		super(colIndices, dict, cachedCounts);
 		_indexes = offsets;
 		_numRows = numRows;
+	}
+
+	public int getNumRows() {
+		return _numRows;
 	}
 
 	@Override
@@ -204,5 +208,10 @@ public abstract class ASDCZero extends APreAgg {
 
 	public AIterator getIterator(int row) {
 		return _indexes.getIterator(row);
+	}
+
+	@Override
+	public AOffset getOffsets() {
+		return _indexes;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
@@ -28,6 +28,8 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ConstScheme;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.lib.CLALibLeftMultBy;
 import org.apache.sysds.runtime.compress.utils.Util;
@@ -534,6 +536,11 @@ public class ColGroupConst extends ADictBasedColGroup {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes) || !this._dict.eq(((ColGroupConst) g[i])._dict))
 				return null;
 		return this;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return ConstScheme.create(this);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -32,6 +32,8 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictiona
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
+import org.apache.sysds.runtime.compress.colgroup.scheme.DDCScheme;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -533,6 +535,12 @@ public class ColGroupDDC extends APreAgg implements AMapToDataGroup {
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
 		return create(_colIndexes, _dict, nd, null);
+	}
+
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return DDCScheme.create(this);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
@@ -31,6 +31,7 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -447,6 +448,11 @@ public class ColGroupDDCFOR extends AMorphingMMColGroup {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.data.DenseBlock;
@@ -327,4 +328,8 @@ public class ColGroupEmpty extends AColGroupCompressed {
 		return this;
 	}
 
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
@@ -672,6 +673,11 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -29,6 +29,7 @@ import org.apache.sysds.runtime.compress.bitmap.ABitmap;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -662,6 +663,11 @@ public class ColGroupOLE extends AColGroupOffset {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -32,6 +32,7 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -974,6 +975,11 @@ public class ColGroupRLE extends AColGroupOffset {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -35,6 +35,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -610,6 +611,12 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 
 		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, nd, null);
 	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
+	}
+
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -576,7 +576,7 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 			final ColGroupSDC gSDC = (ColGroupSDC) g;
 			if(Arrays.equals(_defaultTuple, gSDC._defaultTuple) && gSDC._dict.eq(_dict)) {
 				final AMapToData nd = _data.append(gSDC._data);
-				final AOffset ofd = _indexes.append(gSDC._indexes);
+				final AOffset ofd = _indexes.append(gSDC._indexes, getNumRows());
 				return create(_colIndexes, _numRows + gSDC._numRows, _dict, _defaultTuple, ofd, nd, null);
 			}
 		}
@@ -606,7 +606,7 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 			sumRows += gc.getNumRows();
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 
 		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, nd, null);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -467,7 +467,7 @@ public class ColGroupSDCFOR extends ASDC {
 			sumRows += gc.getNumRows();
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, nd, null, _reference);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -446,7 +446,29 @@ public class ColGroupSDCFOR extends ASDC {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+		int sumRows = 0;
+		for(int i = 1; i < g.length; i++) {
+			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
+				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
+					+ Arrays.toString(g[i]._colIndexes));
+				return null;
+			}
+
+			if(!(g[i] instanceof ColGroupSDCFOR)) {
+				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName());
+				return null;
+			}
+
+			final ColGroupSDCFOR gc = (ColGroupSDCFOR) g[i];
+			if(!gc._dict.eq(_dict)) {
+				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
+				return null;
+			}
+			sumRows += gc.getNumRows();
+		}
+		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		return create(_colIndexes, sumRows, _dict, no, nd, null, _reference);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Divide;
@@ -469,6 +470,11 @@ public class ColGroupSDCFOR extends ASDC {
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, nd, null, _reference);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -605,6 +606,11 @@ public class ColGroupSDCSingle extends ASDC {
 		}
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, null);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -583,7 +583,28 @@ public class ColGroupSDCSingle extends ASDC {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+		int sumRows = 0;
+		for(int i = 1; i < g.length; i++) {
+			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
+				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
+					+ Arrays.toString(g[i]._colIndexes));
+				return null;
+			}
+
+			if(!(g[i] instanceof ColGroupSDCSingle)) {
+				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName() );
+				return null;
+			}
+
+			final ColGroupSDCSingle gc = (ColGroupSDCSingle) g[i];
+			if(!gc._dict.eq(_dict)) {
+				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
+				return null;
+			}
+			sumRows += gc.getNumRows();
+		}
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		return create(_colIndexes, sumRows, _dict, _defaultTuple, no,  null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -592,7 +592,7 @@ public class ColGroupSDCSingle extends ASDC {
 			}
 
 			if(!(g[i] instanceof ColGroupSDCSingle)) {
-				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName() );
+				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName());
 				return null;
 			}
 
@@ -603,8 +603,8 @@ public class ColGroupSDCSingle extends ASDC {
 			}
 			sumRows += gc.getNumRows();
 		}
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
-		return create(_colIndexes, sumRows, _dict, _defaultTuple, no,  null);
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
+		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -836,7 +836,7 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 			}
 			sumRows += gc.getNumRows();
 		}
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, null);
 
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -816,7 +816,29 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+		int sumRows = 0;
+		for(int i = 1; i < g.length; i++) {
+			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
+				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
+					+ Arrays.toString(g[i]._colIndexes));
+				return null;
+			}
+
+			if(!(g[i] instanceof ColGroupSDCSingleZeros)) {
+				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName());
+				return null;
+			}
+
+			final ColGroupSDCSingleZeros gc = (ColGroupSDCSingleZeros) g[i];
+			if(!gc._dict.eq(_dict)) {
+				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
+				return null;
+			}
+			sumRows += gc.getNumRows();
+		}
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		return create(_colIndexes, sumRows, _dict, no, null);
+
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -839,6 +840,11 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, null);
 
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -727,7 +727,30 @@ public class ColGroupSDCZeros extends ASDCZero {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+		int sumRows = 0;
+		for(int i = 1; i < g.length; i++) {
+			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
+				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
+					+ Arrays.toString(g[i]._colIndexes));
+				return null;
+			}
+
+			if(!(g[i] instanceof ColGroupSDCZeros)) {
+				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName());
+				return null;
+			}
+
+			final ColGroupSDCZeros gc = (ColGroupSDCZeros) g[i];
+			if(!gc._dict.eq(_dict)) {
+				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
+				return null;
+			}
+			sumRows += gc.getNumRows();
+		}
+		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+
+		return create(_colIndexes, sumRows, _dict, no, nd, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -748,7 +748,7 @@ public class ColGroupSDCZeros extends ASDCZero {
 			sumRows += gc.getNumRows();
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class));
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 
 		return create(_colIndexes, sumRows, _dict, no, nd, null);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -751,6 +752,11 @@ public class ColGroupSDCZeros extends ASDCZero {
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 
 		return create(_colIndexes, sumRows, _dict, no, nd, null);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -30,6 +30,7 @@ import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictLibMatrixMult;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
@@ -777,6 +778,11 @@ public class ColGroupUncompressed extends AColGroup {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.AOffsetsGroup;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -445,7 +446,17 @@ public abstract class AOffset implements Serializable {
 	 * @param t that offsets
 	 * @return this offsets followed by thats offsets.
 	 */
-	public AOffset append(AOffset t){
+	public AOffset append(AOffset t) {
+		throw new NotImplementedException();
+	}
+
+	/**
+	 * Append a list of offsets together in order.
+	 * 
+	 * @param g The offsets to append together.
+	 * @return The combined offsets.
+	 */
+	public AOffset appendN(AOffsetsGroup[] g) {
 		throw new NotImplementedException();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ConstScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ConstScheme.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public class ConstScheme implements ICLAScheme {
+
+	public static ICLAScheme create(ColGroupConst g){
+		return null;
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data, int[] columns) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/DDCScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/DDCScheme.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupDDC;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public class DDCScheme implements ICLAScheme {
+
+	/**
+	 * Create a scheme for the DDC compression given
+	 * 
+	 * @param g A DDC Compression scheme
+	 * @return
+	 */
+	public static ICLAScheme create(ColGroupDDC g) {
+		return null;
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data) {
+		return null;
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data, int[] columns) {
+		return null;
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.runtime.compress.colgroup.scheme;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
@@ -34,6 +36,9 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
  * A single scheme is only responsible for encoding a single column group type.
  */
 public interface ICLAScheme {
+
+	/** Logging access for the CLA Scheme encoders */
+	public final Log LOG = LogFactory.getLog(ICLAScheme.class.getName());
 
 	/**
 	 * Encode the given matrix block into the scheme provided in the instance.

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+/**
+ * Abstract class for a scheme instance.
+ * 
+ * Instances of this class has the purpose of encoding the minimum values required to reproduce a compression scheme,
+ * and apply it to unseen data.
+ * 
+ * The reproduced compression scheme should be able to apply to unseen data and multiple instance of data into the same
+ * compression plan, and in extension make it possible to continuously extend already compressed data representations.
+ * 
+ * A single scheme is only responsible for encoding a single column group type.
+ */
+public interface ICLAScheme {
+
+	/**
+	 * Create an instance of a scheme based on a specific column group.
+	 * 
+	 * The column group specify what columns is to be encoded and what the return
+	 * 
+	 * @param g A column group to extract the compression scheme from.
+	 * @return An ICLAScheme instance able to encode uncompressed data with the scheme.
+	 */
+	public ICLAScheme create(AColGroup g);
+
+	/**
+	 * Encode the given matrix block into the scheme provided in the instance.
+	 * 
+	 * The method returns null, if it is impossible to encode the input data with the given scheme.
+	 * 
+	 * @param data The data to encode
+	 * @return A compressed column group or null.
+	 */
+	public AColGroup encode(MatrixBlock data);
+
+	/**
+	 * Encode a given matrix block into the scheme provided in the instance but overwrite what columns to use.
+	 * 
+	 * The method returns null, if it is impossible to encode the input data with the given scheme.
+	 * 
+	 * @param data    The data to encode
+	 * @param columns The columns to apply the scheme to, but must be of same number than the encoded scheme
+	 * @throws IllegalArgumentException In the case the columns argument number of columns doesent corelate with the
+	 *                                  Schemes list of columns.
+	 * @return
+	 */
+	public AColGroup encode(MatrixBlock data, int[] columns);
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
@@ -36,16 +36,6 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 public interface ICLAScheme {
 
 	/**
-	 * Create an instance of a scheme based on a specific column group.
-	 * 
-	 * The column group specify what columns is to be encoded and what the return
-	 * 
-	 * @param g A column group to extract the compression scheme from.
-	 * @return An ICLAScheme instance able to encode uncompressed data with the scheme.
-	 */
-	public ICLAScheme create(AColGroup g);
-
-	/**
 	 * Encode the given matrix block into the scheme provided in the instance.
 	 * 
 	 * The method returns null, if it is impossible to encode the input data with the given scheme.

--- a/src/main/java/org/apache/sysds/runtime/compress/io/CompressUnwrap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/io/CompressUnwrap.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.compress.io;
 
 import org.apache.spark.api.java.function.Function;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 public class CompressUnwrap implements Function<CompressedWriteBlock, MatrixBlock> {
@@ -31,9 +32,12 @@ public class CompressUnwrap implements Function<CompressedWriteBlock, MatrixBloc
 
 	@Override
 	public MatrixBlock call(CompressedWriteBlock arg0) throws Exception {
-		if(arg0.get() instanceof CompressedMatrixBlock)
-			return new CompressedMatrixBlock((CompressedMatrixBlock) arg0.get());
+		final MatrixBlock g = arg0.get();
+		if(g instanceof CompressedMatrixBlock)
+			return new CompressedMatrixBlock((CompressedMatrixBlock) g);
+		else if(g.isEmpty())
+			return CompressedMatrixBlockFactory.createConstant(g.getNumRows(), g.getNumColumns(), 0.0);
 		else
-			return new MatrixBlock(arg0.get());
+			return new MatrixBlock(g);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/io/ReaderCompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/io/ReaderCompressed.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.SequenceFile.Reader;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
@@ -80,7 +81,7 @@ public final class ReaderCompressed extends MatrixReader {
 		if(data.size() == 1)
 			return data.entrySet().iterator().next().getValue();
 		else
-			return CLALibCombine.combine(data);
+			return CLALibCombine.combine(data, OptimizerUtils.getParallelTextWriteParallelism());
 	}
 
 	private static void read(Path path, JobConf job, Map<MatrixIndexes, MatrixBlock> data) throws IOException {

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
@@ -184,12 +184,12 @@ public class CLALibCombine {
 						return combineN(x);
 					}).collect(Collectors.toList());
 			}).get();
-
+			
+			pool.shutdown();
 			if(finalGroups.contains(null)) {
 				LOG.warn("Combining via decompression. There was a column group that did not append ");
 				return combineViaDecompression(m, rlen, clen, blen, k);
 			}
-			pool.shutdown();
 			return new CompressedMatrixBlock(rlen, clen, -1, false, finalGroups);
 		}
 		catch(InterruptedException | ExecutionException e) {

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
@@ -196,8 +196,6 @@ public class CLALibCombine {
 			pool.shutdown();
 			throw new DMLRuntimeException("Failed to combine column groups", e);
 		}
-		
-
 	}
 
 	private static AColGroup combineN(AColGroup[] groups) {

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedMatrixTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedMatrixTest.java
@@ -184,7 +184,7 @@ public class CompressedMatrixTest extends AbstractCompressedUnaryTests {
 			if(!(cmb instanceof CompressedMatrixBlock) || _cs == null)
 				return;
 			CompressionStatistics cStat = cmbStats;
-			if(cStat != null)
+			if(cStat != null && !(mb.isEmpty()) && cStat.originalSize > 1000)
 				assertTrue("Compression ration if compressed should be larger than 1", cStat.getRatio() > 1);
 		}
 		catch(Exception e) {
@@ -199,7 +199,7 @@ public class CompressedMatrixTest extends AbstractCompressedUnaryTests {
 			if(!(cmb instanceof CompressedMatrixBlock) || _cs == null)
 				return;
 			CompressionStatistics cStat = cmbStats;
-			if(cStat != null) {
+			if(cStat != null && !(mb.isEmpty()) && cStat.originalSize > 1000) {
 				long colsEstimate = cStat.estimatedSizeCols;
 				long actualSize = cStat.compressedSize;
 				long originalSize = cStat.originalSize;

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupMorphingPerformanceCompare.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupMorphingPerformanceCompare.java
@@ -154,7 +154,7 @@ public class ColGroupMorphingPerformanceCompare {
 		private final MatrixBlock mbDict;
 
 		public SDCNoMorph(ColGroupSDC g) {
-			this(g.getColIndices(), g.getNumRows(), g.getDictionary(), g.getDefaultTuple(), g.getOffsets(), g.getMapping(),
+			this(g.getColIndices(), g.getNumRows(), g.getDictionary(), g.getDefaultTuple(), g.getOffsets(), g.getMapToData(),
 				null);
 		}
 

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
@@ -39,6 +39,7 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCSingleZeros;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCZeros;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
@@ -366,6 +367,12 @@ public class ColGroupNegativeTests {
 			// TODO Auto-generated method stub
 			return null;
 		}
+
+		@Override
+		public ICLAScheme getCompressionScheme() {
+			// TODO Auto-generated method stub
+			return null;
+		}
 	}
 
 	private class FakeDictBasedColGroup extends ADictBasedColGroup {
@@ -581,6 +588,12 @@ public class ColGroupNegativeTests {
 
 		@Override
 		protected AColGroup appendNInternal(AColGroup[] groups) {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public ICLAScheme getCompressionScheme() {
 			// TODO Auto-generated method stub
 			return null;
 		}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
@@ -38,6 +38,7 @@ import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.colgroup.AMorphingMMColGroup;
 import org.apache.sysds.runtime.compress.colgroup.APreAgg;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
@@ -463,7 +464,7 @@ public class ColGroupTest extends ColGroupBase {
 			AColGroup bs = base.rightMultByMatrix(right);
 			AColGroup os = other.rightMultByMatrix(right);
 			if(bs == null || os == null) // if null return
-				if(bs != os){
+				if(bs != os) {
 					fail("both results are not equally null");
 					return;
 				}
@@ -2113,14 +2114,14 @@ public class ColGroupTest extends ColGroupBase {
 
 	// @Test
 	// public void copyMaintainPointers() {
-	// 	AColGroup a = base.copy();
-	// 	AColGroup b = other.copy();
+	// AColGroup a = base.copy();
+	// AColGroup b = other.copy();
 
-	// 	assertTrue(a.getColIndices() == base.getColIndices());
-	// 	assertTrue(b.getColIndices() == other.getColIndices());
-	// 	// assertFalse(a.getColIndices() == other.getColIndices());
-	// 	assertFalse(a == base);
-	// 	assertFalse(b == other);
+	// assertTrue(a.getColIndices() == base.getColIndices());
+	// assertTrue(b.getColIndices() == other.getColIndices());
+	// // assertFalse(a.getColIndices() == other.getColIndices());
+	// assertFalse(a == base);
+	// assertFalse(b == other);
 	// }
 
 	@Test
@@ -2170,7 +2171,7 @@ public class ColGroupTest extends ColGroupBase {
 			AColGroup b = other.sliceRows(rl, ru);
 			final int newNRow = ru - rl;
 
-			if(a == null || b == null) 
+			if(a == null || b == null)
 				// one side is concluded empty
 				// We do not enforce that empty is returned if it is empty, since some column groups
 				// are to expensive to analyze if empty.
@@ -2210,5 +2211,25 @@ public class ColGroupTest extends ColGroupBase {
 			fail(e.getMessage());
 		}
 		assertTrue(exception);
+	}
+
+	@Test
+	public void getScheme() {
+		// create scheme and check if it compress the same matrix input in same way.
+		checkScheme(base.getCompressionScheme(), base, nRow, maxCol);
+		checkScheme(other.getCompressionScheme(), other, nRow, maxCol);
+	}
+
+	private static void checkScheme(ICLAScheme ia, AColGroup a, int nRow, int nCol) {
+		if(ia != null) {
+			// if whatever is returned is not null,
+			// then it should be able to compress the matrix block again
+			// in same scheme
+
+			MatrixBlock ot = sparseMB(nRow, nCol);
+			a.decompressToSparseBlock(ot.getSparseBlock(), 0, nRow);
+			AColGroup g = ia.encode(ot);
+			assertTrue(g.getClass().equals(a.getClass()));
+		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLASchemeTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLASchemeTest.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup.scheme;
+
+public class CLASchemeTest {
+
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/combine/CombineTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/combine/CombineTest.java
@@ -43,6 +43,8 @@ public class CombineTest {
 
 	protected static final Log LOG = LogFactory.getLog(CombineTest.class.getName());
 
+	final int k = 1;
+
 	@Test
 	public void combineEmpty() {
 		CompressedMatrixBlock m1 = CompressedMatrixBlockFactory.createConstant(100, 10, 0.0);
@@ -53,7 +55,7 @@ public class CombineTest {
 		data.put(new MatrixIndexes(2, 1), m1);
 
 		try {
-			MatrixBlock c = CLALibCombine.combine(data, 100 * 2, 10, 100);
+			MatrixBlock c = CLALibCombine.combine(data, 100 * 2, 10, 100, k);
 			assertTrue("The result is not in compressed format", c instanceof CompressedMatrixBlock);
 			assertEquals(0.0, c.sum(), 0.0);
 		}
@@ -74,7 +76,7 @@ public class CombineTest {
 		data.put(new MatrixIndexes(2, 1), m1);
 
 		try {
-			MatrixBlock c = CLALibCombine.combine(data, 100 * 2, 10, 100);
+			MatrixBlock c = CLALibCombine.combine(data, 100 * 2, 10, 100, k);
 			assertTrue("The result is not in compressed format", c instanceof CompressedMatrixBlock);
 			assertEquals(0.0, c.sum(), 100.0 * 10.0 * 2);
 		}
@@ -97,7 +99,7 @@ public class CombineTest {
 		assertEquals(sum * 3, sum3, 0.001);
 	}
 
-	private static AColGroup getDDC(){
+	private static AColGroup getDDC() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(165, 2, 1, 3, 1.0, 2514));
 		CompressedMatrixBlock csb = (CompressedMatrixBlock) CompressedMatrixBlockFactory
 			.compress(mb,


### PR DESCRIPTION
This PR is for the code to enable extracting compression schemes and applying them to unseen data.
The application of this is to compress more data, and append to already compressed matrix blocks without the need of decompression.