### PR TITLE
[SYSTEMDS-3454] CLA Sheme primitive

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -638,6 +639,13 @@ public abstract class AColGroup implements Serializable {
 	 * @return A combined column group or null
 	 */
 	protected abstract AColGroup appendNInternal(AColGroup[] groups);
+
+	/**
+	 * Get the compression scheme for this column group to enable compression of other data.
+	 * 
+	 * @return The compression scheme of this column group
+	 */
+	public abstract ICLAScheme getCompressionScheme();
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -32,6 +32,8 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictiona
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
+import org.apache.sysds.runtime.compress.colgroup.scheme.DDCScheme;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -533,6 +535,12 @@ public class ColGroupDDC extends APreAgg implements AMapToDataGroup {
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
 		return create(_colIndexes, _dict, nd, null);
+	}
+
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return DDCScheme.create(this);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
@@ -31,6 +31,7 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -447,6 +448,11 @@ public class ColGroupDDCFOR extends AMorphingMMColGroup {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.EmptyScheme;
 import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
@@ -330,6 +331,6 @@ public class ColGroupEmpty extends AColGroupCompressed {
 
 	@Override
 	public ICLAScheme getCompressionScheme() {
-		return null;
+		return EmptyScheme.create(this);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.data.DenseBlock;
@@ -327,4 +328,8 @@ public class ColGroupEmpty extends AColGroupCompressed {
 		return this;
 	}
 
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
@@ -672,6 +673,11 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -29,6 +29,7 @@ import org.apache.sysds.runtime.compress.bitmap.ABitmap;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -662,6 +663,11 @@ public class ColGroupOLE extends AColGroupOffset {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -32,6 +32,7 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
 import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -974,6 +975,11 @@ public class ColGroupRLE extends AColGroupOffset {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -35,6 +35,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -610,6 +611,12 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 
 		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, nd, null);
 	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
+	}
+
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -586,7 +586,7 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = 0;
+		int sumRows = getNumRows();
 		for(int i = 1; i < g.length; i++) {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
@@ -616,7 +616,6 @@ public class ColGroupSDC extends ASDC implements AMapToDataGroup {
 	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
-
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -57,7 +57,7 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
  * with no modifications.
  * 
  */
-public class ColGroupSDCFOR extends ASDC {
+public class ColGroupSDCFOR extends ASDC implements AMapToDataGroup {
 
 	private static final long serialVersionUID = 3883228464052204203L;
 
@@ -114,6 +114,11 @@ public class ColGroupSDCFOR extends ASDC {
 	@Override
 	public int[] getCounts(int[] counts) {
 		return _data.getCounts(counts);
+	}
+
+	@Override
+	public AMapToData getMapToData() {
+		return _data;
 	}
 
 	@Override
@@ -447,7 +452,7 @@ public class ColGroupSDCFOR extends ASDC {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = 0;
+		int sumRows = getNumRows();
 		for(int i = 1; i < g.length; i++) {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Divide;
@@ -469,6 +470,11 @@ public class ColGroupSDCFOR extends ASDC {
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, AMapToDataGroup[].class));
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, nd, null, _reference);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -605,6 +606,11 @@ public class ColGroupSDCSingle extends ASDC {
 		}
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, null);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -584,7 +584,7 @@ public class ColGroupSDCSingle extends ASDC {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = 0;
+		int sumRows = getNumRows();
 		for(int i = 1; i < g.length; i++) {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -817,7 +817,7 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = 0;
+		int sumRows = getNumRows();
 		for(int i = 1; i < g.length; i++) {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"
@@ -839,7 +839,6 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 		}
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, null);
-
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffsetIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -839,6 +840,11 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 		return create(_colIndexes, sumRows, _dict, no, null);
 
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -56,7 +56,7 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
  * 
  * This column group is handy in cases where sparse unsafe operations is executed on very sparse columns.
  */
-public class ColGroupSDCZeros extends ASDCZero {
+public class ColGroupSDCZeros extends ASDCZero implements AMapToDataGroup{
 	private static final long serialVersionUID = -3703199743391937991L;
 
 	/** Pointers to row indexes in the dictionary. Note the dictionary has one extra entry. */
@@ -87,6 +87,11 @@ public class ColGroupSDCZeros extends ASDCZero {
 	@Override
 	public ColGroupType getColGroupType() {
 		return ColGroupType.SDCZeros;
+	}
+
+	@Override
+	public AMapToData getMapToData(){
+		return _data;
 	}
 
 	@Override
@@ -728,7 +733,7 @@ public class ColGroupSDCZeros extends ASDCZero {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = 0;
+		int sumRows = getNumRows();
 		for(int i = 1; i < g.length; i++) {
 			if(!Arrays.equals(_colIndexes, g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + Arrays.toString(_colIndexes) + "\n\n"

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -34,6 +34,7 @@ import org.apache.sysds.runtime.compress.colgroup.offset.AIterator;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
 import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
 import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
@@ -751,6 +752,11 @@ public class ColGroupSDCZeros extends ASDCZero {
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 
 		return create(_colIndexes, sumRows, _dict, no, nd, null);
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -30,6 +30,7 @@ import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictLibMatrixMult;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
@@ -777,6 +778,11 @@ public class ColGroupUncompressed extends AColGroup {
 
 	@Override
 	public AColGroup appendNInternal(AColGroup[] g) {
+		return null;
+	}
+
+	@Override
+	public ICLAScheme getCompressionScheme() {
 		return null;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
@@ -26,7 +26,6 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Arrays;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
@@ -1070,10 +1069,10 @@ public class Dictionary extends ADictionary {
 	public boolean eq(ADictionary o) {
 		if(o instanceof Dictionary)
 			return Arrays.equals(_values, ((Dictionary) o)._values);
-		else if(o instanceof MatrixBlockDictionary){
+		else if(o instanceof MatrixBlockDictionary) {
 			final MatrixBlock mb = ((MatrixBlockDictionary) o).getMatrixBlock();
 			if(mb.isInSparseFormat())
-				throw new NotImplementedException();
+				return mb.getSparseBlock().equals(_values, mb.getNumColumns());
 			final double[] dv = mb.getDenseBlockValues();
 			return Arrays.equals(_values, dv);
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
@@ -2150,8 +2150,7 @@ public class MatrixBlockDictionary extends ADictionary {
 			return _data.equals(((MatrixBlockDictionary) o)._data);
 		else if(o instanceof Dictionary) {
 			if(_data.isInSparseFormat())
-				throw new NotImplementedException(
-					"Not supporting one side being sparse while other is dense in compressed dictionary equality");
+				return _data.getSparseBlock().equals(((Dictionary) o)._values, _data.getNumColumns());
 			final double[] dv = _data.getDenseBlockValues();
 			return Arrays.equals(dv, ((Dictionary) o)._values);
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
@@ -2147,10 +2147,11 @@ public class MatrixBlockDictionary extends ADictionary {
 	@Override
 	public boolean eq(ADictionary o) {
 		if(o instanceof MatrixBlockDictionary)
-			throw new NotImplementedException("Comparison if a MatrixBlock is equivalent is not implemented yet");
+			return _data.equals(((MatrixBlockDictionary) o)._data);
 		else if(o instanceof Dictionary) {
 			if(_data.isInSparseFormat())
-				throw new NotImplementedException();
+				throw new NotImplementedException(
+					"Not supporting one side being sparse while other is dense in compressed dictionary equality");
 			final double[] dv = _data.getDenseBlockValues();
 			return Arrays.equals(dv, ((Dictionary) o)._values);
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ConstScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ConstScheme.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
+import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public class ConstScheme implements ICLAScheme {
+
+	/** The instance of a constant column group that in all cases here would be returned to be the same */
+	final ColGroupConst g;
+
+	protected ConstScheme(ColGroupConst g) {
+		this.g = g;
+	}
+
+	public static ICLAScheme create(ColGroupConst g) {
+		return new ConstScheme(g);
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data) {
+		return encode(data, g.getColIndices(), g.getValues());
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data, int[] columns) {
+		if(columns.length != g.getColIndices().length)
+			throw new IllegalArgumentException("Invalid columns to encode");
+		return encode(data, columns, g.getValues());
+	}
+
+	private AColGroup encode(final MatrixBlock data, final int[] cols, final double[] values) {
+		final int nCol = data.getNumColumns();
+		final int nRow = data.getNumRows();
+		if(nCol < cols[cols.length - 1]) {
+			LOG.warn("Invalid to encode matrix with less columns than encode scheme max column");
+			return null;
+		}
+		else if(data.isEmpty()) {
+			LOG.warn("Invalid to encode an empty matrix into constant column group");
+			return null; // Invalid to encode this.
+		}
+		else if(data.isInSparseFormat())
+			return encodeSparse(data, cols, values, nRow, nCol);
+		else if(data.getDenseBlock().isContiguous())
+			return encodeDense(data, cols, values, nRow, nCol);
+		else
+			return encodeGeneric(data, cols, values, nRow, nCol);
+	}
+
+	private AColGroup encodeDense(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
+		final int nCol) {
+		final double[] dv = data.getDenseBlockValues();
+		for(int r = 0; r < nRow; r++) {
+			final int off = r * nCol;
+			for(int ci = 0; ci < cols.length; ci++)
+				if(dv[off + cols[ci]] != values[ci])
+					return null;
+		}
+		return g;
+	}
+
+	private AColGroup encodeSparse(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
+		final int nCol) {
+		SparseBlock sb = data.getSparseBlock();
+		for(int r = 0; r < nRow; r++) {
+			if(sb.isEmpty(r))
+				return null;
+
+			final int apos = sb.pos(r);
+			final int alen = apos + sb.size(r);
+			final double[] aval = sb.values(r);
+			final int[] aix = sb.indexes(r);
+			int p = 0; // pointer into cols;
+			while(p < cols.length && values[p] == 0.0)
+				p++;
+			for(int j = apos; j < alen && p < cols.length; j++) {
+				if(aix[j] == cols[p]) {
+					if(aval[j] != values[p])
+						return null;
+					p++;
+					while(p < cols.length && values[p] == 0.0)
+						p++;
+				}
+				else if(aix[j] > cols[p])
+					return null; // not matching
+			}
+		}
+		return g;
+	}
+
+	private AColGroup encodeGeneric(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
+		final int nCol) {
+		for(int r = 0; r < nRow; r++)
+			for(int ci = 0; ci < cols.length; ci++)
+				if(data.quickGetValue(r, cols[ci]) != values[ci])
+					return null;
+		return g;
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/DDCScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/DDCScheme.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupDDC;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
+import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
+import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
+import org.apache.sysds.runtime.compress.readers.ReaderColumnSelection;
+import org.apache.sysds.runtime.compress.utils.DblArray;
+import org.apache.sysds.runtime.compress.utils.DblArrayCountHashMap;
+import org.apache.sysds.runtime.compress.utils.Util;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public class DDCScheme implements ICLAScheme {
+
+	final private int[] cols;
+	final private int nUnique;
+	final private DblArrayCountHashMap map;
+	final private ADictionary dict;
+
+	private DDCScheme(ColGroupDDC g) {
+		this.cols = g.getColIndices();
+		this.nUnique = g.getNumValues();
+		this.dict = g.getDictionary();
+		final MatrixBlock mbDict = dict.getMBDict(this.cols.length).getMatrixBlock();
+		final int dictRows = mbDict.getNumRows();
+		final int dictCols = mbDict.getNumColumns();
+
+		// Read the mapping data and materialize map.
+		map = new DblArrayCountHashMap(dictRows, dictCols);
+		final ReaderColumnSelection r = ReaderColumnSelection.createReader(mbDict, //
+			Util.genColsIndices(dictCols), false, 0, dictRows);
+		DblArray d = null;
+		while((d = r.nextRow()) != null)
+			map.increment(d);
+
+	}
+
+	/**
+	 * Create a scheme for the DDC compression given
+	 * 
+	 * @param g A DDC Column group
+	 * @return A DDC Compression scheme
+	 */
+	public static ICLAScheme create(ColGroupDDC g) {
+		if(g.getColIndices().length == 1)
+			return null;
+		return new DDCScheme(g);
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data) {
+		return encode(data, cols);
+	}
+
+	@Override
+	public AColGroup encode(MatrixBlock data, int[] columns) {
+		if(columns.length != cols.length)
+			throw new IllegalArgumentException("Invalid columns to encode");
+		final int nRow = data.getNumRows();
+		final ReaderColumnSelection reader = ReaderColumnSelection.createReader(//
+			data, columns, false, 0, nRow);
+		final AMapToData d = MapToFactory.create(nRow,nUnique);
+
+		DblArray cellVals;
+		while((cellVals = reader.nextRow()) != null) {
+			final int row = reader.getCurrentRowIndex();
+			final int id = map.getId(cellVals);
+			if(id == -1)
+				return null;
+			d.set(row, id);
+		}
+
+		return ColGroupDDC.create(columns, dict, d, null);
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/EmptyScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/EmptyScheme.java
@@ -20,102 +20,86 @@
 package org.apache.sysds.runtime.compress.colgroup.scheme;
 
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
-import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupEmpty;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
-public class ConstScheme implements ICLAScheme {
+public class EmptyScheme implements ICLAScheme {
+	/** The instance of a empty column group that in all cases here would be returned to be the same */
+	final ColGroupEmpty g;
 
-	/** The instance of a constant column group that in all cases here would be returned to be the same */
-	final ColGroupConst g;
-
-	protected ConstScheme(ColGroupConst g) {
+	protected EmptyScheme(ColGroupEmpty g) {
 		this.g = g;
 	}
 
-	public static ICLAScheme create(ColGroupConst g) {
-		return new ConstScheme(g);
+	public static EmptyScheme create(ColGroupEmpty g) {
+		return new EmptyScheme(g);
 	}
 
 	@Override
 	public AColGroup encode(MatrixBlock data) {
-		return encode(data, g.getColIndices(), g.getValues());
+		return encode(data, g.getColIndices());
 	}
 
 	@Override
 	public AColGroup encode(MatrixBlock data, int[] columns) {
+
 		if(columns.length != g.getColIndices().length)
 			throw new IllegalArgumentException("Invalid columns to encode");
-		return encode(data, columns, g.getValues());
-	}
-
-	private AColGroup encode(final MatrixBlock data, final int[] cols, final double[] values) {
 		final int nCol = data.getNumColumns();
 		final int nRow = data.getNumRows();
-		if(nCol < cols[cols.length - 1]) {
+		if(nCol < columns[columns.length - 1]) {
 			LOG.warn("Invalid to encode matrix with less columns than encode scheme max column");
 			return null;
 		}
-		else if(data.isEmpty()) {
-			LOG.warn("Invalid to encode an empty matrix into constant column group");
-			return null; // Invalid to encode this.
-		}
+		else if(data.isEmpty()) 
+			return returnG(columns);
 		else if(data.isInSparseFormat())
-			return encodeSparse(data, cols, values, nRow, nCol);
+			return encodeSparse(data, columns, nRow, nCol);
 		else if(data.getDenseBlock().isContiguous())
-			return encodeDense(data, cols, values, nRow, nCol);
+			return encodeDense(data, columns, nRow, nCol);
 		else
-			return encodeGeneric(data, cols, values, nRow, nCol);
+			return encodeGeneric(data, columns, nRow, nCol);
 	}
 
-	private AColGroup encodeDense(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
-		final int nCol) {
+	private AColGroup encodeDense(final MatrixBlock data, final int[] cols, final int nRow, final int nCol) {
 		final double[] dv = data.getDenseBlockValues();
 		for(int r = 0; r < nRow; r++) {
 			final int off = r * nCol;
 			for(int ci = 0; ci < cols.length; ci++)
-				if(dv[off + cols[ci]] != values[ci])
+				if(dv[off + cols[ci]] != 0.0)
 					return null;
 		}
-		return returnG(cols);
+		return g;
 	}
 
-	private AColGroup encodeSparse(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
-		final int nCol) {
+	private AColGroup encodeSparse(final MatrixBlock data, final int[] cols, final int nRow, final int nCol) {
 		SparseBlock sb = data.getSparseBlock();
 		for(int r = 0; r < nRow; r++) {
 			if(sb.isEmpty(r))
-				return null;
+				continue; // great!
 
 			final int apos = sb.pos(r);
 			final int alen = apos + sb.size(r);
-			final double[] aval = sb.values(r);
 			final int[] aix = sb.indexes(r);
 			int p = 0; // pointer into cols;
-			while(values[p] == 0.0)
-				// technically also check for&& p < cols.length
-				// but this verification is indirectly maintained
-				p++;
-			for(int j = apos; j < alen && p < cols.length; j++) {
-				if(aix[j] == cols[p]) {
-					if(aval[j] != values[p])
-						return null;
+			for(int j = apos; j < alen ; j++) {
+				while(p < cols.length && cols[p] < aix[j])
 					p++;
-					while(p < cols.length && values[p] == 0.0)
-						p++;
-				}
-				else if(aix[j] > cols[p])
-					return null; // not matching
+				if(p < cols.length && aix[j] == cols[p])
+					return null;
+
+				if(p >= cols.length)
+					continue;
 			}
 		}
 		return returnG(cols);
 	}
 
-	private AColGroup encodeGeneric(final MatrixBlock data, final int[] cols, final double[] values, final int nRow,
-		final int nCol) {
+	private AColGroup encodeGeneric(final MatrixBlock data, final int[] cols, final int nRow, final int nCol) {
 		for(int r = 0; r < nRow; r++)
 			for(int ci = 0; ci < cols.length; ci++)
-				if(data.quickGetValue(r, cols[ci]) != values[ci])
+				if(data.quickGetValue(r, cols[ci]) != 0.0)
 					return null;
 		return returnG(cols);
 	}
@@ -124,7 +108,7 @@ public class ConstScheme implements ICLAScheme {
 		if(columns == g.getColIndices())
 			return g;// great!
 		else
-			return ColGroupConst.create(columns, g.getValues());
+			return new ColGroupEmpty(columns);
 	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/scheme/ICLAScheme.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.scheme;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+/**
+ * Abstract class for a scheme instance.
+ * 
+ * Instances of this class has the purpose of encoding the minimum values required to reproduce a compression scheme,
+ * and apply it to unseen data.
+ * 
+ * The reproduced compression scheme should be able to apply to unseen data and multiple instance of data into the same
+ * compression plan, and in extension make it possible to continuously extend already compressed data representations.
+ * 
+ * A single scheme is only responsible for encoding a single column group type.
+ */
+public interface ICLAScheme {
+
+	/** Logging access for the CLA Scheme encoders */
+	public final Log LOG = LogFactory.getLog(ICLAScheme.class.getName());
+
+	/**
+	 * Encode the given matrix block into the scheme provided in the instance.
+	 * 
+	 * The method returns null, if it is impossible to encode the input data with the given scheme.
+	 * 
+	 * @param data The data to encode
+	 * @return A compressed column group or null.
+	 */
+	public AColGroup encode(MatrixBlock data);
+
+	/**
+	 * Encode a given matrix block into the scheme provided in the instance but overwrite what columns to use.
+	 * 
+	 * The method returns null, if it is impossible to encode the input data with the given scheme.
+	 * 
+	 * @param data    The data to encode
+	 * @param columns The columns to apply the scheme to, but must be of same number than the encoded scheme
+	 * @throws IllegalArgumentException In the case the columns argument number of columns doesent corelate with the
+	 *                                  Schemes list of columns.
+	 * @return A compressed column group or null
+	 */
+	public AColGroup encode(MatrixBlock data, int[] columns);
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCombine.java
@@ -196,8 +196,6 @@ public class CLALibCombine {
 			pool.shutdown();
 			throw new DMLRuntimeException("Failed to combine column groups", e);
 		}
-		
-
 	}
 
 	private static AColGroup combineN(AColGroup[] groups) {

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayCountHashMap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayCountHashMap.java
@@ -114,6 +114,25 @@ public class DblArrayCountHashMap {
 		return l.v.count;
 	}
 
+	/**
+	 * Get the ID behind the key, if it does not exist -1 is returned.
+	 * 
+	 * @param key The key array
+	 * @return The Id or -1
+	 */
+	public int getId(DblArray key) {
+		final int ix = indexFor(key.hashCode(), _data.length);
+		Bucket l = _data[ix];
+		if(l == null)
+			return -1;
+		while(!(l.v.key.equals(key))) {
+			l = l.n;
+			if(l == null)
+				return -1;
+		}
+		return l.v.id;
+	}
+
 	public ArrayList<DArrCounts> extractValues() {
 		ArrayList<DArrCounts> ret = new ArrayList<>(_size);
 		for(Bucket e : _data) {
@@ -135,7 +154,7 @@ public class DblArrayCountHashMap {
 			}
 	}
 
-	public int getSumCounts(){
+	public int getSumCounts() {
 		int c = 0;
 		for(Bucket e : _data)
 			while(e != null) {

--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlock.java
@@ -573,6 +573,18 @@ public abstract class SparseBlock implements Serializable, Block
 		return true;
 	}
 
+
+	/**
+	 * Get if the dense double array is equivalent to this sparse Block.
+	 * 
+	 * @param denseValues row major double values same dimensions of sparse Block.
+	 * @param nCol        Number of columns in dense values (and hopefully in this sparse block)
+	 * @return If the dense array is equivalent
+	 */
+	public boolean equals(double[] denseValues, int nCol) {
+		return equals(denseValues, nCol, Double.MIN_NORMAL * 1024);
+	}
+
 	/**
 	 * Get if the dense double array is equivalent to this sparse Block.
 	 * 

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
@@ -39,6 +39,7 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCSingleZeros;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCZeros;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
@@ -366,6 +367,12 @@ public class ColGroupNegativeTests {
 			// TODO Auto-generated method stub
 			return null;
 		}
+
+		@Override
+		public ICLAScheme getCompressionScheme() {
+			// TODO Auto-generated method stub
+			return null;
+		}
 	}
 
 	private class FakeDictBasedColGroup extends ADictBasedColGroup {
@@ -581,6 +588,12 @@ public class ColGroupNegativeTests {
 
 		@Override
 		protected AColGroup appendNInternal(AColGroup[] groups) {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public ICLAScheme getCompressionScheme() {
 			// TODO Auto-generated method stub
 			return null;
 		}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
@@ -2112,18 +2112,6 @@ public class ColGroupTest extends ColGroupBase {
 		assertTrue(co < eo);
 	}
 
-	// @Test
-	// public void copyMaintainPointers() {
-	// AColGroup a = base.copy();
-	// AColGroup b = other.copy();
-
-	// assertTrue(a.getColIndices() == base.getColIndices());
-	// assertTrue(b.getColIndices() == other.getColIndices());
-	// // assertFalse(a.getColIndices() == other.getColIndices());
-	// assertFalse(a == base);
-	// assertFalse(b == other);
-	// }
-
 	@Test
 	public void sliceRowsBeforeEnd() {
 		if(nRow > 10)
@@ -2241,4 +2229,54 @@ public class ColGroupTest extends ColGroupBase {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testAppendSelf() {
+		appendSelfVerification(base);
+		appendSelfVerification(other);
+	}
+
+	@Test
+	public void testAppendSomethingElse() {
+		// This is under the assumption that if one is appending
+		// to the other then other should append to this.
+		// If this property does not hold it is because some cases are missing in the append logic.
+		try {
+
+			AColGroup g2 = base.append(other);
+			AColGroup g2n = other.append(base);
+			// both should be null, or both should not be.
+			if(g2 == null)
+				assertTrue(g2n == null);
+			else if(g2 != null)
+				assertTrue(g2n != null);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	private void appendSelfVerification(AColGroup g) {
+		try {
+
+			AColGroup g2 = g.append(g);
+			AColGroup g2n = AColGroup.appendN(new AColGroup[] {g, g});
+
+			if(g2 != null && g2n != null) {
+				double s2 = g2.getSum(nRow * 2);
+				double s = g.getSum(nRow) * 2;
+				double s2n = g2n.getSum(nRow * 2);
+				assertEquals(s2, s, 0.0001);
+				assertEquals(s2n, s, 0.0001);
+
+				UA_ROW(InstructionUtils.parseBasicAggregateUnaryOperator("uar+", 1), 0, nRow * 2, g2, g2n, nRow * 2);
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
@@ -46,6 +46,7 @@ import org.apache.sysds.runtime.compress.colgroup.ColGroupFactory;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupRLE;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCSingleZeros;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
@@ -463,7 +464,7 @@ public class ColGroupTest extends ColGroupBase {
 			AColGroup bs = base.rightMultByMatrix(right);
 			AColGroup os = other.rightMultByMatrix(right);
 			if(bs == null || os == null) // if null return
-				if(bs != os){
+				if(bs != os) {
 					fail("both results are not equally null");
 					return;
 				}
@@ -2113,14 +2114,14 @@ public class ColGroupTest extends ColGroupBase {
 
 	// @Test
 	// public void copyMaintainPointers() {
-	// 	AColGroup a = base.copy();
-	// 	AColGroup b = other.copy();
+	// AColGroup a = base.copy();
+	// AColGroup b = other.copy();
 
-	// 	assertTrue(a.getColIndices() == base.getColIndices());
-	// 	assertTrue(b.getColIndices() == other.getColIndices());
-	// 	// assertFalse(a.getColIndices() == other.getColIndices());
-	// 	assertFalse(a == base);
-	// 	assertFalse(b == other);
+	// assertTrue(a.getColIndices() == base.getColIndices());
+	// assertTrue(b.getColIndices() == other.getColIndices());
+	// // assertFalse(a.getColIndices() == other.getColIndices());
+	// assertFalse(a == base);
+	// assertFalse(b == other);
 	// }
 
 	@Test
@@ -2170,7 +2171,7 @@ public class ColGroupTest extends ColGroupBase {
 			AColGroup b = other.sliceRows(rl, ru);
 			final int newNRow = ru - rl;
 
-			if(a == null || b == null) 
+			if(a == null || b == null)
 				// one side is concluded empty
 				// We do not enforce that empty is returned if it is empty, since some column groups
 				// are to expensive to analyze if empty.
@@ -2210,5 +2211,34 @@ public class ColGroupTest extends ColGroupBase {
 			fail(e.getMessage());
 		}
 		assertTrue(exception);
+	}
+
+	@Test
+	public void getScheme() {
+		// create scheme and check if it compress the same matrix input in same way.
+		checkScheme(base.getCompressionScheme(), base, nRow, maxCol);
+		checkScheme(other.getCompressionScheme(), other, nRow, maxCol);
+	}
+
+	private static void checkScheme(ICLAScheme ia, AColGroup a, int nRow, int nCol) {
+		try {
+			if(ia != null) {
+				// if whatever is returned is not null,
+				// then it should be able to compress the matrix block again
+				// in same scheme
+				MatrixBlock ot = sparseMB(nRow, nCol);
+				a.decompressToSparseBlock(ot.getSparseBlock(), 0, nRow);
+				ot.recomputeNonZeros();
+
+				AColGroup g = ia.encode(ot);
+				if(g == null)
+					fail("Should not be possible to return null on equivalent matrix:\nGroup\n" + a + "\nScheme:\n" + ia);
+
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLAConstSchemeTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLAConstSchemeTest.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup.scheme;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
+import org.apache.sysds.runtime.data.DenseBlockFP64;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.junit.Test;
+
+public class CLAConstSchemeTest {
+
+	private final AColGroup g;
+	private final ICLAScheme sh;
+
+	public CLAConstSchemeTest() {
+		g = ColGroupConst.create(//
+			new int[] {1, 3, 5}, // Columns
+			new double[] {1.1, 1.2, 1.3} // Values
+		);
+		sh = g.getCompressionScheme();
+	}
+
+	@Test
+	public void testConstValid() {
+		assertTrue(sh != null);
+	}
+
+	@Test
+	public void testToSmallMatrix() {
+		assertTrue(sh.encode(new MatrixBlock(1, 3, new double[] {//
+			1.1, 1.2, 1.3})) == null);
+	}
+
+	@Test
+	public void testWrongValuesSingleRow() {
+		assertTrue(sh.encode(new MatrixBlock(1, 5, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.2})) == null);
+	}
+
+	@Test
+	public void testWrongValuesSingleRowV2() {
+		assertTrue(sh.encode(new MatrixBlock(1, 5, new double[] {//
+			0.0, 1.0, 0.2, 1.2, 0.2, 1.3})) == null);
+	}
+
+	@Test
+	public void testValidEncodeSingleRow() {
+		assertTrue(sh.encode(new MatrixBlock(1, 5, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRow() {
+		assertTrue(sh.encode(new MatrixBlock(2, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRowsLarger() {
+		assertTrue(sh.encode(new MatrixBlock(2, 10, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, 1, 1, 1, 1, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, 1, 1, 1, 1, //
+		})) != null);
+	}
+
+	@Test
+	public void testInvalidEncodeMultiRowsValue() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRowDifferentValuesOtherColumns() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.2, 1.1, 0.4, 1.2, 0.3, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.1, 1.3, //
+			0.2, 1.1, 0.4, 1.2, 0.1, 1.3, //
+		})) != null);
+	}
+
+	@Test
+	public void testInvalidEncodeValueMultiRowMultiError() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.4, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) == null);
+	}
+
+	@Test
+	public void testInvalidEncodeMultiRow() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.3, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.4, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) == null);
+	}
+
+	@Test
+	public void testEncodeOtherColumns() {
+		assertTrue(sh.encode(new MatrixBlock(4, 5, new double[] {//
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+		}), new int[] {0, 2, 4}// other columns
+		) != null);
+	}
+
+	@Test
+	public void testEncodeOtherColumnsInvalid() {
+		assertTrue(sh.encode(new MatrixBlock(4, 5, new double[] {//
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.4, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+		}), new int[] {0, 2, 4}// other columns
+		) == null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidArgument_1() {
+		sh.encode(null, new int[] {0, 2, 4, 5});
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidArgument_2() {
+		sh.encode(null, new int[] {0, 2});
+	}
+
+	@Test
+	public void testSparse() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = mb.append(empty);
+
+		assertTrue(sh.encode(mb) != null);
+	}
+
+	@Test
+	public void testSparse_invalid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+
+		assertTrue(sh.encode(mb) == null);
+	}
+
+	@Test
+	public void testSparseValidCustom() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+
+		assertTrue(sh.encode(mb, new int[] {1001, 1003, 1005}) != null);
+	}
+
+	@Test
+	public void testSparseValidCustom2() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		MatrixBlock comb = empty.append(mb).append(mb);
+
+		assertTrue(sh.encode(comb, new int[] {1001, 1003, 1005}) != null);
+	}
+
+	@Test
+	public void testSparseValidCustom3Invalid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.33, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		MatrixBlock comb = empty.append(mb).append(mb);
+
+		assertTrue(sh.encode(comb, new int[] {1001, 1003, 1005}) == null);
+	}
+
+	@Test
+	public void testSparseEmptyRowInvalid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+		MatrixBlock emptyRow = new MatrixBlock(1, 1006, 0.0);
+		mb = mb.append(emptyRow, false);
+
+		assertTrue(sh.encode(mb, new int[] {1001, 1003, 1005}) == null);
+	}
+
+	@Test
+	public void testEmpty() {
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		assertTrue(sh.encode(empty) == null);
+	}
+
+	@Test
+	public void testGenericNonContinuosBlockValid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, //
+			new DenseBlockFP64Mock(new int[] {4, 6}, new double[] {//
+				0.2, 1.1, 0.4, 1.2, 0.3, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.1, 1.3, //
+				0.2, 1.1, 0.4, 1.2, 0.1, 1.3, //
+			}));
+		mb.recomputeNonZeros();
+		assertTrue(sh.encode(mb) != null);
+	}
+
+	@Test
+	public void testGenericNonContinuosBlockInValid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, //
+			new DenseBlockFP64Mock(new int[] {4, 6}, new double[] {//
+				0.2, 1.1, 0.4, 1.2, 0.3, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.1, 1.3, //
+				0.2, 1.22, 0.4, 1.2, 0.1, 1.3, //
+			}));
+		mb.recomputeNonZeros();
+		assertTrue(sh.encode(mb) == null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNull() {
+		sh.encode(null, null);
+	}
+
+	private class DenseBlockFP64Mock extends DenseBlockFP64 {
+		private static final long serialVersionUID = -3601232958390554672L;
+
+		public DenseBlockFP64Mock(int[] dims, double[] data) {
+			super(dims, data);
+		}
+
+		@Override
+		public boolean isContiguous() {
+			return false;
+		}
+
+		@Override
+		public int numBlocks() {
+			return 2;
+		}
+	}
+
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLADDCSchemeTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLADDCSchemeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup.scheme;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import org.apache.sysds.runtime.compress.CompressionSettings;
+import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupFactory;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
+import org.apache.sysds.runtime.compress.estim.ComEstExact;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
+import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
+import org.apache.sysds.runtime.compress.utils.Util;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+public class CLADDCSchemeTest {
+
+	final MatrixBlock src;
+	final AColGroup g;
+	final ICLAScheme sh;
+
+	public CLADDCSchemeTest() {
+		src = TestUtils.round(TestUtils.generateTestMatrixBlock(1023, 3, 0, 3, 0.9, 7));
+
+		int[] colIndexes = Util.genColsIndices(3);
+		CompressionSettings cs = new CompressionSettingsBuilder().setSamplingRatio(1.0)
+			.setValidCompressions(EnumSet.of(CompressionType.DDC)).create();
+		final CompressedSizeInfoColGroup cgi = new ComEstExact(src, cs).getColGroupInfo(colIndexes);
+
+		final CompressedSizeInfo csi = new CompressedSizeInfo(cgi);
+		final List<AColGroup> groups = ColGroupFactory.compressColGroups(src, csi, cs, 1);
+		g = groups.get(0);
+		sh = g.getCompressionScheme();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidColumnApply() {
+		sh.encode(null, new int[] {1, 2});
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidColumnApply_2() {
+		sh.encode(null, new int[] {1, 2, 5, 5});
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNull() {
+		sh.encode(null, null);
+	}
+
+	@Test
+	public void testEncode() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 3, 0, 3, 0.9, 7))) != null);
+	}
+
+	@Test
+	public void testEncode_sparse() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.01, 7))) != null);
+	}
+
+	@Test
+	public void testEncodeSparseDifferentColumns() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.01, 7)),
+			new int[] {13, 16, 30}) != null);
+	}
+
+	@Test
+	public void testEncodeSparseDifferentColumns2() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.01, 7)),
+			new int[] {15, 16, 99}) != null);
+	}
+
+	@Test
+	public void testEncodeSparseDifferentColumns3() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.01, 7)),
+			new int[] {15, 86, 99}) != null);
+	}
+
+	@Test
+	public void testEncodeDenseDifferentColumns() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.86, 7)),
+			new int[] {13, 16, 30}) != null);
+	}
+
+	@Test
+	public void testEncodeDenseDifferentColumns2() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.86, 7)),
+			new int[] {15, 16, 99}) != null);
+	}
+
+	@Test
+	public void testEncodeDenseDifferentColumns3() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 100, 0, 3, 0.86, 7)),
+			new int[] {15, 86, 99}) != null);
+	}
+
+	@Test
+	public void testEncodeInvalid() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(2, 3, 3, 6, 0.9, 7))) == null);
+	}
+
+	@Test
+	public void testEncodeInvalid_2() {
+		assertTrue(sh.encode(TestUtils.round(TestUtils.generateTestMatrixBlock(200, 3, 3, 6, 0.9, 7))) == null);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLAEmptySchemeTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/scheme/CLAEmptySchemeTest.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup.scheme;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupEmpty;
+import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
+import org.apache.sysds.runtime.data.DenseBlockFP64;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.junit.Test;
+
+public class CLAEmptySchemeTest {
+
+	private final AColGroup g;
+	private final ICLAScheme sh;
+
+	public CLAEmptySchemeTest() {
+		g = new ColGroupEmpty(//
+			new int[] {1, 3, 5} // Columns
+		);
+		sh = g.getCompressionScheme();
+	}
+
+	@Test
+	public void testConstValid() {
+		assertTrue(sh != null);
+	}
+
+	@Test
+	public void testToSmallMatrix() {
+		assertTrue(sh.encode(new MatrixBlock(1, 3, new double[] {//
+			1.1, 1.2, 1.3})) == null);
+	}
+
+	@Test
+	public void testWrongValuesSingleRow() {
+		assertTrue(sh.encode(new MatrixBlock(1, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.2})) == null);
+	}
+
+	@Test
+	public void testWrongValuesSingleRowV2() {
+		assertTrue(sh.encode(new MatrixBlock(1, 6, new double[] {//
+			0.0, 1.0, 0.2, 1.2, 0.2, 1.3})) == null);
+	}
+
+	@Test
+	public void testValidEncodeSingleRow() {
+		assertTrue(sh.encode(new MatrixBlock(1, 6, new double[] {//
+			0.1, 0.0, 0.04, 0.0, 0.03, 0.0})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRow() {
+		assertTrue(sh.encode(new MatrixBlock(2, 6, new double[] {//
+			132, 0.0, 241, 0.0, 142, 0.0, //
+			132, 0.0, 241, 0.0, 142, 0.0, //
+		})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRowsLarger() {
+		assertTrue(sh.encode(new MatrixBlock(2, 10, new double[] {//
+			0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 1, 1, //
+			0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 1, 1, //
+		})) != null);
+	}
+
+	@Test
+	public void testInvalidEncodeMultiRowsValue() {
+		assertTrue(sh.encode(new MatrixBlock(4, 8, new double[] {//
+			0.0, 0.0, 0.2, 0.0, 1.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 1.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 1.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 1.2, 0.0, 0.2, 1.3, //
+		})) != null);
+	}
+
+	@Test
+	public void testValidEncodeMultiRowDifferentValuesOtherColumns() {
+		assertTrue(sh.encode(new MatrixBlock(4, 12, new double[] {//
+			0.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.1, 0.4, 1.2, 0.3, 1.3, //
+			0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.1, 0.2, 1.2, 0.1, 1.3, //
+			0.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.1, 0.4, 1.2, 0.1, 1.3, //
+		})) != null);
+	}
+
+	@Test
+	public void testInvalidEncodeValueMultiRowMultiError() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.4, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) == null);
+	}
+
+	@Test
+	public void testInvalidEncodeMultiRow() {
+		assertTrue(sh.encode(new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.3, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.4, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		})) == null);
+	}
+
+	@Test
+	public void testEncodeOtherColumns() {
+		assertTrue(sh.encode(new MatrixBlock(4, 5, new double[] {//
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+		}), new int[] {0, 2, 4}// other columns
+		) == null);
+	}
+
+	@Test
+	public void testEncodeOtherColumnsValid() {
+		assertTrue(sh.encode(new MatrixBlock(4, 8, new double[] {//
+			0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+		}), new int[] {0, 2, 4}// other columns
+		) != null);
+	}
+
+	@Test
+	public void testEncodeOtherColumnsInvalid() {
+		assertTrue(sh.encode(new MatrixBlock(4, 5, new double[] {//
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+			1.1, 0.2, 1.4, 0.2, 1.3, //
+			1.1, 0.2, 1.2, 0.2, 1.3, //
+		}), new int[] {0, 2, 4}// other columns
+		) == null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidArgument_1() {
+		sh.encode(null, new int[] {0, 2, 4, 5});
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidArgument_2() {
+		sh.encode(null, new int[] {0, 2});
+	}
+
+	@Test
+	public void testSparse() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = mb.append(empty);
+
+		assertTrue(sh.encode(mb) != null);
+	}
+
+	@Test
+	public void testSpars_AllCosOver() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = mb.append(empty);
+
+		assertTrue(sh.encode(mb, new int[] {100, 102, 999}) != null);
+	}
+
+	@Test
+	public void testSpars_InsideInvalid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+			0.01, 0.0, 0.2, 0.0, 0.2, 0.0, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = mb.append(empty);
+
+		assertTrue(sh.encode(mb, new int[] {1, 4, 5}) == null);
+	}
+
+	@Test
+	public void testSparse_Append() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 0.0, 0.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 0.2, 1.3, //
+			0.0, 0.0, 0.2, 0.0, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+
+		assertTrue(sh.encode(mb) != null);
+	}
+
+	@Test
+	public void testSparseValidCustom() {
+		MatrixBlock mb = new MatrixBlock(4, 9, new double[] {//
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+
+		assertTrue(sh.encode(mb, new int[] {1001, 1003, 1005}) != null);
+	}
+
+	@Test
+	public void testSparseValidCustom2() {
+		MatrixBlock mb = new MatrixBlock(4, 9, new double[] {//
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		MatrixBlock comb = empty.append(mb).append(mb);
+
+		assertTrue(sh.encode(comb, new int[] {1001, 1003, 1005}) != null);
+	}
+
+	@Test
+	public void testSparseValidCustom3Valid() {
+		MatrixBlock mb = new MatrixBlock(4, 9, new double[] {//
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.33, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+			0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		MatrixBlock comb = empty.append(mb).append(mb);
+
+		assertTrue(sh.encode(comb, new int[] {1001, 1003, 1005}) != null);
+	}
+
+	@Test
+	public void testSparseEmptyRow() {
+		MatrixBlock mb = new MatrixBlock(4, 6, new double[] {//
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+			0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+		});
+
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		mb = empty.append(mb);
+		MatrixBlock emptyRow = new MatrixBlock(1, 1006, 0.0);
+		mb = mb.append(emptyRow, false);
+
+		assertTrue(sh.encode(mb, new int[] {44, 45, 999}) != null);
+	}
+
+	@Test
+	public void testEmpty() {
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		assertTrue(sh.encode(empty) != null);
+	}
+
+	@Test
+	public void testEmptyOtherColumns() {
+		MatrixBlock empty = new MatrixBlock(4, 1000, 0.0);
+		assertTrue(sh.encode(empty, new int[] {33, 34, 99}) != null);
+	}
+
+	@Test
+	public void testGenericNonContinuosBlockValid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, //
+			new DenseBlockFP64Mock(new int[] {4, 9}, new double[] {//
+				0.2, 0.0, 1.1, 0.0, 0.4, 0.0, 1.2, 0.3, 1.3, //
+				0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.2, 1.3, //
+				0.0, 0.0, 1.1, 0.0, 0.2, 0.0, 1.2, 0.1, 1.3, //
+				0.2, 0.0, 1.1, 0.0, 0.4, 0.0, 1.2, 0.1, 1.3, //
+			}));
+		mb.recomputeNonZeros();
+		assertTrue(sh.encode(mb) != null);
+	}
+
+	@Test
+	public void testGenericNonContinuosBlockInValid() {
+		MatrixBlock mb = new MatrixBlock(4, 6, //
+			new DenseBlockFP64Mock(new int[] {4, 6}, new double[] {//
+				0.2, 1.1, 0.4, 1.2, 0.3, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.2, 1.3, //
+				0.0, 1.1, 0.2, 1.2, 0.1, 1.3, //
+				0.2, 1.22, 0.4, 1.2, 0.1, 1.3, //
+			}));
+		mb.recomputeNonZeros();
+		assertTrue(sh.encode(mb) == null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNull() {
+		sh.encode(null, null);
+	}
+
+	private class DenseBlockFP64Mock extends DenseBlockFP64 {
+		private static final long serialVersionUID = -3601232958390554672L;
+
+		public DenseBlockFP64Mock(int[] dims, double[] data) {
+			super(dims, data);
+		}
+
+		@Override
+		public boolean isContiguous() {
+			return false;
+		}
+
+		@Override
+		public int numBlocks() {
+			return 2;
+		}
+	}
+
+}


### PR DESCRIPTION
This PR is for the code to enable extracting compression schemes and applying them to unseen data.
The application of this is to compress more data, and append to already compressed matrix blocks without the need of decompression.