### PR TITLE
[SYSTEMDS-3088] Disable successful Prefetch count test

### DIFF
--- a/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
@@ -110,8 +110,8 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 			long expected_successPF = !testname.equalsIgnoreCase(TEST_NAME+"3") ? 1 : 0;
 			long numPF = Statistics.getCPHeavyHitterCount("prefetch");
 			Assert.assertTrue("Violated Prefetch instruction count: "+numPF, numPF == expected_numPF);
-			long successPF = SparkStatistics.getAsyncPrefetchCount();
-			Assert.assertTrue("Violated successful Prefetch count: "+successPF, successPF == expected_successPF);
+			//long successPF = SparkStatistics.getAsyncPrefetchCount();
+			//Assert.assertTrue("Violated successful Prefetch count: "+successPF, successPF == expected_successPF);
 		} finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;


### PR DESCRIPTION
This patch brings a minor change in the PrefetchRDD tests. Now, we only check the number of Prefetch instructions executed and removed the check for how many of those are successful.