### PR TITLE
[MINOR] Reduce package time by excluding generated content

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -95,7 +95,11 @@ jobs:
         architecture: 'x64'
   
     - name: Install pip Dependencies
-      run: pip install numpy py4j wheel scipy sklearn requests pandas unittest-parallel
+      run: |
+        # Install pip twice to update past the versions.
+        pip install --upgrade pip 
+        pip install --upgrade pip
+        pip install numpy py4j wheel scipy sklearn requests pandas unittest-parallel
 
     - name: Build Python Package
       run: |

--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -38,8 +38,11 @@
 			<excludes>
 				<exclude>algorithms/obsolete/*</exclude>
 				<exclude>algorithms/obsolete</exclude>
-				<exclude>perftest/**/*</exclude>
-				<exclude>perftest</exclude>
+				<exclude>monitoring/.angular/**</exclude>
+				<exclude>monitoring/node_modules/**</exclude>
+				<exclude>**/obsolete/**</exclude>
+				<exclude>tutorials/**</exclude>
+				<exclude>perftest/**</exclude>
 				<exclude>perftestDeprecated/*</exclude>
 				<exclude>perftestDeprecated</exclude>
 				<exclude>staging/**/*</exclude>

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -48,6 +48,15 @@
 				<exclude>**/target/**/*</exclude>
 				<exclude>**/temp</exclude>
 				<exclude>**/temp/**/*</exclude>
+				<exclude>scripts/monitoring/.angular/**</exclude>
+				<exclude>scripts/monitoring/node_modules/**</exclude>
+				<exclude>**/obsolete/**</exclude>
+				<exclude>scripts/tutorials/**</exclude>
+				<exclude>scripts/perftest/**</exclude>
+				<exclude>scripts/staging/**</exclude>
+				<exclude>./src/main/python/**</exclude>
+				<!-- exclude docs dir, since it is for webpage and docs are included in src -->
+				<exclude>docs/**</exclude> 
 				<exclude>./src/test/config/hadoop_bin_windows/**</exclude>
 				<exclude>./src/main/cpp/lib/**</exclude>
 				<exclude>pom.xml.versionsBackup</exclude>


### PR DESCRIPTION
This commit change our files to include in bin and src releases. Locally on my machine it started taking upwards of 5-8 minutes to do 'mvn clean package -P distribution', because we were packing libraries, datasets, and resources that was not needed for the release archives.

systemds.zip after 31.7 MB before: 664.6 MB
systemds-bin.zip after 75.2 MB before: 396.5 MB