### PR TITLE
[SYSTEMDS-3465] Typed return on CacheBlock Interface Slice

### DIFF
--- a/src/main/java/org/apache/sysds/hops/recompile/Recompiler.java
+++ b/src/main/java/org/apache/sysds/hops/recompile/Recompiler.java
@@ -1610,8 +1610,8 @@ public class Recompiler {
 	
 	@SuppressWarnings("unchecked")
 	public static void executeInMemoryReblock(ExecutionContext ec, String varin, String varout, LineageItem litem) {
-		CacheableData<CacheBlock> in = (CacheableData<CacheBlock>) ec.getCacheableData(varin);
-		CacheableData<CacheBlock> out = (CacheableData<CacheBlock>) ec.getCacheableData(varout);
+		CacheableData<CacheBlock<?>> in = (CacheableData<CacheBlock<?>>) ec.getCacheableData(varin);
+		CacheableData<CacheBlock<?>> out = (CacheableData<CacheBlock<?>>) ec.getCacheableData(varout);
 
 		if( in.isFederated() ) {
 			out.setMetaData(in.getMetaData());

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -59,7 +59,6 @@ import org.apache.sysds.runtime.compress.lib.CLALibSquash;
 import org.apache.sysds.runtime.compress.lib.CLALibTSMM;
 import org.apache.sysds.runtime.compress.lib.CLALibUnary;
 import org.apache.sysds.runtime.compress.lib.CLALibUtils;
-import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysds.runtime.data.DenseBlock;
@@ -591,7 +590,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	@Override
-	public MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep, CacheBlock ret) {
+	public MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep, MatrixBlock ret) {
 		validateSliceArgument(rl, ru, cl, cu);
 		return CLALibSlice.slice(this, rl, ru, cl, cu, deep);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
@@ -93,7 +93,7 @@ public class QDictionary extends ADictionary {
 
 	public static long getInMemorySize(int valuesCount) {
 		// object + values array + double
-		return 16 + MemoryEstimates.byteArrayCost(valuesCount) + 8;
+		return 16 + (long)MemoryEstimates.byteArrayCost(valuesCount) + 8;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToBit.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToBit.java
@@ -78,7 +78,7 @@ public class MapToBit extends AMapToData {
 
 	@Override
 	public long getInMemorySize() {
-		return getInMemorySize(_data.size());
+		return getInMemorySize(_data.size()-1);
 	}
 
 	public static long getInMemorySize(int dataLength) {

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/ByteBuffer.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/ByteBuffer.java
@@ -43,14 +43,14 @@ public class ByteBuffer
 	private final long _size;
 	
 	protected byte[]     _bdata = null; //sparse matrix
-	protected CacheBlock _cdata = null; //dense matrix/frame
+	protected CacheBlock<?> _cdata = null; //dense matrix/frame
 	
 	public ByteBuffer( long size ) {
 		_size = size;
 		_serialized = false;
 	}
 
-	public void serializeBlock( CacheBlock cb ) 
+	public void serializeBlock( CacheBlock<?> cb ) 
 		throws IOException
 	{	
 		_shallow = cb.isShallowSerialize(true);
@@ -85,10 +85,10 @@ public class ByteBuffer
 		_serialized = true;
 	}
 
-	public CacheBlock deserializeBlock() 
+	public CacheBlock<?> deserializeBlock() 
 		throws IOException
 	{
-		CacheBlock ret = null;
+		CacheBlock<?> ret = null;
 		
 		if( !_shallow ) { //sparse matrix / string frame
 			DataInput din = _matrix ? new CacheDataInput(_bdata) :
@@ -163,7 +163,7 @@ public class ByteBuffer
 	 * @param cb cache block
 	 * @return true if valid capacity
 	 */
-	public static boolean isValidCapacity( long size, CacheBlock cb )
+	public static boolean isValidCapacity( long size, CacheBlock<?> cb )
 	{
 		if( !cb.isShallowSerialize(true) ) { //SPARSE matrix blocks
 			// since cache blocks are serialized into a byte representation

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlock.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.controlprogram.caching;
 
 import org.apache.hadoop.io.Writable;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
+import org.apache.sysds.runtime.util.IndexRange;
 
 
 /**
@@ -28,7 +29,7 @@ import org.apache.sysds.runtime.meta.DataCharacteristics;
  * allows us to keep the buffer pool independent of matrix and frame blocks. 
  * 
  */
-public interface CacheBlock extends Writable 
+public interface CacheBlock <T> extends Writable 
 {
 
 	public int getNumRows();
@@ -84,33 +85,89 @@ public interface CacheBlock extends Writable
 	 * Free unnecessarily allocated empty block.
 	 */
 	public void compactEmptyBlock();
+
+	/**
+	 * Slice a sub block out of the current block and write into the given output block. This method returns the passed
+	 * instance if not null.
+	 * 
+	 * @param ixrange index range inclusive
+	 * @param ret outputBlock
+	 * @return sub-block of cache block
+	 */
+	public CacheBlock<T> slice(IndexRange ixrange, T ret);
 	
 	/**
-	 * Slice a sub block out of the current block and write into the given output block.
-	 * This method returns the passed instance if not null.
+	 * Slice a sub block out of the current block and write into the given output block. This method returns the passed
+	 * instance if not null.
 	 * 
 	 * @param rl row lower
-	 * @param ru row upper
+	 * @param ru row upper inclusive
+	 * @return sub-block of cache block
+	 */
+	public CacheBlock<T> slice(int rl, int ru);
+
+	/**
+	 * Slice a sub block out of the current block and write into the given output block. This method returns the passed
+	 * instance if not null.
+	 * 
+	 * @param rl row lower
+	 * @param ru row upper inclusive
+	 * @param deep enforce deep-copy
+	 * @return sub-block of cache block
+	 */
+	public CacheBlock<T> slice(int rl, int ru, boolean deep);
+
+	/**
+	 * Slice a sub block out of the current block and write into the given output block. This method returns the passed
+	 * instance if not null.
+	 * 
+	 * @param rl row lower
+	 * @param ru row upper inclusive
 	 * @param cl column lower
-	 * @param cu column upper
+	 * @param cu column upper inclusive
+	 * @return sub-block of cache block
+	 */
+	public CacheBlock<T> slice(int rl, int ru, int cl, int cu);
+
+	/**
+	 * Slice a sub block out of the current block and write into the given output block. This method returns the passed
+	 * instance if not null.
+	 * 
+	 * @param rl    row lower
+	 * @param ru    row upper inclusive
+	 * @param cl    column lower
+	 * @param cu    column upper inclusive
 	 * @param block cache block
 	 * @return sub-block of cache block
 	 */
-	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block);
-	
+	public CacheBlock<T> slice(int rl, int ru, int cl, int cu, T block);
+
 	/**
 	 * Slice a sub block out of the current block and write into the given output block.
 	 * This method returns the passed instance if not null.
 	 * 
-	 * @param rl row lower
-	 * @param ru row upper
+	 * @param rl row lower 
+	 * @param ru row upper inclusive
 	 * @param cl column lower
-	 * @param cu column upper
+	 * @param cu column upper inclusive
+	 * @param deep enforce deep-copy
+	 * @return sub-block of cache block
+	 */
+	public CacheBlock<T> slice(int rl, int ru, int cl, int cu, boolean deep);
+
+	/**
+	 * Slice a sub block out of the current block and write into the given output block.
+	 * This method returns the passed instance if not null.
+	 * 
+	 * @param rl row lower 
+	 * @param ru row upper inclusive
+	 * @param cl column lower
+	 * @param cu column upper inclusive
 	 * @param deep enforce deep-copy
 	 * @param block cache block
 	 * @return sub-block of cache block
 	 */
-	public CacheBlock slice(int rl, int ru, int cl, int cu, boolean deep, CacheBlock block);
+	public CacheBlock<T> slice(int rl, int ru, int cl, int cu, boolean deep, T block);
 	
 	
 	/**
@@ -120,7 +177,7 @@ public interface CacheBlock extends Writable
 	 * @param that cache block
 	 * @param appendOnly ?
 	 */
-	public void merge(CacheBlock that, boolean appendOnly);
+	public void merge(T that, boolean appendOnly);
 
 	/**
 	 * Returns the double value at the passed row and column.
@@ -129,7 +186,7 @@ public interface CacheBlock extends Writable
 	 * @param c column of the value
 	 * @return double value at the passed row and column
 	 */
-	double getDouble(int r, int c);
+	public double getDouble(int r, int c);
 
 	/**
 	 * Returns the double value at the passed row and column.
@@ -138,7 +195,7 @@ public interface CacheBlock extends Writable
 	 * @param c column of the value
 	 * @return double value at the passed row and column
 	 */
-	double getDoubleNaN(int r, int c);
+	public double getDoubleNaN(int r, int c);
 
 	/**
 	 * Returns the string of the value at the passed row and column.
@@ -147,5 +204,5 @@ public interface CacheBlock extends Writable
 	 * @param c column of the value
 	 * @return string of the value at the passed row and column
 	 */
-	String getString(int r, int c);
+	public String getString(int r, int c);
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheBlockFactory.java
@@ -35,7 +35,7 @@ import org.apache.sysds.runtime.matrix.data.Pair;
  */
 public class CacheBlockFactory 
 {
-	public static CacheBlock newInstance(int code) {
+	public static CacheBlock<?> newInstance(int code) {
 		switch( code ) {
 			case 0: return new MatrixBlock();
 			case 1: return new FrameBlock();
@@ -44,7 +44,17 @@ public class CacheBlockFactory
 		throw new RuntimeException("Unsupported cache block type: "+code);
 	}
 
-	public static int getCode(CacheBlock block) {
+	public static CacheBlock<?> newInstance(CacheBlock<?> block) {
+		if(block instanceof MatrixBlock)
+			return new MatrixBlock();
+		else if(block instanceof FrameBlock)
+			return new FrameBlock();
+		else if(block instanceof TensorBlock)
+			return new TensorBlock();
+		throw new RuntimeException("Unsupported cache block type: " + block.getClass().getName());
+	}
+
+	public static int getCode(CacheBlock<?> block) {
 		if (block instanceof MatrixBlock)
 			return 0;
 		else if (block instanceof FrameBlock)
@@ -54,7 +64,7 @@ public class CacheBlockFactory
 		throw new RuntimeException("Unsupported cache block type: " + block.getClass().getName());
 	}
 
-	public static ArrayList<?> getPairList(CacheBlock block) {
+	public static ArrayList<?> getPairList(CacheBlock<?> block) {
 		int code = getCode(block);
 		switch (code) {
 			case 0: return new ArrayList<Pair<MatrixIndexes, MatrixBlock>>();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheMaintenanceService.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheMaintenanceService.java
@@ -44,7 +44,7 @@ public class CacheMaintenanceService
 			LocalFileUtils.deleteFileIfExists(fname, true);
 	}
 
-	public void serializeData(ByteBuffer bbuff, CacheBlock cb) {
+	public void serializeData(ByteBuffer bbuff, CacheBlock<?> cb) {
 		//sync or async file delete
 		if( CacheableData.CACHING_ASYNC_SERIALIZE )
 			_pool.submit(new CacheMaintenanceService.DataSerializerTask(bbuff, cb));
@@ -85,9 +85,9 @@ public class CacheMaintenanceService
 
 	private static class DataSerializerTask implements Runnable {
 		private ByteBuffer _bbuff = null;
-		private CacheBlock _cb = null;
+		private CacheBlock<?> _cb = null;
 
-		public DataSerializerTask(ByteBuffer bbuff, CacheBlock cb) {
+		public DataSerializerTask(ByteBuffer bbuff, CacheBlock<?> cb) {
 			_bbuff = bbuff;
 			_cb = cb;
 		}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -73,7 +73,7 @@ import org.apache.sysds.utils.Statistics;
  * to allow Java garbage collection. If other parts of the system continue
  * keep references to the cache block, its eviction will not release any memory.
  */
-public abstract class CacheableData<T extends CacheBlock> extends Data
+public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 {
 	private static final long serialVersionUID = -413810592207212835L;
 
@@ -1047,7 +1047,7 @@ public abstract class CacheableData<T extends CacheBlock> extends Data
 		return (_data.getInMemorySize() <= CACHING_THRESHOLD);
 	}
 	
-	public static boolean isBelowCachingThreshold(CacheBlock data) {
+	public static boolean isBelowCachingThreshold(CacheBlock<?> data) {
 		boolean ret;
 		if (OptimizerUtils.isUMMEnabled())
 			ret = UnifiedMemoryManager.getCacheBlockSize(data) <= CACHING_THRESHOLD;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/LazyWriteBuffer.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/LazyWriteBuffer.java
@@ -47,7 +47,7 @@ public class LazyWriteBuffer
 	//maintenance service for synchronous or asynchronous delete of evicted files
 	private static CacheMaintenanceService _fClean;
 	
-	public static int writeBlock(String fname, CacheBlock cb)
+	public static int writeBlock(String fname, CacheBlock<?> cb)
 		throws IOException
 	{
 		//obtain basic meta data of cache block
@@ -131,10 +131,10 @@ public class LazyWriteBuffer
 			_fClean.deleteFile(fname);
 	}
 	
-	public static CacheBlock readBlock(String fname, boolean matrix)
+	public static CacheBlock<?> readBlock(String fname, boolean matrix)
 		throws IOException
 	{
-		CacheBlock cb = null;
+		CacheBlock<?> cb = null;
 		ByteBuffer ldata = null;
 		
 		//probe write buffer
@@ -211,7 +211,7 @@ public class LazyWriteBuffer
 		return _mQueue.size();
 	}
 	
-	public static long getCacheBlockSize(CacheBlock cb) {
+	public static long getCacheBlockSize(CacheBlock<?> cb) {
 		return cb.isShallowSerialize() ?
 			cb.getInMemorySize() : cb.getExactSerializedSize();
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/UnifiedMemoryManager.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/UnifiedMemoryManager.java
@@ -253,10 +253,10 @@ public class UnifiedMemoryManager
 	}
 
 	// Reads a cached object. This is called from cacheabledata implementations
-	public static CacheBlock readBlock(String fname, boolean matrix)
+	public static CacheBlock<?> readBlock(String fname, boolean matrix)
 		throws IOException
 	{
-		CacheBlock cb = null;
+		CacheBlock<?> cb = null;
 		ByteBuffer ldata = null;
 
 		//probe write buffer
@@ -336,7 +336,7 @@ public class UnifiedMemoryManager
 	}
 
 	// Write an object to the cache
-	public static int writeBlock(String fname, CacheBlock cb)
+	public static int writeBlock(String fname, CacheBlock<?> cb)
 		throws IOException
 	{
 		//obtain basic metadata of the cache block
@@ -380,7 +380,7 @@ public class UnifiedMemoryManager
 		return numEvicted;
 	}
 
-	public static long getCacheBlockSize(CacheBlock cb) {
+	public static long getCacheBlockSize(CacheBlock<?> cb) {
 		return cb.isShallowSerialize() ?
 			cb.getInMemorySize() : cb.getExactSerializedSize();
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -639,7 +639,7 @@ public class ExecutionContext {
 		setVariable(varName, fo);
 	}
 
-	public static CacheableData<?> createCacheableData(CacheBlock cb) {
+	public static CacheableData<?> createCacheableData(CacheBlock<?> cb) {
 		if( cb instanceof MatrixBlock )
 			return createMatrixObject((MatrixBlock) cb);
 		else if( cb instanceof FrameBlock )

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -622,9 +622,9 @@ public class SparkExecutionContext extends ExecutionContext
 		return rdd;
 	}
 
-	public Broadcast<CacheBlock> broadcastVariable(CacheableData<CacheBlock> cd) {
+	public Broadcast<CacheBlock<?>> broadcastVariable(CacheableData<CacheBlock<?>> cd) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
-		Broadcast<CacheBlock> brBlock = null;
+		Broadcast<CacheBlock<?>> brBlock = null;
 
 		// reuse existing non partitioned broadcast handle
 		if (cd.getBroadcastHandle() != null && cd.getBroadcastHandle().isNonPartitionedBroadcastValid()) {
@@ -639,7 +639,7 @@ public class SparkExecutionContext extends ExecutionContext
 				CacheableData.addBroadcastSize(-cd.getBroadcastHandle().getSize());
 
 			// read the matrix block
-			CacheBlock cb = cd.acquireRead();
+			CacheBlock<?> cb = cd.acquireRead();
 			cd.release();
 
 			// broadcast a non-empty frame whose size is smaller than 2G
@@ -854,12 +854,12 @@ public class SparkExecutionContext extends ExecutionContext
 		return bret;
 	}
 	
-	private Broadcast<PartitionedBlock<? extends CacheBlock>> createPartitionedBroadcast(
-			PartitionedBlock<? extends CacheBlock> pmb, int numPerPart, int pos) {
+	private Broadcast<PartitionedBlock<? extends CacheBlock<?>>> createPartitionedBroadcast(
+			PartitionedBlock<? extends CacheBlock<?>> pmb, int numPerPart, int pos) {
 		int offset = pos * numPerPart;
 		int numBlks = Math.min(numPerPart, pmb.getNumRowBlocks() * pmb.getNumColumnBlocks() - offset);
-		PartitionedBlock<? extends CacheBlock> tmp = pmb.createPartition(offset, numBlks);
-		Broadcast<PartitionedBlock<? extends CacheBlock>> ret = getSparkContext().broadcast(tmp);
+		PartitionedBlock<? extends CacheBlock<?>> tmp = pmb.createPartition(offset, numBlks);
+		Broadcast<PartitionedBlock<? extends CacheBlock<?>>> ret = getSparkContext().broadcast(tmp);
 		if (!isLocalMaster())
 			tmp.clearBlocks();
 		return ret;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -151,7 +151,7 @@ public class FederatedData {
 		return executeFederatedOperation(request);
 	}
 
-	public synchronized Future<FederatedResponse> initFederatedDataFromLocal(long id, CacheBlock block) {
+	public synchronized Future<FederatedResponse> initFederatedDataFromLocal(long id, CacheBlock<?> block) {
 		if(isInitialized())
 			throw new DMLRuntimeException("Tried to init already initialized data");
 		if(!_dataType.isMatrix() && !_dataType.isFrame())

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedRequest.java
@@ -176,7 +176,7 @@ public class FederatedRequest implements Serializable {
 
 			if (ob instanceof CacheBlock) {
 				try {
-					CacheBlock cb = (CacheBlock)ob;
+					CacheBlock<?> cb = (CacheBlock<?>)ob;
 					long cbsize = LazyWriteBuffer.getCacheBlockSize(cb);
 					DataOutput dout = new CacheDataOutput(new byte[(int)cbsize]);
 					cb.write(dout);
@@ -200,7 +200,7 @@ public class FederatedRequest implements Serializable {
 		if(_data != null) {
 			for(Object obj : _data) {
 				if(obj instanceof CacheBlock)
-					minBufferSize += ((CacheBlock)obj).getExactSerializedSize();
+					minBufferSize += ((CacheBlock<?>)obj).getExactSerializedSize();
 			}
 		}
 		if(_lineageTrace != null)

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
@@ -98,7 +98,7 @@ public class FederatedResponse implements Serializable {
 		if(_data != null) {
 			for(Object obj : _data) {
 				if(obj instanceof CacheBlock)
-					minBufferSize += ((CacheBlock)obj).getExactSerializedSize();
+					minBufferSize += ((CacheBlock<?>)obj).getExactSerializedSize();
 			}
 		}
 		return minBufferSize;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedStatistics.java
@@ -582,7 +582,7 @@ public class FederatedStatistics {
 		fedReuseReadBytesCount.add(data.getDataSize());
 	}
 
-	public static void incFedReuseReadBytesCount(CacheBlock cb) {
+	public static void incFedReuseReadBytesCount(CacheBlock<?> cb) {
 		fedReuseReadBytesCount.add(cb.getInMemorySize());
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -150,7 +150,7 @@ public class FederatedWorker {
 			if(linReusePossible) {
 				FederatedResponse response = (FederatedResponse)msg;
 				if(response.getData() != null && response.getData().length != 0
-					&& response.getData()[0] instanceof CacheBlock) {
+					&& response.getData()[0] instanceof CacheBlock<?>) {
 					objLI = response.getLineageItem();
 
 					byte[] cachedBytes = LineageCache.reuseSerialization(objLI);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
@@ -39,6 +39,7 @@ import org.apache.sysds.hops.fedplanner.FTypes.FType;
 import org.apache.sysds.lops.RightIndex;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlockFactory;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.RequestType;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
@@ -130,7 +131,7 @@ public class FederationMap {
 			return new FederatedRequest(RequestType.NOOP, data.getFedMapping().getID());
 		// prepare single request for all federated data
 		long id = FederationUtils.getNextFedDataID();
-		CacheBlock cb = data.acquireReadAndRelease();
+		CacheBlock<?> cb = data.acquireReadAndRelease();
 
 		// create new fed mapping for broadcast (a potential overwrite
 		// is fine, because with broadcast all data on all workers)
@@ -171,7 +172,7 @@ public class FederationMap {
 
 		// prepare broadcast id and pin input
 		long id = FederationUtils.getNextFedDataID();
-		CacheBlock cb = data.acquireReadAndRelease();
+		CacheBlock<?> cb = data.acquireReadAndRelease();
 
 		// prepare indexing ranges
 		int[][] ix = new int[_fedMap.size()][];
@@ -223,7 +224,7 @@ public class FederationMap {
 
 		// prepare broadcast id and pin input
 		long id = FederationUtils.getNextFedDataID();
-		CacheBlock cb = data.acquireReadAndRelease();
+		CacheBlock<?> cb = data.acquireReadAndRelease();
 
 		// multi-threaded block slicing and federation request creation
 		FederatedRequest[] ret = new FederatedRequest[ix.length];
@@ -232,7 +233,7 @@ public class FederationMap {
 		return ret;
 	}
 
-	private FederatedRequest sliceBroadcastBlock(int[] ix, long id, CacheBlock cb, LineageItem objLi, boolean isFrame) {
+	private FederatedRequest sliceBroadcastBlock(int[] ix, long id, CacheBlock<?> cb, LineageItem objLi, boolean isFrame) {
 		LineageItem li = null;
 		if(objLi != null) {
 			// manually create a lineage item for indexing to complete the lineage trace for slicing
@@ -244,7 +245,7 @@ public class FederationMap {
 				ru.getLiteralLineageItem(), cl.getLiteralLineageItem(), cu.getLiteralLineageItem()});
 		}
 		FederatedRequest fr = new FederatedRequest(RequestType.PUT_VAR, li, id,
-			cb.slice(ix[0], ix[1], ix[2], ix[3], isFrame ? new FrameBlock() : new MatrixBlock()));
+			cb.slice(ix[0], ix[1], ix[2], ix[3]));
 		return fr;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/CachedReuseVariables.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/CachedReuseVariables.java
@@ -45,7 +45,8 @@ public class CachedReuseVariables
 		return _data.containsKey(pfid);
 	}
 	
-	public synchronized void reuseVariables(long pfid, LocalVariableMap vars, Collection<String> excludeList, Map<String, Broadcast<CacheBlock>> _brInputs, boolean cleanCache) {
+	public synchronized void reuseVariables(long pfid, LocalVariableMap vars, Collection<String> excludeList,
+		Map<String, Broadcast<CacheBlock<?>>> _brInputs, boolean cleanCache) {
 
 		//fetch the broadcast variables
 		if (ParForProgramBlock.ALLOW_BROADCAST_INPUTS && !containsVars(pfid)) {
@@ -78,10 +79,10 @@ public class CachedReuseVariables
 	}
 
 	@SuppressWarnings("unchecked")
-	private static void loadBroadcastVariables(LocalVariableMap variables, Map<String, Broadcast<CacheBlock>> brInputs) {
-		for( Entry<String, Broadcast<CacheBlock>> e : brInputs.entrySet() ) {
+	private static void loadBroadcastVariables(LocalVariableMap variables, Map<String, Broadcast<CacheBlock<?>>> brInputs) {
+		for( Entry<String, Broadcast<CacheBlock<?>>> e : brInputs.entrySet() ) {
 			Data d = variables.get(e.getKey());
-			CacheableData<CacheBlock> cdcb = (CacheableData<CacheBlock>) d;
+			CacheableData<CacheBlock<?>> cdcb = (CacheableData<CacheBlock<?>>) d;
 			cdcb.acquireModify(e.getValue().getValue());
 			cdcb.setEmptyStatus(); // avoid eviction
 			cdcb.refreshMetaData();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/RemoteParForSpark.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/RemoteParForSpark.java
@@ -85,7 +85,7 @@ public class RemoteParForSpark
 			RemoteParForSparkWorker.cleanupCachedVariables(jobid);
 
 		// broadcast the inputs except the result variables
-		Map<String, Broadcast<CacheBlock>> brInputs = null;
+		Map<String, Broadcast<CacheBlock<?>>> brInputs = null;
 		if (ParForProgramBlock.ALLOW_BROADCAST_INPUTS)
 			brInputs = broadcastInputs(sec, brVars);
 		
@@ -120,14 +120,14 @@ public class RemoteParForSpark
 	}
 
 	@SuppressWarnings("unchecked")
-	private static Map<String, Broadcast<CacheBlock>> broadcastInputs(SparkExecutionContext sec, Set<String> brVars) {
+	private static Map<String, Broadcast<CacheBlock<?>>> broadcastInputs(SparkExecutionContext sec, Set<String> brVars) {
 		// construct broadcast objects
-		Map<String, Broadcast<CacheBlock>> result = new HashMap<>();
+		Map<String, Broadcast<CacheBlock<?>>> result = new HashMap<>();
 		for (String key : brVars) {
 			Data var = sec.getVariable(key);
 			if ((var instanceof ScalarObject) || (var instanceof MatrixObject && ((MatrixObject) var).isPartitioned()))
 				continue;
-			result.put(key, sec.broadcastVariable((CacheableData<CacheBlock>) var));
+			result.put(key, sec.broadcastVariable((CacheableData<CacheBlock<?>>) var));
 		}
 		return result;
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/parfor/RemoteParForSparkWorker.java
@@ -63,11 +63,11 @@ public class RemoteParForSparkWorker extends ParWorker implements PairFlatMapFun
 	private final LongAccumulator _aTasks;
 	private final LongAccumulator _aIters;
 
-	private final Map<String, Broadcast<CacheBlock>> _brInputs;
+	private final Map<String, Broadcast<CacheBlock<?>>> _brInputs;
 	
 	public RemoteParForSparkWorker(long jobid, String program, boolean isLocal,
 		HashMap<String, byte[]> clsMap, boolean cpCaching, LongAccumulator atasks, LongAccumulator aiters,
-		Map<String, Broadcast<CacheBlock>> brInputs, boolean cleanCache, Map<String,String> lineage) 
+		Map<String, Broadcast<CacheBlock<?>>> brInputs, boolean cleanCache, Map<String,String> lineage) 
 	{
 		_jobid = jobid;
 		_prog = program;

--- a/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
@@ -37,6 +37,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.TensorCharacteristics;
+import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 /**
@@ -47,7 +48,7 @@ import org.apache.sysds.runtime.util.UtilFunctions;
  * The format determines if the <code>TensorBlock</code> uses a <code>BasicTensorBlock</code> or a <code>DataTensorBlock</code>
  * for storing the data.
  */
-public class TensorBlock implements CacheBlock, Externalizable {
+public class TensorBlock implements CacheBlock<TensorBlock>, Externalizable {
 	private static final long serialVersionUID = -8768054067319422277L;
 	
 	private enum SERIALIZED_TYPES {
@@ -283,13 +284,39 @@ public class TensorBlock implements CacheBlock, Externalizable {
 		// TODO Auto-generated method stub
 	}
 
+
 	@Override
-	public CacheBlock slice(int rl, int ru, int cl, int cu, CacheBlock block) {
-		return slice(rl, ru, cl, cu, false, block);
+	public final TensorBlock slice(IndexRange ixrange, TensorBlock ret) {
+		return slice((int) ixrange.rowStart, (int) ixrange.rowEnd, (int) ixrange.colStart, (int) ixrange.colEnd, ret);
 	}
-	
+
 	@Override
-	public CacheBlock slice(int rl, int ru, int cl, int cu, boolean deep, CacheBlock block) {
+	public final TensorBlock slice(int rl, int ru) {
+		return slice(rl, ru, 0, getNumColumns()-1, false, null);
+	}
+
+	@Override
+	public final TensorBlock slice(int rl, int ru, boolean deep) {
+		return slice(rl, ru, 0, getNumColumns()-1, deep, null);
+	}
+
+	@Override
+	public final TensorBlock slice(int rl, int ru, int cl, int cu) {
+		return slice(rl, ru, cl, cu, false, null);
+	}
+
+	@Override
+	public final TensorBlock slice(int rl, int ru, int cl, int cu, TensorBlock ret) {
+		return slice(rl, ru, cl, cu, false, ret);
+	}
+
+	@Override
+	public final TensorBlock slice(int rl, int ru, int cl, int cu, boolean deep) {
+		return slice(rl, ru, cl, cu, deep, null);
+	}
+
+	@Override
+	public TensorBlock slice(int rl, int ru, int cl, int cu, boolean deep, TensorBlock block) {
 		if( !(block instanceof TensorBlock) )
 			throw new RuntimeException("TensorBlock.slice(int,int,int,int,CacheBlock) CacheBlock was no TensorBlock");
 		TensorBlock tb = (TensorBlock) block;
@@ -305,8 +332,8 @@ public class TensorBlock implements CacheBlock, Externalizable {
 	}
 
 	@Override
-	public void merge(CacheBlock that, boolean appendOnly) {
-		// TODO Auto-generated method stub
+	public void merge(TensorBlock that, boolean appendOnly) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -22,9 +22,9 @@ package org.apache.sysds.runtime.frame.data.columns;
 import java.lang.ref.SoftReference;
 import java.util.HashMap;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.hadoop.io.Writable;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
 
 /**
  * generic, resizable native arrays
@@ -35,10 +35,22 @@ import org.apache.sysds.common.Types.ValueType;
 public abstract class Array<T> implements Writable {
 	protected SoftReference<HashMap<String, Long>> _rcdMapCache = null;
 
-	protected int _size = 0;
+	protected int _size;
 
 	protected int newSize() {
 		return Math.max(_size * 2, 4);
+	}
+
+	public final SoftReference<HashMap<String, Long>> getCache(){
+		return _rcdMapCache;
+	}
+	
+	public final void setCache(SoftReference<HashMap<String, Long>> m){
+		_rcdMapCache = m;
+	}
+	
+	public final int size(){
+		return _size;
 	}
 
 	public abstract T get(int index);
@@ -49,18 +61,6 @@ public abstract class Array<T> implements Writable {
 	 * @return The underlying array.
 	 */
 	public abstract Object get();
-
-	public final SoftReference<HashMap<String, Long>> getCache(){
-		return _rcdMapCache;
-	}
-
-	public final void setCache(SoftReference<HashMap<String, Long>> m){
-		_rcdMapCache = m;
-	}
-
-	public final int size(){
-		return _size;
-	}
 
 	public abstract void set(int index, T value);
 
@@ -84,6 +84,17 @@ public abstract class Array<T> implements Writable {
 	public abstract byte[] getAsByteArray(int nRow);
 
 	public abstract ValueType getValueType();
+
+	public abstract FrameArrayType getFrameArrayType();
+
+	/**
+	 * Get in memory size, not counting reference to this object.
+	 * 
+	 * @return the size in memory of this object.
+	 */
+	public abstract long getInMemorySize();
+
+	public abstract long getExactSerializedSize();
 	
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.utils.MemoryEstimates;
 
 public class BooleanArray extends Array<Boolean> {
-	private boolean[] _data = null;
+	private boolean[] _data;
 
 	public BooleanArray(boolean[] data) {
 		_data = data;
@@ -82,6 +84,7 @@ public class BooleanArray extends Array<Boolean> {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		out.writeByte(FrameArrayType.BOOLEAN.ordinal());
 		for(int i = 0; i < _size; i++)
 			out.writeBoolean(_data[i]);
 	}
@@ -123,6 +126,23 @@ public class BooleanArray extends Array<Boolean> {
 	@Override
 	public ValueType getValueType() {
 		return ValueType.BOOLEAN;
+	}
+
+	@Override
+	public FrameArrayType getFrameArrayType(){
+		return FrameArrayType.BOOLEAN;
+	}
+
+	@Override
+	public long getInMemorySize(){
+		long size = 16 ; // object header + object reference
+		size += MemoryEstimates.booleanArrayCost(_data.length);	
+		return size;
+	}
+
+	@Override
+	public long getExactSerializedSize(){
+		return 1 + _data.length;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
@@ -27,10 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.sysds.common.Types.ValueType;
-
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.utils.MemoryEstimates;
 
 public class DoubleArray extends Array<Double> {
-	private double[] _data = null;
+	private double[] _data;
 
 	public DoubleArray(double[] data) {
 		_data = data;
@@ -83,6 +84,7 @@ public class DoubleArray extends Array<Double> {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		out.writeByte(FrameArrayType.FP64.ordinal());
 		for(int i = 0; i < _size; i++)
 			out.writeDouble(_data[i]);
 	}
@@ -126,12 +128,29 @@ public class DoubleArray extends Array<Double> {
 	}
 
 	@Override
-	public String toString(){
+	public FrameArrayType getFrameArrayType() {
+		return FrameArrayType.FP64;
+	}
+
+	@Override
+	public long getInMemorySize() {
+		long size = 16; // object header + object reference
+		size += MemoryEstimates.doubleArrayCost(_data.length);
+		return size;
+	}
+
+	@Override
+	public long getExactSerializedSize() {
+		return 1 + 8 * _data.length;
+	}
+
+	@Override
+	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size-1; i++)
-			sb.append(_data[i]  + ",");
-		sb.append(_data[_size-1]);
+		for(int i = 0; i < _size - 1; i++)
+			sb.append(_data[i] + ",");
+		sb.append(_data[_size - 1]);
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.utils.MemoryEstimates;
 
 public class FloatArray extends Array<Float> {
-	private float[] _data = null;
+	private float[] _data;
 
 	public FloatArray(float[] data) {
 		_data = data;
@@ -82,6 +84,7 @@ public class FloatArray extends Array<Float> {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		out.writeByte(FrameArrayType.FP32.ordinal());
 		for(int i = 0; i < _size; i++)
 			out.writeFloat(_data[i]);
 	}
@@ -125,12 +128,29 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
-	public String toString(){
+	public FrameArrayType getFrameArrayType() {
+		return FrameArrayType.FP32;
+	}
+
+	@Override
+	public long getInMemorySize() {
+		long size = 16; // object header + object reference
+		size += MemoryEstimates.floatArrayCost(_data.length);
+		return size;
+	}
+
+	@Override
+	public long getExactSerializedSize() {
+		return 1 + 4 * _data.length;
+	}
+
+	@Override
+	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size-1; i++)
-			sb.append(_data[i]  + ",");
-		sb.append(_data[_size-1]);
+		for(int i = 0; i < _size - 1; i++)
+			sb.append(_data[i] + ",");
+		sb.append(_data[_size - 1]);
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.utils.MemoryEstimates;
 
 public class IntegerArray extends Array<Integer> {
-	private int[] _data = null;
+	private int[] _data;
 
 	public IntegerArray(int[] data) {
 		_data = data;
@@ -82,8 +84,9 @@ public class IntegerArray extends Array<Integer> {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		out.writeByte(FrameArrayType.INT32.ordinal());
 		for(int i = 0; i < _size; i++)
-			out.writeLong(_data[i]);
+			out.writeInt(_data[i]);
 	}
 
 	@Override
@@ -119,18 +122,35 @@ public class IntegerArray extends Array<Integer> {
 		return intBuffer.array();
 	}
 
-	@Override 
-	public ValueType getValueType(){
+	@Override
+	public ValueType getValueType() {
 		return ValueType.INT32;
 	}
 
 	@Override
-	public String toString(){
+	public FrameArrayType getFrameArrayType() {
+		return FrameArrayType.INT32;
+	}
+
+	@Override
+	public long getInMemorySize() {
+		long size = 16; // object header + object reference
+		size += MemoryEstimates.intArrayCost(_data.length);
+		return size;
+	}
+
+	@Override
+	public long getExactSerializedSize() {
+		return 1 + 4 * _data.length;
+	}
+
+	@Override
+	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size-1; i++)
-			sb.append(_data[i]  + ",");
-		sb.append(_data[_size-1]);
+		for(int i = 0; i < _size - 1; i++)
+			sb.append(_data[i] + ",");
+		sb.append(_data[_size - 1]);
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.utils.MemoryEstimates;
 
 public class LongArray extends Array<Long> {
-	private long[] _data = null;
+	private long[] _data;
 
 	public LongArray(long[] data) {
 		_data = data;
@@ -82,6 +84,7 @@ public class LongArray extends Array<Long> {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		out.writeByte(FrameArrayType.INT64.ordinal());
 		for(int i = 0; i < _size; i++)
 			out.writeLong(_data[i]);
 	}
@@ -119,18 +122,35 @@ public class LongArray extends Array<Long> {
 		return longBuffer.array();
 	}
 
-	@Override 
-	public ValueType getValueType(){
+	@Override
+	public ValueType getValueType() {
 		return ValueType.INT64;
 	}
 
 	@Override
-	public String toString(){
+	public FrameArrayType getFrameArrayType() {
+		return FrameArrayType.INT64;
+	}
+
+	@Override
+	public long getInMemorySize() {
+		long size = 16; // object header + object reference
+		size += MemoryEstimates.longArrayCost(_data.length);
+		return size;
+	}
+
+	@Override
+	public long getExactSerializedSize() {
+		return 1 + 8 * _data.length;
+	}
+
+	@Override
+	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size-1; i++)
-			sb.append(_data[i]  + ",");
-		sb.append(_data[_size-1]);
+		for(int i = 0; i < _size - 1; i++)
+			sb.append(_data[i] + ",");
+		sb.append(_data[_size - 1]);
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/DataGenCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/DataGenCPInstruction.java
@@ -299,7 +299,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 
 	@Override
 	public void processInstruction(ExecutionContext ec) {
-		CacheBlock out = null;
+		CacheBlock<?> out = null;
 		ScalarObject soresScalar = null;
 
 		// process specific datagen operator
@@ -390,8 +390,8 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			setCacheBlockOutput(ec, out);
 	}
 
-	private CacheBlock processRandInstruction(ExecutionContext ec) {
-		CacheBlock out;
+	private CacheBlock<?> processRandInstruction(ExecutionContext ec) {
+		CacheBlock<?> out;
 		long lSeed = generateSeed();
 
 		if(output.isTensor())
@@ -405,7 +405,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 		return out;
 	}
 
-	private CacheBlock processRandInstructionMatrix(ExecutionContext ec, long lSeed){
+	private CacheBlock<?> processRandInstructionMatrix(ExecutionContext ec, long lSeed){
 
 		long lrows = ec.getScalarInput(rows).getLongValue();
 		long lcols = ec.getScalarInput(cols).getLongValue();
@@ -426,9 +426,9 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			return MatrixBlock.randOperations(getGenerator(lrows, lcols), lSeed, numThreads);
 	}
 
-	private CacheBlock processRandInstructionTensor(ExecutionContext ec, long lSeed) {
+	private CacheBlock<?> processRandInstructionTensor(ExecutionContext ec, long lSeed) {
 		int[] tDims = DataConverter.getTensorDimensions(ec, dims);
-		CacheBlock out = new TensorBlock(output.getValueType(), tDims).allocateBlock();
+		CacheBlock<?> out = new TensorBlock(output.getValueType(), tDims).allocateBlock();
 		TensorBlock outT = (TensorBlock) out;
 		if(minValueStr.equals(maxValueStr)) {
 			if(minMaxAreDoubles)
@@ -477,7 +477,7 @@ public class DataGenCPInstruction extends UnaryCPInstruction {
 			pdfParams);
 	}
 
-	private void setCacheBlockOutput(ExecutionContext ec, CacheBlock out) {
+	private void setCacheBlockOutput(ExecutionContext ec, CacheBlock<?> out) {
 		if(output.isMatrix()) {
 			MatrixBlock outB = (MatrixBlock) out;
 			if(out.getInMemorySize() < OptimizerUtils.SAFE_REP_CHANGE_THRES)

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ParameterizedBuiltinCPInstruction.java
@@ -439,7 +439,7 @@ public class ParameterizedBuiltinCPInstruction extends ComputationCPInstruction 
 		}
 	}
 
-	private void warnOnTrunction(CacheBlock data, int rows, int cols) {
+	private void warnOnTrunction(CacheBlock<?> data, int rows, int cols) {
 		// warn on truncation because users might not be aware and use toString for verification
 		if((getParam("rows") == null && data.getNumRows() > rows) ||
 			(getParam("cols") == null && data.getNumColumns() > cols)) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -223,7 +223,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		List<Pair<FederatedRange, FederatedData>> feds = new ArrayList<>();
 
 		CacheableData<?> co = ec.getCacheableData(_localObject);
-		CacheBlock cb =  co.acquireReadAndRelease();
+		CacheBlock<?> cb =  co.acquireReadAndRelease();
 
 		if(addresses.getLength() * 2 != ranges.getLength())
 			throw new DMLRuntimeException("Federated read needs twice the amount of addresses as ranges "
@@ -248,7 +248,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 			throw new DMLRuntimeException("type \"" + type + "\" non valid federated type");
 
 		long[] usedDims = new long[] {0, 0};
-		CacheBlock[] cbs = new CacheBlock[addresses.getLength()];
+		CacheBlock<?>[] cbs = new CacheBlock<?>[addresses.getLength()];
 		for(int i = 0; i < addresses.getLength(); i++) {
 			Data addressData = addresses.getData().get(i);
 			if(addressData instanceof StringObject) {
@@ -282,7 +282,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 				usedDims[0] = Math.max(usedDims[0], endDims[0]);
 				usedDims[1] = Math.max(usedDims[1], endDims[1]);
 
-				CacheBlock slice = cb instanceof MatrixBlock ? ((MatrixBlock)cb).slice((int) beginDims[0], (int) endDims[0]-1, (int) beginDims[1], (int) endDims[1]-1, true) :
+				CacheBlock<?> slice = cb instanceof MatrixBlock ? ((MatrixBlock)cb).slice((int) beginDims[0], (int) endDims[0]-1, (int) beginDims[1], (int) endDims[1]-1, true) :
 					((FrameBlock)cb).slice((int) beginDims[0], (int) endDims[0]-1, (int) beginDims[1], (int) endDims[1]-1, true, new FrameBlock());
 				cbs[i] = slice;
 
@@ -393,7 +393,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		federateMatrix(output, workers, null);
 	}
 
-	public static void federateMatrix(CacheableData<?> output, List<Pair<FederatedRange, FederatedData>> workers, CacheBlock[] blocks) {
+	public static void federateMatrix(CacheableData<?> output, List<Pair<FederatedRange, FederatedData>> workers, CacheBlock<?>[] blocks) {
 
 		List<Pair<FederatedRange, FederatedData>> fedMapping = new ArrayList<>();
 		for(Pair<FederatedRange, FederatedData> e : workers)
@@ -455,7 +455,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		federateFrame(output, workers, null);
 	}
 
-	public static void federateFrame(FrameObject output, List<Pair<FederatedRange, FederatedData>> workers, CacheBlock[] blocks) {
+	public static void federateFrame(FrameObject output, List<Pair<FederatedRange, FederatedData>> workers, CacheBlock<?>[] blocks) {
 		List<Pair<FederatedRange, FederatedData>> fedMapping = new ArrayList<>();
 		for(Pair<FederatedRange, FederatedData> e : workers)
 			fedMapping.add(e);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/BroadcastObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/BroadcastObject.java
@@ -24,7 +24,7 @@ import java.lang.ref.SoftReference;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 
-public class BroadcastObject<T extends CacheBlock> extends LineageObject {
+public class BroadcastObject<T extends CacheBlock<?>> extends LineageObject {
 	//soft reference storage for graceful cleanup in case of memory pressure
 	private SoftReference<PartitionedBroadcast<T>> _pbcRef; // partitioned broadcast object reference
 	private SoftReference<Broadcast<T>> _npbcRef; // non partitioned broadcast object reference

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/PartitionedBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/PartitionedBlock.java
@@ -43,6 +43,7 @@ import org.apache.sysds.runtime.util.UtilFunctions;
  * variables which are shared by all tasks within an executor.  
  * 
  */
+@SuppressWarnings("rawtypes")
 public class PartitionedBlock<T extends CacheBlock> implements Externalizable
 {
 	private static final long serialVersionUID = 1298817743064415129L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/PartitionedBroadcast.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
  * Despite various jiras, this issue still showed up in Spark 2.1. 
  * 
  */
+@SuppressWarnings("rawtypes")
 public class PartitionedBroadcast<T extends CacheBlock> implements Serializable
 {
 	private static final long serialVersionUID = 7041959166079438401L;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -119,7 +119,7 @@ import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.NativeHelper;
 
 
-public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizable {
+public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>, Externalizable {
 	private static final Log LOG = LogFactory.getLog(MatrixBlock.class.getName());
 
 	private static final long serialVersionUID = 7319972089143154056L;
@@ -1781,11 +1781,6 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 		}
 	}
 
-	@Override
-	public void merge(CacheBlock that, boolean appendOnly) {
-		merge((MatrixBlock)that, appendOnly);
-	}
-
 	/**
 	 * Merge disjoint: merges all non-zero values of the given input into the current
 	 * matrix block. Note that this method does NOT check for overlapping entries;
@@ -1798,6 +1793,8 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 	 * @param that matrix block
 	 * @param appendOnly ?
 	 */
+
+	@Override
 	public void merge(MatrixBlock that, boolean appendOnly) {
 		merge(that, appendOnly, false, true);
 	}
@@ -4029,97 +4026,40 @@ public class MatrixBlock extends MatrixValue implements CacheBlock, Externalizab
 		return ret;
 	}
 
-	public MatrixBlock slice(IndexRange ixrange, MatrixBlock ret) {
+	@Override
+	public final MatrixBlock slice(IndexRange ixrange, MatrixBlock ret) {
 		return slice(
 			(int)ixrange.rowStart, (int)ixrange.rowEnd, 
 			(int)ixrange.colStart, (int)ixrange.colEnd, true, ret);
 	}
 	
-	/**
-	 * Slice out a block in the range
-	 * 
-	 * @param rl row lower (inclusive)
-	 * @param ru row upper (inclusive)
-	 * @return The sliced out matrix block.
-	 */
+	@Override
 	public final MatrixBlock slice(int rl, int ru) {
 		return slice(rl, ru, 0, clen-1, true, null);
 	}
 
-	/**
-	 * Slice out a block in the range
-	 * 
-	 * @param rl row lower (inclusive)
-	 * @param ru row upper (inclusive)
-	 * @param deep Deep copy or not
-	 * @return The sliced out matrix block.
-	 */
+	@Override
 	public final MatrixBlock slice(int rl, int ru, boolean deep){
 		return slice(rl,ru, 0, clen-1, deep, null);
 	}
-	
-	/**
-	 * Slice out a block in the range
-	 * 
-	 * @param rl row lower (inclusive)
-	 * @param ru row upper (inclusive)
-	 * @param cl column lower (inclusive)
-	 * @param cu column upper (inclusive)
-	 * @return The sliced out matrix block.
-	 */
+
+	@Override
 	public final MatrixBlock slice(int rl, int ru, int cl, int cu){
 		return slice(rl, ru, cl, cu, true, null);
 	}
 
-	/**
-	 * Slice out a block in the range
-	 * 
-	 * @param rl row lower (inclusive)
-	 * @param ru row upper (inclusive)
-	 * @param cl column lower (inclusive)
-	 * @param cu column upper (inclusive)
-	 * @param ret output sliced out matrix block
-	 * @return The sliced out matrix block.
-	 */
 	@Override
-	public final MatrixBlock slice(int rl, int ru, int cl, int cu, CacheBlock ret) {
+	public final MatrixBlock slice(int rl, int ru, int cl, int cu, MatrixBlock ret) {
 		return slice(rl, ru, cl, cu, true, ret);
 	}
 
-	/**
-	 * Slice out a block in the range
-	 * 
-	 * @param rl row lower (inclusive) 
-	 * @param ru row upper (inclusive) 
-	 * @param cl column lower (inclusive)
-	 * @param cu column upper (inclusive)
-	 * @param deep Deep copy or not
-	 * @return The sliced out matrix block.
-	 */
+	@Override
 	public final MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep){
 		return slice(rl, ru, cl, cu, deep, null);
 	}
 	
-	/**
-	 * Method to perform rightIndex operation for a given lower and upper bounds in row and column dimensions.
-	 * Extracted submatrix is returned as "result". Note: This operation is now 0-based.
-	 * 
-	 * This means that if you call with rl == ru then you get 1 row output.
-	 * 
-	 * If rl or cl less than 0 an exception is thrown
-	 * If ru or cu greater than or equals to nRows or nCols an exception is thrown
-	 * 
-	 * @param rl row lower (inclusive) 
-	 * @param ru row upper (inclusive) 
-	 * @param cl column lower (inclusive)
-	 * @param cu column upper (inclusive)
-	 * @param deep should perform deep copy, this is relevant in cases where the matrix is in sparse format,
-	 *            or the entire matrix is sliced out
-	 * @param ret output sliced out matrix block
-	 * @return matrix block output matrix block
-	 */
 	@Override
-	public MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep, CacheBlock ret) {
+	public MatrixBlock slice(int rl, int ru, int cl, int cu, boolean deep, MatrixBlock ret) {
 		validateSliceArgument(rl, ru, cl, cu);
 		
 		// Output matrix will have the same sparsity as that of the input matrix.

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -102,7 +102,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		if(!isApplicable())
 			return;
@@ -119,7 +119,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 			TransformStatistics.incBinningBuildTime(System.nanoTime()-t0);
 	}
 
-	public void build(CacheBlock in, double[] equiHeightMaxs) {
+	public void build(CacheBlock<?> in, double[] equiHeightMaxs) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		if(!isApplicable())
 			return;
@@ -135,7 +135,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 			TransformStatistics.incBinningBuildTime(System.nanoTime()-t0);
 	}
 
-	protected double getCode(CacheBlock in, int row){
+	protected double getCode(CacheBlock<?> in, int row){
 		// find the right bucket for a single row
 		double bin = 0;
 		if( _binMins.length == 0 || _binMaxs.length == 0 ) {
@@ -160,7 +160,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 	
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		// find the right bucket for a block of rows
 		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
 		double[] codes = new double[endInd-startInd];
@@ -194,7 +194,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		return TransformType.BIN;
 	}
 
-	private static double[] getMinMaxOfCol(CacheBlock in, int colID, int startRow, int blockSize) {
+	private static double[] getMinMaxOfCol(CacheBlock<?> in, int colID, int startRow, int blockSize) {
 		// derive bin boundaries from min/max per column
 		double min = Double.POSITIVE_INFINITY;
 		double max = Double.NEGATIVE_INFINITY;
@@ -208,7 +208,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		return new double[] {min, max};
 	}
 
-	private static double[] prepareDataForEqualHeightBins(CacheBlock in, int colID, int startRow, int blockSize) {
+	private static double[] prepareDataForEqualHeightBins(CacheBlock<?> in, int colID, int startRow, int blockSize) {
 		int endRow = getEndIndex(in.getNumRows(), startRow, blockSize);
 		double[] vals = new double[endRow-startRow];
 		for(int i = startRow; i < endRow; i++) {
@@ -224,12 +224,12 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	@Override
-	public Callable<Object> getBuildTask(CacheBlock in) {
+	public Callable<Object> getBuildTask(CacheBlock<?> in) {
 		return new ColumnBinBuildTask(this, in);
 	}
 
 	@Override
-	public Callable<Object> getPartialBuildTask(CacheBlock in, int startRow, int blockSize,
+	public Callable<Object> getPartialBuildTask(CacheBlock<?> in, int startRow, int blockSize,
 			HashMap<Integer, Object> ret) {
 		return new BinPartialBuildTask(in, _colID, startRow, blockSize, _binMethod, ret);
 	}
@@ -290,7 +290,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new BinSparseApplyTask(this, in, out, outputCol);
 	}
 
@@ -393,12 +393,12 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class BinSparseApplyTask extends ColumnApplyTask<ColumnEncoderBin> {
 
-		public BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock input,
+		public BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock<?> input,
 				MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
-		private BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock input, MatrixBlock out, int outputCol) {
+		private BinSparseApplyTask(ColumnEncoderBin encoder, CacheBlock<?> input, MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
@@ -420,7 +420,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class BinPartialBuildTask implements Callable<Object> {
 
-		private final CacheBlock _input;
+		private final CacheBlock<?> _input;
 		private final int _blockSize;
 		private final int _startRow;
 		private final int _colID;
@@ -428,7 +428,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		private final HashMap<Integer, Object> _partialData;
 
 		// if a pool is passed the task may be split up into multiple smaller tasks.
-		protected BinPartialBuildTask(CacheBlock input, int colID, int startRow, 
+		protected BinPartialBuildTask(CacheBlock<?> input, int colID, int startRow, 
 				int blocksize, BinMethod method, HashMap<Integer, Object> partialData) {
 			_input = input;
 			_blockSize = blocksize;
@@ -552,9 +552,9 @@ public class ColumnEncoderBin extends ColumnEncoder {
 
 	private static class ColumnBinBuildTask implements Callable<Object> {
 		private final ColumnEncoderBin _encoder;
-		private final CacheBlock _input;
+		private final CacheBlock<?> _input;
 
-		protected ColumnBinBuildTask(ColumnEncoderBin encoder, CacheBlock input) {
+		protected ColumnBinBuildTask(ColumnEncoderBin encoder, CacheBlock<?> input) {
 			_encoder = encoder;
 			_input = input;
 		}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
@@ -100,13 +100,13 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		for(ColumnEncoder columnEncoder : _columnEncoders)
 			columnEncoder.build(in);
 	}
 
 	@Override
-	public void build(CacheBlock in, Map<Integer, double[]> equiHeightMaxs) {
+	public void build(CacheBlock<?> in, Map<Integer, double[]> equiHeightMaxs) {
 		for(ColumnEncoder columnEncoder : _columnEncoders)
 			if(columnEncoder instanceof ColumnEncoderBin && ((ColumnEncoderBin) columnEncoder).getBinMethod() == ColumnEncoderBin.BinMethod.EQUI_HEIGHT) {
 				columnEncoder.build(in, equiHeightMaxs.get(columnEncoder.getColID()));
@@ -116,7 +116,7 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	}
 
 	@Override
-	public List<DependencyTask<?>> getApplyTasks(CacheBlock in, MatrixBlock out, int outputCol) {
+	public List<DependencyTask<?>> getApplyTasks(CacheBlock<?> in, MatrixBlock out, int outputCol) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		List<Integer> sizes = new ArrayList<>();
 		for(int i = 0; i < _columnEncoders.size(); i++) {
@@ -148,12 +148,12 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		throw new NotImplementedException();
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock<?> in) {
 		List<DependencyTask<?>> tasks = new ArrayList<>();
 		Map<Integer[], Integer[]> depMap = null;
 		for(ColumnEncoder columnEncoder : _columnEncoders) {
@@ -199,7 +199,7 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	}
 
 	@Override
-	public MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
+	public MatrixBlock apply(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk) {
 		try {
 			for(int i = 0; i < _columnEncoders.size(); i++) {
 				if(i == 0) {
@@ -219,12 +219,12 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 	}
 
 	@Override
-	protected double getCode(CacheBlock in, int row) {
+	protected double getCode(CacheBlock<?> in, int row) {
 		throw new DMLRuntimeException("CompositeEncoder does not have a Code");
 	}
 
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		throw new DMLRuntimeException("CompositeEncoder does not have a Code");
 	}
 
@@ -373,7 +373,7 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 		return false;
 	}
 
-	public void computeRCDMapSizeEstimate(CacheBlock in, int[] sampleIndices) {
+	public void computeRCDMapSizeEstimate(CacheBlock<?> in, int[] sampleIndices) {
 		int estNumDist = 0;
 		for (ColumnEncoder e : _columnEncoders)
 			if (e.getClass().equals(ColumnEncoderRecode.class)) {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -60,26 +60,26 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		// do nothing
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock<?> in) {
 		return null;
 	}
 
 	@Override
-	protected double getCode(CacheBlock in, int row) {
+	protected double getCode(CacheBlock<?> in, int row) {
 		throw new DMLRuntimeException("DummyCoder does not have a code");
 	}
 
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		throw new DMLRuntimeException("DummyCoder does not have a code");
 	}
 
-	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+	protected void applySparse(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		if (!(in instanceof MatrixBlock)){
 			throw new DMLRuntimeException("ColumnEncoderDummycode called with: " + in.getClass().getSimpleName() +
 					" and not MatrixBlock");
@@ -139,7 +139,7 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 		}
 	}
 
-	protected void applyDense(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+	protected void applyDense(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		if (!(in instanceof MatrixBlock)){
 			throw new DMLRuntimeException("ColumnEncoderDummycode called with: " + in.getClass().getSimpleName() +
 					" and not MatrixBlock");
@@ -171,7 +171,7 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		if (!(in instanceof MatrixBlock)){
 			throw new DMLRuntimeException("ColumnEncoderDummycode called with: " + in.getClass().getSimpleName() +
 					" and not MatrixBlock");

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderFeatureHash.java
@@ -65,7 +65,7 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 	}
 
 	@Override
-	protected double getCode(CacheBlock in, int row) {
+	protected double getCode(CacheBlock<?> in, int row) {
 		// hash a single row
 		String key = in.getString(row, _colID - 1);
 		if(key == null)
@@ -73,7 +73,7 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 		return (key.hashCode() % _K) + 1;
 	}
 
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		// hash a block of rows
 		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
 		double codes[] = new double[endInd-startInd];
@@ -94,18 +94,18 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		// do nothing (no meta data other than K)
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock<?> in) {
 		return null;
 	}
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new FeatureHashSparseApplyTask(this, in, out, outputCol, startRow, blk);
 	}
 
@@ -157,12 +157,12 @@ public class ColumnEncoderFeatureHash extends ColumnEncoder {
 
 	public static class FeatureHashSparseApplyTask extends ColumnApplyTask<ColumnEncoderFeatureHash>{
 
-		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock input,
+		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock<?> input,
 				MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 
-		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock input,
+		public FeatureHashSparseApplyTask(ColumnEncoderFeatureHash encoder, CacheBlock<?> input,
 				MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -46,28 +46,28 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		// do nothing
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock<?> in) {
 		return null;
 	}
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder>
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk) {
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk) {
 		return new PassThroughSparseApplyTask(this, in, out, outputCol, startRow, blk);
 	}
 
 	@Override
-	protected double getCode(CacheBlock in, int row) {
+	protected double getCode(CacheBlock<?> in, int row) {
 		return in.getDoubleNaN(row, _colID - 1);
 	}
 
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
 		double[] codes = new double[endInd-startInd];
 		for (int i=startInd; i<endInd; i++) {
@@ -76,7 +76,7 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 		return codes;
 	}
 
-	protected void applySparse(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk){
+	protected void applySparse(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk){
 		//Set<Integer> sparseRowsWZeros = null;
 		ArrayList<Integer> sparseRowsWZeros = null;
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
@@ -148,13 +148,13 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 	public static class PassThroughSparseApplyTask extends ColumnApplyTask<ColumnEncoderPassThrough>{
 
 
-		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, CacheBlock input,
+		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, CacheBlock<?> input,
 				MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
 		protected PassThroughSparseApplyTask(ColumnEncoderPassThrough encoder, 
-				CacheBlock input, MatrixBlock out, int outputCol, int startRow, int blk) {
+				CacheBlock<?> input, MatrixBlock out, int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderRecode.java
@@ -113,7 +113,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 			putCode(map, key);
 	}
 
-	private static void makeRcdMap(CacheBlock in, HashMap<String, Long> map, int colID, int startRow, int blk) {
+	private static void makeRcdMap(CacheBlock<?> in, HashMap<String, Long> map, int colID, int startRow, int blk) {
 		for(int row = startRow; row < getEndIndex(in.getNumRows(), startRow, blk); row++){
 			String key = in.getString(row, colID - 1);
 			if(key != null && !key.isEmpty() && !map.containsKey(key))
@@ -129,7 +129,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 		return (tmp != null) ? tmp : -1;
 	}
 
-	public void computeRCDMapSizeEstimate(CacheBlock in, int[] sampleIndices) {
+	public void computeRCDMapSizeEstimate(CacheBlock<?> in, int[] sampleIndices) {
 		if (getEstMetaSize() != 0)
 			return;
 
@@ -170,7 +170,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		if(!isApplicable())
 			return;
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
@@ -181,12 +181,12 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	}
 
 	@Override
-	public Callable<Object> getBuildTask(CacheBlock in) {
+	public Callable<Object> getBuildTask(CacheBlock<?> in) {
 		return new ColumnRecodeBuildTask(this, in);
 	}
 
 	@Override
-	public Callable<Object> getPartialBuildTask(CacheBlock in, int startRow, 
+	public Callable<Object> getPartialBuildTask(CacheBlock<?> in, int startRow, 
 			int blockSize, HashMap<Integer, Object> ret) {
 		return new RecodePartialBuildTask(in, _colID, startRow, blockSize, ret);
 	}
@@ -206,7 +206,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 		map.put(key, (long) (map.size() + 1));
 	}
 
-	protected double getCode(CacheBlock in, int r){
+	protected double getCode(CacheBlock<?> in, int r){
 		// lookup for a single row
 		Object okey = in.getString(r, _colID - 1);
 		String key = (okey != null) ? okey.toString() : null;
@@ -217,7 +217,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	}
 	
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		// lookup for a block of rows
 		int endInd = getEndIndex(in.getNumRows(), startInd, blkSize);
 		double codes[] = new double[endInd-startInd];
@@ -257,7 +257,7 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 
 	@Override
 	protected ColumnApplyTask<? extends ColumnEncoder> 
-		getSparseTask(CacheBlock in, MatrixBlock out, int outputCol, int startRow, int blk){
+		getSparseTask(CacheBlock<?> in, MatrixBlock out, int outputCol, int startRow, int blk){
 		return new RecodeSparseApplyTask(this, in ,out, outputCol, startRow, blk);
 	}
 
@@ -368,11 +368,11 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 
 	private static class RecodeSparseApplyTask extends ColumnApplyTask<ColumnEncoderRecode>{
 
-		public RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock input, MatrixBlock out, int outputCol) {
+		public RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock<?> input, MatrixBlock out, int outputCol) {
 			super(encoder, input, out, outputCol);
 		}
 
-		protected RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock input, MatrixBlock out,
+		protected RecodeSparseApplyTask(ColumnEncoderRecode encoder, CacheBlock<?> input, MatrixBlock out,
 										int outputCol, int startRow, int blk) {
 			super(encoder, input, out, outputCol, startRow, blk);
 		}
@@ -400,13 +400,13 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 
 	private static class RecodePartialBuildTask implements Callable<Object> {
 
-		private final CacheBlock _input;
+		private final CacheBlock<?> _input;
 		private final int _blockSize;
 		private final int _startRow;
 		private final int _colID;
 		private final HashMap<Integer, Object> _partialMaps;
 
-		protected RecodePartialBuildTask(CacheBlock input, int colID, int startRow, 
+		protected RecodePartialBuildTask(CacheBlock<?> input, int colID, int startRow, 
 				int blocksize, HashMap<Integer, Object> partialMaps) {
 			_input = input;
 			_blockSize = blocksize;
@@ -472,9 +472,9 @@ public class ColumnEncoderRecode extends ColumnEncoder {
 	private static class ColumnRecodeBuildTask implements Callable<Object> {
 
 		private final ColumnEncoderRecode _encoder;
-		private final CacheBlock _input;
+		private final CacheBlock<?> _input;
 
-		protected ColumnRecodeBuildTask(ColumnEncoderRecode encoder, CacheBlock input) {
+		protected ColumnRecodeBuildTask(ColumnEncoderRecode encoder, CacheBlock<?> input) {
 			_encoder = encoder;
 			_input = input;
 		}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderUDF.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderUDF.java
@@ -64,17 +64,17 @@ public class ColumnEncoderUDF extends ColumnEncoder {
 	}
 
 	@Override
-	public void build(CacheBlock in) {
+	public void build(CacheBlock<?> in) {
 		// do nothing
 	}
 
 	@Override
-	public List<DependencyTask<?>> getBuildTasks(CacheBlock in) {
+	public List<DependencyTask<?>> getBuildTasks(CacheBlock<?> in) {
 		return null;
 	}
 	
 	@Override
-	public void applyDense(CacheBlock in, MatrixBlock out, int outputCol, int rowStart, int blk) {
+	public void applyDense(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk) {
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		//create execution context and input
 		ExecutionContext ec = ExecutionContextFactory.createContext(new Program(new DMLProgram()));
@@ -126,7 +126,7 @@ public class ColumnEncoderUDF extends ColumnEncoder {
 	}
 	
 	@Override
-	protected ColumnApplyTask<ColumnEncoderUDF> getSparseTask(CacheBlock in,
+	protected ColumnApplyTask<ColumnEncoderUDF> getSparseTask(CacheBlock<?> in,
 		MatrixBlock out, int outputCol, int startRow, int blk)
 	{
 		throw new DMLRuntimeException("UDF encoders do not support sparse tasks.");
@@ -157,12 +157,12 @@ public class ColumnEncoderUDF extends ColumnEncoder {
 	}
 
 	@Override
-	protected double getCode(CacheBlock in, int row) {
+	protected double getCode(CacheBlock<?> in, int row) {
 		throw new DMLRuntimeException("UDF encoders only support full column access.");
 	}
 
 	@Override
-	protected double[] getCodeCol(CacheBlock in, int startInd, int blkSize) {
+	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int blkSize) {
 		throw new DMLRuntimeException("UDF encoders only support full column access.");
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/Encoder.java
@@ -36,7 +36,7 @@ public interface Encoder extends Externalizable {
 	 *
 	 * @param in input frame block
 	 */
-	void build(CacheBlock in);
+	void build(CacheBlock<?> in);
 
 	/**
 	 * Apply the generated metadata to the FrameBlock and saved the result in out.
@@ -46,7 +46,7 @@ public interface Encoder extends Externalizable {
 	 * @param outputCol is a offset in the output matrix. column in FrameBlock + outputCol = column in out
 	 * @return output matrix block
 	 */
-	MatrixBlock apply(CacheBlock in, MatrixBlock out, int outputCol);
+	MatrixBlock apply(CacheBlock<?> in, MatrixBlock out, int outputCol);
 	
 	/** 
 	 * Pre-allocate a FrameBlock for metadata collection.

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderMVImpute.java
@@ -260,7 +260,10 @@ public class EncoderMVImpute extends LegacyEncoder {
 
 		if(_rcList == null)
 			_rcList = new ArrayList<>();
-		List<Integer> rcList = _rcList.stream().filter(ixRange::inColRange).map(i -> (int) (i - (ixRange.colStart - 1)))
+		 
+		List<Integer> rcList = _rcList.stream() //
+			.filter((x) -> ixRange.inColRange((long)x)) //
+			.map(i -> (int) (i - (ixRange.colStart - 1))) //
 			.collect(Collectors.toList());
 
 		return new EncoderMVImpute(colList, mvMethodList, replacementList, meanList, countList, rcList,

--- a/src/main/java/org/apache/sysds/runtime/transform/tokenize/Tokenizer.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/tokenize/Tokenizer.java
@@ -102,7 +102,8 @@ public class Tokenizer implements Serializable {
 			LOG.debug("Tokenizing with full DAG on " + k + " Threads");
 			try {
 				List<DependencyTask<?>> tokenizeTasks = getTokenizeTasks(in, out, pool);
-				int lastRow = pool.submitAllAndWait(tokenizeTasks).stream().map(s -> s == null? 0 :(Integer)s).max(Integer::compare).get();
+				int lastRow = pool.submitAllAndWait(tokenizeTasks).stream()//
+					.map(s -> s == null? 0 :(Integer)s).max((x,y) -> Integer.compare(x, y)).get();
 				if(lastRow != out.getNumRows()){
 					out = out.slice(0, lastRow - 1, 0, out.getNumColumns() - 1, null);
 				}
@@ -165,7 +166,8 @@ public class Tokenizer implements Serializable {
 			DependencyThreadPool pool = new DependencyThreadPool(k);
 			try{
 				List<DependencyTask<?>> taskList = tokenizerApplier.getApplyTasks(this.internalRepresentation, out);
-				lastRow = pool.submitAllAndWait(taskList).stream().map(s -> (Integer)s).max(Integer::compare).get();
+				lastRow = pool.submitAllAndWait(taskList)//
+					.stream().map(x -> (Integer) x).max((x,y) -> Integer.compare(x, y)).get();
 			}
 			catch(ExecutionException | InterruptedException e) {
 				LOG.error("MT Tokenizer apply failed");

--- a/src/main/java/org/apache/sysds/runtime/util/EMAUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/util/EMAUtils.java
@@ -20,11 +20,12 @@
 
 package org.apache.sysds.runtime.util;
 
-import org.apache.sysds.common.Types;
-import org.apache.sysds.runtime.frame.data.FrameBlock;
+import java.util.ArrayList;
+import java.util.Random;
 
-import java.util.*;
-import java.lang.Math;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
 
 
 class LinearRegression {
@@ -102,7 +103,9 @@ public class EMAUtils {
 					lst = triple_exponential_smoothing(data, alpha, beta, gamma, freq);
 				}
 
-				if (i == 0 || lst.rsme < best_cont.rsme) {
+				if(lst == null)
+					throw new DMLRuntimeException("invalid null pointer");
+				else if (i == 0 || lst.rsme < best_cont.rsme) {
 					best_cont = lst;
 					data_list.add(best_cont.values);
 				}

--- a/src/main/java/org/apache/sysds/runtime/util/LocalFileUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/util/LocalFileUtils.java
@@ -109,8 +109,8 @@ public class LocalFileUtils
 	 * @return cache block (common interface to MatrixBlock and FrameBlock)
 	 * @throws IOException if IOException occurs
 	 */
-	public static CacheBlock readCacheBlockFromLocal(String fname, boolean matrix) throws IOException {
-		return (CacheBlock) readWritableFromLocal(fname, matrix?new MatrixBlock():new FrameBlock());
+	public static CacheBlock<?> readCacheBlockFromLocal(String fname, boolean matrix) throws IOException {
+		return (CacheBlock<?>) readWritableFromLocal(fname, matrix?new MatrixBlock():new FrameBlock());
 	}
 	
 	/**
@@ -216,7 +216,7 @@ public class LocalFileUtils
 	 * @param cb cache block (common interface to matrix block and frame block)
 	 * @throws IOException if IOException occurs
 	 */
-	public static void writeCacheBlockToLocal(String fname, CacheBlock cb) throws IOException {
+	public static void writeCacheBlockToLocal(String fname, CacheBlock<?> cb) throws IOException {
 		writeWritableToLocal(fname, cb);
 	}
 	

--- a/src/main/java/org/apache/sysds/utils/Explain.java
+++ b/src/main/java/org/apache/sysds/utils/Explain.java
@@ -849,7 +849,7 @@ public class Explain
 				inst instanceof FEDInstruction )
 			tmp = inst.toString();
 
-		if( REPLACE_SPECIAL_CHARACTERS ){
+		if( REPLACE_SPECIAL_CHARACTERS && tmp != null){
 			tmp = tmp.replaceAll(Lop.OPERAND_DELIMITOR, " ");
 			tmp = tmp.replaceAll(Lop.DATATYPE_PREFIX, ".");
 			tmp = tmp.replaceAll(Lop.INSTRUCTION_DELIMITOR, ", ");

--- a/src/main/java/org/apache/sysds/utils/MemoryEstimates.java
+++ b/src/main/java/org/apache/sysds/utils/MemoryEstimates.java
@@ -37,8 +37,8 @@ public class MemoryEstimates {
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static long bitSetCost(int length) {
-		long size = 0;
+	public static double bitSetCost(long length) {
+		double size = 0;
 		size += 8; // object reference
 		size += longArrayCost(length / 64 + (length % 64 > 0 ? 1 : 0));
 		size += 4; // words in Use
@@ -48,12 +48,24 @@ public class MemoryEstimates {
 	}
 
 	/**
+	 * Get the worst case memory usage of an array of booleans.
+	 * 
+	 * Unfortunately in java booleans are allocated as bytes.
+	 * 
+	 * @param length The length of the array.
+	 * @return The memory estimate in bytes.
+	 */
+	public static double booleanArrayCost(long length) {
+		return byteArrayCost(length);
+	}
+
+	/**
 	 * Get the worst case memory usage of an array of bytes.
 	 * 
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static long byteArrayCost(int length) {
+	public static double byteArrayCost(long length) {
 		long size = 0;
 		size += 8; // Byte array Reference
 		size += 20; // Byte array Object header
@@ -62,7 +74,7 @@ public class MemoryEstimates {
 		}
 		else { // byte array pads to next 8 bytes after the first 4.
 			size += length;
-			int diff = (length - 4) % 8;
+			double diff = (length - 4) % 8;
 			if(diff > 0) {
 				size += 8 - diff;
 			}
@@ -76,8 +88,8 @@ public class MemoryEstimates {
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static long charArrayCost(int length) {
-		long size = 0;
+	public static double charArrayCost(long length) {
+		double size = 0;
 		size += 8; // char array Reference
 		size += 20; // char array Object header
 		if(length <= 2) { // char array fills out the first 2 chars differently than the later bytes.
@@ -85,7 +97,7 @@ public class MemoryEstimates {
 		}
 		else {
 			size += length * 2;// 2 bytes per char
-			int diff = (length * 2 - 4) % 8;
+			double diff = (length * 2 - 4) % 8;
 			if(diff > 0) {
 				size += 8 - diff; // next object alignment
 			}
@@ -108,11 +120,21 @@ public class MemoryEstimates {
 		}
 		else {
 			size += 4d * length; // offsets 4 bytes per int
-			if(length % 2 == 0) {
+			if(length % 2 == 0)
 				size += 4;
-			}
 		}
 		return size;
+	}
+
+	/**
+	 * Get the worst case memory usage of an array of integers.
+	 * 
+	 * @param length The length of the array.
+	 * @return The memory estimate in bytes.
+	 */
+	public static double floatArrayCost(long length) {
+		// exact same size as intArrayCost
+		return intArrayCost(length);
 	}
 
 	/**
@@ -121,7 +143,7 @@ public class MemoryEstimates {
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static double doubleArrayCost(long length) {
+	public static final double doubleArrayCost(long length) {
 		double size = 0;
 		size += 8; // _values double array reference
 		size += 20; // double array object header
@@ -133,14 +155,16 @@ public class MemoryEstimates {
 	/**
 	 * Get the worst case memory usage for an array of objects.
 	 * 
+	 * Note this does not take into account each objects allocated variables, just the objects themselves.
+	 * 
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static double objectArrayCost(long length) {
+	public static final double objectArrayCost(long length) {
 		double size = 0;
-		size += 8; // reference to array
-		size += 20; // header
-		size += 4; // padding before first reference
+		size += 8d; // reference to array
+		size += 20d; // header
+		size += 4d; // padding before first reference
 		size += 8d * length; // references to all objects.
 		return size;
 	}
@@ -151,8 +175,49 @@ public class MemoryEstimates {
 	 * @param length The length of the array.
 	 * @return The memory estimate in bytes
 	 */
-	public static double longArrayCost(int length) {
-		return doubleArrayCost(length);
+	public static final double longArrayCost(long length) {
 		// exactly the same size as a double array
+		return doubleArrayCost(length);
 	}
+
+	/**
+	 * Get the worst case memory usage of an array containing strings.
+	 * 
+	 * In case anyone is wondering ... strings are expensive.
+	 * 
+	 * @param strings The strings array.
+	 * @return The array memory cost
+	 */
+	public static final double stringArrayCost(String[] strings) {
+		double size = 0;
+		for(int i = 0; i < strings.length; i++)
+			size += stringCost(strings[i]);
+		return size;
+	}
+
+	/**
+	 * Get the worst case memory usage of a single string.
+	 * 
+	 * In case anyone is wondering ... strings are expensive.
+	 * 
+	 * @param value The String to measure
+	 * @return The size in memory.
+	 */
+	public static double stringCost(String value) {
+		return value == null ? 16 + 8 : stringCost(value.length()); // char array
+	}
+
+	/**
+	 * Get the worst case memory usage of a single string, assuming given length.
+	 * 
+	 * @param length The length of the string
+	 * @return The size in memory
+	 */
+	public static double stringCost(int length) {
+		return 16 // object
+			+ 4 // hash
+			+ 8 // array ref
+			+ 32 + length; // char array
+	}
+
 }

--- a/src/main/python/systemds/utils/converters.py
+++ b/src/main/python/systemds/utils/converters.py
@@ -142,29 +142,31 @@ def frame_block_to_pandas(sds: "SystemDSContext", fb: JavaObject):
     df = pd.DataFrame()
 
     for c_index in range(num_cols):
-        d_type = fb.getColumnType(c_index)
-        if d_type == "String":
+        col_array = fb.getColumn(c_index);
+
+        d_type = col_array.getFrameArrayType().toString()
+        if d_type == "STRING":
             ret = []
             for row in range(num_rows):
-                ent = fb.getIndexAsBytes(c_index, row)
+                ent = col_array.getIndexAsBytes(row)
                 if ent:
                     ent = ent.decode()
                     ret.append(ent)
                 else:
                     ret.append(None)
-        elif d_type == "Int":
-            byteArray = fb.getColumnAsBytes(c_index)
+        elif d_type == "INT32":
+            byteArray = fb.getColumn(c_index).getAsByteArray(num_rows)
             ret = np.frombuffer(byteArray, dtype=np.int32)
-        elif d_type == "Long":
-            byteArray = fb.getColumnAsBytes(c_index)
+        elif d_type == "INT64":
+            byteArray = fb.getColumn(c_index).getAsByteArray(num_rows)
             ret = np.frombuffer(byteArray, dtype=np.int64)
-        elif d_type == "Double":
-            byteArray = fb.getColumnAsBytes(c_index)
+        elif d_type == "FP64":
+            byteArray = fb.getColumn(c_index).getAsByteArray(num_rows)
             ret = np.frombuffer(byteArray, dtype=np.float64)
-        elif d_type == "Boolean":
+        elif d_type == "BOOLEAN":
             # TODO maybe it is more efficient to bit pack the booleans.
             # https://stackoverflow.com/questions/5602155/numpy-boolean-array-with-1-bit-entries
-            byteArray = fb.getColumnAsBytes(c_index)
+            byteArray = fb.getColumn(c_index).getAsByteArray(num_rows)
             ret = np.frombuffer(byteArray, dtype=np.dtype("?"))
         else:
             raise NotImplementedError(

--- a/src/test/java/org/apache/sysds/test/component/compress/mapping/MappingTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/mapping/MappingTests.java
@@ -75,9 +75,12 @@ public class MappingTests {
 			tests.add(new Object[] {5, t, 64 + 63, false});
 			tests.add(new Object[] {5, t, 127, false});
 			tests.add(new Object[] {5, t, 128, false});
+			tests.add(new Object[] {4, t, 128, false});
+			tests.add(new Object[] {3, t, 128, false});
 			tests.add(new Object[] {5, t, 129, false});
 			tests.add(new Object[] {7, t, 255, false});
 			tests.add(new Object[] {8, t, 256, false});
+			tests.add(new Object[] {8, t, 257, false});
 			tests.add(new Object[] {5, t, 1234, false});
 			tests.add(new Object[] {5, t, 13, true});
 		}

--- a/src/test/java/org/apache/sysds/test/component/frame/array/ColumnMetadataTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/ColumnMetadataTests.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.frame.array;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.sysds.runtime.frame.data.columns.ColumnMetadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class ColumnMetadataTests {
+
+	public ColumnMetadata d;
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		ArrayList<Object[]> tests = new ArrayList<>();
+
+		try {
+			tests.add(new Object[] {new ColumnMetadata()});
+			tests.add(new Object[] {new ColumnMetadata(3241)});
+			tests.add(new Object[] {new ColumnMetadata(32)});
+			tests.add(new Object[] {new ColumnMetadata(32L, "")});
+			tests.add(new Object[] {new ColumnMetadata(-1, "")});
+			tests.add(new Object[] {new ColumnMetadata(-1, "131")});
+			tests.add(new Object[] {new ColumnMetadata(32, "Hi")});
+			tests.add(new Object[] {new ColumnMetadata(32L, "something")});
+			tests.add(new Object[] {new ColumnMetadata(32, null)});
+			tests.add(new Object[] {new ColumnMetadata(new ColumnMetadata(32, null))});
+			tests.add(new Object[] {new ColumnMetadata(new ColumnMetadata())});
+			tests.add(new Object[] {new ColumnMetadata(new ColumnMetadata(333))});
+			tests.add(new Object[] {new ColumnMetadata(new ColumnMetadata(3, "others"))});
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("failed constructing tests");
+		}
+
+		return tests;
+	}
+
+	public ColumnMetadataTests(ColumnMetadata d) {
+		this.d = d;
+
+	}
+
+	@Test
+	public void copyConstructor() {
+		assertTrue(d.equals(new ColumnMetadata(d)));
+	}
+
+	@Test
+	public void notEquals_1() {
+		ColumnMetadata b = new ColumnMetadata(d);
+		b.setNumDistinct(b.getNumDistinct() + 132415L);
+		assertFalse(d.equals(b));
+	}
+
+	@Test
+	public void notEquals_2() {
+		if(d.getMvValue() != null && !d.getMvValue().equals("")) {
+			ColumnMetadata b = new ColumnMetadata(d);
+			b.setMvValue("");
+			assertFalse(d.equals(b));
+		}
+	}
+
+	@Test
+	public void notEquals_3() {
+		try {
+			if(d.getMvValue() == null || !d.getMvValue().equals("a")) {
+				ColumnMetadata b = new ColumnMetadata(d);
+				b.setMvValue("a");
+				assertFalse(d.equals(b));
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void equalsObject() {
+		assertTrue(d.equals((Object) new ColumnMetadata(d)));
+		assertFalse(d.equals(1324));
+	}
+
+	@Test
+	public void getSetDistinct() {
+		ColumnMetadata dd = new ColumnMetadata(d);
+		long before = dd.getNumDistinct();
+		long set = 12355555L + before;
+		dd.setNumDistinct(12355555L + before);
+		long after = dd.getNumDistinct();
+		assertTrue(after == set);
+	}
+
+	@Test
+	public void getSetDistinctNegative() {
+		ColumnMetadata dd = new ColumnMetadata(d);
+		dd.setNumDistinct(-1324142L);
+		long after = dd.getNumDistinct();
+		assertTrue(after == -1);
+	}
+
+	@Test
+	public void getSetMyValue() {
+		ColumnMetadata dd = new ColumnMetadata(d);
+		String before = dd.getMvValue();
+		String set = 12355555L + before;
+		dd.setMvValue(12355555L + before);
+		String after = dd.getMvValue();
+		assertTrue(after.equals(set));
+	}
+
+	@Test
+	public void getSetEmptyMyValue() {
+		ColumnMetadata dd = new ColumnMetadata(d);
+		String before = dd.getMvValue();
+		String set = 12355555L + before;
+		dd.setMvValue(12355555L + before);
+		String after = dd.getMvValue();
+		assertTrue(after.equals(set));
+	}
+
+	@Test
+	public void toStringTest() {
+		// just verify we can get a string
+		d.toString();
+	}
+
+	@Test
+	public void testGetInMemorySize() {
+		ColumnMetadata dd = new ColumnMetadata(d);
+		long m = dd.getInMemorySize();
+		dd.setMvValue(d.getMvValue() + "HHH");
+		long m2 = dd.getInMemorySize();
+		assertTrue(16 < m);
+		assertTrue(m < m2);
+	}
+
+	@Test
+	public void isDefault() {
+		assertTrue(new ColumnMetadata().isDefault());
+		if(d.getNumDistinct() > 0)
+			assertFalse(d.isDefault());
+	}
+
+	@Test
+	public void serialize() {
+		assertTrue(d.equals(serializeAndBack(d)));
+	}
+
+	public static ColumnMetadata serializeAndBack(ColumnMetadata a) {
+		try {
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			DataOutputStream fos = new DataOutputStream(bos);
+			a.write(fos);
+			DataInputStream fis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+			return ColumnMetadata.read(fis);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("Error in io", e);
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.frame.array;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.columns.Array;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.frame.data.columns.StringArray;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class FrameArrayTests {
+
+	public Array<?> a;
+	public StringArray s;
+	public FrameArrayType t;
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		ArrayList<Object[]> tests = new ArrayList<>();
+
+		try {
+			for(FrameArrayType t : FrameArrayType.values()) {
+				tests.add(new Object[] {create(t, 1, 2), t});
+				tests.add(new Object[] {create(t, 10, 52), t});
+				tests.add(new Object[] {create(t, 80, 22), t});
+			}
+			tests.add(new Object[] {ArrayFactory.create(new String[] {"a", "b", "c"}), FrameArrayType.STRING});
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("failed constructing tests");
+		}
+
+		return tests;
+	}
+
+	public FrameArrayTests(Array<?> a, FrameArrayType t) {
+		try {
+
+			this.a = a;
+			this.t = t;
+			this.s = toStringArray(a);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("Failed initializing Frame Test");
+		}
+	}
+
+	@Test
+	public void serialize() {
+		compare(a, serializeAndBack(a));
+	}
+
+	@Test
+	public void testGet() {
+		int size = a.size();
+		for(int i = 0; i < size; i++)
+			assumeTrue(a.get(i).toString().equals(s.get(i)));
+	}
+
+	@Test(expected = ArrayIndexOutOfBoundsException.class)
+	public void testGetOutOfBoundsUpper() {
+		a.get(a.size());
+	}
+
+	@Test(expected = ArrayIndexOutOfBoundsException.class)
+	public void testGetOutOfBoundsLower() {
+		a.get(-1);
+	}
+
+	@Test
+	public void getSizeEstimateVsReal() {
+		assumeTrue(a.getInMemorySize() <= ArrayFactory.getInMemorySize(a.getValueType(), a.size()));
+	}
+
+	protected static void compare(Array<?> a, Array<?> b) {
+		int size = a.size();
+		for(int i = 0; i < size; i++)
+			assumeTrue(a.get(i).toString().equals(b.get(i).toString()));
+	}
+
+	protected static Array<?> serializeAndBack(Array<?> g) {
+		try {
+			int nRow = g.size();
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			DataOutputStream fos = new DataOutputStream(bos);
+			g.write(fos);
+			DataInputStream fis = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
+			return ArrayFactory.read(fis, nRow);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("Error in io", e);
+		}
+	}
+
+	protected static Array<?> create(FrameArrayType t, int size, int seed) {
+		switch(t) {
+			case STRING:
+				return ArrayFactory.create(generateRandomString(size, seed));
+			case BOOLEAN:
+				return ArrayFactory.create(generateRandomBoolean(size, seed));
+			case INT32:
+				return ArrayFactory.create(generateRandomInteger(size, seed));
+			case INT64:
+				return ArrayFactory.create(generateRandomLong(size, seed));
+			case FP32:
+				return ArrayFactory.create(generateRandomFloat(size, seed));
+			case FP64:
+				return ArrayFactory.create(generateRandomDouble(size, seed));
+			default:
+				throw new DMLRuntimeException("Unsupported value type: " + t);
+
+		}
+	}
+
+	protected static StringArray toStringArray(Array<?> a) {
+		String[] ret = new String[a.size()];
+		for(int i = 0; i < a.size(); i++) {
+			ret[i] = a.get(i).toString();
+		}
+		return ArrayFactory.create(ret);
+	}
+
+	public static String[] generateRandomString(int size, int seed) {
+		Random r = new Random(seed);
+		String[] ret = new String[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextInt(99) + "ad " + r.nextInt(99);
+		return ret;
+	}
+
+	protected static boolean[] generateRandomBoolean(int size, int seed) {
+		Random r = new Random(seed);
+		boolean[] ret = new boolean[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextBoolean();
+		return ret;
+	}
+
+	protected static int[] generateRandomInteger(int size, int seed) {
+		Random r = new Random(seed);
+		int[] ret = new int[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextInt();
+		return ret;
+	}
+
+	protected static int[] generateRandomInt8(int size, int seed) {
+		Random r = new Random(seed);
+		int[] ret = new int[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextInt(256) - 127;
+		return ret;
+	}
+
+	protected static long[] generateRandomLong(int size, int seed) {
+		Random r = new Random(seed);
+		long[] ret = new long[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextLong();
+		return ret;
+	}
+
+	protected static float[] generateRandomFloat(int size, int seed) {
+		Random r = new Random(seed);
+		float[] ret = new float[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextFloat();
+		return ret;
+	}
+
+	protected static double[] generateRandomDouble(int size, int seed) {
+		Random r = new Random(seed);
+		double[] ret = new double[size];
+		for(int i = 0; i < size; i++)
+			ret[i] = r.nextDouble();
+		return ret;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.frame.array;
+
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
+import org.junit.Test;
+
+public class NegativeArrayTests {
+
+	@Test(expected = DMLRuntimeException.class)
+	public void testAllocateInvalidArray() {
+		ArrayFactory.allocate(ValueType.UNKNOWN, 1324);
+	}
+
+
+	@Test(expected = DMLRuntimeException.class)
+	public void testEstimateMemorySizeInvalid() {
+		ArrayFactory.getInMemorySize(ValueType.UNKNOWN, 0);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/transformCustomTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/transformCustomTest.java
@@ -37,7 +37,7 @@ public class transformCustomTest {
 	final FrameBlock data;
 
 	public transformCustomTest() {
-		data = TestUtils.generateRandomFrameBlock(100, 1, new ValueType[] {ValueType.UINT8}, 231);
+		data = TestUtils.generateRandomFrameBlock(100, new ValueType[] {ValueType.UINT8}, 231);
 		data.setSchema(new ValueType[] {ValueType.INT32});
 	}
 

--- a/src/test/java/org/apache/sysds/test/component/misc/MemoryEstimateTest.java
+++ b/src/test/java/org/apache/sysds/test/component/misc/MemoryEstimateTest.java
@@ -72,19 +72,19 @@ public class MemoryEstimateTest {
 		switch(arrayToMeasure) {
 			case BYTE:
 				byte[] arrayByte = new byte[length];
-				assertEquals(MemoryEstimates.byteArrayCost(length), measure(arrayByte));
+				assertEquals(MemoryEstimates.byteArrayCost(length), measure(arrayByte), 0.2);
 				break;
 			case CHAR:
 				char[] arrayChar = new char[length];
-				assertEquals(MemoryEstimates.charArrayCost(length), measure(arrayChar));
+				assertEquals(MemoryEstimates.charArrayCost(length), measure(arrayChar), 0.2);
 				break;
 			case INT:
 				int[] arrayInt = new int[length];
-				assertEquals((long)MemoryEstimates.intArrayCost(length), measure(arrayInt));
+				assertEquals(MemoryEstimates.intArrayCost(length), measure(arrayInt), 0.2);
 				break;
 			case DOUBLE:
 				double[] arrayDouble = new double[length];
-				assertEquals((long)MemoryEstimates.doubleArrayCost(length), measure(arrayDouble));
+				assertEquals(MemoryEstimates.doubleArrayCost(length), measure(arrayDouble), 0.2);
 				break;
 			default:
 				System.out.println(arrayToMeasure.getClass().getSimpleName());

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part1/BuiltinDMVTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part1/BuiltinDMVTest.java
@@ -157,7 +157,7 @@ public class BuiltinDMVTest extends AutomatedTestBase {
 					frameBlock.set(row, col, defined_strings[col][row]);
 			return frameBlock;
 		}
-		return TestUtils.generateRandomFrameBlock(rows, cols, schema ,TestUtils.getPositiveRandomInt());
+		return TestUtils.generateRandomFrameBlock(rows, schema ,TestUtils.getPositiveRandomInt());
 	}
 
 	private static ArrayList<List<Integer>> getDisguisedPositions(FrameBlock frame,

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part1/BuiltinDateProcessingTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part1/BuiltinDateProcessingTest.java
@@ -258,6 +258,6 @@ public class BuiltinDateProcessingTest extends AutomatedTestBase {
 					frameBlock.set(row, col, defined_strings[col][row]);
 			return frameBlock;
 		}
-		return TestUtils.generateRandomFrameBlock(rows, cols, schema ,TestUtils.getPositiveRandomInt());
+		return TestUtils.generateRandomFrameBlock(rows, schema ,TestUtils.getPositiveRandomInt());
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
@@ -149,7 +149,7 @@ public class FrameDropInvalidTypeTest extends AutomatedTestBase {
 			String[] meta = new String[] {"FP64", "STRING"};
 
 			// initialize a frame with one column
-			FrameBlock frame1 = TestUtils.generateRandomFrameBlock(rows, 1, new ValueType[]{ValueType.FP64}, 132); 
+			FrameBlock frame1 = TestUtils.generateRandomFrameBlock(rows,  new ValueType[]{ValueType.FP64}, 132); 
 
 			switch (test) { //Double in String
 				case 1:

--- a/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLParallelTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLParallelTest.java
@@ -81,7 +81,7 @@ public class FrameReaderWriterJSONLParallelTest
 		FrameReaderJSONLParallel frameReaderJSONL = new FrameReaderJSONLParallel();
 
 		// Generate Random frameBlock to be written
-		FrameBlock writeBlock = TestUtils.generateRandomFrameBlock(rows, cols, schema, random);
+		FrameBlock writeBlock = TestUtils.generateRandomFrameBlock(rows, schema, random);
 
 		// Write FrameBlock
 		frameWriterJSONL.writeFrameToHDFS(writeBlock, FILENAME_SINGLE, schemaMap, rows,cols);

--- a/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLTest.java
@@ -77,7 +77,7 @@ public class FrameReaderWriterJSONLTest
 		FrameReaderJSONL frameReaderJSONL = new FrameReaderJSONL();
 
 		// Generate Random frameBlock to be written
-		FrameBlock writeBlock = TestUtils.generateRandomFrameBlock(rows, cols, schema, random);
+		FrameBlock writeBlock = TestUtils.generateRandomFrameBlock(rows, schema, random);
 
 		// Write FrameBlock
 		frameWriterJSONL.writeFrameToHDFS(writeBlock, FILENAME_SINGLE, schemaMap, rows,cols);

--- a/src/test/java/org/apache/sysds/test/functions/io/proto/FrameReaderWriterProtoTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/proto/FrameReaderWriterProtoTest.java
@@ -68,7 +68,7 @@ public class FrameReaderWriterProtoTest {
 	public void testWriteReadFrameBlockWith(int rows, int cols) throws IOException {
 		final Random random = new Random(SEED);
 		Types.ValueType[] schema = TestUtils.generateRandomSchema(cols, random);
-		FrameBlock expectedFrame = TestUtils.generateRandomFrameBlock(rows, cols, schema, random);
+		FrameBlock expectedFrame = TestUtils.generateRandomFrameBlock(rows, schema, random);
 
 		frameWriterProto.writeFrameToHDFS(expectedFrame, FILENAME_SINGLE, rows, cols);
 		FrameBlock actualFrame = frameReaderProto.readFrameFromHDFS(FILENAME_SINGLE, schema, rows, cols);


### PR DESCRIPTION
This commit type CacheBlocks, such that we can return subtypes through implementations of the interface.
In practice this means we do not have to cast the MatrixBlock or FrameBlock (or TensorBlock) in instances where we call slice, and therefore do not need to know what type of CacheBlock it is.