### PR TITLE
[SYSTEMDS-3467] Add support for MULTI_BLOCK Spark backend support for countDistinct()

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinct/BitMapValueCombiner.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinct/BitMapValueCombiner.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data.sketch.countdistinct;
+
+import java.util.Set;
+import java.util.function.BinaryOperator;
+
+public class BitMapValueCombiner implements BinaryOperator<Set<Long>> {
+
+	@Override
+	public Set<Long> apply(Set<Long> set0, Set<Long> set1) {
+		if (set0.isEmpty()) {
+			return set1;
+		}
+
+		if (set1.isEmpty()) {
+			return set0;
+		}
+
+		// Merging left-right is identical to merging right-left
+		set0.addAll(set1);
+		return set0;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowColBase.java
+++ b/src/test/java/org/apache/sysds/test/functions/countDistinct/CountDistinctRowColBase.java
@@ -59,6 +59,13 @@ public abstract class CountDistinctRowColBase extends CountDistinctBase {
 	}
 
 	@Test
+	public void testSparkDenseXLarge() {
+		ExecType ex = ExecType.SPARK;
+		double tolerance = baseTolerance + 1723 * percentTolerance;
+		countDistinctScalarTest(1723, 5000, 2000, 1.0, ex, tolerance);
+	}
+
+	@Test
 	public void testCPDense1Unique() {
 		ExecType ex = ExecType.CP;
 		double tolerance = 0.00001;


### PR DESCRIPTION
This patch adds support for running MULTI_BLOCK aggregations for countDistinct() builtin on the Spark backend. The implementation augments the CountDistinctFunctionSketch with the union() function implementation.

Tests:
    [X] Unit tests
    [ ] Integration tests
    [ ] N/A
