### PR TITLE
[SYSTEMDS-3468] Adding the outline for the survey of builtin functions

### DIFF
--- a/docs/survey/README.md
+++ b/docs/survey/README.md
@@ -1,0 +1,7 @@
+This is a survey of the capabilities of SystemDS compared to other popular languages and libraries. The survey has been
+broken down into 3 components based on the different phases of the ML lifecycle: source, build, and deploy. A further
+grouping is based on the DSLs supported by SystemDS: DML and Python. 
+
+# References
+1. Boehm, Matthias, Arun Kumar, and Jun Yang. "Data management in machine learning systems." Synthesis Lectures on Data
+Management 11.1 (2019): 1-173.

--- a/docs/survey/source/README.md
+++ b/docs/survey/source/README.md
@@ -1,0 +1,9 @@
+# Overview
+
+The source phase of the ML lifecycle includes the following tasks [1]:
+1. Data ingestion
+2. Data validation
+3. Data preprocessing
+
+# References
+1. Hapke, Hannes, and Catherine Nelson. Building machine learning pipelines. O'Reilly Media, 2020.

--- a/docs/survey/source/dml/R.md
+++ b/docs/survey/source/dml/R.md
@@ -1,0 +1,6 @@
+# Data ingestion
+# Data validation
+# Data preprocessing
+
+# References
+1. https://rpubs.com/prtk/900512

--- a/docs/survey/source/dml/pandas.md
+++ b/docs/survey/source/dml/pandas.md
@@ -1,0 +1,6 @@
+# Data ingestion
+# Data validation
+# Data preprocessing
+
+# References
+1. https://pandas.pydata.org/pandas-docs/stable/user_guide/index.html

--- a/docs/survey/source/dml/sklearn.md
+++ b/docs/survey/source/dml/sklearn.md
@@ -1,0 +1,6 @@
+# Data ingestion
+# Data validation
+# Data preprocessing
+
+# References
+1. https://scikit-learn.org/stable/modules/classes.html


### PR DESCRIPTION
This patch proposes a comparison of builtin functions based on a grouping by ML lifecycle phase and ML task. This patch presents only the basic outline- subsequent patches will do the actual comparison.