### PR TITLE
[SYSTEMDS-3469] New operator ordering to maximize inter-op parallelism

### DIFF
--- a/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
+++ b/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.CompilerConfig.ConfigType;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.lops.Compression.CompressConfig;
+import org.apache.sysds.lops.compile.linearization.ILinearize;
 
 /**
  * Singleton for accessing the parsed and merged system configuration.
@@ -237,9 +238,23 @@ public class ConfigurationManager
 			|| OptimizerUtils.ASYNC_PREFETCH_SPARK);
 	}
 
+	public static boolean isMaxPrallelizeEnabled() {
+		return (getLinearizationOrder() == ILinearize.DagLinearization.MAX_PARALLELIZE
+			|| OptimizerUtils.MAX_PARALLELIZE_ORDER);
+	}
+
 	public static boolean isBroadcastEnabled() {
 		return (getDMLConfig().getBooleanValue(DMLConfig.ASYNC_SPARK_BROADCAST)
 			|| OptimizerUtils.ASYNC_BROADCAST_SPARK);
+	}
+
+	public static ILinearize.DagLinearization getLinearizationOrder() {
+		if (OptimizerUtils.MAX_PARALLELIZE_ORDER)
+			return ILinearize.DagLinearization.MAX_PARALLELIZE;
+		else
+			return ILinearize.DagLinearization
+			.valueOf(ConfigurationManager.getDMLConfig().getTextValue(DMLConfig.DAG_LINEARIZATION).toUpperCase());
+
 	}
 
 	///////////////////////////////////////

--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -285,6 +285,12 @@ public class OptimizerUtils
 	public static boolean ASYNC_PREFETCH_SPARK = false;
 	public static boolean ASYNC_BROADCAST_SPARK = false;
 
+	/**
+	 * Heuristic-based instruction ordering to maximize inter-operator parallelism.
+	 * Place the Spark operator chains first and trigger them to execute in parallel.
+	 */
+	public static boolean MAX_PARALLELIZE_ORDER = false;
+
 	//////////////////////
 	// Optimizer levels //
 	//////////////////////

--- a/src/main/java/org/apache/sysds/lops/Lop.java
+++ b/src/main/java/org/apache/sysds/lops/Lop.java
@@ -188,6 +188,14 @@ public abstract class Lop
 		_visited = visited;
 	}
 
+	public void setVisited() {
+		setVisited(VisitStatus.DONE);
+	}
+
+	public boolean isVisited() {
+		return _visited == VisitStatus.DONE;
+	}
+
 	
 	public boolean[] getReachable() {
 		return reachable;
@@ -295,6 +303,10 @@ public abstract class Lop
 			int index = inputs.indexOf(oldInp);
 			inputs.set(index, newInp);
 		}
+	}
+
+	public void removeInput(Lop op) {
+		inputs.remove(op);
 	}
 
 	/**
@@ -414,7 +426,11 @@ public abstract class Lop
 	public void setExecType(ExecType newExecType){
  		lps.setExecType(newExecType);
 	}
-	
+
+	public boolean isExecSpark () {
+		return (lps.getExecType() == ExecType.SPARK);
+	}
+
 	public boolean getProducesIntermediateOutput() {
 		return lps.getProducesIntermediateOutput();
 	}

--- a/src/main/java/org/apache/sysds/lops/compile/Dag.java
+++ b/src/main/java/org/apache/sysds/lops/compile/Dag.java
@@ -74,7 +74,6 @@ import org.apache.sysds.runtime.instructions.cp.CPInstruction.CPType;
 import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 
-
 /**
  * 
  * Class to maintain a DAG of lops and compile it into 
@@ -193,17 +192,11 @@ public class Dag<N extends Lop>
 		}
 
 		List<Lop> node_v = ILinearize.linearize(nodes);
-		
-		// add Prefetch and broadcast lops, if necessary
-		List<Lop> node_pf = ConfigurationManager.isPrefetchEnabled() ? addPrefetchLop(node_v) : node_v;
-		List<Lop> node_bc = ConfigurationManager.isBroadcastEnabled() ? addBroadcastLop(node_pf) : node_pf;
-		// TODO: Merge via a single traversal of the nodes
-
-		prefetchFederated(node_bc);
+		prefetchFederated(node_v);
 
 		// do greedy grouping of operations
-		ArrayList<Instruction> inst = doPlainInstructionGen(sb, node_bc);
-		
+		ArrayList<Instruction> inst = doPlainInstructionGen(sb, node_v);
+
 		// cleanup instruction (e.g., create packed rmvar instructions)
 		return cleanupInstructions(inst);
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -672,11 +672,11 @@ public class SparkExecutionContext extends ExecutionContext
 		//the broadcasts are created (other than in local mode) in order to avoid 
 		//unnecessary memory requirements during the lifetime of this broadcast handle.
 		
-		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 
 		PartitionedBroadcast<MatrixBlock> bret = null;
 
 		synchronized (mo) {  //synchronize with the async. broadcast thread
+			long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 			//reuse existing broadcast handle
 			if (mo.getBroadcastHandle() != null && mo.getBroadcastHandle().isPartitionedBroadcastValid()) {
 				bret = mo.getBroadcastHandle().getPartitionedBroadcast();
@@ -719,10 +719,10 @@ public class SparkExecutionContext extends ExecutionContext
 					OptimizerUtils.estimatePartitionedSizeExactSparsity(mo.getDataCharacteristics()));
 				CacheableData.addBroadcastSize(mo.getBroadcastHandle().getSize());
 
-				if (DMLScript.STATISTICS) {
-					SparkStatistics.accBroadCastTime(System.nanoTime() - t0);
-					SparkStatistics.incBroadcastCount(1);
-				}
+			}
+			if (DMLScript.STATISTICS) {
+				SparkStatistics.accBroadCastTime(System.nanoTime() - t0);
+				SparkStatistics.incBroadcastCount(1);
 			}
 		}
 		return bret;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
@@ -109,7 +109,7 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 		//perform aggregation if necessary and put output into symbol table
 		if( _aggtype == SparkAggType.SINGLE_BLOCK )
 		{
-			if (ConfigurationManager.isPrefetchEnabled()) {
+			if (ConfigurationManager.isMaxPrallelizeEnabled()) {
 				//Trigger the chain of Spark operations and maintain a future to the result
 				//TODO: Make memory for the future matrix block
 				try {

--- a/src/test/java/org/apache/sysds/test/functions/async/AsyncBroadcastTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/AsyncBroadcastTest.java
@@ -88,9 +88,11 @@ public class AsyncBroadcastTest extends AutomatedTestBase {
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
 
+			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
 			OptimizerUtils.ASYNC_BROADCAST_SPARK = true;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			OptimizerUtils.ASYNC_BROADCAST_SPARK = false;
+			OptimizerUtils.MAX_PARALLELIZE_ORDER = false;
 			HashMap<MatrixValue.CellIndex, Double> R_bc = readDMLScalarFromOutputDir("R");
 
 			//compare matrices

--- a/src/test/java/org/apache/sysds/test/functions/async/AsyncTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/AsyncTest.java
@@ -31,62 +31,50 @@ import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
-import org.apache.sysds.utils.Statistics;
-import org.junit.Assert;
 import org.junit.Test;
 
-public class PrefetchRDDTest extends AutomatedTestBase {
-	
+public class AsyncTest extends AutomatedTestBase {
+
 	protected static final String TEST_DIR = "functions/async/";
-	protected static final String TEST_NAME = "PrefetchRDD";
-	protected static final int TEST_VARIANTS = 3;
-	protected static String TEST_CLASS_DIR = TEST_DIR + PrefetchRDDTest.class.getSimpleName() + "/";
-	
+	protected static final String TEST_NAME = "MaxParallelizeOrder";
+	protected static final int TEST_VARIANTS = 2;
+	protected static String TEST_CLASS_DIR = TEST_DIR + AsyncTest.class.getSimpleName() + "/";
+
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		for( int i=1; i<=TEST_VARIANTS; i++ )
+		for(int i=1; i<=TEST_VARIANTS; i++)
 			addTestConfiguration(TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i));
 	}
-	
+
 	@Test
-	public void testAsyncSparkOPs1() {
-		//Single CP consumer. Prefetch Lop has one output.
+	public void testlmds() {
 		runTest(TEST_NAME+"1");
 	}
 
 	@Test
-	public void testAsyncSparkOPs2() {
-		//Two CP consumers. Prefetch Lop has two outputs.
+	public void testl2svm() {
 		runTest(TEST_NAME+"2");
 	}
 
-	@Test
-	public void testAsyncSparkOPs3() {
-		//SP binary consumer, followed by an action. No Prefetch.
-		runTest(TEST_NAME+"3");
-	}
-	
 	public void runTest(String testname) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
 		boolean old_trans_exec_type = OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE;
 		ExecMode oldPlatform = setExecMode(ExecMode.HYBRID);
-		
+
 		long oldmem = InfrastructureAnalyzer.getLocalMaxMemory();
 		long mem = 1024*1024*8;
 		InfrastructureAnalyzer.setLocalMaxMemory(mem);
-		
+
 		try {
-			//OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
-			//OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
-			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = false;
 			getAndLoadTestConfiguration(testname);
 			fullDMLScriptName = getScript();
-			
+
 			List<String> proArgs = new ArrayList<>();
-			
+
 			proArgs.add("-explain");
+			//proArgs.add("recompile_runtime");
 			proArgs.add("-stats");
 			proArgs.add("-args");
 			proArgs.add(output("R"));
@@ -95,24 +83,17 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
 
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = true;
+			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<MatrixValue.CellIndex, Double> R_mp = readDMLScalarFromOutputDir("R");
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = false;
 			OptimizerUtils.MAX_PARALLELIZE_ORDER = false;
-			HashMap<MatrixValue.CellIndex, Double> R_pf = readDMLScalarFromOutputDir("R");
 
 			//compare matrices
-			boolean matchVal = TestUtils.compareMatrices(R, R_pf, 1e-6, "Origin", "withPrefetch");
+			boolean matchVal = TestUtils.compareMatrices(R, R_mp, 1e-6, "Origin", "withPrefetch");
 			if (!matchVal)
-				System.out.println("Value w/o Prefetch "+R+" w/ Prefetch "+R_pf);
-			//assert Prefetch instructions and number of success.
-			long expected_numPF = !testname.equalsIgnoreCase(TEST_NAME+"3") ? 1 : 0;
-			long expected_successPF = !testname.equalsIgnoreCase(TEST_NAME+"3") ? 1 : 0;
-			long numPF = Statistics.getCPHeavyHitterCount("prefetch");
-			Assert.assertTrue("Violated Prefetch instruction count: "+numPF, numPF == expected_numPF);
-			//long successPF = SparkStatistics.getAsyncPrefetchCount();
-			//Assert.assertTrue("Violated successful Prefetch count: "+successPF, successPF == expected_successPF);
+				System.out.println("Value w/o Prefetch "+R+" w/ Prefetch "+R_mp);
 		} finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;

--- a/src/test/java/org/apache/sysds/test/functions/linearization/DagLinearizationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/linearization/DagLinearizationTest.java
@@ -39,7 +39,7 @@ public class DagLinearizationTest extends AutomatedTestBase {
 	private final String testNames[] = {"matrixmult_dag_linearization", "csplineCG_dag_linearization",
 		"linear_regression_dag_linearization"};
 
-	private final String testConfigs[] = {"breadth-first", "depth-first", "incorrect", "min-intermediate"};
+	private final String testConfigs[] = {"breadth-first", "depth-first", "min-intermediate", "max-parallelize"};
 
 	private final String testDir = "functions/linearization/";
 

--- a/src/test/scripts/functions/async/MaxParallelizeOrder1.dml
+++ b/src/test/scripts/functions/async/MaxParallelizeOrder1.dml
@@ -1,0 +1,52 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N) return (Matrix[double] beta)
+{
+  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+}
+
+no_lamda = 10;
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+lim = 0.1;
+
+X = rand(rows=10000, cols=200, seed=42);
+y = rand(rows=10000, cols=1, seed=43);
+N = ncol(X);
+R = matrix(0, rows=N, cols=no_lamda+2);
+i = 1;
+
+while (lamda < lim)
+{
+  beta = SimlinRegDS(X, y, lamda, N);
+  #beta = lmDS(X=X, y=y, reg=lamda);
+  R[,i] = beta;
+  lamda = lamda + stp;
+  i = i + 1;
+}
+
+R = sum(R);
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/async/MaxParallelizeOrder2.dml
+++ b/src/test/scripts/functions/async/MaxParallelizeOrder2.dml
@@ -1,0 +1,69 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+l2norm = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B, Boolean icpt)
+return (Matrix[Double] loss) {
+  if (icpt)
+    X = cbind(X, matrix(1, nrow(X), 1));
+  loss = as.matrix(sum((y - X%*%B)^2));
+}
+
+M = 100000;
+N = 20;
+sp = 1.0;
+no_lamda = 1;
+
+X = rand(rows=M, cols=N, sparsity=sp, seed=42);
+y = rand(rows=M, cols=1, min=0, max=2, seed=42);
+y = ceil(y);
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+Rbeta = matrix(0, rows=ncol(X)+1, cols=no_lamda*2);
+Rloss = matrix(0, rows=no_lamda*2, cols=1);
+i = 1;
+
+
+for (l in 1:no_lamda)
+{
+  beta = l2svm(X=X, Y=y, intercept=FALSE, epsilon=1e-12,
+#      lambda = lamda, maxIterations=10, verbose=FALSE);
+      reg = lamda, verbose=FALSE);
+  Rbeta[1:nrow(beta),i] = beta;
+  Rloss[i,] = l2norm(X, y, beta, FALSE);
+  i = i + 1;
+
+  beta = l2svm(X=X, Y=y, intercept=TRUE, epsilon=1e-12,
+#      lambda = lamda, maxIterations=10, verbose=FALSE);
+      reg = lamda, verbose=FALSE);
+  Rbeta[1:nrow(beta),i] = beta;
+  Rloss[i,] = l2norm(X, y, beta, TRUE);
+  i = i + 1;
+
+  lamda = lamda + stp;
+}
+
+leastLoss = rowIndexMin(t(Rloss));
+bestModel = Rbeta[,as.scalar(leastLoss)];
+
+R = sum(bestModel);
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/linearization/SystemDS-config-max-parallelize.xml
+++ b/src/test/scripts/functions/linearization/SystemDS-config-max-parallelize.xml
@@ -18,5 +18,5 @@
 -->
 
 <root>
-    <sysds.compile.linearization>something_incorrect</sysds.compile.linearization>
+    <sysds.compile.linearization>max_parallelize</sysds.compile.linearization>
 </root>


### PR DESCRIPTION
This patch introduces a new heuristic-based operator linearization order, which aims to maximize inter-operator parallelism among Spark and local operators. We first traverse the LOP DAGs to collect the roots of the Spark operator chains and the number of Spark instructions in all subDAGs. We then first place the Spark operator chains followed by the CP lanes. Finally, we place the appropriate asynchronous operators to trigger the Spark operator chains in parallel.
This change along with the future-based execution of Spark actions and a manual reuse of partitioned broadcast variables improve lmDS by 2x.