### PR TITLE
[SYSTEMDS-3470] Lineage-based local reuse of Spark actions

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateUnarySPInstruction.java
@@ -222,6 +222,10 @@ public class AggregateUnarySPInstruction extends UnarySPInstruction {
 		}
 	}
 
+	public SparkAggType getAggType() {
+		return _aggtype;
+	}
+
 	private static class RDDUAggFunction implements PairFunction<Tuple2<MatrixIndexes, MatrixBlock>, MatrixIndexes, MatrixBlock>
 	{
 		private static final long serialVersionUID = 2672082409287856038L;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
@@ -148,7 +148,11 @@ public class CpmmSPInstruction extends AggregateBinarySPInstruction {
 			}
 		}
 	}
-	
+
+	public SparkAggType getAggType() {
+		return _aggtype;
+	}
+
 	private static int getPreferredParJoin(DataCharacteristics mc1, DataCharacteristics mc2, int numPar1, int numPar2) {
 		int defPar = SparkExecutionContext.getDefaultParallelism(true);
 		int maxParIn = Math.max(numPar1, numPar2);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/MapmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/MapmmSPInstruction.java
@@ -126,8 +126,8 @@ public class MapmmSPInstruction extends AggregateBinarySPInstruction {
 		}
 		
 		//get inputs
-		PartitionedBroadcast<MatrixBlock> in2 = sec.getBroadcastForVariable(bcastVar); 
-		
+		PartitionedBroadcast<MatrixBlock> in2 = sec.getBroadcastForVariable(bcastVar);
+
 		//empty input block filter
 		if( !_outputEmpty )
 			in1 = in1.filter(new FilterNonEmptyBlocksFunction());
@@ -174,6 +174,10 @@ public class MapmmSPInstruction extends AggregateBinarySPInstruction {
 			//update output statistics if not inferred
 			updateBinaryMMOutputDataCharacteristics(sec, true);
 		}
+	}
+
+	public SparkAggType getAggType() {
+		return _aggtype;
 	}
 
 	private static boolean preservesPartitioning(DataCharacteristics mcIn, CacheType type )

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -53,7 +53,8 @@ public class LineageCacheConfig
 		"uamean", "max", "min", "ifelse", "-", "sqrt", ">", "uak+", "<=",
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
 		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
-		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri", "mapmm"
+		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri",
+		"mapmm", "cpmm"
 		//TODO: Reuse everything. 
 	};
 	private static String[] REUSE_OPCODES  = new String[] {};
@@ -205,9 +206,8 @@ public class LineageCacheConfig
 		boolean insttype = (inst instanceof ComputationCPInstruction 
 			|| inst instanceof ComputationFEDInstruction
 			|| inst instanceof GPUInstruction
-			|| inst instanceof ComputationSPInstruction)
+			|| (inst instanceof ComputationSPInstruction && isRightSparkOp(inst)))
 			&& !(inst instanceof ListIndexingCPInstruction);
-		boolean isSparkaction = isRightSparkOp(inst);
 		boolean rightop = (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
 			|| (inst.getOpcode().equals("append") && isVectorAppend(inst, ec))
 			|| (inst.getOpcode().startsWith("spoof"))
@@ -215,7 +215,7 @@ public class LineageCacheConfig
 		boolean updateInplace = (inst instanceof MatrixIndexingCPInstruction)
 			&& ec.getMatrixObject(((ComputationCPInstruction)inst).input1).getUpdateType().isInPlace();
 		boolean federatedOutput = false;
-		return insttype && isSparkaction && rightop && !updateInplace && !federatedOutput;
+		return insttype && rightop && !updateInplace && !federatedOutput;
 	}
 	
 	private static boolean isVectorAppend(Instruction inst, ExecutionContext ec) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -21,8 +21,10 @@ package org.apache.sysds.runtime.lineage;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
+import org.apache.sysds.hops.AggBinaryOp;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.Instruction;
@@ -33,6 +35,11 @@ import org.apache.sysds.runtime.instructions.cp.ListIndexingCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.MatrixIndexingCPInstruction;
 import org.apache.sysds.runtime.instructions.fed.ComputationFEDInstruction;
 import org.apache.sysds.runtime.instructions.gpu.GPUInstruction;
+import org.apache.sysds.runtime.instructions.spark.AggregateUnarySPInstruction;
+import org.apache.sysds.runtime.instructions.spark.ComputationSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.CpmmSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.MapmmSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.TsmmSPInstruction;
 
 import java.util.Comparator;
 
@@ -46,7 +53,7 @@ public class LineageCacheConfig
 		"uamean", "max", "min", "ifelse", "-", "sqrt", ">", "uak+", "<=",
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
 		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
-		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri"
+		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri", "mapmm"
 		//TODO: Reuse everything. 
 	};
 	private static String[] REUSE_OPCODES  = new String[] {};
@@ -197,8 +204,10 @@ public class LineageCacheConfig
 	public static boolean isReusable (Instruction inst, ExecutionContext ec) {
 		boolean insttype = (inst instanceof ComputationCPInstruction 
 			|| inst instanceof ComputationFEDInstruction
-			|| inst instanceof GPUInstruction)
+			|| inst instanceof GPUInstruction
+			|| inst instanceof ComputationSPInstruction)
 			&& !(inst instanceof ListIndexingCPInstruction);
+		boolean isSparkaction = isRightSparkOp(inst);
 		boolean rightop = (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
 			|| (inst.getOpcode().equals("append") && isVectorAppend(inst, ec))
 			|| (inst.getOpcode().startsWith("spoof"))
@@ -206,7 +215,7 @@ public class LineageCacheConfig
 		boolean updateInplace = (inst instanceof MatrixIndexingCPInstruction)
 			&& ec.getMatrixObject(((ComputationCPInstruction)inst).input1).getUpdateType().isInPlace();
 		boolean federatedOutput = false;
-		return insttype && rightop && !updateInplace && !federatedOutput;
+		return insttype && isSparkaction && rightop && !updateInplace && !federatedOutput;
 	}
 	
 	private static boolean isVectorAppend(Instruction inst, ExecutionContext ec) {
@@ -226,6 +235,14 @@ public class LineageCacheConfig
 			long c2 = ec.getMatrixObject(cpinst.input2).getNumColumns();
 			return(c1 == 1 || c2 == 1);
 		}
+		if (inst instanceof ComputationSPInstruction) {
+			ComputationSPInstruction fedinst = (ComputationSPInstruction) inst;
+			if (!fedinst.input1.isMatrix() || !fedinst.input2.isMatrix())
+				return false;
+			long c1 = ec.getMatrixObject(fedinst.input1).getNumColumns();
+			long c2 = ec.getMatrixObject(fedinst.input2).getNumColumns();
+			return(c1 == 1 || c2 == 1);
+		}
 		else { //GPUInstruction
 			GPUInstruction gpuinst = (GPUInstruction)inst;
 			if( !gpuinst._input1.isMatrix() || !gpuinst._input2.isMatrix() )
@@ -234,6 +251,30 @@ public class LineageCacheConfig
 			long c2 = ec.getMatrixObject(gpuinst._input2).getNumColumns();
 			return(c1 == 1 || c2 == 1);
 		}
+	}
+
+	// Check if the Spark instruction returns result back to local
+	private static boolean isRightSparkOp(Instruction inst) {
+		if (!(inst instanceof ComputationSPInstruction))
+			return false;
+
+		boolean spAction = false;
+		if (inst instanceof MapmmSPInstruction &&
+			((MapmmSPInstruction) inst).getAggType() == AggBinaryOp.SparkAggType.SINGLE_BLOCK)
+			spAction = true;
+		else if (inst instanceof TsmmSPInstruction)
+			spAction = true;
+		else if (inst instanceof AggregateUnarySPInstruction &&
+			((AggregateUnarySPInstruction) inst).getAggType() == AggBinaryOp.SparkAggType.SINGLE_BLOCK)
+			spAction = true;
+		else if (inst instanceof CpmmSPInstruction &&
+			((CpmmSPInstruction) inst).getAggType() == AggBinaryOp.SparkAggType.SINGLE_BLOCK)
+			spAction = true;
+		else if (((ComputationSPInstruction) inst).output.getDataType() == Types.DataType.SCALAR)
+			spAction = true;
+		//TODO: include other cases
+
+		return spAction;
 	}
 	
 	public static boolean isOutputFederated(Instruction inst, Data data) {

--- a/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.async;
+
+	import java.util.ArrayList;
+	import java.util.HashMap;
+	import java.util.List;
+
+	import org.apache.sysds.common.Types.ExecMode;
+	import org.apache.sysds.hops.OptimizerUtils;
+	import org.apache.sysds.hops.recompile.Recompiler;
+	import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
+	import org.apache.sysds.runtime.lineage.Lineage;
+	import org.apache.sysds.runtime.matrix.data.MatrixValue;
+	import org.apache.sysds.test.AutomatedTestBase;
+	import org.apache.sysds.test.TestConfiguration;
+	import org.apache.sysds.test.TestUtils;
+	import org.apache.sysds.utils.Statistics;
+	import org.junit.Assert;
+	import org.junit.Test;
+
+public class LineageReuseSparkTest extends AutomatedTestBase {
+
+	protected static final String TEST_DIR = "functions/async/";
+	protected static final String TEST_NAME = "LineageReuseSpark";
+	protected static final int TEST_VARIANTS = 1;
+	protected static String TEST_CLASS_DIR = TEST_DIR + LineageReuseSparkTest.class.getSimpleName() + "/";
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		for(int i=1; i<=TEST_VARIANTS; i++)
+			addTestConfiguration(TEST_NAME+i, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME+i));
+	}
+
+	@Test
+	public void testlmds() {
+		runTest(TEST_NAME+"1");
+	}
+
+	public void runTest(String testname) {
+		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		boolean old_trans_exec_type = OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE;
+		ExecMode oldPlatform = setExecMode(ExecMode.HYBRID);
+
+		long oldmem = InfrastructureAnalyzer.getLocalMaxMemory();
+		long mem = 1024*1024*8;
+		InfrastructureAnalyzer.setLocalMaxMemory(mem);
+
+		try {
+			getAndLoadTestConfiguration(testname);
+			fullDMLScriptName = getScript();
+
+			List<String> proArgs = new ArrayList<>();
+
+			proArgs.add("-explain");
+			proArgs.add("-stats");
+			proArgs.add("-args");
+			proArgs.add(output("R"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
+			long numTsmm = Statistics.getCPHeavyHitterCount("sp_tsmm");
+			long numMapmm = Statistics.getCPHeavyHitterCount("sp_mapmm");
+
+			proArgs.add("-explain");
+			proArgs.add("-stats");
+			proArgs.add("-lineage");
+			proArgs.add("reuse_hybrid");
+			proArgs.add("-args");
+			proArgs.add(output("R"));
+			programArgs = proArgs.toArray(new String[proArgs.size()]);
+
+			Lineage.resetInternalState();
+			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
+			HashMap<MatrixValue.CellIndex, Double> R_reused = readDMLScalarFromOutputDir("R");
+			long numTsmm_r = Statistics.getCPHeavyHitterCount("sp_tsmm");
+			long numMapmm_r= Statistics.getCPHeavyHitterCount("sp_mapmm");
+
+			//compare matrices
+			boolean matchVal = TestUtils.compareMatrices(R, R_reused, 1e-6, "Origin", "withPrefetch");
+			if (!matchVal)
+				System.out.println("Value w/o reuse "+R+" w/ reuse "+R_reused);
+			Assert.assertTrue("Violated sp_tsmm: reuse count: "+numTsmm_r+" < "+numTsmm, numTsmm_r < numTsmm);
+			Assert.assertTrue("Violated sp_mapmm: reuse count: "+numMapmm_r+" < "+numMapmm, numMapmm_r < numMapmm);
+
+		} finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
+			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = old_trans_exec_type;
+			resetExecMode(oldPlatform);
+			InfrastructureAnalyzer.setLocalMaxMemory(oldmem);
+			Recompiler.reinitRecompiler();
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteListTsmmCVTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteListTsmmCVTest.java
@@ -128,7 +128,8 @@ public class RewriteListTsmmCVTest extends AutomatedTestBase
 			if( instType == ExecType.CP )
 				Assert.assertEquals(0, Statistics.getNoOfExecutedSPInst());
 			if( rewrites ) {
-				boolean expectedReuse = lineage && instType == ExecType.CP;
+				//boolean expectedReuse = lineage && instType == ExecType.CP;
+				boolean expectedReuse = lineage;
 				String[] codes = (instType==ExecType.CP) ?
 					new String[]{"rbind","tsmm","ba+*","n+"} :
 					new String[]{"sp_append","sp_tsmm","sp_mapmm","sp_n+"};

--- a/src/test/scripts/functions/async/LineageReuseSpark1.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark1.dml
@@ -1,0 +1,53 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N) return (Matrix[double] beta)
+{
+  # Reuse sp_tsmm and sp_mapmm if not future-based
+  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+}
+
+no_lamda = 10;
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+lim = 0.1;
+
+X = rand(rows=10000, cols=200, seed=42);
+y = rand(rows=10000, cols=1, seed=43);
+N = ncol(X);
+R = matrix(0, rows=N, cols=no_lamda+2);
+i = 1;
+
+while (lamda < lim)
+{
+  beta = SimlinRegDS(X, y, lamda, N);
+  #beta = lmDS(X=X, y=y, reg=lamda);
+  R[,i] = beta;
+  lamda = lamda + stp;
+  i = i + 1;
+}
+
+R = sum(R);
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch extends the lineage cache framework to cache the results of the Spark instruction, which return intermediates back to local. Only caching the actions avoids unnecessary triggering and fetching all Spark intermediates. For now, we avoid caching the future-based results.