### PR TITLE
[SYSTEMDS-3470] Generalize selecting reusable Spark instructions

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -442,6 +442,10 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 		if( _rddHandle != null )
 			rdd.setBackReference(this);
 	}
+
+	public boolean hasRDDHandle() {
+		return _rddHandle != null && _rddHandle.hasBackReference();
+	}
 	
 	public BroadcastObject<T> getBroadcastHandle() {
 		return _bcHandle;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -579,6 +579,12 @@ public class LineageCache
 					continue;
 				}
 
+				if (data instanceof MatrixObject && ((MatrixObject) data).hasRDDHandle()) {
+					// Avoid triggering pre-matured Spark instruction chains
+					removePlaceholder(item);
+					continue;
+				}
+
 				if (LineageCacheConfig.isOutputFederated(inst, data)) {
 					// Do not cache federated outputs (in the coordinator)
 					// Cannot skip putting the placeholder as the above is only known after execution

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -206,7 +206,7 @@ public class LineageCacheConfig
 		boolean insttype = (inst instanceof ComputationCPInstruction 
 			|| inst instanceof ComputationFEDInstruction
 			|| inst instanceof GPUInstruction
-			|| (inst instanceof ComputationSPInstruction && isRightSparkOp(inst)))
+			|| inst instanceof ComputationSPInstruction)
 			&& !(inst instanceof ListIndexingCPInstruction);
 		boolean rightop = (ArrayUtils.contains(REUSE_OPCODES, inst.getOpcode())
 			|| (inst.getOpcode().equals("append") && isVectorAppend(inst, ec))

--- a/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
@@ -51,15 +51,22 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void testlmds() {
-		runTest(TEST_NAME+"1");
+	public void testlmdsHB() {
+		runTest(TEST_NAME+"1", ExecMode.HYBRID);
 	}
 
-	public void runTest(String testname) {
+	@Test
+	public void testlmdsSP() {
+		// Only reuse the actions
+		runTest(TEST_NAME+"1", ExecMode.SPARK);
+	}
+
+	public void runTest(String testname, ExecMode execMode) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
 		boolean old_trans_exec_type = OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE;
 		ExecMode oldPlatform = setExecMode(ExecMode.HYBRID);
+		rtplatform = execMode;
 
 		long oldmem = InfrastructureAnalyzer.getLocalMaxMemory();
 		long mem = 1024*1024*8;


### PR DESCRIPTION
This patch allows putting any Matrix Object in the lineage cache which does not have a valid RDD. This change makes it easier to separate Spark instructions which returns intermediate back to local.