### PR TITLE
[SYSTEMDS-3471] Enable multi-threaded transformencode/apply

### DIFF
--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -152,7 +152,7 @@ public class DMLConfig
 		_defaultVals.put(CP_PARALLEL_IO,         "true" );
 		_defaultVals.put(PARALLEL_TOKENIZE,      "false");
 		_defaultVals.put(PARALLEL_TOKENIZE_NUM_BLOCKS, "64");
-		_defaultVals.put(PARALLEL_ENCODE,        "false" );
+		_defaultVals.put(PARALLEL_ENCODE,        "true" );
 		_defaultVals.put(PARALLEL_ENCODE_STAGED, "false" );
 		_defaultVals.put(PARALLEL_ENCODE_APPLY_BLOCKS, "-1");
 		_defaultVals.put(PARALLEL_ENCODE_BUILD_BLOCKS, "-1");

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/MultiReturnParameterizedBuiltinFEDInstruction.java
@@ -344,7 +344,8 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 				.createEncoder(_spec, colNames, fb.getNumColumns(), null, _offset, _offset + fb.getNumColumns());
 
 			// build necessary structures for encoding
-			encoder.build(fb, OptimizerUtils.getTransformNumThreads()); // FIXME skip equi-height sorting
+			//encoder.build(fb, OptimizerUtils.getTransformNumThreads()); // FIXME skip equi-height sorting
+			encoder.build(fb, 1); // FIXME skip equi-height sorting
 			fo.release();
 
 			// create federated response
@@ -375,7 +376,8 @@ public class MultiReturnParameterizedBuiltinFEDInstruction extends ComputationFE
 			// offset is applied on the Worker to shift the local encoders to their respective column
 			_encoder.applyColumnOffset();
 			// apply transformation
-			MatrixBlock mbout = _encoder.apply(fb, OptimizerUtils.getTransformNumThreads());
+			//MatrixBlock mbout = _encoder.apply(fb, OptimizerUtils.getTransformNumThreads());
+			MatrixBlock mbout = _encoder.apply(fb, 1);
 
 			// create output matrix object
 			MatrixObject mo = ExecutionContext.createMatrixObject(mbout);


### PR DESCRIPTION
This patch changes the defaults of the Encode config flags to use the multi-threaded build, apply, allocation and compactions methods.