### PR TITLE
[SYSTEMDS-3473] Push down rmvars for asynchronous instructions

### DIFF
--- a/src/main/java/org/apache/sysds/lops/Lop.java
+++ b/src/main/java/org/apache/sysds/lops/Lop.java
@@ -150,6 +150,12 @@ public abstract class Lop
 	protected OutputParameters outParams = null;
 
 	protected LopProperties lps = null;
+
+	/**
+	 * Indicates if this lop is a candidate for asynchronous execution.
+	 * Examples include spark unary aggregate, mapmm, prefetch
+	 */
+	protected boolean _asynchronous = false;
 	
 
 	/**
@@ -363,6 +369,14 @@ public abstract class Lop
 	public int removeConsumer() {
 		consumerCount--;
 		return consumerCount;
+	}
+
+	public void setAsynchronous(boolean isAsync) {
+		_asynchronous = isAsync;
+	}
+
+	public boolean isAsynchronousOp() {
+		return _asynchronous;
 	}
 
 	/**

--- a/src/test/java/org/apache/sysds/test/functions/async/MaxParallelizeOrderTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/MaxParallelizeOrderTest.java
@@ -37,7 +37,7 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 
 	protected static final String TEST_DIR = "functions/async/";
 	protected static final String TEST_NAME = "MaxParallelizeOrder";
-	protected static final int TEST_VARIANTS = 2;
+	protected static final int TEST_VARIANTS = 4;
 	protected static String TEST_CLASS_DIR = TEST_DIR + MaxParallelizeOrderTest.class.getSimpleName() + "/";
 
 	@Override
@@ -55,6 +55,16 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 	@Test
 	public void testl2svm() {
 		runTest(TEST_NAME+"2");
+	}
+
+	@Test
+	public void testSparkAction() {
+		runTest(TEST_NAME+"3");
+	}
+
+	@Test
+	public void testSparkTransformations() {
+		runTest(TEST_NAME+"4");
 	}
 
 	public void runTest(String testname) {
@@ -85,10 +95,13 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = true;
 			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
+			if (testname.equalsIgnoreCase(TEST_NAME+"4"))
+				OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = false;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R_mp = readDMLScalarFromOutputDir("R");
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = false;
 			OptimizerUtils.MAX_PARALLELIZE_ORDER = false;
+			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = true;
 
 			//compare matrices
 			boolean matchVal = TestUtils.compareMatrices(R, R_mp, 1e-6, "Origin", "withPrefetch");

--- a/src/test/scripts/functions/async/MaxParallelizeOrder3.dml
+++ b/src/test/scripts/functions/async/MaxParallelizeOrder3.dml
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = rand(rows=10000, cols=200, seed=42); #sp_rand
+v = rand(rows=200, cols=1, seed=42); #cp_rand
+
+# CP instructions
+v = ((v + v) * 1 - v) / (1+1);
+v = ((v + v) * 2 - v) / (2+1);
+
+# Spark transformation operations 
+sp1 = X + ceil(X);
+sp2 = sp1 %*% v; #output fits in local
+
+# CP binary triggers the DAG of SP operations
+# if transitive spark exec type is off
+cp = sp2 + sum(v);
+R = sum(cp);
+write(R, $1, format="text");

--- a/src/test/scripts/functions/async/MaxParallelizeOrder4.dml
+++ b/src/test/scripts/functions/async/MaxParallelizeOrder4.dml
@@ -1,0 +1,37 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = rand(rows=10000, cols=200, seed=42); #sp_rand
+v = rand(rows=200, cols=1, seed=42); #cp_rand
+v2 = rand(rows=200, cols=1, seed=43); #cp_rand
+
+# CP instructions
+v = ((v + v) * 1 - v) / (1+1);
+v = ((v + v) * 2 - v) / (2+1);
+
+# Spark transformation operations 
+sp1 = X + ceil(X);
+sp2 = sp1 %*% v2; #output fits in local
+
+# CP binary triggers the DAG of SP operations
+# if transitive spark exec type is off
+cp = sp2 + sum(v);
+R = sum(cp);
+write(R, $1, format="text");


### PR DESCRIPTION
This patch repositions the rmvar instructions for the inputs to an asynchronous instruction after the consumers of the asynchronous instruction. This change allows keeping the inputs to an asynchronous operator alive until get() is called for the future object. Moreover, this patch adds more tests for the new operator ordering and fixes minor bugs.