### PR TITLE
[SYSTEMDS-3474] Lineage-based reuse of prefetch instruction

### DIFF
--- a/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
+++ b/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
@@ -44,6 +44,7 @@ import org.apache.sysds.lops.CSVReBlock;
 import org.apache.sysds.lops.CentralMoment;
 import org.apache.sysds.lops.Checkpoint;
 import org.apache.sysds.lops.CoVariance;
+import org.apache.sysds.lops.DataGen;
 import org.apache.sysds.lops.GroupedAggregate;
 import org.apache.sysds.lops.GroupedAggregateM;
 import org.apache.sysds.lops.Lop;
@@ -359,7 +360,7 @@ public interface ILinearize {
 				&& !(lop instanceof CoVariance)
 				// Not qualified for prefetching
 				&& !(lop instanceof Checkpoint) && !(lop instanceof ReBlock)
-				&& !(lop instanceof CSVReBlock)
+				&& !(lop instanceof CSVReBlock) && !(lop instanceof DataGen)
 				// Cannot filter Transformation cases from Actions (FIXME)
 				&& !(lop instanceof MMTSJ) && !(lop instanceof UAggOuterChain)
 				&& !(lop instanceof ParameterizedBuiltin) && !(lop instanceof SpoofFused);

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -54,7 +54,7 @@ public class LineageCacheConfig
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
 		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
 		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri",
-		"mapmm", "cpmm"
+		"mapmm", "cpmm", "prefetch"
 		//TODO: Reuse everything. 
 	};
 	private static String[] REUSE_OPCODES  = new String[] {};

--- a/src/test/scripts/functions/async/LineageReuseSpark2.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark2.dml
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = rand(rows=10000, cols=200, seed=42); #sp_rand
+v = rand(rows=200, cols=1, seed=42); #cp_rand
+
+# Spark transformation operations 
+for (i in 1:10) {
+  while(FALSE){}
+  sp1 = X + ceil(X);
+  sp2 = sp1 %*% v; #output fits in local
+  # Place a prefetch after mapmm and reuse
+
+  # CP instructions
+  v2 = ((v + v) * 1 - v) / (1+1);
+  v2 = ((v + v) * 2 - v) / (2+1);
+
+  # CP binary triggers the DAG of SP operations
+  cp = sp2 + sum(v2);
+  R = sum(cp);
+}
+
+write(R, $1, format="text");


### PR DESCRIPTION
This patch enables caching and reusing prefetch instruction outputs. This is the first step towards reusing asynchronous operators.