### PR TITLE
[SYSTEMDS-3479] Persist and reuse of Spark RDDs

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -889,6 +889,11 @@ public class SparkExecutionContext extends ExecutionContext
 		obj.setRDDHandle( rddhandle );
 	}
 
+	public void setRDDHandleForVariable(String varname, RDDObject rddhandle) {
+		CacheableData<?> obj = getCacheableData(varname);
+		obj.setRDDHandle(rddhandle);
+	}
+
 	public static JavaPairRDD<MatrixIndexes,MatrixBlock> toMatrixJavaPairRDD(JavaSparkContext sc, MatrixBlock src, int blen) {
 		return toMatrixJavaPairRDD(sc, src, blen, -1, true);
 	}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CheckpointSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CheckpointSPInstruction.java
@@ -40,6 +40,7 @@ import org.apache.sysds.runtime.instructions.spark.data.RDDObject;
 import org.apache.sysds.runtime.instructions.spark.functions.CopyFrameBlockFunction;
 import org.apache.sysds.runtime.instructions.spark.functions.CreateSparseBlockFunction;
 import org.apache.sysds.runtime.instructions.spark.utils.SparkUtils;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -101,7 +102,8 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 			return;
 		}
 
-		if (sec.getCacheableData(input1).getRDDHandle().isCheckpointRDD()) {
+		if (!LineageCacheConfig.ReuseCacheType.isNone() && sec.getCacheableData(input1).getRDDHandle() != null
+			&& sec.getCacheableData(input1).getRDDHandle().isCheckpointRDD()) {
 			// Do nothing if the RDD is already checkpointed
 			sec.setVariable(output.getName(), sec.getCacheableData(input1.getName()));
 			Statistics.decrementNoOfExecutedSPInst();

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -31,9 +31,11 @@ import org.apache.sysds.lops.MMTSJ.MMTSJType;
 import org.apache.sysds.parser.DataIdentifier;
 import org.apache.sysds.parser.Statement;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.context.MatrixObjectFuture;
+import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedStatistics;
 import org.apache.sysds.runtime.controlprogram.federated.FederatedUDF;
@@ -51,7 +53,9 @@ import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.instructions.fed.ComputationFEDInstruction;
 import org.apache.sysds.runtime.instructions.gpu.GPUInstruction;
 import org.apache.sysds.runtime.instructions.gpu.context.GPUObject;
+import org.apache.sysds.runtime.instructions.spark.CheckpointSPInstruction;
 import org.apache.sysds.runtime.instructions.spark.ComputationSPInstruction;
+import org.apache.sysds.runtime.instructions.spark.data.RDDObject;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.LineageCacheStatus;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -182,6 +186,14 @@ public class LineageCache
 							return false;  //the executing thread removed this entry from cache
 						else
 							ec.setScalarOutput(outName, so);
+					}
+					else if (e.isRDDPersist()) {
+						//Reuse the RDD which is also persisted in Spark
+						RDDObject rdd = e.getRDDObject();
+						if (rdd == null && e.getCacheStatus() == LineageCacheStatus.NOTCACHED)
+							return false;
+						else
+							((SparkExecutionContext)ec).setRDDHandleForVariable(outName, rdd);
 					}
 					else { //TODO handle locks on gpu objects
 						//shallow copy the cached GPUObj to the output MatrixObject
@@ -520,7 +532,9 @@ public class LineageCache
 			//if (!isMarkedForCaching(inst, ec)) return;
 			List<Pair<LineageItem, Data>> liData = null;
 			GPUObject liGpuObj = null;
+			RDDObject rddObj = null;
 			LineageItem instLI = ((LineageTraceable) inst).getLineageItem(ec).getValue();
+			LineageItem instInputLI = null;
 			if (inst instanceof MultiReturnBuiltinCPInstruction) {
 				liData = new ArrayList<>();
 				MultiReturnBuiltinCPInstruction mrInst = (MultiReturnBuiltinCPInstruction)inst;
@@ -542,6 +556,15 @@ public class LineageCache
 				if (liGpuObj == null)
 					liData = Arrays.asList(Pair.of(instLI, ec.getVariable(((GPUInstruction)inst)._output)));
 			}
+			else if (inst instanceof CheckpointSPInstruction) {
+				// Get the lineage of the instruction being checkpointed
+				instInputLI = ec.getLineageItem(((ComputationSPInstruction)inst).input1);
+				// Get the RDD handle of the persisted RDD
+				CacheableData<?> cd = ec.getCacheableData(((ComputationSPInstruction)inst).output.getName());
+				rddObj = ((CacheableData<?>) cd).getRDDHandle();
+				// Remove the lineage item of the chkpoint instruction
+				removePlaceholder(instLI);
+			}
 			else
 				if (inst instanceof ComputationCPInstruction)
 					liData = Arrays.asList(Pair.of(instLI, ec.getVariable(((ComputationCPInstruction) inst).output)));
@@ -550,10 +573,12 @@ public class LineageCache
 				else if (inst instanceof ComputationSPInstruction)
 					liData = Arrays.asList(Pair.of(instLI, ec.getVariable(((ComputationSPInstruction) inst).output)));
 
-			if (liGpuObj == null)
+			if (liGpuObj == null && rddObj == null)
 				putValueCPU(inst, liData, computetime);
-			else
+			if (liGpuObj != null)
 				putValueGPU(liGpuObj, instLI, computetime);
+			if (rddObj != null)
+				putValueRDD(rddObj, instInputLI, computetime);
 		}
 	}
 	
@@ -579,6 +604,13 @@ public class LineageCache
 					// We don't want to call get() on the future immediately after the execution
 					// For the async. instructions, caching is handled separately by the tasks
 					removePlaceholder(item);
+					continue;
+				}
+
+				if (LineageCacheConfig.isToPersist(inst)) {
+					// The immediately following instruction must be a checkpoint, which will
+					// fill the rdd in this cache entry.
+					// TODO: Instead check if this instruction is marked for checkpointing
 					continue;
 				}
 
@@ -637,6 +669,23 @@ public class LineageCache
 			centry.setGPUValue(gpuObj, computetime);
 			// Maintain order for eviction
 			LineageGPUCacheEviction.addEntry(centry);
+		}
+	}
+
+	private static void putValueRDD(RDDObject rdd, LineageItem instLI, long computetime) {
+		synchronized( _cache ) {
+			// Not available in the cache indicates this RDD is not marked for caching
+			if (!probe(instLI))
+				return;
+
+			LineageCacheEntry centry = _cache.get(instLI);
+			if (centry.isRDDPersist() && centry.getRDDObject().isCheckpointRDD())
+				// Do nothing if the cached RDD is already checkpointed
+				return;
+
+			centry.setRDDValue(rdd, computetime);
+			// Maintain order for eviction
+			LineageCacheEviction.addEntry(centry);
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -607,7 +607,7 @@ public class LineageCache
 					continue;
 				}
 
-				if (LineageCacheConfig.isToPersist(inst)) {
+				if (LineageCacheConfig.isToPersist(inst) && LineageCacheConfig.getCompAssRW()) {
 					// The immediately following instruction must be a checkpoint, which will
 					// fill the rdd in this cache entry.
 					// TODO: Instead check if this instruction is marked for checkpointing

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -199,7 +199,7 @@ public class LineageCacheConfig
 		OPCODES_CHECKPOINTS = OPCODES_CP;
 		//setSpill(true); 
 		setCachePolicy(LineageCachePolicy.COSTNSIZE);
-		setCompAssRW(true);
+		setCompAssRW(false);
 	}
 
 	public static void setReusableOpcodes(String... ops) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -58,10 +58,11 @@ public class LineageCacheConfig
 		//TODO: Reuse everything. 
 	};
 
-	private static final String[] OPCODES_CP = new String[] {
+	/*private static final String[] OPCODES_CP = new String[] {
 		"cpmm", "rmm"
 		//TODO: Instead mark an instruction to be checkpointed
-	};
+	};*/
+	private static final String[] OPCODES_CP = new String[] {};
 
 	private static String[] REUSE_OPCODES  = new String[] {};
 	private static String[] OPCODES_CHECKPOINTS  = new String[] {};

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -58,11 +58,10 @@ public class LineageCacheConfig
 		//TODO: Reuse everything. 
 	};
 
-	/*private static final String[] OPCODES_CP = new String[] {
+	private static final String[] OPCODES_CP = new String[] {
 		"cpmm", "rmm"
 		//TODO: Instead mark an instruction to be checkpointed
-	};*/
-	private static final String[] OPCODES_CP = new String[] {};
+	};
 
 	private static String[] REUSE_OPCODES  = new String[] {};
 	private static String[] OPCODES_CHECKPOINTS  = new String[] {};

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -54,11 +54,18 @@ public class LineageCacheConfig
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
 		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
 		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri",
-		"mapmm", "cpmm", "prefetch"
+		"mapmm", "cpmm", "rmm", "prefetch", "chkpoint"
 		//TODO: Reuse everything. 
 	};
+
+	private static final String[] OPCODES_CP = new String[] {
+		"cpmm", "rmm"
+		//TODO: Instead mark an instruction to be checkpointed
+	};
+
 	private static String[] REUSE_OPCODES  = new String[] {};
-	
+	private static String[] OPCODES_CHECKPOINTS  = new String[] {};
+
 	public enum ReuseCacheType {
 		REUSE_FULL,
 		REUSE_PARTIAL,
@@ -189,6 +196,7 @@ public class LineageCacheConfig
 	static {
 		//setup static configuration parameters
 		REUSE_OPCODES = OPCODES;
+		OPCODES_CHECKPOINTS = OPCODES_CP;
 		//setSpill(true); 
 		setCachePolicy(LineageCachePolicy.COSTNSIZE);
 		setCompAssRW(true);
@@ -200,6 +208,10 @@ public class LineageCacheConfig
 
 	public static String[] getReusableOpcodes() {
 		return REUSE_OPCODES;
+	}
+
+	public static boolean isToPersist(Instruction inst) {
+		return ArrayUtils.contains(OPCODES_CHECKPOINTS, inst.getOpcode());
 	}
 	
 	public static void resetReusableOpcodes() {

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
@@ -158,7 +158,7 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// start the coordinator processes
 		String scriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-config", CONFIG_DIR + "SystemDS-MultiTenant-config.xml",
-			"-explian","-stats", "100", "-fedStats", "100", "-nvargs",
+			"-explain","-stats", "100", "-fedStats", "100", "-nvargs",
 			"in_X1=" + TestUtils.federatedAddress(workerPorts[0], input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(workerPorts[1], input("X2")),
 			"in_X3=" + TestUtils.federatedAddress(workerPorts[2], input("X3")),

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
@@ -146,7 +146,7 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// empty script name because we don't execute any script, just start the worker
 		fullDMLScriptName = "";
 
-		int[] workerPorts = startFedWorkers(4, new String[]{"-explain","-lineage", "reuse"});
+		int[] workerPorts = startFedWorkers(4, new String[]{"-lineage", "reuse"});
 
 		rtplatform = execMode;
 		if(rtplatform == ExecMode.SPARK) {
@@ -158,7 +158,7 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// start the coordinator processes
 		String scriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-config", CONFIG_DIR + "SystemDS-MultiTenant-config.xml",
-			"-explain","-stats", "100", "-fedStats", "100", "-nvargs",
+			"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
 			"in_X1=" + TestUtils.federatedAddress(workerPorts[0], input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(workerPorts[1], input("X2")),
 			"in_X3=" + TestUtils.federatedAddress(workerPorts[2], input("X3")),

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
@@ -158,7 +158,8 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// start the coordinator processes
 		String scriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-config", CONFIG_DIR + "SystemDS-MultiTenant-config.xml",
-			"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
+			//"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
+			"-stats", "100", "-fedStats", "100", "-nvargs",
 			"in_X1=" + TestUtils.federatedAddress(workerPorts[0], input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(workerPorts[1], input("X2")),
 			"in_X3=" + TestUtils.federatedAddress(workerPorts[2], input("X3")),

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseSlicesTest.java
@@ -146,7 +146,7 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// empty script name because we don't execute any script, just start the worker
 		fullDMLScriptName = "";
 
-		int[] workerPorts = startFedWorkers(4, new String[]{"-lineage", "reuse"});
+		int[] workerPorts = startFedWorkers(4, new String[]{"-explain","-lineage", "reuse"});
 
 		rtplatform = execMode;
 		if(rtplatform == ExecMode.SPARK) {
@@ -158,7 +158,7 @@ public class FederatedReuseSlicesTest extends MultiTenantTestBase {
 		// start the coordinator processes
 		String scriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-config", CONFIG_DIR + "SystemDS-MultiTenant-config.xml",
-			"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
+			"-explian","-stats", "100", "-fedStats", "100", "-nvargs",
 			"in_X1=" + TestUtils.federatedAddress(workerPorts[0], input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(workerPorts[1], input("X2")),
 			"in_X3=" + TestUtils.federatedAddress(workerPorts[2], input("X3")),

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedSerializationReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedSerializationReuseTest.java
@@ -159,7 +159,8 @@ public class FederatedSerializationReuseTest extends MultiTenantTestBase {
 		// start the coordinator processes
 		String scriptName = HOME + TEST_NAME + ".dml";
 		programArgs = new String[] {"-config", CONFIG_DIR + "SystemDS-MultiTenant-config.xml",
-			"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
+			//"-lineage", "reuse", "-stats", "100", "-fedStats", "100", "-nvargs",
+			"-stats", "100", "-fedStats", "100", "-nvargs",
 			"in_X1=" + TestUtils.federatedAddress(workerPorts[0], input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(workerPorts[1], input("X2")),
 			"in_X3=" + TestUtils.federatedAddress(workerPorts[2], input("X3")),


### PR DESCRIPTION
This patch extends lineage cache to store the RDD objects which are checkpointed. This addition allows the compiler to place a chkpoint after a potentially redundant operator. During runtime, we then persist the RDD, save the RDD in the lineage cache, and reuse if the instruction repeats. It is a bit tricky to cache a RDD for a lineage trace of a previous instruction. A better way would be to be able to mark any instruction to persist the result RDD and skip the chkpoint instruction.
Hyperparameter tuning of LmDS with 2.5k columns improves by 4x by caching the cpmm results in the executors.