### PR TITLE
[SYSTEMDS-3479] Mark Spark instructions to persist and locally cache

### DIFF
--- a/src/main/java/org/apache/sysds/hops/AggBinaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/AggBinaryOp.java
@@ -217,7 +217,7 @@ public class AggBinaryOp extends MultiThreadedHop {
 						input1.getDim1(), input1.getDim2(), input1.getBlocksize(), input1.getNnz(),
 						input2.getDim1(), input2.getDim2(), input2.getBlocksize(), input2.getNnz(),
 						mmtsj, chain, _hasLeftPMInput, tmmRewrite );
-				//dispatch SPARK lops construction 
+				//dispatch SPARK lops construction
 				switch( _method )
 				{
 					case TSMM:
@@ -790,6 +790,7 @@ public class AggBinaryOp extends MultiThreadedHop {
 			Lop cpmm = new MMCJ(getInput().get(0).constructLops(), getInput().get(1).constructLops(),
 				getDataType(), getValueType(), _outputEmptyBlocks, aggtype, ExecType.SPARK);
 			setOutputDimensions( cpmm );
+			//setMarkForLineageCaching(cpmm);
 			setLineNumbers( cpmm );
 			setLops( cpmm );
 		}
@@ -823,6 +824,7 @@ public class AggBinaryOp extends MultiThreadedHop {
 		Lop rmm = new MMRJ(getInput().get(0).constructLops(),getInput().get(1).constructLops(), 
 			getDataType(), getValueType(), ExecType.SPARK);
 		setOutputDimensions(rmm);
+		//setMarkForLineageCaching(rmm);
 		setLineNumbers( rmm );
 		setLops(rmm);
 	}

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -57,6 +57,7 @@ import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
 import org.apache.sysds.runtime.controlprogram.parfor.util.IDSequence;
 import org.apache.sysds.runtime.instructions.fed.FEDInstruction.FederatedOutput;
 import org.apache.sysds.runtime.instructions.gpu.context.GPUContextPool;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
@@ -1233,6 +1234,13 @@ public abstract class Hop implements ParseInfo {
 	protected void setOutputDimensions(Lop lop) {
 		lop.getOutputParameters().setDimensions(
 			getDim1(), getDim2(), getBlocksize(), getNnz(), getUpdateType());
+	}
+
+	protected void setMarkForLineageCaching(Lop lop) {
+		//TODO: set the flag in the HOP via a rewrite
+		//lop.getOutputParameters().setLineageCacheCandidate(requiresLineageCaching());
+		if (!LineageCacheConfig.ReuseCacheType.isNone())
+			lop.getOutputParameters().setLineageCacheCandidate(true);
 	}
 
 	protected void setOutputDimensionsIncludeCompressedSize(Lop lop) {

--- a/src/main/java/org/apache/sysds/lops/MMCJ.java
+++ b/src/main/java/org/apache/sysds/lops/MMCJ.java
@@ -109,6 +109,8 @@ public class MMCJ extends Lop
 		}
 		else
 			sb.append(_type.name());
+		sb.append( OPERAND_DELIMITOR );
+		sb.append(getOutputParameters().getLinCacheMarking());
 		
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/lops/MMRJ.java
+++ b/src/main/java/org/apache/sysds/lops/MMRJ.java
@@ -59,11 +59,13 @@ public class MMRJ extends Lop
 
 	@Override
 	public String getInstructions(String input1, String input2, String output) {
+		boolean toCache = getOutputParameters().getLinCacheMarking();
 		return InstructionUtils.concatOperands(
 			getExecType().name(),
 			"rmm",
 			getInputs().get(0).prepInputOperand(input1),
 			getInputs().get(1).prepInputOperand(input2),
-			prepOutputOperand(output));
+			prepOutputOperand(output),
+			Boolean.toString(toCache));
 	}
 }

--- a/src/main/java/org/apache/sysds/lops/OutputParameters.java
+++ b/src/main/java/org/apache/sysds/lops/OutputParameters.java
@@ -162,6 +162,10 @@ public class OutputParameters
 	public void setUpdateType(UpdateType update) {
 		_updateType = update;
 	}
+
+	public void setLineageCacheCandidate(boolean reqCaching) {
+		_linCacheCandidate = reqCaching;
+	}
 	
 	public boolean getLinCacheMarking() {
 		return _linCacheCandidate;

--- a/src/main/java/org/apache/sysds/lops/OutputParameters.java
+++ b/src/main/java/org/apache/sysds/lops/OutputParameters.java
@@ -39,7 +39,7 @@ public class OutputParameters
 	private long _blocksize = -1;
 	private String _file_name = null;
 	private String _file_label = null;
-	private boolean _linCacheCandidate = true;
+	private boolean _linCacheCandidate = false;
 	private long _compressedSize = -1;
 
 	FileFormat matrix_format = FileFormat.BINARY;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/MatrixObject.java
@@ -476,7 +476,7 @@ public class MatrixObject extends CacheableData<MatrixBlock> {
 		FileFormat fmt = iimd.getFileFormat();
 		MatrixBlock mb = null;
 		try {
-			// prevent unnecessary collect through rdd checkpoint
+			// prevent unnecessary collect through rdd checkpoint (unless lineage cached)
 			if(rdd.allowsShortCircuitCollect()) {
 				lrdd = (RDDObject) rdd.getLineageChilds().get(0);
 			}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1522,7 +1522,9 @@ public class SparkExecutionContext extends ExecutionContext
 		if( lob instanceof RDDObject ) {
 			RDDObject rdd = (RDDObject)lob;
 			int rddID = rdd.getRDD().id();
-			cleanupRDDVariable(rdd.getRDD());
+			//skip unpersisting if locally cached
+			if (!lob.isInLineageCache())
+				cleanupRDDVariable(rdd.getRDD());
 			if( rdd.getHDFSFilename()!=null ) { //deferred file removal
 				HDFSTool.deleteFileWithMTDIfExistOnHDFS(rdd.getHDFSFilename());
 			}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateBinarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/AggregateBinarySPInstruction.java
@@ -26,8 +26,12 @@ import org.apache.sysds.runtime.matrix.operators.Operator;
  * Class to group the different MM <code>SPInstruction</code>s together.
  */
 public abstract class AggregateBinarySPInstruction extends BinarySPInstruction {
-	protected AggregateBinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2, CPOperand out,
-			String opcode, String istr) {
+	protected AggregateBinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(type, op, in1, in2, out, opcode, istr);
+	}
+
+	protected AggregateBinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+		String opcode, boolean toCache, String istr) {
+		super(type, op, in1, in2, out, opcode, toCache, istr);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/BinarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/BinarySPInstruction.java
@@ -56,7 +56,12 @@ public abstract class BinarySPInstruction extends ComputationSPInstruction {
 	protected BinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
 		super(type, op, in1, in2, out, opcode, istr);
 	}
-	
+
+	protected BinarySPInstruction(SPType type, Operator op, CPOperand in1, CPOperand in2,
+		CPOperand out, String opcode, boolean toCache, String istr) {
+		super(type, op, in1, in2, out, opcode, toCache, istr);
+	}
+
 	public static BinarySPInstruction parseInstruction ( String str ) {
 		CPOperand in1 = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);
 		CPOperand in2 = new CPOperand("", ValueType.UNKNOWN, DataType.UNKNOWN);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CpmmSPInstruction.java
@@ -66,8 +66,9 @@ public class CpmmSPInstruction extends AggregateBinarySPInstruction {
 	private final boolean _outputEmptyBlocks;
 	private final SparkAggType _aggtype;
 	
-	private CpmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, boolean outputEmptyBlocks, SparkAggType aggtype, String opcode, String istr) {
-		super(SPType.CPMM, op, in1, in2, out, opcode, istr);
+	private CpmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+		boolean outputEmptyBlocks, SparkAggType aggtype, String opcode, boolean toCache, String istr) {
+		super(SPType.CPMM, op, in1, in2, out, opcode, toCache, istr);
 		_outputEmptyBlocks = outputEmptyBlocks;
 		_aggtype = aggtype;
 	}
@@ -83,7 +84,8 @@ public class CpmmSPInstruction extends AggregateBinarySPInstruction {
 		AggregateBinaryOperator aggbin = InstructionUtils.getMatMultOperator(1);
 		boolean outputEmptyBlocks = Boolean.parseBoolean(parts[4]);
 		SparkAggType aggtype = SparkAggType.valueOf(parts[5]);
-		return new CpmmSPInstruction(aggbin, in1, in2, out, outputEmptyBlocks, aggtype, opcode, str);
+		boolean toCache = parts.length == 7 ? Boolean.parseBoolean(parts[6]) : false;
+		return new CpmmSPInstruction(aggbin, in1, in2, out, outputEmptyBlocks, aggtype, opcode, toCache, str);
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/RmmSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/RmmSPInstruction.java
@@ -49,8 +49,9 @@ import java.util.LinkedList;
 
 public class RmmSPInstruction extends AggregateBinarySPInstruction {
 
-	private RmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out, String opcode, String istr) {
-		super(SPType.RMM, op, in1, in2, out, opcode, istr);
+	private RmmSPInstruction(Operator op, CPOperand in1, CPOperand in2, CPOperand out,
+		String opcode, boolean toCache, String istr) {
+		super(SPType.RMM, op, in1, in2, out, opcode, toCache, istr);
 	}
 
 	public static RmmSPInstruction parseInstruction( String str ) {
@@ -61,8 +62,9 @@ public class RmmSPInstruction extends AggregateBinarySPInstruction {
 			CPOperand in1 = new CPOperand(parts[1]);
 			CPOperand in2 = new CPOperand(parts[2]);
 			CPOperand out = new CPOperand(parts[3]);
+			boolean toCache = parts.length == 5 ? Boolean.parseBoolean(parts[4]) : false;
 			
-			return new RmmSPInstruction(null, in1, in2, out, opcode, str);
+			return new RmmSPInstruction(null, in1, in2, out, opcode, toCache, str);
 		} 
 		else {
 			throw new DMLRuntimeException("RmmSPInstruction.parseInstruction():: Unknown opcode " + opcode);

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
@@ -28,6 +28,7 @@ public abstract class LineageObject
 {
 	//basic lineage information
 	protected int _numRef = -1;
+	protected boolean _lineageCached = false;
 	protected final List<LineageObject> _childs;
 	
 	//N:1 back reference to matrix/frame object
@@ -35,6 +36,7 @@ public abstract class LineageObject
 	
 	protected LineageObject() {
 		_numRef = 0;
+		_lineageCached = false;
 		_childs = new ArrayList<>();
 	}
 	
@@ -48,6 +50,14 @@ public abstract class LineageObject
 	
 	public boolean hasBackReference() {
 		return (_cd != null);
+	}
+
+	public void setLineageCached() {
+		_lineageCached = true;
+	}
+
+	public boolean isInLineageCache() {
+		return _lineageCached;
 	}
 	
 	public void incrementNumReferences() {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
@@ -103,6 +103,11 @@ public class RDDObject extends LineageObject
 
 	public boolean allowsShortCircuitCollect()
 	{
+		// If the RDD is marked to be persisted and cached locally, we want to collect the RDD
+		// so that the next time we can reuse the RDD.
+		if (isInLineageCache())
+			return false;
+
 		return ( isCheckpointRDD() && getLineageChilds().size() == 1
 			     && getLineageChilds().get(0) instanceof RDDObject );
 	}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -58,13 +58,7 @@ public class LineageCacheConfig
 		//TODO: Reuse everything. 
 	};
 
-	private static final String[] OPCODES_CP = new String[] {
-		"cpmm", "rmm"
-		//TODO: Instead mark an instruction to be checkpointed
-	};
-
 	private static String[] REUSE_OPCODES  = new String[] {};
-	private static String[] OPCODES_CHECKPOINTS  = new String[] {};
 
 	public enum ReuseCacheType {
 		REUSE_FULL,
@@ -196,10 +190,9 @@ public class LineageCacheConfig
 	static {
 		//setup static configuration parameters
 		REUSE_OPCODES = OPCODES;
-		OPCODES_CHECKPOINTS = OPCODES_CP;
-		//setSpill(true); 
+		//setSpill(true);
 		setCachePolicy(LineageCachePolicy.COSTNSIZE);
-		setCompAssRW(false);
+		setCompAssRW(true);
 	}
 
 	public static void setReusableOpcodes(String... ops) {
@@ -210,10 +203,6 @@ public class LineageCacheConfig
 		return REUSE_OPCODES;
 	}
 
-	public static boolean isToPersist(Instruction inst) {
-		return ArrayUtils.contains(OPCODES_CHECKPOINTS, inst.getOpcode());
-	}
-	
 	public static void resetReusableOpcodes() {
 		REUSE_OPCODES = OPCODES;
 	}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
@@ -161,6 +161,10 @@ public class LineageCacheEntry {
 		return _rddObject != null;
 	}
 
+	public boolean isGPUObject() {
+		return _gpuObject != null;
+	}
+
 	public boolean isSerializedBytes() {
 		return _dt.isUnknown() && _key.getOpcode().equals(LineageItemUtils.SERIALIZATION_OPCODE);
 	}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
@@ -41,10 +41,13 @@ public class LineageCacheStatistics {
 	private static final LongAdder _ctimeFSWrite    = new LongAdder();
 	private static final LongAdder _ctimeSaved      = new LongAdder();
 	private static final LongAdder _ctimeMissed     = new LongAdder();
-	// Bellow entries are for specific to gpu lineage cache
+	// Bellow entries are specific to gpu lineage cache
 	private static final LongAdder _numHitsGpu      = new LongAdder();
 	private static final LongAdder _numAsyncEvictGpu= new LongAdder();
 	private static final LongAdder _numSyncEvictGpu = new LongAdder();
+	// Below entries are specific to Spark instructions
+	private static final LongAdder _numHitsRdd      = new LongAdder();
+	private static final LongAdder _numHitsSparkActions = new LongAdder();
 
 	public static void reset() {
 		_numHitsMem.reset();
@@ -64,6 +67,8 @@ public class LineageCacheStatistics {
 		_numHitsGpu.reset();
 		_numAsyncEvictGpu.reset();
 		_numSyncEvictGpu.reset();
+		_numHitsRdd.reset();
+		_numHitsSparkActions.reset();
 	}
 	
 	public static void incrementMemHits() {
@@ -197,6 +202,17 @@ public class LineageCacheStatistics {
 		_numSyncEvictGpu.increment();
 	}
 
+	public static void incrementRDDHits() {
+		// Number of times a persisted RDD are reused.
+		_numHitsRdd.increment();
+	}
+
+	public static void incrementSparkCollectHits() {
+		// Spark instructions that bring intermediate back to local.
+		// Both synchronous and asynchronous (e.g. tsmm, prefetch)
+		_numHitsSparkActions.increment();
+	}
+
 	public static String displayHits() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(_numHitsMem.longValue());
@@ -255,6 +271,14 @@ public class LineageCacheStatistics {
 		sb.append(_numAsyncEvictGpu.longValue());
 		sb.append("/");
 		sb.append(_numSyncEvictGpu.longValue());
+		return sb.toString();
+	}
+
+	public static String displaySparkStats() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(_numHitsSparkActions.longValue());
+		sb.append("/");
+		sb.append(_numHitsRdd.longValue());
 		return sb.toString();
 	}
 }

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -639,6 +639,7 @@ public class Statistics
 				sb.append("LinCache hits (Mem/FS/Del): \t" + LineageCacheStatistics.displayHits() + ".\n");
 				sb.append("LinCache MultiLevel (Ins/SB/Fn):" + LineageCacheStatistics.displayMultiLevelHits() + ".\n");
 				sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
+				sb.append("LinCache Spark (Col/RDD): \t\t" + LineageCacheStatistics.displaySparkStats() + ".\n");
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");
 				sb.append("LinCache FStimes (Rd/Wr): \t" + LineageCacheStatistics.displayFSTime() + " sec.\n");
 				sb.append("LinCache Computetime (S/M): \t" + LineageCacheStatistics.displayComputeTime() + " sec.\n");

--- a/src/test/scripts/functions/async/LineageReuseSpark2.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark2.dml
@@ -1,0 +1,53 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N) return (Matrix[double] beta)
+{
+  # Reuse sp_tsmm and sp_mapmm if not future-based
+  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  b = t(X) %*% y;
+  beta = solve(A, b);
+}
+
+no_lamda = 10;
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+lim = 0.1;
+
+X = rand(rows=1500, cols=1500, seed=42);
+y = rand(rows=1500, cols=1, seed=43);
+N = ncol(X);
+R = matrix(0, rows=N, cols=no_lamda+2);
+i = 1;
+
+while (lamda < lim)
+{
+  beta = SimlinRegDS(X, y, lamda, N);
+  #beta = lmDS(X=X, y=y, reg=lamda);
+  R[,i] = beta;
+  lamda = lamda + stp;
+  i = i + 1;
+}
+
+R = sum(R);
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch adds the compiler flags and runtime support to checkpoint any Spark instruction which is marked for caching. During postprocessing of a marked instruction, we first inplace persist the RDD and then store the RDD in the local Lineage cache for reuse. This patch also fixes a bug in the last commit which was unpersisting the locally cached RDDs during rmvar. Future commits will add rewrites to mark the Spark instructions for caching in a cost-based manner.
Hyperparameter tuning of LmDS with 2.5k columns improves by 22x by caching the cpmm results in the executors.