### PR TITLE
[SYSTEMDS-3483] Compile-time checkpoint placement for shared Spark OPs

### DIFF
--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -639,7 +639,7 @@ public class Statistics
 				sb.append("LinCache hits (Mem/FS/Del): \t" + LineageCacheStatistics.displayHits() + ".\n");
 				sb.append("LinCache MultiLevel (Ins/SB/Fn):" + LineageCacheStatistics.displayMultiLevelHits() + ".\n");
 				sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
-				sb.append("LinCache Spark (Col/RDD): \t\t" + LineageCacheStatistics.displaySparkStats() + ".\n");
+				sb.append("LinCache Spark (Col/RDD): \t" + LineageCacheStatistics.displaySparkStats() + ".\n");
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");
 				sb.append("LinCache FStimes (Rd/Wr): \t" + LineageCacheStatistics.displayFSTime() + " sec.\n");
 				sb.append("LinCache Computetime (S/M): \t" + LineageCacheStatistics.displayComputeTime() + " sec.\n");

--- a/src/main/java/org/apache/sysds/utils/stats/SparkStatistics.java
+++ b/src/main/java/org/apache/sysds/utils/stats/SparkStatistics.java
@@ -34,6 +34,7 @@ public class SparkStatistics {
 	private static final LongAdder asyncPrefetchCount = new LongAdder();
 	private static final LongAdder asyncBroadcastCount = new LongAdder();
 	private static final LongAdder asyncTriggerCheckpointCount = new LongAdder();
+	private static final LongAdder asyncSparkOpCount = new LongAdder();
 
 	public static boolean createdSparkContext() {
 		return ctxCreateTime > 0;
@@ -80,12 +81,20 @@ public class SparkStatistics {
 		asyncTriggerCheckpointCount.add(c);
 	}
 
+	public static void incAsyncSparkOpCount(long c) {
+		asyncSparkOpCount.add(c);
+	}
+
 	public static long getSparkCollectCount() {
 		return collectCount.longValue();
 	}
 
 	public static long getAsyncPrefetchCount() {
 		return asyncPrefetchCount.longValue();
+	}
+
+	public static long getAsyncSparkOpCount() {
+		return asyncSparkOpCount.longValue();
 	}
 
 	public static long getAsyncBroadcastCount() {
@@ -122,8 +131,8 @@ public class SparkStatistics {
 						parallelizeTime.longValue()*1e-9,
 						broadcastTime.longValue()*1e-9,
 						collectTime.longValue()*1e-9));
-		sb.append("Spark async. count (pf,bc,cp): \t" +
-				String.format("%d/%d/%d.\n", getAsyncPrefetchCount(), getAsyncBroadcastCount(), getasyncTriggerCheckpointCount()));
+		sb.append("Spark async. count (pf,bc,op): \t" +
+				String.format("%d/%d/%d.\n", getAsyncPrefetchCount(), getAsyncBroadcastCount(), getAsyncSparkOpCount()));
 		return sb.toString();
 	}
 }

--- a/src/test/scripts/functions/async/CheckpointSharedOps1.dml
+++ b/src/test/scripts/functions/async/CheckpointSharedOps1.dml
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = rand(rows=1500, cols=1500, seed=42); #sp_rand
+v = rand(rows=1500, cols=1, seed=42); #cp_rand
+v2 = rand(rows=1500, cols=1, seed=43); #cp_rand
+
+# CP instructions
+v = ((v + v) * 1 - v) / (1+1);
+v = ((v + v) * 2 - v) / (2+1);
+
+# Spark operations 
+sp1 = X + ceil(X);
+sp2 = t(sp1) %*% sp1; #shared among Job 1 and 2
+
+# Job1: SP unary triggers the DAG of SP operations
+sp3 = sp2 + sum(v);
+R1 = sum(sp3);
+
+# Job2: SP unary triggers the DAG of SP operations
+sp4 = sp2 + sum(v2);
+R2 = sum(sp4);
+
+R = R1 + R2;
+write(R, $1, format="text");


### PR DESCRIPTION
This patch brings the initial implementation of placing checkpoint Lops after expensive Spark operations, which are shared among multiple Spark jobs. In addition, this patch fixes bugs and extends statistics.