### PR TITLE
[SYSTEMDS-???] Precompile Patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ scripts/perftest/temp
 scripts/perftest/fed/results
 scripts/perftest/fed/scratch_space
 scripts/perftest/fed/temp
+
+src/test/scripts/functions/iogen/*.raw

--- a/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
+++ b/src/main/java/org/apache/sysds/conf/ConfigurationManager.java
@@ -262,6 +262,10 @@ public class ConfigurationManager{
 			|| OptimizerUtils.MAX_PARALLELIZE_ORDER);
 	}
 
+	public static boolean isParallelIOEnabled(){
+		return getDMLConfig().getBooleanValue(DMLConfig.CP_PARALLEL_IO);
+	}
+
 	public static boolean isBroadcastEnabled() {
 		return (getDMLConfig().getBooleanValue(DMLConfig.ASYNC_SPARK_BROADCAST)
 			|| OptimizerUtils.ASYNC_BROADCAST_SPARK);

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -551,7 +551,6 @@ public class UnaryOp extends MultiThreadedHop
 			setDim2(1);
 		}
 		else if(_op == OpOp1.TYPEOF || _op == OpOp1.DETECTSCHEMA || _op == OpOp1.COLNAMES) {
-			//TODO these three builtins should rather be moved to unary aggregates
 			setDim1(1);
 			setDim2(input.getDim2());
 		}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -122,6 +122,14 @@ public abstract class Array<T> implements Writable {
 	public abstract void set(int index, double value);
 
 	/**
+	 * Set index to the given value of the string parsed.
+	 * 
+	 * @param index The index to set
+	 * @param value The value to assign
+	 */
+	public abstract void set(int index, String value);
+
+	/**
 	 * Set range to given arrays value
 	 * 
 	 * @param rl    row lower
@@ -215,7 +223,7 @@ public abstract class Array<T> implements Writable {
 	/**
 	 * Slice out the sub range and return new array with the specified type.
 	 * 
-	 * If the conversion fails fallback to normal slice
+	 * If the conversion fails fallback to normal slice.
 	 * 
 	 * @param rl row start
 	 * @param ru row end (not included)
@@ -389,6 +397,8 @@ public abstract class Array<T> implements Writable {
 	 * @param val the value to fill with.
 	 */
 	public abstract void fill(T val);
+
+	public abstract boolean isShallowSerialize();
 
 	/**
 	 * Overwrite of the java internal clone function for arrays, return a clone of underlying data that is mutable, (not

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
@@ -47,6 +47,8 @@ public class BitSetArray extends Array<Boolean> {
 
 	public BitSetArray(boolean[] data) {
 		super(data.length);
+		if(data.length == 11)
+			throw new DMLRuntimeException("Invalid length");
 		_data = new long[_size / 64 + 1];
 		// set bits.
 		for(int i = 0; i < data.length; i++)
@@ -99,6 +101,11 @@ public class BitSetArray extends Array<Boolean> {
 	@Override
 	public void set(int index, double value) {
 		set(index, value == 1.0);
+	}
+
+	@Override
+	public void set(int index, String value) {
+		set(index, BooleanArray.parseBoolean(value));
 	}
 
 	@Override
@@ -241,7 +248,7 @@ public class BitSetArray extends Array<Boolean> {
 		final int endSize = this._size + other.size();
 		final BitSetArray retBS = new BitSetArray(endSize);
 		retBS.set(0, this._size - 1, this, 0);
-		retBS.set(this._size, endSize - 1, other,0);
+		retBS.set(this._size, endSize - 1, other, 0);
 		return retBS;
 	}
 
@@ -286,8 +293,8 @@ public class BitSetArray extends Array<Boolean> {
 	}
 
 	private BitSetArray sliceSimple(int rl, int ru) {
-		final boolean[] ret = new boolean[ru - rl + 1];
-		for(int i = rl, off = 0; i <= ru; i++, off++)
+		final boolean[] ret = new boolean[ru - rl];
+		for(int i = rl, off = 0; i < ru; i++, off++)
 			ret[off] = get(i);
 		return new BitSetArray(ret);
 	}
@@ -380,7 +387,7 @@ public class BitSetArray extends Array<Boolean> {
 
 	@Override
 	protected Array<Boolean> changeTypeBitSet() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -458,6 +465,11 @@ public class BitSetArray extends Array<Boolean> {
 	@Override
 	public double getAsDouble(int i) {
 		return get(i) ? 1.0 : 0.0;
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	public static String longToBits(long l) {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -64,6 +64,11 @@ public class BooleanArray extends Array<Boolean> {
 	}
 
 	@Override
+	public void set(int index, String value) {
+		set(index, BooleanArray.parseBoolean(value));
+	}
+
+	@Override
 	public void set(int rl, int ru, Array<Boolean> value) {
 		set(rl, ru, value, 0);
 	}
@@ -222,7 +227,7 @@ public class BooleanArray extends Array<Boolean> {
 
 	@Override
 	protected Array<Boolean> changeTypeBoolean() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -278,14 +283,8 @@ public class BooleanArray extends Array<Boolean> {
 	}
 
 	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
-		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size - 1; i++)
-			sb.append((_data[i] ? 1 : 0) + ",");
-		sb.append(_data[_size - 1] ? 1 : 0);
-		sb.append("]");
-		return sb.toString();
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	@Override
@@ -295,5 +294,16 @@ public class BooleanArray extends Array<Boolean> {
 
 	protected static boolean parseBoolean(String value) {
 		return value != null && (Boolean.parseBoolean(value) || value.equals("1") || value.equals("1.0"));
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
+		sb.append(super.toString() + ":[");
+		for(int i = 0; i < _size - 1; i++)
+			sb.append((_data[i] ? 1 : 0) + ",");
+		sb.append(_data[_size - 1] ? 1 : 0);
+		sb.append("]");
+		return sb.toString();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
@@ -62,6 +62,11 @@ public class DoubleArray extends Array<Double> {
 	}
 
 	@Override
+	public void set(int index, String value){
+		set(index, parseDouble(value) );
+	}
+
+	@Override
 	public void set(int rl, int ru, Array<Double> value) {
 		set(rl, ru, value, 0);
 	}
@@ -256,7 +261,7 @@ public class DoubleArray extends Array<Double> {
 
 	@Override
 	protected Array<Double> changeTypeDouble() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -318,6 +323,11 @@ public class DoubleArray extends Array<Double> {
 			return 0.0;
 		else
 			return Double.parseDouble(value);
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -60,6 +60,12 @@ public class FloatArray extends Array<Float> {
 		_data[index] = (float) value;
 	}
 
+
+	@Override
+	public void set(int index, String value){
+		set(index,parseFloat(value) );
+	}
+
 	@Override
 	public void set(int rl, int ru, Array<Float> value) {
 		set(rl, ru, value, 0);
@@ -240,7 +246,7 @@ public class FloatArray extends Array<Float> {
 
 	@Override
 	protected Array<Float> changeTypeFloat() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -272,6 +278,11 @@ public class FloatArray extends Array<Float> {
 			return 0.0f;
 		else
 			return Float.parseFloat(value);
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
@@ -61,6 +61,11 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
+	public void set(int index, String value) {
+		set(index, parseInt(value));
+	}
+
+	@Override
 	public void set(int rl, int ru, Array<Integer> value) {
 		set(rl, ru, value, 0);
 	}
@@ -113,7 +118,7 @@ public class IntegerArray extends Array<Integer> {
 		final int endSize = this._size + other.size();
 		final int[] ret = new int[endSize];
 		System.arraycopy(_data, 0, ret, 0, this._size);
-		System.arraycopy((int[])other.get(), 0, ret, this._size, other.size());
+		System.arraycopy((int[]) other.get(), 0, ret, this._size, other.size());
 		return new IntegerArray(ret);
 	}
 
@@ -144,7 +149,7 @@ public class IntegerArray extends Array<Integer> {
 	public void reset(int size) {
 		if(_data.length < size || _data.length > 2 * size)
 			_data = new int[size];
-			else
+		else
 			for(int i = 0; i < size; i++)
 				_data[i] = 0;
 		_size = size;
@@ -228,7 +233,7 @@ public class IntegerArray extends Array<Integer> {
 
 	@Override
 	protected Array<Integer> changeTypeInteger() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -259,7 +264,7 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
-	public double getAsDouble(int i){
+	public double getAsDouble(int i) {
 		return _data[i];
 	}
 
@@ -270,12 +275,17 @@ public class IntegerArray extends Array<Integer> {
 			return Integer.parseInt(s);
 		}
 		catch(NumberFormatException e) {
-			if(s.contains(".")){
+			if(s.contains(".")) {
 				return Integer.parseInt(s.split("\\.")[0]);
 			}
 			else
 				throw e;
 		}
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -61,6 +61,11 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
+	public void set(int index, String value) {
+		set(index, parseLong(value));
+	}
+
+	@Override
 	public void set(int rl, int ru, Array<Long> value) {
 		set(rl, ru, value, 0);
 	}
@@ -112,7 +117,7 @@ public class LongArray extends Array<Long> {
 		final int endSize = this._size + other.size();
 		final long[] ret = new long[endSize];
 		System.arraycopy(_data, 0, ret, 0, this._size);
-		System.arraycopy((long[])other.get(), 0, ret, this._size, other.size());
+		System.arraycopy((long[]) other.get(), 0, ret, this._size, other.size());
 		return new LongArray(ret);
 	}
 
@@ -144,7 +149,7 @@ public class LongArray extends Array<Long> {
 	public void reset(int size) {
 		if(_data.length < size || _data.length > 2 * size)
 			_data = new long[size];
-			else
+		else
 			for(int i = 0; i < size; i++)
 				_data[i] = 0;
 		_size = size;
@@ -239,7 +244,7 @@ public class LongArray extends Array<Long> {
 
 	@Override
 	protected Array<Long> changeTypeLong() {
-		return clone();
+		return this;
 	}
 
 	@Override
@@ -278,6 +283,11 @@ public class LongArray extends Array<Long> {
 			else
 				throw e;
 		}
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/iterators/RowIterator.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/iterators/RowIterator.java
@@ -21,10 +21,15 @@ package org.apache.sysds.runtime.frame.data.iterators;
 
 import java.util.Iterator;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 public abstract class RowIterator<T> implements Iterator<T[]> {
+
+	protected static final Log LOG = LogFactory.getLog(RowIterator.class.getName());
+
 	protected final FrameBlock _fb;
 	protected final int[] _cols;
 	protected final T[] _curRow;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibAppend.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibAppend.java
@@ -83,7 +83,6 @@ public class FrameLibAppend {
 		else if(b.getNumRows() == 0)
 			return a;
 
-		// ret._schema = a.getSchema().clone();
 		String[] retColNames = (a.getColumnNames(false) != null) ? a.getColumnNames().clone() : null;
 		ColumnMetadata[] retColMeta = new ColumnMetadata[a.getNumColumns()];
 		for(int j = 0; j < nCol; j++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
@@ -71,6 +71,13 @@ public class FrameLibApplySchema {
 			applySingleThread();
 		else
 			applyMultiThread();
+		
+		boolean same = true;
+		for(int i = 0; i < columnsIn.length && same; i++)
+			same = columnsIn[i] == columnsOut[i];
+		
+		if(same)
+			return this.fb;
 
 		final String[] colNames = fb.getColumnNames(false);
 		final ColumnMetadata[] meta = fb.getColumnMetadata();

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.frame.data.lib;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,6 +35,12 @@ import org.apache.sysds.runtime.util.UtilFunctions;
 public interface FrameUtil {
 	public static final Log LOG = LogFactory.getLog(FrameUtil.class.getName());
 
+	public static final Pattern booleanPattern = Pattern.compile("([tT]((rue)|(RUE))?|[fF]((alse)|(ALSE))?|0\\.0+|1\\.0+|0|1)");
+	public static final Pattern integerFloatPattern = Pattern.compile("[-+]?\\d+(\\.0+)?");
+	public static final Pattern floatPattern = Pattern.compile("[-+]?[0-9]*\\.?[0-9]*([eE][-+]?[0-9]+)?");
+
+	public static final Pattern dotSplitPattern = Pattern.compile("\\.");
+
 	public static Array<?>[] add(Array<?>[] ar, Array<?> e) {
 		if(ar == null)
 			return new Array[] {e};
@@ -43,58 +50,124 @@ public interface FrameUtil {
 		return ret;
 	}
 
-	public static ValueType isType(String val) {
-		if (val == null)
-			return ValueType.UNKNOWN;
-		val = val.trim().toLowerCase().replaceAll("\"", "");
-		if(val.matches("(true|false|t|f|0|1|0\\.0+|1\\.0+)"))
+	private static ValueType isBooleanType(final String val, int len) {
+		if(val.length() <= 16 && booleanPattern.matcher(val).matches())
 			return ValueType.BOOLEAN;
-		else if(val.matches("[-+]?\\d+\\.0+")) { // 11.00000000 1313241.0
-			long maxValue = Long.parseLong(val.split("\\.")[0]);
-			if((maxValue >= Integer.MIN_VALUE) && (maxValue <= Integer.MAX_VALUE))
-				return ValueType.INT32;
-			else
-				return ValueType.INT64;
+		return null;
+	}
+
+	private static boolean simpleIntMatch(final String val, final int len) {
+		for(int i = 0; i < len; i++) {
+			final char c = val.charAt(i);
+			if(c < '0' || c > '9')
+				return false;
 		}
-		else if(val.matches("[-+]?\\d+")) { // 1 3 6 192 14152131
-			long maxValue = Long.parseLong(val);
-			if((maxValue >= Integer.MIN_VALUE) && (maxValue <= Integer.MAX_VALUE))
-				return ValueType.INT32;
-			else
-				return ValueType.INT64;
+		return true;
+	}
+
+	private static ValueType intType(final long value) {
+		if(value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE)
+			return ValueType.INT32;
+		else
+			return ValueType.INT64;
+	}
+
+	private static ValueType isIntType(final String val, final int len) {
+		if(len <= 22) {
+			if(simpleIntMatch(val, len)){
+				if(len < 8)
+					return ValueType.INT32;
+				return intType(Long.parseLong(val));
+			}
+			else if(integerFloatPattern.matcher(val).matches()) {
+				// 11.00000000 1313241.0 13 2415 -22
+				final long value = Long.parseLong(val.contains(".") ? dotSplitPattern.split(val)[0] : val);
+				return intType(value);
+			}
 		}
-		else if(val.matches("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?")) {
-			// parse float, and make back to string if equivalent use float.
+		return null;
+	}
+
+	private static ValueType isFloatType(final String val, final int len) {
+
+		if(len <= 25 && floatPattern.matcher(val).matches()) {
+			// return isFloatType(v);
+			// parse float and double,
+			// and make back to string if equivalent use float.
+			// This is expensive but accurate.
 			float f = Float.parseFloat(val);
-			if(val.equals(Float.toString(f)))
+			double d = Double.parseDouble(val);
+			String v1 = Float.toString(f);
+			String v2 = Double.toString(d);
+			if(v1.equals(v2))
 				return ValueType.FP32;
 			else
 				return ValueType.FP64;
 		}
 		else if(val.equals("infinity") || val.equals("-infinity") || val.equals("nan"))
 			return ValueType.FP64;
-		else
-			return ValueType.STRING;
+		return null;
 	}
 
-	public static ValueType isType(double val){
+	/**
+	 * Get type type subject to minimum another type.
+	 * 
+	 * This enable skipping checking for boolean type if floats are already found.
+	 * 
+	 * @param val     The string value to check
+	 * @param minType the minimum type to check.
+	 * @return ValueType subject to restriction
+	 */
+	public static ValueType isType(String val, ValueType minType) {
+		if(val == null)
+			return ValueType.UNKNOWN;
+		final int len = val.length();
+		if(len == 0)
+			return ValueType.UNKNOWN;
+		ValueType r = null;
+		switch(minType) {
+			case UNKNOWN:
+			case BOOLEAN:
+				if(isBooleanType(val, len) != null)
+					return ValueType.BOOLEAN;
+			case UINT8:
+			case INT32:
+			case INT64:
+				r = isIntType(val, len);
+				if(r != null)
+					return r;
+			case FP32:
+			case FP64:
+				r = isFloatType(val, len);
+				if(r != null)
+					return r;
+			case STRING:
+				return ValueType.STRING;
+			default:
+				throw new DMLRuntimeException("");
+		}
+	}
+
+	public static ValueType isType(String val) {
+		return isType(val, ValueType.BOOLEAN);
+	}
+
+	public static ValueType isType(double val) {
 		if(val == 1.0d || val == 0.0d)
 			return ValueType.BOOLEAN;
-		else if((long)(val) == val){
-			if((int)val == val)
+		else if((long) (val) == val) {
+			if((int) val == val)
 				return ValueType.INT32;
 			else
 				return ValueType.INT64;
 		}
-		else if((double)((float) val) == val )
+		else if((double) ((float) val) == val)
 			// Detecting FP32 could use some extra work.
-			return ValueType.FP32; 
-		
-		
+			return ValueType.FP32;
+
 		return ValueType.FP64;
 
 	}
-
 
 	public static FrameBlock mergeSchema(FrameBlock temp1, FrameBlock temp2) {
 		String[] rowTemp1 = IteratorFactory.getStringRowIterator(temp1).next();

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
@@ -62,7 +62,9 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction {
 			ValueType[] schema = new ValueType[inBlock2.getNumColumns()];
 			for(int i=0; i<inBlock2.getNumColumns(); i++)
 				schema[i] = ValueType.fromExternalString(inBlock2.get(0, i).toString());
-			ec.setFrameOutput(output.getName(), inBlock1.applySchema(schema, ((MultiThreadedOperator)_optr).getNumThreads()));
+			final int k = ((MultiThreadedOperator)_optr).getNumThreads();
+			final FrameBlock out = inBlock1.applySchema(schema, k);
+			ec.setFrameOutput(output.getName(), out);
 		}
 		else {
 			// Execute binary operations

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -59,7 +59,6 @@ import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-import org.apache.sysds.runtime.matrix.operators.MultiThreadedOperator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.meta.MetaData;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/ComputationSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/ComputationSPInstruction.java
@@ -41,8 +41,6 @@ import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 
-import java.util.Map;
-
 public abstract class ComputationSPInstruction extends SPInstruction implements LineageTraceable {
 	public CPOperand output;
 	public CPOperand input1, input2, input3;

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
@@ -620,7 +620,6 @@ public class FrameRDDConverterUtils
 			//preallocate physical columns (to avoid re-allocations)
 			fb.ensureAllocatedColumns(_maxRowsPerBlock);
 			fb.reset(0, false); //reset data but keep schema
-			fb.setNumRows(0);   //reset num rows to allow for append
 			
 			//handle meta data
 			if( _colnames != null )

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriter.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriter.java
@@ -21,6 +21,8 @@ package org.apache.sysds.runtime.io;
 
 import java.io.IOException;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
@@ -32,9 +34,8 @@ import org.apache.sysds.runtime.frame.data.FrameBlock;
  * for creating format-specific writers. 
  * 
  */
-public abstract class FrameWriter 
-{
-
+public abstract class FrameWriter {
+	protected static final Log LOG = LogFactory.getLog(FrameWriter.class.getName());
 	public abstract void writeFrameToHDFS( FrameBlock src, String fname, long rlen, long clen )
 		throws IOException, DMLRuntimeException;
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -160,7 +160,6 @@ public class EncoderFactory {
 					HashMap<String, Integer> colPos = getColumnPositions(colnames2);
 					// create temporary meta frame block w/ shallow column copy
 					FrameBlock meta2 = new FrameBlock(meta.getSchema(), colnames2);
-					meta2.setNumRows(meta.getNumRows());
 					for(int i = 0; i < colnames.length; i++) {
 						if(!colPos.containsKey(colnames[i])) {
 							throw new DMLRuntimeException("Column name not found in meta data: " + colnames[i]

--- a/src/main/java/org/apache/sysds/utils/MemoryEstimates.java
+++ b/src/main/java/org/apache/sysds/utils/MemoryEstimates.java
@@ -189,7 +189,7 @@ public class MemoryEstimates {
 	 * @return The array memory cost
 	 */
 	public static final double stringArrayCost(String[] strings) {
-		double size = 0;
+		long size = 0;
 		for(int i = 0; i < strings.length; i++)
 			size += stringCost(strings[i]);
 		return size;
@@ -203,8 +203,9 @@ public class MemoryEstimates {
 	 * @param value The String to measure
 	 * @return The size in memory.
 	 */
-	public static double stringCost(String value) {
-		return value == null ? 16 + 8 : stringCost(value.length()); // char array
+	public static long stringCost(String value) {
+		// if null 16 object + 8 array ref
+		return value == null ? 24L : stringCost(value.length()); // char array
 	}
 
 	/**
@@ -213,11 +214,13 @@ public class MemoryEstimates {
 	 * @param length The length of the string
 	 * @return The size in memory
 	 */
-	public static double stringCost(int length) {
-		return 16 // object
-			+ 4 // hash
-			+ 8 // array ref
-			+ 32 + length; // char array
+	public static long stringCost(long length) {
+		// 16 object
+		// 4 hash
+		// 8 array ref
+		// 32 char array
+		// total base : 60
+		return 60L + length * 2L; // char array
 	}
 
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameTest.java
@@ -25,10 +25,12 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
@@ -37,7 +39,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(value = Parameterized.class)
-public class FrameAppendTest {
+public class FrameTest {
 	public FrameBlock f;
 
 	@Parameters
@@ -62,7 +64,7 @@ public class FrameAppendTest {
 		return tests;
 	}
 
-	public FrameAppendTest(FrameBlock f) {
+	public FrameTest(FrameBlock f) {
 		this.f = f;
 	}
 
@@ -180,6 +182,18 @@ public class FrameAppendTest {
 		for(int r = 0; r < f.getNumRows(); r++)
 			for(int c = 0; c < f.getNumColumns(); c++)
 				assertEquals(ff.get(r + 240, c).toString(), f.get(r, c).toString());
+	}
+
+	@Test
+	public void testIterator() {
+
+		Iterator<Object[]> it = IteratorFactory.getObjectRowIterator(f);
+
+		for(int r = 0; r < f.getNumRows(); r++){
+			Object[] row = it.next();
+			for(int c = 0; c < f.getNumColumns(); c++)
+				assertEquals(f.get(r, c).toString(), row[c].toString());
+		}
 	}
 
 	private static FrameBlock append(FrameBlock a, FrameBlock b, boolean cBind) {

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameUtilTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameUtilTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.frame;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.lib.FrameUtil;
+import org.junit.Test;
+
+public class FrameUtilTest {
+
+	@Test
+	public void testIsTypeMinimumFloat_1() {
+		assertEquals(ValueType.FP32, FrameUtil.isType("1", ValueType.FP32));
+	}
+
+	@Test
+	public void testIsTypeMinimumFloat_2() {
+		assertEquals(ValueType.FP32, FrameUtil.isType("32.", ValueType.FP32));
+	}
+
+	@Test
+	public void testIsTypeMinimumFloat_3() {
+		assertEquals(ValueType.FP32, FrameUtil.isType(".9", ValueType.FP32));
+	}
+
+	@Test
+	public void testIsTypeMinimumFloat_4() {
+		assertEquals(ValueType.FP32, FrameUtil.isType(".9", ValueType.FP64));
+	}
+
+	@Test
+	public void testIsTypeMinimumFloat_5() {
+		assertEquals(ValueType.FP64, FrameUtil.isType(".999999999999", ValueType.FP64));
+	}
+
+	@Test
+	public void testIsTypeMinimumFloat_6() {
+		assertEquals(ValueType.FP64, FrameUtil.isType(".999999999999", ValueType.FP32));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_1() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("TRUE", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_2() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("True", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_3() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("true", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_4() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("t", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_5() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("f", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_6() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("false", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_7() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("False", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumBoolean_8() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("FALSE", ValueType.UNKNOWN));
+	}
+
+
+	@Test
+	public void testIsTypeMinimumString_1() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("FALSEE", ValueType.UNKNOWN));
+	}
+
+
+	@Test
+	public void testIsTypeMinimumString_2() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("falsse", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumString_3() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("agsss", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsTypeMinimumString_4() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("AAGss", ValueType.UNKNOWN));
+	}
+
+
+	@Test
+	public void testIsTypeMinimumString_5() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("ttrue", ValueType.UNKNOWN));
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
@@ -168,7 +168,7 @@ public class CustomArrayTests {
 	public void analyzeValueTypeStringFP32() {
 		StringArray a = ArrayFactory.create(new String[] {"132", "131.1", "-142"});
 		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.FP32);
+		assertEquals(ValueType.FP32, t);
 	}
 
 	@Test
@@ -182,7 +182,7 @@ public class CustomArrayTests {
 	public void analyzeValueTypeStringFP32_string() {
 		StringArray a = ArrayFactory.create(new String[] {"\"132\"", "131.1", "-142"});
 		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.FP32);
+		assertEquals(ValueType.STRING, t);
 	}
 
 	@Test
@@ -468,22 +468,22 @@ public class CustomArrayTests {
 	}
 
 	@Test
-	public void LongToBits_0(){
+	public void LongToBits_0() {
 		assertEquals(BitSetArray.longToBits(0), "0000000000000000000000000000000000000000000000000000000000000000");
 	}
 
 	@Test
-	public void LongToBits_2(){
+	public void LongToBits_2() {
 		assertEquals(BitSetArray.longToBits(2), "0000000000000000000000000000000000000000000000000000000000000010");
 	}
 
 	@Test
-	public void LongToBits_5(){
+	public void LongToBits_5() {
 		assertEquals(BitSetArray.longToBits(5), "0000000000000000000000000000000000000000000000000000000000000101");
 	}
 
 	@Test
-	public void LongToBits_minusOne(){
+	public void LongToBits_minusOne() {
 		assertEquals(BitSetArray.longToBits(-1), "1111111111111111111111111111111111111111111111111111111111111111");
 	}
 

--- a/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
@@ -442,7 +442,7 @@ public class FrameArrayTests {
 			case STRING:
 
 				String vs = "1324L";
-				((Array<String>) a).set(0, vs);
+				a.set(0,vs);
 				assertEquals(((Array<String>) a).get(0), vs);
 
 				return;
@@ -584,7 +584,7 @@ public class FrameArrayTests {
 	@Test
 	public void setNull() {
 		// should not crash
-		a.set(0, null);
+		a.set(0, (String)null);
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysds/test/component/misc/IOUtilFunctionsTest.java
+++ b/src/test/java/org/apache/sysds/test/component/misc/IOUtilFunctionsTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.misc;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.sysds.runtime.io.IOUtilFunctions;
+import org.junit.Test;
+
+public class IOUtilFunctionsTest {
+
+	@Test
+	public void splitCSV_1() {
+		String in = "\"1\",\"Prof\",\"B\",19,18,\"Male\",139750";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"1\"", "\"Prof\"", "\"B\"", "19", "18", "\"Male\"", "139750"}, ret);
+	}
+
+	@Test
+	public void splitCSV_2() {
+		String in = "\"1,,,2\",139750";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"1,,,2\"", "139750"}, ret);
+	}
+
+	@Test
+	public void splitCSV_3() {
+		String in = "\"1,,,\"2,139750";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"1,,,\"2", "139750"}, ret);
+	}
+
+	@Test
+	public void splitCSV_4() {
+		String in = "\"1,,\",2,139750";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"1,,\"", "2", "139750"}, ret);
+	}
+
+	@Test
+	public void splitCSV_5() {
+		String in = "\"1,,\"aaaa,2,139750";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"1,,\"aaaa", "2", "139750"}, ret);
+	}
+
+	@Test
+	public void splitCustom() {
+		String in = "0.0,-3.756323061556275,0.0,0.0,9.360046523539289,-2.8007958172584324,-6.233057304650478";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"0.0", "-3.756323061556275", "0.0", "0.0", "9.360046523539289",
+			"-2.8007958172584324", "-6.233057304650478"}, ret);
+
+	}
+
+	@Test
+	public void splitCustom_2() {
+		String in = "aaaaaa \" abb";
+		String[] ret = IOUtilFunctions.splitCSV(in, " ");
+		assertArrayEquals(new String[] {"aaaaaa", "\"", "abb"}, ret);
+	}
+
+	@Test(expected = StringIndexOutOfBoundsException.class)
+	public void splitCustom_3() {
+		// try{
+			String in = "aaaaaa \"\"\" abb";
+			String[] ret = IOUtilFunctions.splitCSV(in, " ");
+			assertArrayEquals(new String[] {"aaaaaa", "\"\"\"", "abb"}, ret);
+
+		// }
+		// catch(Exception e){
+			// e.printStackTrace();
+			// throw e;
+			// fail(e.getMessage());
+		// }
+	}
+
+	@Test
+	public void splitCustom_4() {
+		String in = "aaaaaa \"\"\"\" abb";
+		String[] ret = IOUtilFunctions.splitCSV(in, " ");
+		assertArrayEquals(new String[] {"aaaaaa", "\"\"\"\"", "abb"}, ret);
+	}
+
+	@Test
+	public void splitCustom_5() {
+		String in = "aaaaaa \"\"\"\"";
+		String[] ret = IOUtilFunctions.splitCSV(in, " ");
+		assertArrayEquals(new String[] {"aaaaaa", "\"\"\"\""}, ret);
+	}
+
+	// @Test
+	// public void splitCustom_6() {
+	// 	String in = "aaaaaa \"\"\"";
+	// 	String[] ret = IOUtilFunctions.splitCSV(in, " ");
+	// 	assertArrayEquals(new String[] {"aaaaaa", "\""}, ret);
+	// }
+
+	@Test
+	public void splitCustom_7() {
+		String in = "aaaaaa \"";
+		String[] ret = IOUtilFunctions.splitCSV(in, " ");
+		assertArrayEquals(new String[] {"aaaaaa", "\""}, ret);
+	}
+
+	@Test
+	public void splitRFC4180Standard_1() {
+		String in = "\"aaa\",\"b \r\n\",\"ccc\"";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"aaa\"", "\"b \r\n\"", "\"ccc\""}, ret);
+	}
+
+	@Test
+	public void splitRFC4180Standard_BreakRule_1() {
+		String in = "\"aaa\",\"b\"\"bb\",\"ccc\"";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"aaa\"", "\"b\"\"bb\"", "\"ccc\""}, ret);
+	}
+
+	@Test
+	public void splitRFC4180Standard_BreakRule_2() {
+		String in = "\"aaa\",\"b\"\"bb\"";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"aaa\"", "\"b\"\"bb\""}, ret);
+	}
+
+	@Test
+	public void splitEmptyMatch_1() {
+		String in = "\"aaa\",,,";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",");
+		assertArrayEquals(new String[] {"\"aaa\"", "", "", ""}, ret);
+	}
+
+	@Test
+	public void splitEmptyMatch_2() {
+		String in = "\"aaa\",,a";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,");
+		assertArrayEquals(new String[] {"\"aaa\"", "a"}, ret);
+	}
+
+	@Test
+	public void split_cache_1() {
+		String in = "\"aaa\",,a";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", new String[2]);
+		assertArrayEquals(new String[] {"\"aaa\"", "a"}, ret);
+	}
+
+	@Test
+	public void split_cache_2() {
+		String in = "\"aaa\",,";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", new String[2]);
+		assertArrayEquals(new String[] {"\"aaa\"", ""}, ret);
+	}
+
+	@Test
+	public void split_cache_3() {
+		String in = "";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", new String[2]);
+		assertArrayEquals(new String[] {"", ""}, ret);
+	}
+
+	@Test
+	public void split_empty_1() {
+		String in = "";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", null);
+		assertArrayEquals(new String[] {""}, ret);
+	}
+
+	@Test
+	public void split_empty_2() {
+		String in = "";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,");
+		assertArrayEquals(new String[] {""}, ret);
+	}
+
+	@Test
+	public void split_null() {
+		String in = null;
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", null);
+		assertArrayEquals(new String[] {""}, ret);
+	}
+
+	@Test
+	public void split_null_2() {
+		String in = null;
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,");
+		assertArrayEquals(new String[] {""}, ret);
+	}
+
+	@Test
+	public void splitEmptyMatch_cache_2() {
+		String in = "\"aaa\",,a";
+		String[] ret = IOUtilFunctions.splitCSV(in, ",,", null);
+		assertArrayEquals(new String[] {"\"aaa\"", "a"}, ret);
+	}
+
+	@Test
+	public void splitCustom_fromRddTest(){
+		String in = "aaa,\"\"\",,,b,,\",\"c,c,c\"";
+
+		String[] ret = IOUtilFunctions.splitCSV(in, ",", null);
+		assertArrayEquals(new String[] {"aaa", "\"\"\",,,b,,\"", "\"c,c,c\""}, ret);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/codegen/CellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/CellwiseTmplTest.java
@@ -536,7 +536,7 @@ public class CellwiseTmplTest extends AutomatedTestBase
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
 		File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, TEST_CONF);
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/DAGCellwiseTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/DAGCellwiseTmplTest.java
@@ -165,7 +165,7 @@ public class DAGCellwiseTmplTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/MiscPatternTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/MiscPatternTest.java
@@ -174,7 +174,7 @@ public class MiscPatternTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/MultiAggTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/MultiAggTmplTest.java
@@ -210,7 +210,7 @@ public class MultiAggTmplTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/OuterProdTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/OuterProdTmplTest.java
@@ -313,7 +313,7 @@ public class OuterProdTmplTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/RowAggTmplTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/RowAggTmplTest.java
@@ -872,7 +872,7 @@ public class RowAggTmplTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/RowConv2DOperationsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/RowConv2DOperationsTest.java
@@ -125,7 +125,7 @@ public class RowConv2DOperationsTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/RowVectorComparisonTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/RowVectorComparisonTest.java
@@ -168,7 +168,7 @@ public class RowVectorComparisonTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/codegen/SumProductChainTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/SumProductChainTest.java
@@ -153,7 +153,7 @@ public class SumProductChainTest extends AutomatedTestBase
 	@Override
 	protected File getConfigTemplateFile() {
 		// Instrumentation in this test's output log to show custom configuration file used for template.
-		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+		LOG.debug("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
 		return TEST_CONF_FILE;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/data/tensor/TensorTextCellTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/data/tensor/TensorTextCellTest.java
@@ -58,7 +58,7 @@ public class TensorTextCellTest {
 	@Test
 	public void testReadWriteTextCellBasicTensorString() {
 		TensorBlock tb1 = TestUtils.createBasicTensor(ValueType.STRING, 70, 30, 0.7);
-		tb1.set(new int[]{0, 0}, "\"  f  f  \"");
+		tb1.set(new int[]{0, 0}, "  f  f  ");
 		tb1.set(new int[]{69, 29}, "respect");
 		TensorBlock tb2 = writeAndReadBasicTensorTextCell(tb1);
 		TestUtils.compareTensorBlocks(tb1, tb2);
@@ -98,7 +98,7 @@ public class TensorTextCellTest {
 	@Test
 	public void testReadWriteTextCellDataTensorString() {
 		TensorBlock tb1 = TestUtils.createDataTensor(ValueType.STRING, 70, 30, 0.7);
-		tb1.set(new int[]{0, 0}, "\"  f  f  \"");
+		tb1.set(new int[]{0, 0}, "  f  f  ");
 		tb1.set(new int[]{69, 29}, "respect");
 		TensorBlock tb2 = writeAndReadDataTensorTextCell(tb1);
 		TestUtils.compareTensorBlocks(tb1, tb2);
@@ -132,6 +132,7 @@ public class TensorTextCellTest {
 			return reader.readTensorFromHDFS(FILENAME, dims, 1024, tb1.getSchema());
 		}
 		catch (Exception ex) {
+			ex.printStackTrace();
 			throw new DMLRuntimeException(ex);
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/functions/data/tensor/TensorTextCellTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/data/tensor/TensorTextCellTest.java
@@ -58,7 +58,7 @@ public class TensorTextCellTest {
 	@Test
 	public void testReadWriteTextCellBasicTensorString() {
 		TensorBlock tb1 = TestUtils.createBasicTensor(ValueType.STRING, 70, 30, 0.7);
-		tb1.set(new int[]{0, 0}, "  f  f  ");
+		tb1.set(new int[]{0, 0}, "\"  f  f  \"");
 		tb1.set(new int[]{69, 29}, "respect");
 		TensorBlock tb2 = writeAndReadBasicTensorTextCell(tb1);
 		TestUtils.compareTensorBlocks(tb1, tb2);
@@ -98,7 +98,7 @@ public class TensorTextCellTest {
 	@Test
 	public void testReadWriteTextCellDataTensorString() {
 		TensorBlock tb1 = TestUtils.createDataTensor(ValueType.STRING, 70, 30, 0.7);
-		tb1.set(new int[]{0, 0}, "  f  f  ");
+		tb1.set(new int[]{0, 0}, "\"  f  f  \"");
 		tb1.set(new int[]{69, 29}, "respect");
 		TensorBlock tb2 = writeAndReadDataTensorTextCell(tb1);
 		TestUtils.compareTensorBlocks(tb1, tb2);
@@ -132,7 +132,6 @@ public class TensorTextCellTest {
 			return reader.readTensorFromHDFS(FILENAME, dims, 1024, tb1.getSchema());
 		}
 		catch (Exception ex) {
-			ex.printStackTrace();
 			throw new DMLRuntimeException(ex);
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedLineageTraceReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedLineageTraceReuseTest.java
@@ -148,6 +148,13 @@ public class FederatedLineageTraceReuseTest extends MultiTenantTestBase {
 
 		int[] workerPorts = startFedWorkers(4, new String[]{"-lineage", "reuse"});
 
+		try {
+			Thread.sleep(4000);
+		}
+		catch(InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		rtplatform = execMode;
 		if(rtplatform == ExecMode.SPARK) {
 			DMLScript.USE_LOCAL_SPARK_CONFIG = true;

--- a/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseReadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/multitenant/FederatedReuseReadTest.java
@@ -104,8 +104,7 @@ public class FederatedReuseReadTest extends MultiTenantTestBase {
 
 	@Test
 	public void testModifiedValCP() {
-		//TODO with 4 runs sporadically into non-terminating state
-		runReuseReadTest(OpType.MODIFIED_VAL, 3, ExecMode.SINGLE_NODE, false);
+		runReuseReadTest(OpType.MODIFIED_VAL, 2, ExecMode.SINGLE_NODE, false);
 	}
 
 	@Test
@@ -117,7 +116,6 @@ public class FederatedReuseReadTest extends MultiTenantTestBase {
 	@Test
 	@Ignore
 	public void testModifiedValLineageCP() {
-		//TODO with 4 runs sporadically into non-terminating state
 		runReuseReadTest(OpType.MODIFIED_VAL, 3, ExecMode.SINGLE_NODE, true);
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameMapTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameMapTest.java
@@ -20,8 +20,8 @@
 package org.apache.sysds.test.functions.frame;
 
 import org.apache.sysds.common.Types;
-import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.common.Types.ExecType;
+import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.apache.sysds.runtime.io.FrameWriterFactory;
@@ -133,12 +133,13 @@ public class FrameMapTest extends AutomatedTestBase {
 				String[][] date = new String[rows2][1];
 				for(int i = 0; i<rows2; i++)
 					date[i][0] = (i%30)+"/"+(i%12)+"/200"+(i%20);
+				FrameBlock a = new FrameBlock(schemaStrings1, date);
 				FrameWriterFactory.createFrameWriter(FileFormat.CSV).
-					writeFrameToHDFS(new FrameBlock(schemaStrings1, date), input("A"), rows2, 1);
+					writeFrameToHDFS(a, input("A"), rows2, 1);
 			}
 			else if(type == TestType.SHERLOCK_PREP) {
 				String[][] data = new String[1][1];
-				data[0][0] =  "\"['Global', 'United States', 'Australia']\"";
+				data[0][0] =  "'Global', 'United States', 'Australia'";
 				FileFormatPropertiesCSV ffp = new FileFormatPropertiesCSV();
 				ffp.setDelim(";");
 				FrameWriterFactory.createFrameWriter(FileFormat.CSV, ffp).
@@ -157,7 +158,7 @@ public class FrameMapTest extends AutomatedTestBase {
 
 			String[] output = (String[])outputFrame.getColumnData(0);
 			String[] input = (String[])inputFrame.getColumnData(0);
-
+			
 			switch (type) {
 				case SPLIT:
 					for(int i = 0; i<input.length; i++)
@@ -177,8 +178,10 @@ public class FrameMapTest extends AutomatedTestBase {
 						TestUtils.compareScalars(String.valueOf(input[i].toUpperCase()), output[i]);
 					break;
 				case DATE_UTILS:
-					for(int i =0; i<input.length; i++)
-						TestUtils.compareScalars(String.valueOf(UtilFunctions.toMillis(input[i])), output[i]);
+					for(int i =0; i<input.length; i++){
+						String c = String.valueOf(UtilFunctions.toMillis(input[i]));
+						TestUtils.compareScalars(c, output[i]);
+					}
 					break;
 				case SHERLOCK_PREP:
 					for(int i =0; i<input.length; i++) 

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformCSVFrameEncodeReadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformCSVFrameEncodeReadTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.sysds.test.functions.transform;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
@@ -143,8 +144,17 @@ public class TransformCSVFrameEncodeReadTest extends AutomatedTestBase
 			FrameBlock fb2 = reader2.readFrameFromHDFS(output("R"), -1L, -1L);
 			String[] fromDisk = DataConverter.toString(fb2).split("\n");
 			String[] printed = stdOut.split("\n");
-			for(int i = 0; i < fromDisk.length; i++)
-				assertEquals(fromDisk[i], printed[i]);
+			boolean equal = true;
+			String err = "";
+			for(int i = 0; i < fromDisk.length; i++){
+				if(! fromDisk[i].equals(printed[i])){
+					err += "\n not equal: \n"+ (fromDisk[i] + "\n" + printed[i]);
+					equal = false;
+				}
+				
+			}
+			if(!equal)
+				fail(err);
 			
 		}
 		catch(Exception ex) {

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeDecodeTokenTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeDecodeTokenTest.java
@@ -86,16 +86,17 @@ public class TransformFrameEncodeDecodeTokenTest extends AutomatedTestBase
 		try
 		{
 			getAndLoadTestConfiguration(TEST_NAME1);
+			setOutputBuffering(true);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME1 + ".dml";
-			programArgs = new String[]{"-explain","-nvargs", 
+			programArgs = new String[]{"-nvargs", 
 				"DATA=" + DATASET_DIR + DATASET1,
 				"TFSPEC=" + DATASET_DIR+ SPEC1,
 				"TFDATA=" + output("tfout"), "SEP= ",
 				"OFMT=" + ofmt, "OSEP= " };
 	
-			runTest(true, false, null, -1);
+			runTest(null);
 			
 			//read input/output and compare
 			FrameReader reader1 = FrameReaderFactory.createFrameReader(FileFormat.CSV, 


### PR DESCRIPTION
This PR optimizes the pattern matching for type detection via precompiling patterns, and other minor optimizations.

Before:

```txt
SystemDS Statistics:
Total elapsed time:		12.991 sec.
Total compilation time:		0.233 sec.
Total execution time:		12.758 sec.
Cache hits (Mem/Li/WB/FS/HDFS):	4/0/0/0/1.
Cache writes (Li/WB/FS/HDFS):	0/2/0/0.
Cache times (ACQr/m, RLS, EXP):	1.885/0.189/1.075/0.889 sec.
HOP DAGs recompiled (PRED, SB):	0/1.
HOP DAGs recompile time:	0.003 sec.
Total JIT compile time:		5.697 sec.
Total JVM GC count:		49.
Total JVM GC time:		0.884 sec.
Heavy hitter instructions:
 #  Instruction   Time(s)  Count
 1  detectSchema   10.570      1
 2  applySchema     1.281      1
 3  write           0.889      1
 4  createvar       0.008      4
 5  toString        0.003      1
```

After:

```txt
SystemDS Statistics:
Total elapsed time:		6.387 sec.
Total compilation time:		0.233 sec.
Total execution time:		6.154 sec.
Cache hits (Mem/Li/WB/FS/HDFS):	4/0/0/0/1.
Cache writes (Li/WB/FS/HDFS):	0/2/0/0.
Cache times (ACQr/m, RLS, EXP):	1.897/0.179/1.075/0.901 sec.
HOP DAGs recompiled (PRED, SB):	0/1.
HOP DAGs recompile time:	0.004 sec.
Total JIT compile time:		4.692 sec.
Total JVM GC count:		6.
Total JVM GC time:		1.076 sec.
Heavy hitter instructions:
 #  Instruction   Time(s)  Count
 1  detectSchema    3.971      1
 2  applySchema     1.260      1
 3  write           0.901      1
 4  createvar       0.011      4
```


Currently much time is spend on analyzing Frames size in memory of String Arrays, and actually apply schema use 1 sec. on just that. 
Does it make sense to make memory estimation parallel? or should it be simplified to not be exact in frame cases?