### PR TITLE
[SYSTEMDS-3487] Optional Array

### DIFF
--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -102,8 +102,8 @@ public class Types
 		public static ValueType fromExternalString(String value) {
 			//for now we support both internal and external strings
 			//until we have completely changed the external types
-			String lvalue = (value != null) ? value.toUpperCase() : null;
-			switch(lvalue) {
+			String lValue = (value != null) ? value.toUpperCase() : null;
+			switch(lValue) {
 				case "FP32":     return FP32;
 				case "FP64":
 				case "DOUBLE":   return FP64;

--- a/src/main/java/org/apache/sysds/hops/LiteralOp.java
+++ b/src/main/java/org/apache/sysds/hops/LiteralOp.java
@@ -255,6 +255,8 @@ public class LiteralOp extends Hop
 				return String.valueOf(value_double);
 			case STRING:
 				return value_string;
+			case CHARACTER:
+				return value_string;
 			case UNKNOWN:
 				//do nothing (return null)
 		}

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -607,6 +607,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			output.setBlocksize(0);
 			switch (id.getValueType()) {
 				case STRING: // TODO think about what we want to get when we sum tensor of strings
+				case CHARACTER: // TODO here also for Characters.
 				case FP64:
 				case FP32:
 					output.setValueType(ValueType.FP64);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1353,8 +1353,7 @@ public class SparkExecutionContext extends ExecutionContext
 			schema = UtilFunctions.nCopies(clen, ValueType.STRING);
 
 		//create output frame block (w/ lazy allocation)
-		FrameBlock out = new FrameBlock(schema);
-		out.ensureAllocatedColumns(rlen);
+		FrameBlock out = new FrameBlock(schema, rlen);
 
 		List<Tuple2<Long,FrameBlock>> list = rdd.collect();
 

--- a/src/main/java/org/apache/sysds/runtime/data/LibTensorAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/data/LibTensorAgg.java
@@ -260,6 +260,7 @@ public class LibTensorAgg {
 				out.set(new int[out.getNumDims()], sum);
 				break;
 			}
+			case CHARACTER:
 			case UNKNOWN:
 				throw new NotImplementedException();
 		}

--- a/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/data/TensorBlock.java
@@ -668,6 +668,7 @@ public class TensorBlock implements CacheBlock<TensorBlock>, Externalizable {
 						getNextIndexes(bt.getDims(), ix);
 					}
 					break;
+				case CHARACTER:
 				case UNKNOWN:
 					throw new NotImplementedException();
 			}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
@@ -31,14 +31,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
-import java.util.function.IntFunction;
-import java.util.stream.IntStream;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -60,8 +57,8 @@ import org.apache.sysds.runtime.frame.data.columns.ColumnMetadata;
 import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
 import org.apache.sysds.runtime.frame.data.lib.FrameFromMatrixBlock;
 import org.apache.sysds.runtime.frame.data.lib.FrameLibAppend;
-import org.apache.sysds.runtime.frame.data.lib.FrameLibApplySchema;
 import org.apache.sysds.runtime.frame.data.lib.FrameLibDetectSchema;
+import org.apache.sysds.runtime.frame.data.lib.FrameLibRemoveEmpty;
 import org.apache.sysds.runtime.frame.data.lib.FrameUtil;
 import org.apache.sysds.runtime.functionobjects.ValueComparisonFunction;
 import org.apache.sysds.runtime.instructions.cp.BooleanObject;
@@ -77,7 +74,6 @@ import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.transform.encode.ColumnEncoderRecode;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.DMVUtils;
-import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.runtime.util.EMAUtils;
 import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
@@ -85,8 +81,8 @@ import org.apache.sysds.utils.MemoryEstimates;
 
 @SuppressWarnings({"rawtypes", "unchecked"}) // allow generic native arrays
 public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
-	private static final long serialVersionUID = -3993450030207130665L;
 	private static final Log LOG = LogFactory.getLog(FrameBlock.class.getName());
+	private static final long serialVersionUID = -3993450030207130665L;
 	private static final IDSequence CLASS_ID = new IDSequence();
 
 	/** Buffer size variable: 1M elements, size of default matrix block */
@@ -106,6 +102,11 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 
 	/** The data frame data as an ordered list of columns */
 	private Array[] _coldata = null;
+
+	/** Locks on the columns not tied to the columns objects. */
+	private SoftReference<Object[]> _columnLocks = null;
+
+	private int _nRow = 0;
 
 	/** Cached size in memory to avoid repeated scans of string columns */
 	private long _msize = -1;
@@ -133,8 +134,18 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		this(schema, null, null);
 	}
 
+	public FrameBlock(ValueType[] schema, int rlen) {
+		this(schema, null,null);
+		_nRow = rlen;
+	}
+
 	public FrameBlock(ValueType[] schema, String[] names) {
 		this(schema, names, null);
+	}
+
+	public FrameBlock(ValueType[] schema, String[] names, int rlen) {
+		this(schema, names, null);
+		_nRow = rlen;
 	}
 
 	public FrameBlock(ValueType[] schema, String[][] data) {
@@ -152,18 +163,23 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	public FrameBlock(ValueType[] schema, String constant, int nRow) {
 		this();
 		// allocate the values.
-
+		_nRow = nRow;
 		for(int i = 0; i < schema.length; i++)
 			appendColumn(ArrayFactory.allocate(schema[i], nRow, constant));
 	}
 
 	public FrameBlock(ValueType[] schema, String[] names, String[][] data) {
 		_schema = schema;
+		if(names != null && schema != null && schema.length != names.length)
+			throw new DMLRuntimeException("Invalid FrameBlock construction");
+
 		_colnames = names;
 		ensureAllocateMeta();
-		if(data != null)
+		if(data != null) {
+			_nRow = data.length;
 			for(int i = 0; i < data.length; i++)
 				appendRow(data[i]);
+		}
 	}
 
 	public FrameBlock(ValueType[] schema, String[] colNames, ColumnMetadata[] meta, Array<?>[] data) {
@@ -171,6 +187,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		_colnames = colNames;
 		_colmeta = meta;
 		_coldata = data;
+		_nRow = data[0].size();
 	}
 
 	/**
@@ -180,24 +197,17 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	 */
 	@Override
 	public int getNumRows() {
-		return (_coldata == null || _coldata.length == 0 || _coldata[0] == null) ? 0 : _coldata[0].size();
+		return _nRow;
 	}
 
 	@Override
 	public double getDouble(int r, int c) {
-		Object o = get(r, c);
-		if(o == null || (getSchema()[c] == ValueType.STRING && o.toString().isEmpty()))
-			return 0;
-		return UtilFunctions.objectToDouble(getSchema()[c], o);
+		return _coldata[c].getAsDouble(r);
 	}
 
 	@Override
 	public double getDoubleNaN(int r, int c) {
-		Object o = get(r, c);
-		if(o == null || (getSchema()[c] == ValueType.STRING && o.toString().isEmpty()))
-			return Double.NaN;
-		return UtilFunctions.objectToDouble(getSchema()[c], o);
-
+		return _coldata[c].getAsNaNDouble(r);
 	}
 
 	@Override
@@ -285,6 +295,12 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		_colnames = colnames;
 	}
 
+	public void setColumnName(int index, String name) {
+		if(_colnames == null)
+			_colnames = createColNames(getNumColumns());
+		_colnames[index] = name;
+	}
+
 	public ColumnMetadata[] getColumnMetadata() {
 		return _colmeta;
 	}
@@ -351,11 +367,14 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 			}
 			return;
 		}
+		else {
 
-		// allocate columns if necessary
-		_coldata = new Array[_schema.length];
-		for(int j = 0; j < _schema.length; j++)
-			_coldata[j] = ArrayFactory.allocate(_schema[j], numRows);
+			// allocate columns if necessary
+			_coldata = new Array[_schema.length];
+			for(int j = 0; j < _schema.length; j++)
+				_coldata[j] = ArrayFactory.allocate(_schema[j], numRows);
+			_nRow = numRows;
+		}
 	}
 
 	private void ensureAllocateMeta() {
@@ -375,8 +394,10 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	 */
 	public void ensureColumnCompatibility(int newLen) {
 		final int nRow = getNumRows();
-		if(_coldata != null && _coldata.length > 0 && nRow != newLen)
+		if(_coldata != null && _coldata.length > 0 && ((nRow == 0) || nRow != newLen)){
 			throw new RuntimeException("Mismatch in number of rows: " + newLen + " (expected: " + nRow + ")");
+		}
+		_nRow = newLen;
 	}
 
 	public static String[] createColNames(int size) {
@@ -466,6 +487,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 			for(int i = 0; i < _coldata.length; i++)
 				_coldata[i].reset(nrow);
 		}
+		_nRow = nrow;
 		_msize = -1;
 	}
 
@@ -482,6 +504,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		ensureAllocatedColumns(0);
 		for(int j = 0; j < row.length; j++)
 			_coldata[j].append(row[j]);
+		_nRow++;
 		_msize = -1;
 	}
 
@@ -494,6 +517,8 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		ensureAllocatedColumns(0);
 		for(int j = 0; j < row.length; j++)
 			_coldata[j].append(row[j]);
+		_nRow++;
+		_msize = -1;
 	}
 
 	/**
@@ -599,6 +624,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 																																								// modification
 		_schema = empty ? tmpSchema : (ValueType[]) ArrayUtils.addAll(_schema, tmpSchema);
 		_coldata = empty ? tmpData : (Array[]) ArrayUtils.addAll(_coldata, tmpData);
+		_nRow = cols[0].length;
 		_msize = -1;
 	}
 
@@ -630,8 +656,12 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	}
 
 	public void setColumn(int c, Array<?> column) {
-		if(_coldata == null)
+		if(_coldata == null){
 			_coldata = new Array[getNumColumns()];
+			_nRow = column.size();
+		}
+		if(column.size()  != _nRow )
+			throw new DMLRuntimeException("Invalid number of rows in set column");
 		_coldata[c] = column;
 		_msize = -1;
 	}
@@ -671,7 +701,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	@Override
 	public void readFields(DataInput in) throws IOException {
 		// read head (rows, cols)
-		final int nRow = in.readInt();
+		_nRow = in.readInt();
 		final int numCols = in.readInt();
 		final boolean isDefaultMeta = in.readBoolean();
 		// allocate schema/meta data arrays
@@ -688,11 +718,11 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 				_colnames[j] = in.readUTF();
 				_colmeta[j] = ColumnMetadata.read(in);
 			}
-			else {
+			else
 				_colmeta[j] = new ColumnMetadata(); // must be allocated.
-			}
+
 			if(type >= 0) // if in allocated column data then read it
-				_coldata[j] = ArrayFactory.read(in, nRow);
+				_coldata[j] = ArrayFactory.read(in, _nRow);
 		}
 		_msize = -1;
 	}
@@ -708,9 +738,6 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		// redirect deserialization to writable impl
 		readFields(in);
 	}
-
-	////////
-	// CacheBlock implementation
 
 	@Override
 	public long getInMemorySize() {
@@ -736,12 +763,20 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 
 		// data array
 		size += MemoryEstimates.objectArrayCost(clen);
+		size += arraysSizeInMemory();
 
+		return _msize = (long) size;
+	}
+
+	private double arraysSizeInMemory() {
+		final int clen = getNumColumns();
+		final int rlen = getNumRows();
+		double size = 0;
 		if(_coldata == null) // not allocated estimate if allocated
 			for(int j = 0; j < clen; j++)
-				size += ArrayFactory.getInMemorySize(_schema[j], getNumRows());
+				size += ArrayFactory.getInMemorySize(_schema[j], rlen);
 		else {// allocated
-			if(getNumRows() > 1000 && getNumColumns() > 10 && ConfigurationManager.isParallelIOEnabled()) {
+			if(rlen > 1000 && clen > 10 && ConfigurationManager.isParallelIOEnabled()) {
 				final ExecutorService pool = CommonThreadPool.get(InfrastructureAnalyzer.getLocalParallelism());
 				try {
 					size += pool.submit(() -> {
@@ -761,8 +796,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 					size += aa.getInMemorySize();
 			}
 		}
-		
-		return _msize = (long) size;
+		return size;
 	}
 
 	@Override
@@ -889,9 +923,6 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		return false;
 	}
 
-	///////
-	// indexing and append operations
-
 	public FrameBlock leftIndexingOperations(FrameBlock rhsFrame, IndexRange ixrange, FrameBlock ret) {
 		return leftIndexingOperations(rhsFrame, (int) ixrange.rowStart, (int) ixrange.rowEnd, (int) ixrange.colStart,
 			(int) ixrange.colEnd, ret);
@@ -921,6 +952,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		ret._colnames = (_colnames != null) ? _colnames.clone() : null;
 		ret._colmeta = _colmeta.clone();
 		ret._coldata = new Array[getNumColumns()];
+		ret._nRow = _nRow;
 
 		// copy data to output and partial overwrite w/ rhs
 		for(int j = 0; j < getNumColumns(); j++) {
@@ -977,22 +1009,23 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		// allocate output frame
 		if(ret == null)
 			ret = new FrameBlock();
-		else
-			ret.reset(ru - rl + 1, true);
 
 		// copy output schema and colnames
 		int numCols = cu - cl + 1;
 		boolean isDefNames = isColNamesDefault();
+		ret._nRow = ru - rl +1;
 		ret._schema = new ValueType[numCols];
 		ret._colnames = !isDefNames ? new String[numCols] : null;
 		ret._colmeta = new ColumnMetadata[numCols];
 
+		// names
 		for(int j = cl; j <= cu; j++) {
 			ret._schema[j - cl] = _schema[j];
 			ret._colmeta[j - cl] = _colmeta[j];
 			if(!isDefNames)
 				ret._colnames[j - cl] = getColumnName(j);
 		}
+
 		if(ret._coldata == null)
 			ret._coldata = new Array[numCols];
 
@@ -1061,6 +1094,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 
 	public void copy(FrameBlock src) {
 		int nCol = src.getNumColumns();
+		_nRow = src.getNumRows();
 		_schema = Arrays.copyOf(src._schema, nCol);
 		if(src._colnames != null)
 			_colnames = Arrays.copyOf(src._colnames, nCol);
@@ -1084,22 +1118,26 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	 * @param src source FrameBlock
 	 */
 	public void copy(int rl, int ru, int cl, int cu, FrameBlock src) {
-
 		// If full copy, fall back to default copy
 		if(rl == 0 && cl == 0 && ru + 1 == this.getNumRows() && cu + 1 == this.getNumColumns()) {
 			copy(src);
 			return;
 		}
-
-		// allocate columns if necessary
-		ensureAllocatedColumns(ru - rl + 1);
-		for(int j = cl; j <= cu; j++) {// copy values
-			// special case: column mem copy directly into column
-			if(_schema[j].equals(src._schema[j - cl]))
-				_coldata[j].set(rl, ru, src._coldata[j - cl]);
-			else {// general case w/ schema transformation
-				for(int i = rl; i <= ru; i++)
-					set(i, j, UtilFunctions.objectToObject(_schema[j], src.get(i - rl, j - cl)));
+		ensureAllocateMeta();
+		if(_coldata == null)
+			_coldata = new Array[_schema.length];
+		synchronized(this) {
+			if(_columnLocks == null) {
+				Object[] locks = new Object[_schema.length];
+				for(int i = 0; i < locks.length; i++)
+					locks[i] = new Object();
+				_columnLocks = new SoftReference<>(locks);
+			}
+		}
+		Object[] locks = _columnLocks.get();
+		for(int j = cl; j <= cu; j++) {
+			synchronized(locks[j]) { // synchronize on the column.
+				_coldata[j] = ArrayFactory.set(_coldata[j], src._coldata[j - cl], rl, ru, _nRow);
 			}
 		}
 	}
@@ -1124,6 +1162,9 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		// construct recode map
 		HashMap<String, Long> map = new HashMap<>();
 		Array<?> ldata = _coldata[col];
+		int nRow = _coldata[0].size();
+		if(nRow != _nRow)
+			throw new DMLRuntimeException("Invalid intermediate size:" + nRow + " " + _nRow);
 		for(int i = 0; i < getNumRows(); i++) {
 			Object val = ldata.get(i);
 			if(val != null) {
@@ -1579,137 +1620,18 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	}
 
 	public FrameBlock removeEmptyOperations(boolean rows, boolean emptyReturn, MatrixBlock select) {
-		if(rows)
-			return removeEmptyRows(select, emptyReturn);
-		else // cols
-			return removeEmptyColumns(select, emptyReturn);
-	}
-
-	private FrameBlock removeEmptyRows(MatrixBlock select, boolean emptyReturn) {
-		if(select != null && (select.getNumRows() != getNumRows() && select.getNumColumns() != getNumRows()))
-			throw new DMLRuntimeException("Frame rmempty: Incorrect select vector dimensions.");
-
-		FrameBlock ret = new FrameBlock(_schema, _colnames);
-
-		if(select == null) {
-			Object[] row = new Object[getNumColumns()];
-			for(int i = 0; i < getNumRows(); i++) {
-				boolean isEmpty = true;
-				for(int j = 0; j < getNumColumns(); j++) {
-					row[j] = _coldata[j].get(i);
-					isEmpty &= ArrayUtils.contains(new double[] {0.0, Double.NaN},
-						UtilFunctions.objectToDoubleSafe(_schema[j], row[j]));
-				}
-				if(!isEmpty)
-					ret.appendRow(row);
-			}
-		}
-		else {
-			if(select.getNonZeros() == getNumRows())
-				return this;
-
-			int[] indices = DataConverter.convertVectorToIndexList(select);
-
-			Object[] row = new Object[getNumColumns()];
-			for(int i : indices) {
-				for(int j = 0; j < getNumColumns(); j++)
-					row[j] = _coldata[j].get(i);
-				ret.appendRow(row);
-			}
-		}
-
-		if(ret.getNumRows() == 0 && emptyReturn) {
-			String[][] arr = new String[1][getNumColumns()];
-			Arrays.fill(arr, new String[] {null});
-			ValueType[] schema = new ValueType[getNumColumns()];
-			Arrays.fill(schema, ValueType.STRING);
-			return new FrameBlock(schema, arr);
-		}
-
-		ret._msize = -1;
-		return ret;
-	}
-
-	private FrameBlock removeEmptyColumns(MatrixBlock select, boolean emptyReturn) {
-		if(select != null && (select.getNumRows() != getNumColumns() && select.getNumColumns() != getNumColumns())) {
-			throw new DMLRuntimeException("Frame rmempty: Incorrect select vector dimensions.");
-		}
-
-		FrameBlock ret = new FrameBlock();
-		List<ColumnMetadata> columnMetadata = new ArrayList<>();
-
-		if(select == null) {
-			for(int i = 0; i < getNumColumns(); i++) {
-				Array colData = _coldata[i];
-				ValueType type = _schema[i];
-				boolean isEmpty = IntStream.range(0, colData.size()).mapToObj((IntFunction<Object>) colData::get).allMatch(
-					e -> ArrayUtils.contains(new double[] {0.0, Double.NaN}, UtilFunctions.objectToDoubleSafe(type, e)));
-
-				if(!isEmpty) {
-					ret.appendColumn(_coldata[i]);
-					columnMetadata.add(new ColumnMetadata(_colmeta[i]));
-				}
-			}
-		}
-		else {
-			if(select.getNonZeros() == getNumColumns())
-				return new FrameBlock(this);
-
-			int[] indices = DataConverter.convertVectorToIndexList(select);
-			int k = 0;
-			for(int i : indices) {
-				ret.appendColumn(_coldata[i]);
-				columnMetadata.add(new ColumnMetadata(_colmeta[i]));
-				if(_colnames != null)
-					ret._colnames[k++] = _colnames[i];
-			}
-		}
-
-		if(ret.getNumColumns() == 0 && emptyReturn) {
-			String[][] arr = new String[getNumRows()][];
-			Arrays.fill(arr, new String[] {null});
-			return new FrameBlock(new ValueType[] {ValueType.STRING}, arr);
-		}
-
-		ret._colmeta = new ColumnMetadata[columnMetadata.size()];
-		columnMetadata.toArray(ret._colmeta);
-		ret.setColumnMetadata(ret._colmeta);
-
-		ret._msize = -1;
-		return ret;
-	}
-
-	/**
-	 * Method to create a new FrameBlock where the given schema is applied.
-	 * 
-	 * @param schema of value types.
-	 * @return A new FrameBlock with the schema applied.
-	 */
-	public FrameBlock applySchema(ValueType[] schema) {
-		return FrameLibApplySchema.applySchema(this, schema, 1);
-	}
-
-	/**
-	 * Method to create a new FrameBlock where the given schema is applied.
-	 * 
-	 * @param schema of value types.
-	 * @param k      parallelization degree
-	 * @return A new FrameBlock with the schema applied.
-	 */
-	public FrameBlock applySchema(ValueType[] schema, int k) {
-		return FrameLibApplySchema.applySchema(this, schema, k);
+		return FrameLibRemoveEmpty.removeEmpty(this, rows, emptyReturn, select);
 	}
 
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("FrameBlock");
+		if(_colnames != null) {
+			sb.append("\n");
+			sb.append(Arrays.toString(_colnames));
+		}
 		if(!isColumnMetadataDefault()) {
-
-			if(_colnames != null) {
-				sb.append("\n");
-				sb.append(Arrays.toString(_colnames));
-			}
 			sb.append("\n");
 			sb.append(Arrays.toString(_colmeta));
 		}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -46,6 +46,8 @@ public abstract class Array<T> implements Writable {
 
 	protected Array(int size) {
 		_size = size;
+		if(size <= 0)
+			throw new DMLRuntimeException("Invalid zero/negative size of Array");
 	}
 
 	protected int newSize() {
@@ -483,7 +485,13 @@ public abstract class Array<T> implements Writable {
 	 * 
 	 * @param select Modify this to true in indexes that are not empty.
 	 */
-	public abstract void findEmpty(boolean[] select);
+	public final void findEmpty(boolean[] select){
+		for(int i = 0; i < select.length; i++)
+			if(isNotEmpty(i))
+				select[i] = true;
+	}
+
+	public abstract boolean isNotEmpty(int i);
 
 	/**
 	 * Find the filled rows, it is assumed that the input i to be only modified to set variables to true;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
@@ -32,7 +32,7 @@ public interface ArrayFactory {
 	public final static int bitSetSwitchPoint = 64;
 
 	public enum FrameArrayType {
-		STRING, BOOLEAN, BITSET, INT32, INT64, FP32, FP64, CHARACTER;
+		STRING, BOOLEAN, BITSET, INT32, INT64, FP32, FP64, CHARACTER, OPTIONAL;
 	}
 
 	public static StringArray create(String[] col) {
@@ -65,6 +65,10 @@ public interface ArrayFactory {
 
 	public static CharArray create(char[] col) {
 		return new CharArray(col);
+	}
+
+	public static <T> OptionalArray<T> create(T[] col) {
+		return new OptionalArray<T>(col);
 	}
 
 	public static long getInMemorySize(ValueType type, int _numRows) {
@@ -100,10 +104,33 @@ public interface ArrayFactory {
 		return a;
 	}
 
+	public static Array<?> allocateOptional(ValueType v, int nRow) {
+		switch(v) {
+			case BOOLEAN:
+				if(nRow > bitSetSwitchPoint)
+					return new OptionalArray<>(new BitSetArray(nRow));
+				else
+					return new OptionalArray<>(new BooleanArray(new boolean[nRow]));
+			case UINT8:
+			case INT32:
+				return new OptionalArray<>(new IntegerArray(new int[nRow]));
+			case INT64:
+				return new OptionalArray<>(new LongArray(new long[nRow]));
+			case FP32:
+				return new OptionalArray<>(new FloatArray(new float[nRow]));
+			case FP64:
+				return new OptionalArray<>(new DoubleArray(new double[nRow]));
+			case CHARACTER:
+				return new OptionalArray<>(new CharArray(new char[nRow]));
+			case UNKNOWN:
+			case STRING:
+			default:
+				return new StringArray(new String[nRow]);
+		}
+	}
+
 	public static Array<?> allocate(ValueType v, int nRow) {
 		switch(v) {
-			case STRING:
-				return new StringArray(new String[nRow]);
 			case BOOLEAN:
 				if(nRow > bitSetSwitchPoint)
 					return new BitSetArray(nRow);
@@ -120,8 +147,10 @@ public interface ArrayFactory {
 				return new DoubleArray(new double[nRow]);
 			case CHARACTER:
 				return new CharArray(new char[nRow]);
+			case UNKNOWN:
+			case STRING:
 			default:
-				throw new DMLRuntimeException("Unsupported value type: " + v);
+				return new StringArray(new String[nRow]);
 		}
 	}
 
@@ -150,8 +179,9 @@ public interface ArrayFactory {
 			case CHARACTER:
 				arr = new CharArray(new char[nRow]);
 				break;
-			case STRING:
-			default:
+			case OPTIONAL:
+				return OptionalArray.readOpt(in, nRow);
+			default: // String
 				arr = new StringArray(new String[nRow]);
 				break;
 		}
@@ -181,4 +211,61 @@ public interface ArrayFactory {
 		return ac.append(bc);
 	}
 
+	/**
+	 * Set the target array in the range of rl to ru with the src array. The type returned is the common or highest
+	 * common type of array.
+	 * 
+	 * @param <C>    THe highest common type to return.
+	 * @param target The target to pout the values into
+	 * @param src    The source to take the values from
+	 * @param rl     The index to start on
+	 * @param ru     The index to end on
+	 * @param rlen   The length of the target (a parameter in case target is null)
+	 * @return A new or modified array.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <C> Array<C> set(Array<?> target, Array<?> src, int rl, int ru, int rlen) {
+		if(target == null) {
+			if(src.getFrameArrayType() == FrameArrayType.OPTIONAL)
+				target = allocateOptional(src.getValueType(), rlen);
+			else
+				target = allocate(src.getValueType(), rlen);
+
+		}
+		final ValueType ta = target.getValueType();
+		final ValueType tb = src.getValueType();
+		final ValueType tc = ValueType.getHighestCommonType(ta, tb);
+
+		Array<C> targetC = (Array<C>) (ta != tc ? target.changeType(tc) : target);
+		Array<C> srcC = (Array<C>) (tb != tc ? src.changeType(tc) : src);
+		targetC.set(rl, ru, srcC);
+		return targetC;
+
+	}
+
+	public static Object parseString(String s, ValueType v) {
+		switch(v) {
+			case BOOLEAN:
+				return BooleanArray.parseBoolean(s);
+			case CHARACTER:
+				return CharArray.parseChar(s);
+			case FP32:
+				return FloatArray.parseFloat(s);
+			case FP64:
+				return DoubleArray.parseDouble(s);
+			case INT32:
+			case UINT8:
+				return IntegerArray.parseInt(s);
+			case INT64:
+				return LongArray.parseLong(s);
+			case STRING:
+			case UNKNOWN:
+			default:
+				return s;
+		}
+	}
+
+	public static Object defaultNullValue(ValueType v) {
+		return parseString(null, v);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
@@ -42,16 +42,12 @@ public class BitSetArray extends Array<Boolean> {
 	long[] _data;
 
 	protected BitSetArray(int size) {
-		super(size);
-		_data = new long[size / 64 + 1];
+		this(new long[longSize(size)], size);
 	}
 
 	public BitSetArray(boolean[] data) {
 		super(data.length);
-		if(data.length == 11)
-			throw new DMLRuntimeException("Invalid length");
-		_data = new long[_size / 64 + 1];
-		// set bits.
+		_data = new long[longSize(_size)];
 		for(int i = 0; i < data.length; i++)
 			if(data[i]) // slightly more efficient to check.
 				set(i, true);
@@ -62,9 +58,13 @@ public class BitSetArray extends Array<Boolean> {
 		_data = data;
 		if(_size > _data.length * 64)
 			throw new DMLRuntimeException("Invalid allocation long array must be long enough");
-		if(_data.length > _size / 64 + 1)
+		if(_data.length > longSize(_size))
 			throw new DMLRuntimeException(
-				"Invalid allocation long array must not be to long: " + _data.length + " " + _size + " " + (size / 64 + 1));
+				"Invalid allocation long array must not be to long: " + _data.length + " " + _size + " " + (longSize(_size)));
+	}
+
+	private static int longSize(int size){
+		return Math.max(size >> 6, 0) +1;
 	}
 
 	public BitSetArray(BitSet data, int size) {
@@ -489,7 +489,7 @@ public class BitSetArray extends Array<Boolean> {
 
 	@Override
 	public boolean isEmpty() {
-		for(int i = 0; i < _data.length; i++){
+		for(int i = 0; i < _data.length; i++) {
 			if(_data[i] != 0L)
 				return false;
 		}
@@ -516,14 +516,12 @@ public class BitSetArray extends Array<Boolean> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		for(int i = 0; i < select.length; i++)
-			if(get(i))
-				select[i] = true;
+	public final boolean isNotEmpty(int i) {
+		return get(i);
 	}
 
 	@Override
-	public void findEmptyInverse(boolean[] select){
+	public void findEmptyInverse(boolean[] select) {
 		for(int i = 0; i < select.length; i++)
 			if(!get(i))
 				select[i] = true;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -36,7 +36,7 @@ import org.apache.sysds.utils.MemoryEstimates;
 public class BooleanArray extends Array<Boolean> {
 	protected boolean[] _data;
 
-	public BooleanArray(int size) {
+	private BooleanArray(int size) {
 		super(size);
 		_data = new boolean[size];
 	}
@@ -327,10 +327,9 @@ public class BooleanArray extends Array<Boolean> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		throw new NotImplementedException();
+	public final boolean isNotEmpty(int i) {
+		return _data[i];
 	}
-
 
 	@Override 
 	public void findEmptyInverse(boolean[] select){

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -26,8 +26,10 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
@@ -195,8 +197,8 @@ public class BooleanArray extends Array<Boolean> {
 	}
 
 	@Override
-	public ValueType analyzeValueType() {
-		return ValueType.BOOLEAN;
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(ValueType.BOOLEAN, false);
 	}
 
 	@Override
@@ -298,17 +300,57 @@ public class BooleanArray extends Array<Boolean> {
 		return _data[i] ? 1.0 : 0.0;
 	}
 
-	protected static boolean parseBoolean(String value) {
+	@Override
+	public boolean isEmpty() {
+		for(int i = 0; i < _data.length; i++)
+			if(_data[i])
+				return false;
+		return true;
+	}
+
+	@Override
+	public Array<Boolean> select(int[] indices) {
+		final boolean[] ret = new boolean[indices.length];
+		for(int i = 0; i < indices.length; i++)
+			ret[i] = _data[indices[i]];
+		return new BooleanArray(ret);
+	}
+
+	@Override
+	public Array<Boolean> select(boolean[] select, int nTrue) {
+		final boolean[] ret = new boolean[nTrue];
+		int k = 0;
+		for(int i = 0; i < select.length; i++)
+			if(select[i])
+				ret[k++] = _data[i];
+		return new BooleanArray(ret);
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		throw new NotImplementedException();
+	}
+
+
+	@Override 
+	public void findEmptyInverse(boolean[] select){
+		throw new NotImplementedException();
+
+	}
+
+	public static boolean parseBoolean(String value) {
 		return value != null && (Boolean.parseBoolean(value) || value.equals("1") || value.equals("1.0"));
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder(_data.length + 2);
+		StringBuilder sb = new StringBuilder(_data.length * 2 + 10);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size - 1; i++)
-			sb.append((_data[i] ? 1 : 0) + ",");
-		sb.append(_data[_size - 1] ? 1 : 0);
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++)
+				sb.append((_data[i] ? 1 : 0) + ",");
+			sb.append(_data[_size - 1] ? 1 : 0);
+		}
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
@@ -26,7 +26,6 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
@@ -322,10 +321,10 @@ public class CharArray extends Array<Character> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		throw new NotImplementedException();
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != 0;
 	}
-
+	
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 2 + 15);

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
@@ -26,10 +26,12 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
 import org.apache.sysds.runtime.frame.data.lib.FrameUtil;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 public class CharArray extends Array<Character> {
@@ -170,8 +172,8 @@ public class CharArray extends Array<Character> {
 	}
 
 	@Override
-	public ValueType analyzeValueType() {
-		return ValueType.CHARACTER;
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(ValueType.CHARACTER, false);
 	}
 
 	@Override
@@ -189,8 +191,8 @@ public class CharArray extends Array<Character> {
 		BitSet ret = new BitSet(size());
 		for(int i = 0; i < size(); i++) {
 			if(_data[i] != 0 && _data[i] != 1)
-				throw new DMLRuntimeException("Unable to change to Boolean from char array because of value:" + _data[i]);
-			ret.set(i, _data[i] == 0 ? false : true);
+				throw new DMLRuntimeException("Unable to change to boolean from char array because of value:" + _data[i]);
+			ret.set(i, _data[i] != 0);
 		}
 		return new BitSetArray(ret, size());
 	}
@@ -200,9 +202,8 @@ public class CharArray extends Array<Character> {
 		boolean[] ret = new boolean[size()];
 		for(int i = 0; i < size(); i++) {
 			if(_data[i] != 0 && _data[i] != 1)
-				throw new DMLRuntimeException(
-					"Unable to change to Boolean from Integer array because of value:" + _data[i]);
-			ret[i] = _data[i] == 0 ? false : true;
+				throw new DMLRuntimeException("Unable to change to boolean from char array because of value:" + _data[i]);
+			ret[i] = _data[i] != 0;
 		}
 		return new BooleanArray(ret);
 	}
@@ -225,7 +226,7 @@ public class CharArray extends Array<Character> {
 		try {
 			float[] ret = new float[size()];
 			for(int i = 0; i < size(); i++)
-				ret[i] = Float.parseFloat(_data[i] + "");
+				ret[i] = (int) _data[i];
 			return new FloatArray(ret);
 		}
 		catch(NumberFormatException e) {
@@ -295,15 +296,48 @@ public class CharArray extends Array<Character> {
 	}
 
 	@Override
+	public boolean isEmpty() {
+		for(int i = 0; i < _data.length; i++)
+			if(_data[i] != 0)
+				return false;
+		return true;
+	}
+
+	@Override
+	public Array<Character> select(int[] indices) {
+		final char[] ret = new char[indices.length];
+		for(int i = 0; i < indices.length; i++)
+			ret[i] = _data[indices[i]];
+		return new CharArray(ret);
+	}
+
+	@Override
+	public Array<Character> select(boolean[] select, int nTrue) {
+		final char[] ret = new char[nTrue];
+		int k = 0;
+		for(int i = 0; i < select.length; i++)
+			if(select[i])
+				ret[k++] = _data[i];
+		return new CharArray(ret);
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		throw new NotImplementedException();
+	}
+
+	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder(_data.length);
+		StringBuilder sb = new StringBuilder(_data.length * 2 + 15);
 		sb.append(super.toString());
 		sb.append(":[");
-		for(int i = 0; i < _size - 1; i++) {
-			sb.append(_data[i]);
-			sb.append(',');
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++) {
+				sb.append(_data[i]);
+				sb.append(',');
+			}
+			sb.append(_data[_size - 1]);
 		}
-		sb.append(_data[_size - 1]);
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
@@ -366,14 +366,8 @@ public class DoubleArray extends Array<Double> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		for(int i = 0; i < select.length; i++)
-			if(isNotEmpty(i))
-				select[i] = true;
-	}
-
-	private final boolean isNotEmpty(int i) {
-		return _data[i] != 0.0 || Double.isNaN(_data[i]);
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != 0.0d;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
@@ -170,8 +172,8 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
-	public ValueType analyzeValueType() {
-		return ValueType.FP32;
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(ValueType.FP32, false);
 	}
 
 	@Override
@@ -278,7 +280,7 @@ public class FloatArray extends Array<Float> {
 		return _data[i];
 	}
 
-	protected static float parseFloat(String value) {
+	public static float parseFloat(String value) {
 		if(value == null)
 			return 0.0f;
 		else
@@ -291,12 +293,45 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
+	public boolean isEmpty() {
+		for(int i = 0; i < _data.length; i++)
+			if(_data[i] != 0.0 || Float.isNaN(_data[i]))
+				return false;
+		return true;
+	}
+
+	@Override
+	public Array<Float> select(int[] indices) {
+		final float[] ret = new float[indices.length];
+		for(int i = 0; i < indices.length; i++)
+			ret[i] = _data[indices[i]];
+		return new FloatArray(ret);
+	}
+
+	@Override
+	public Array<Float> select(boolean[] select, int nTrue) {
+		final float[] ret = new float[nTrue];
+		int k = 0;
+		for(int i = 0; i < select.length; i++)
+			if(select[i])
+				ret[k++] = _data[i];
+		return new FloatArray(ret);
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		throw new NotImplementedException();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size - 1; i++)
-			sb.append(_data[i] + ",");
-		sb.append(_data[_size - 1]);
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++)
+				sb.append(_data[i] + ",");
+			sb.append(_data[_size - 1]);
+		}
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -27,7 +27,6 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
@@ -319,8 +318,8 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		throw new NotImplementedException();
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != 0.0f;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
@@ -27,7 +27,6 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
@@ -324,8 +323,8 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		throw new NotImplementedException();
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != 0;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
@@ -170,8 +172,8 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
-	public ValueType analyzeValueType() {
-		return ValueType.INT32;
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(ValueType.INT32, false);
 	}
 
 	@Override
@@ -275,16 +277,16 @@ public class IntegerArray extends Array<Integer> {
 		return _data[i];
 	}
 
-	protected static int parseInt(String s) {
+	public static int parseInt(String s) {
 		if(s == null)
 			return 0;
 		try {
 			return Integer.parseInt(s);
 		}
 		catch(NumberFormatException e) {
-			if(s.contains(".")) {
-				return Integer.parseInt(s.split("\\.")[0]);
-			}
+			// we use exceptions as normal behavior here since we want faster default parsing.
+			if(s.contains("."))
+				return (int) Double.parseDouble(s);
 			else
 				throw e;
 		}
@@ -296,12 +298,45 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
+	public boolean isEmpty() {
+		for(int i = 0; i < _data.length; i++)
+			if(_data[i] != 0)
+				return false;
+		return true;
+	}
+
+	@Override
+	public Array<Integer> select(int[] indices) {
+		final int[] ret = new int[indices.length];
+		for(int i = 0; i < indices.length; i++)
+			ret[i] = _data[indices[i]];
+		return new IntegerArray(ret);
+	}
+
+	@Override
+	public Array<Integer> select(boolean[] select, int nTrue) {
+		final int[] ret = new int[nTrue];
+		int k = 0;
+		for(int i = 0; i < select.length; i++)
+			if(select[i])
+				ret[k++] = _data[i];
+		return new IntegerArray(ret);
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		throw new NotImplementedException();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size - 1; i++)
-			sb.append(_data[i] + ",");
-		sb.append(_data[_size - 1]);
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++)
+				sb.append(_data[i] + ",");
+			sb.append(_data[_size - 1]);
+		}
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -27,9 +27,11 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
@@ -170,8 +172,8 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
-	public ValueType analyzeValueType() {
-		return ValueType.INT64;
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(ValueType.INT64, false);
 	}
 
 	@Override
@@ -270,7 +272,7 @@ public class LongArray extends Array<Long> {
 		return _data[i];
 	}
 
-	protected static long parseLong(String s) {
+	public static long parseLong(String s) {
 		if(s == null)
 			return 0;
 		try {
@@ -278,7 +280,7 @@ public class LongArray extends Array<Long> {
 		}
 		catch(NumberFormatException e) {
 			if(s.contains("."))
-				return Long.parseLong(s.split("\\.")[0]);
+				return (long) Double.parseDouble(s);
 			else
 				throw e;
 		}
@@ -298,12 +300,45 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
+	public boolean isEmpty() {
+		for(int i = 0; i < _data.length; i++)
+			if(_data[i] != 0L)
+				return false;
+		return true;
+	}
+
+	@Override
+	public Array<Long> select(int[] indices) {
+		final long[] ret = new long[indices.length];
+		for(int i = 0; i < indices.length; i++)
+			ret[i] = _data[indices[i]];
+		return new LongArray(ret);
+	}
+
+	@Override
+	public Array<Long> select(boolean[] select, int nTrue) {
+		final long[] ret = new long[nTrue];
+		int k = 0;
+		for(int i = 0; i < select.length; i++)
+			if(select[i])
+				ret[k++] = _data[i];
+		return new LongArray(ret);
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		throw new NotImplementedException();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(_data.length * 5 + 2);
 		sb.append(super.toString() + ":[");
-		for(int i = 0; i < _size - 1; i++)
-			sb.append(_data[i] + ",");
-		sb.append(_data[_size - 1]);
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++)
+				sb.append(_data[i] + ",");
+			sb.append(_data[_size - 1]);
+		}
 		sb.append("]");
 		return sb.toString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -27,7 +27,6 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.BitSet;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
@@ -326,9 +325,10 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		throw new NotImplementedException();
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != 0;
 	}
+
 
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.frame.data.columns;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory.FrameArrayType;
+import org.apache.sysds.runtime.matrix.data.Pair;
+import org.apache.sysds.runtime.util.UtilFunctions;
+
+public class OptionalArray<T> extends Array<T> {
+
+	/** Underlying values not able to contain null values */
+	protected Array<T> _a;
+	/** A Bitset specifying where there are null, in it false means null */
+	protected Array<Boolean> _n;
+
+	@SuppressWarnings("unchecked")
+	public OptionalArray(T[] a) {
+		super(a.length);
+
+		if(a instanceof Boolean[])
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.BOOLEAN, a.length);
+		else if(a instanceof Integer[])
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.INT32, a.length);
+		else if(a instanceof Double[])
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.FP64, a.length);
+		else if(a instanceof Float[])
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.FP32, a.length);
+		else if(a instanceof Long[])
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.INT64, a.length);
+		else // Character
+			_a = (Array<T>) ArrayFactory.allocate(ValueType.CHARACTER, a.length);
+
+		_n = new BitSetArray(a.length);
+		for(int i = 0; i < a.length; i++) {
+			_a.set(i, a[i]);
+			_n.set(i, a[i] != null);
+		}
+
+		if(_a instanceof OptionalArray)
+			throw new DMLRuntimeException("Not allowed optional optional array");
+	}
+
+	public OptionalArray(Array<T> a) {
+		super(a.size());
+		if(a instanceof OptionalArray)
+			throw new DMLRuntimeException("Not allowed optional optional array");
+		_a = a;
+		_n = new BitSetArray(a.size());
+	}
+
+	public OptionalArray(Array<T> a, Array<Boolean> n) {
+		super(a.size());
+		if(a instanceof OptionalArray)
+			throw new DMLRuntimeException("Not allowed optional optional array");
+		_a = a;
+		_n = n;
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		if(_a instanceof OptionalArray)
+			throw new DMLRuntimeException("Not allowed optional optional array");
+		out.writeByte(FrameArrayType.OPTIONAL.ordinal());
+		_a.write(out);
+		_n.write(out);
+	}
+
+	@Override
+	public long getExactSerializedSize() {
+		return 1L + _a.getExactSerializedSize() + _n.getExactSerializedSize();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void readFields(DataInput in) throws IOException {
+		// throw new DMLRuntimeException("Should not be called");
+		// // (FrameArrayType.OPTIONAL.ordinal());
+		in.readByte();// ignore ordinal
+		_a = (Array<T>) ArrayFactory.read(in, _size);
+		// if(_a instanceof OptionalArray)
+		// throw new DMLRuntimeException("Invalid nested Optional array read");
+		_n = (BitSetArray) ArrayFactory.read(in, _size);
+
+	}
+
+	@SuppressWarnings("unchecked")
+	protected static OptionalArray<?> readOpt(DataInput in, int nRow) throws IOException {
+		Array<?> a = ArrayFactory.read(in, nRow);
+		Array<Boolean> n = (Array<Boolean>) ArrayFactory.read(in, nRow);
+		if(a instanceof OptionalArray)
+			throw new DMLRuntimeException("Not allowed optional optional array");
+		switch(a.getValueType()) {
+			case BOOLEAN:
+				return new OptionalArray<Boolean>((Array<Boolean>) a, n);
+			case FP32:
+				return new OptionalArray<Float>((Array<Float>) a, n);
+			case FP64:
+				return new OptionalArray<Double>((Array<Double>) a, n);
+			case UINT8:
+			case INT32:
+				return new OptionalArray<Integer>((Array<Integer>) a, n);
+			case INT64:
+				return new OptionalArray<Long>((Array<Long>) a, n);
+			case CHARACTER:
+			default:
+				return new OptionalArray<Character>((Array<Character>) a, n);
+		}
+	}
+
+	@Override
+	public T get(int index) {
+		return _n.get(index) ? _a.get(index) : null;
+	}
+
+	@Override
+	public Object get() {
+		return _a.get();
+	}
+
+	@Override
+	public double getAsDouble(int i) {
+		return _n.get(i) ? _a.getAsDouble(i) : 0.0;
+	}
+
+	@Override
+	public double getAsNaNDouble(int i) {
+		return _n.get(i) ? _a.getAsDouble(i) : Double.NaN;
+	}
+
+	@Override
+	public void set(int index, T value) {
+		if(value == null)
+			_n.set(index, false);
+		else {
+			_n.set(index, true);
+			_a.set(index, value);
+		}
+	}
+
+	@Override
+	public void set(int index, double value) {
+		_a.set(index, value);
+		_n.set(index, true);
+	}
+
+	@Override
+	public void set(int index, String value) {
+		if(value == null)
+			_n.set(index, false);
+		else {
+			_a.set(index, value);
+			_n.set(index, true);
+		}
+	}
+
+	@Override
+	public void setFromOtherType(int rl, int ru, Array<?> value) {
+		for(int i = rl; i <= ru; i++) {
+			final Object o = value.get(i);
+			if(o == null)
+				_n.set(i, false);
+			else {
+				_a.set(i, UtilFunctions.objectToString(value.get(i)));
+				_n.set(i, true);
+			}
+		}
+	}
+
+	@Override
+	public void set(int rl, int ru, Array<T> value) {
+		set(rl, ru, value, 0);
+	}
+
+	@Override
+	public void set(int rl, int ru, Array<T> value, int rlSrc) {
+		if(value instanceof OptionalArray)
+			_a.set(rl, ru, getBasic(value), rlSrc);
+		else
+			_a.set(rl, ru, value, rlSrc);
+
+		Array<Boolean> nulls = value.getNulls();
+		if(nulls != null)
+			_n.set(rl, ru, nulls, rlSrc);
+	}
+
+	private static <T> Array<T> getBasic(Array<T> value) {
+		while(value instanceof OptionalArray)
+			value = ((OptionalArray<T>) value)._a;
+		return value;
+	}
+
+	@Override
+	public void setNz(int rl, int ru, Array<T> value) {
+		for(int i = rl; i <= ru; i++) {
+			T v = value.get(i);
+			if(v != null)
+				set(i, v);
+
+		}
+	}
+
+	@Override
+	public void setFromOtherTypeNz(int rl, int ru, Array<?> value) {
+		for(int i = rl; i <= ru; i++) {
+			String v = UtilFunctions.objectToString(value.get(i));
+			if(v != null)
+				set(i, v);
+
+		}
+	}
+
+	@Override
+	public void append(String value) {
+		_n.append(value != null);
+		_a.append(value);
+		_size = _a.size();
+	}
+
+	@Override
+	public void append(T value) {
+		_n.append(value != null);
+		_a.append(value);
+		_size = _a.size();
+	}
+
+	@Override
+	public Array<T> append(Array<T> other) {
+		BitSetArray otherB = new BitSetArray(other.size());
+		for(int i = 0; i < other.size(); i++)
+			otherB.set(i, other.get(i) != null);
+		Array<Boolean> n = _n.append(otherB);
+		Array<T> a = _a.append(other);
+		return new OptionalArray<T>(a, n);
+	}
+
+	@Override
+	public Array<T> slice(int rl, int ru) {
+		return new OptionalArray<T>(_a.slice(rl, ru), _n.slice(rl, ru));
+	}
+
+	@Override
+	public void reset(int size) {
+		_size = size;
+		_a.reset(size);
+		_n.reset(size);
+	}
+
+	@Override
+	public byte[] getAsByteArray() {
+		// technically not correct.
+		return _a.getAsByteArray();
+	}
+
+	@Override
+	public ValueType getValueType() {
+		return _a.getValueType();
+	}
+
+	@Override
+	public Pair<ValueType, Boolean> analyzeValueType() {
+		return new Pair<ValueType, Boolean>(getValueType(), true);
+	}
+
+	@Override
+	public FrameArrayType getFrameArrayType() {
+		return FrameArrayType.OPTIONAL;
+	}
+
+	@Override
+	protected Array<Boolean> changeTypeBitSet() {
+		Array<Boolean> a = _a.changeTypeBitSet();
+		return new OptionalArray<Boolean>(a, _n);
+	}
+
+	@Override
+	protected Array<Boolean> changeTypeBoolean() {
+		Array<Boolean> a = _a.changeTypeBoolean();
+		return new OptionalArray<Boolean>(a, _n);
+	}
+
+	@Override
+	protected Array<Double> changeTypeDouble() {
+		Array<Double> a = _a.changeTypeDouble();
+		return new OptionalArray<Double>(a, _n);
+	}
+
+	@Override
+	protected Array<Float> changeTypeFloat() {
+		Array<Float> a = _a.changeTypeFloat();
+		return new OptionalArray<Float>(a, _n);
+	}
+
+	@Override
+	protected Array<Integer> changeTypeInteger() {
+		Array<Integer> a = _a.changeTypeInteger();
+		return new OptionalArray<Integer>(a, _n);
+	}
+
+	@Override
+	protected Array<Long> changeTypeLong() {
+		Array<Long> a = _a.changeTypeLong();
+		return new OptionalArray<Long>(a, _n);
+	}
+
+	@Override
+	protected Array<Character> changeTypeCharacter() {
+		Array<Character> a = _a.changeTypeCharacter();
+		return new OptionalArray<Character>(a, _n);
+	}
+
+	@Override
+	protected Array<String> changeTypeString() {
+		StringArray a = (StringArray) _a.changeTypeString();
+		String[] d = a.get();
+		for(int i = 0; i < _size; i++)
+			if(!_n.get(i))
+				d[i] = null;
+		return a;
+	}
+
+	@Override
+	public void fill(String val) {
+		_n.fill(val != null);
+		_a.fill(val);
+	}
+
+	@Override
+	public void fill(T val) {
+		_n.fill(val != null);
+		_a.fill(val);
+	}
+
+	@Override
+	public boolean isShallowSerialize() {
+		return _a.isShallowSerialize();
+	}
+
+	@Override
+	public Array<Boolean> getNulls() {
+		return _n;
+	}
+
+	@Override
+	public Array<T> clone() {
+		return new OptionalArray<T>(_a.clone(), _n.clone());
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return !_n.isEmpty() && _a.isEmpty();
+	}
+
+	@Override
+	public Array<T> select(int[] indices) {
+		return new OptionalArray<T>(_a.select(indices), _n.select(indices));
+	}
+
+	@Override
+	public Array<T> select(boolean[] select, int nTrue) {
+		return new OptionalArray<T>(_a.select(select, nTrue), _n.select(select, nTrue));
+	}
+
+	@Override
+	public void findEmpty(boolean[] select) {
+		_n.findEmptyInverse(select);
+		_a.findEmpty(select);
+	}
+
+	@Override
+	public Array<?> changeTypeWithNulls(ValueType t) {
+
+		switch(t) {
+			case BOOLEAN:
+				if(size() > ArrayFactory.bitSetSwitchPoint)
+					return changeTypeBitSet();
+				else
+					return changeTypeBoolean();
+			case FP32:
+				return changeTypeFloat();
+			case FP64:
+				return changeTypeDouble();
+			case UINT8:
+				throw new NotImplementedException();
+			case INT32:
+				return changeTypeInteger();
+			case INT64:
+				return changeTypeLong();
+			case CHARACTER:
+				return changeTypeCharacter();
+			case STRING:
+			case UNKNOWN:
+			default:
+				return changeTypeString(); // String can contain null
+		}
+
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder(_size + 2);
+		sb.append(super.toString() + "<" + _a.getClass().getSimpleName() + ">:[");
+		if(_size > 0) {
+			for(int i = 0; i < _size - 1; i++)
+				sb.append(get(i) + ",");
+			sb.append(get(_size - 1));
+		}
+		sb.append("]");
+		return sb.toString();
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
@@ -54,7 +54,7 @@ public class OptionalArray<T> extends Array<T> {
 		else // Character
 			_a = (Array<T>) ArrayFactory.allocate(ValueType.CHARACTER, a.length);
 
-		_n = new BitSetArray(a.length);
+		_n = (Array<Boolean>) ArrayFactory.allocate(ValueType.BOOLEAN, a.length);
 		for(int i = 0; i < a.length; i++) {
 			_a.set(i, a[i]);
 			_n.set(i, a[i] != null);
@@ -385,9 +385,8 @@ public class OptionalArray<T> extends Array<T> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		_n.findEmptyInverse(select);
-		_a.findEmpty(select);
+	public final boolean isNotEmpty(int i) {
+		return _n.isNotEmpty(i) && _a.isNotEmpty(i);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
@@ -549,10 +549,8 @@ public class StringArray extends Array<String> {
 	}
 
 	@Override
-	public void findEmpty(boolean[] select) {
-		for(int i = 0; i < select.length; i++)
-			if(_data[i] != null && !_data[i].equals("0"))
-				select[i] = true;
+	public final boolean isNotEmpty(int i) {
+		return _data[i] != null && !_data[i].equals("0");
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibAppend.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibAppend.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
@@ -32,6 +34,7 @@ import org.apache.sysds.runtime.frame.data.columns.ColumnMetadata;
 
 public class FrameLibAppend {
 
+	protected static final Log LOG = LogFactory.getLog(FrameLibAppend.class.getName());
 	/**
 	 * Appends the given argument FrameBlock 'that' to this FrameBlock by creating a deep copy to prevent side effects.
 	 * For cbind, the frames are appended column-wise (same number of rows), while for rbind the frames are appended
@@ -43,10 +46,8 @@ public class FrameLibAppend {
 	 * @return frame block of the two blocks combined.
 	 */
 	public static FrameBlock append(FrameBlock a, FrameBlock b, boolean cbind) {
-		if(cbind)
-			return appendCbind(a, b);
-		else
-			return appendRbind(a, b);
+		FrameBlock ret = cbind ? appendCbind(a, b): appendRbind(a, b);
+		return ret;
 	}
 
 	public static FrameBlock appendCbind(FrameBlock a, FrameBlock b) {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibRemoveEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibRemoveEmpty.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.frame.data.lib;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.columns.Array;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
+import org.apache.sysds.runtime.frame.data.columns.ColumnMetadata;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.util.DataConverter;
+
+public class FrameLibRemoveEmpty {
+	protected static final Log LOG = LogFactory.getLog(FrameLibRemoveEmpty.class.getName());
+
+	private final FrameBlock in;
+	private final boolean rows;
+	private final boolean emptyReturn;
+	private final MatrixBlock select;
+
+	private final int nRow;
+	private final int nCol;
+
+	public static FrameBlock removeEmpty(FrameBlock fb, boolean rows, boolean emptyReturn, MatrixBlock select) {
+		return new FrameLibRemoveEmpty(fb, rows, emptyReturn, select).apply();
+	}
+
+	private FrameLibRemoveEmpty(FrameBlock in, boolean rows, boolean emptyReturn, MatrixBlock select) {
+		this.in = in;
+		this.rows = rows;
+		this.emptyReturn = emptyReturn;
+		this.select = select;
+
+		nRow = in.getNumRows();
+		nCol = in.getNumColumns();
+		verify();
+	}
+
+	private void verify() {
+		if(select != null) {
+			final int SnRows = select.getNumRows();
+			final int SnCols = select.getNumColumns();
+			// in remove empty columns case
+			boolean notValid = !rows && (SnCols != nCol || SnRows != 1);
+			// in remove empty rows case
+			notValid |= rows && (SnRows != nRow || SnCols != 1);
+			if(notValid)
+				throw new DMLRuntimeException("Frame rmempty incorrect select vector dimensions");
+		}
+	}
+
+	private FrameBlock apply() {
+		FrameBlock ret = rows ? removeEmptyRows() : removeEmptyColumns();
+		return ret;
+	}
+
+	private FrameBlock removeEmptyRows() {
+		return select == null ? removeEmptyRowsNoSelect() : removeEMptyRowsWithSelect();
+	}
+
+	private FrameBlock removeEmptyRowsNoSelect() {
+		final FrameBlock ret = new FrameBlock();
+		final boolean[] select = new boolean[nRow];
+		for(int i = 0; i < nCol; i++)
+			in.getColumn(i).findEmpty(select);
+		final int nTrue = getNumberTrue(select);
+
+		if(nTrue == 0)
+			return removeEmptyRowsEmptyReturn();
+		else if(nTrue == nRow)
+			return new FrameBlock(in);
+
+		final String[] colNames = in.getColumnNames(false);
+		for(int i = 0; i < nCol; i++) {
+			ret.appendColumn(in.getColumn(i).select(select, nTrue));
+			if(colNames != null)
+				ret.setColumnName(i, colNames[i]);
+		}
+
+		return ret;
+	}
+
+	private FrameBlock removeEMptyRowsWithSelect() {
+		if(select.getNonZeros() == nRow)
+			return in;
+		else if(select.isEmpty())
+			return removeEmptyRowsEmptyReturn();
+
+		final String[] colNames = in.getColumnNames(false);
+		final FrameBlock ret = new FrameBlock();
+		final int[] indices = DataConverter.convertVectorToIndexList(select);
+		for(int i = 0; i < nCol; i++) {
+			ret.appendColumn(in.getColumn(i).select(indices));
+			if(colNames != null)
+				ret.setColumnName(i, colNames[i]);
+		}
+
+		return ret;
+	}
+
+	private FrameBlock removeEmptyRowsEmptyReturn() {
+		final ValueType[] schema = in.getSchema();
+		final String[] colNames = in.getColumnNames(false);
+		if(emptyReturn) { // single null row
+			String[][] arr = new String[1][nCol];
+			Arrays.fill(arr, new String[] {null});
+			return new FrameBlock(schema, colNames, arr);
+		}
+		else // no rows
+			return new FrameBlock(schema, colNames);
+	}
+
+	private static int getNumberTrue(boolean[] select) {
+		int i = 0;
+		for(boolean b : select)
+			i += b ? 1 : 0;
+		return i;
+	}
+
+	private FrameBlock removeEmptyColumns() {
+
+		List<ColumnMetadata> columnMetadata = new ArrayList<>();
+
+		final String[] colNames = in.getColumnNames(false);
+		int k = 0;
+		FrameBlock ret = new FrameBlock();
+		if(select == null) {
+			for(int i = 0; i < nCol; i++) {
+				final Array<?> colData = in.getColumn(i);
+				if(!colData.isEmpty()) {
+					ret.appendColumn(colData);
+					columnMetadata.add(new ColumnMetadata(in.getColumnMetadata(i)));
+					if(colNames != null)
+						ret.setColumnName(k++, colNames[i]);
+				}
+			}
+			if(ret.getNumColumns() == 0)
+				return removeEmptyColumnsEmptyReturn();
+			return ret;
+		}
+		else {
+			if(select.getNonZeros() == nCol)
+				return new FrameBlock(in);
+			else if(select.getNonZeros() == 0)
+				return removeEmptyColumnsEmptyReturn();
+			else {
+				for(int i : DataConverter.convertVectorToIndexList(select)) {
+					ret.appendColumn(in.getColumn(i));
+					columnMetadata.add(new ColumnMetadata(in.getColumnMetadata(i)));
+					if(colNames != null)
+						ret.setColumnName(k++, colNames[i]);
+				}
+				return ret;
+			}
+		}
+	}
+
+	private FrameBlock removeEmptyColumnsEmptyReturn() {
+		if(emptyReturn) {
+			FrameBlock ret = new FrameBlock();
+			ret.appendColumn(ArrayFactory.create(new String[nRow]));
+			return ret;
+		}
+		else
+			return new FrameBlock();
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibRemoveEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibRemoveEmpty.java
@@ -126,8 +126,8 @@ public class FrameLibRemoveEmpty {
 		final ValueType[] schema = in.getSchema();
 		final String[] colNames = in.getColumnNames(false);
 		if(emptyReturn) { // single null row
-			String[][] arr = new String[1][nCol];
-			Arrays.fill(arr, new String[] {null});
+			String[][] arr = new String[1][];
+			arr[0] = new String[schema.length];
 			return new FrameBlock(schema, colNames, arr);
 		}
 		else // no rows

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/MatrixBlockFromFrame.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/MatrixBlockFromFrame.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.runtime.frame.data.lib;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+
+public interface MatrixBlockFromFrame {
+	public static final Log LOG = LogFactory.getLog(MatrixBlockFromFrame.class.getName());
+
+	public static final int blocksizeIJ = 32;
+
+	/**
+	 * Converts a frame block with arbitrary schema into a matrix block. Since matrix block only supports value type
+	 * double, we do a best effort conversion of non-double types which might result in errors for non-numerical data.
+	 *
+	 * @param frame frame block
+	 * @return matrix block
+	 */
+	public static MatrixBlock convertToMatrixBlock(FrameBlock frame) {
+		final int m = frame.getNumRows();
+		final int n = frame.getNumColumns();
+		final MatrixBlock mb = new MatrixBlock(m, n, false);
+		mb.allocateDenseBlock();
+
+		if(mb.getDenseBlock().isContiguous())
+			convertContiguous(frame, mb, m, n);
+		else
+			convertGeneric(frame, mb, m, n);
+
+		mb.examSparsity();
+		return mb;
+	}
+
+	private static void convertContiguous(final FrameBlock frame, final MatrixBlock mb, final int m, final int n) {
+		long lnnz = 0;
+		double[] c = mb.getDenseBlockValues();
+		for(int bi = 0; bi < m; bi += blocksizeIJ) {
+			for(int bj = 0; bj < n; bj += blocksizeIJ) {
+				int bimin = Math.min(bi + blocksizeIJ, m);
+				int bjmin = Math.min(bj + blocksizeIJ, n);
+				for(int i = bi, aix = bi * n; i < bimin; i++, aix += n)
+					for(int j = bj; j < bjmin; j++)
+						lnnz += (c[aix + j] = frame.getDoubleNaN(i, j)) != 0 ? 1 : 0;
+			}
+		}
+		mb.setNonZeros(lnnz);
+	}
+
+	private static void convertGeneric(final FrameBlock frame, final MatrixBlock mb, final int m, final int n) {
+		long lnnz = 0;
+		final DenseBlock c = mb.getDenseBlock();
+		for(int bi = 0; bi < m; bi += blocksizeIJ) {
+			for(int bj = 0; bj < n; bj += blocksizeIJ) {
+				int bimin = Math.min(bi + blocksizeIJ, m);
+				int bjmin = Math.min(bj + blocksizeIJ, n);
+				for(int i = bi; i < bimin; i++) {
+					double[] cvals = c.values(i);
+					int cpos = c.pos(i);
+					for(int j = bj; j < bjmin; j++)
+						lnnz += (cvals[cpos + j] = frame.getDoubleNaN(i, j)) != 0 ? 1 : 0;
+				}
+			}
+		}
+		mb.setNonZeros(lnnz);
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryFrameFrameCPInstruction.java
@@ -19,9 +19,9 @@
 
 package org.apache.sysds.runtime.instructions.cp;
 
-import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.lib.FrameLibApplySchema;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.MultiThreadedOperator;
 
@@ -58,12 +58,8 @@ public class BinaryFrameFrameCPInstruction extends BinaryCPInstruction {
 			ec.setFrameOutput(output.getName(), retBlock);
 		}
 		else if(getOpcode().equals("applySchema")) {
-			// apply frame schema from DML
-			ValueType[] schema = new ValueType[inBlock2.getNumColumns()];
-			for(int i=0; i<inBlock2.getNumColumns(); i++)
-				schema[i] = ValueType.fromExternalString(inBlock2.get(0, i).toString());
 			final int k = ((MultiThreadedOperator)_optr).getNumThreads();
-			final FrameBlock out = inBlock1.applySchema(schema, k);
+			final FrameBlock out = FrameLibApplySchema.applySchema(inBlock1, inBlock2, k);
 			ec.setFrameOutput(output.getName(), out);
 		}
 		else {

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/FrameIndexingCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/FrameIndexingCPInstruction.java
@@ -49,6 +49,7 @@ public final class FrameIndexingCPInstruction extends IndexingCPInstruction {
 		
 		//right indexing
 		if( opcode.equalsIgnoreCase(RightIndex.OPCODE) ) {
+
 			//execute right indexing operation
 			FrameBlock in = ec.getFrameInput(input1.getName());
 			FrameBlock out = in.slice(ixrange, new FrameBlock());

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/FrameReblockBuffer.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/FrameReblockBuffer.java
@@ -112,12 +112,13 @@ public class FrameReblockBuffer
 			
 			int ci = UtilFunctions.computeCellInBlock(_buff[i].getRow(), _blen);
 			int cj = UtilFunctions.computeCellInBlock(_buff[i].getCol(), _blen);
+			String bv = (String)_buff[i].getObjVal();
 			if( ci == -3 )
-				tmpBlock.getColumnMetadata(cj).setMvValue(_buff[i].getObjVal().toString());
+				tmpBlock.getColumnMetadata(cj).setMvValue(bv);
 			else if( ci == -2 )
-				tmpBlock.getColumnMetadata(cj).setNumDistinct(Long.parseLong(_buff[i].getObjVal().toString()));
+				tmpBlock.getColumnMetadata(cj).setNumDistinct(Long.parseLong(bv));
 			else
-				tmpBlock.set(ci, cj, _buff[i].getObjVal());
+				tmpBlock.set(ci, cj, bv);
 		}
 		
 		//output last block 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
@@ -864,7 +864,7 @@ public class FrameRDDConverterUtils
 				st.reset( strVal );
 				long row = st.nextLong();
 				long col = st.nextLong();
-				Object val = UtilFunctions.stringToObject(_schema[(int)col-1], st.nextToken());
+				String val =  st.nextToken();
 				
 				//flush buffer if necessary
 				if( rbuff.getSize() >= rbuff.getCapacity() )

--- a/src/main/java/org/apache/sysds/runtime/io/FrameReaderBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameReaderBinaryBlock.java
@@ -48,7 +48,7 @@ public class FrameReaderBinaryBlock extends FrameReader{
 		//allocate output frame block
 		ValueType[] lschema = createOutputSchema(schema, clen);
 		String[] lnames = createOutputNames(names, clen);
-		FrameBlock ret = createOutputFrameBlock(lschema, lnames, rlen);
+		FrameBlock ret = new FrameBlock(lschema, lnames, (int)rlen);
 		
 		//prepare file access
 		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());	
@@ -60,7 +60,6 @@ public class FrameReaderBinaryBlock extends FrameReader{
 	
 		//core read (sequential/parallel)
 		readBinaryBlockFrameFromHDFS(path, job, fs, ret, rlen, clen);
-		
 		return ret;
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCSV.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCSV.java
@@ -88,7 +88,6 @@ public class FrameReaderTextCSV extends FrameReader {
 	@Override
 	public FrameBlock readFrameFromInputStream(InputStream is, ValueType[] schema, String[] names, long rlen, long clen)
 		throws IOException, DMLRuntimeException {
-		LOG.debug("readFrameFromInputStream csv");
 		// allocate output frame block
 		ValueType[] lschema = createOutputSchema(schema, clen);
 		String[] lnames = createOutputNames(names, clen);

--- a/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCell.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCell.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.transform.TfUtils;
@@ -106,7 +106,7 @@ public class FrameReaderTextCell extends FrameReader
 	protected static void readTextCellFrameFromInputSplit( InputSplit split, TextInputFormat informat, JobConf job, FrameBlock dest)
 		throws IOException
 	{
-		ValueType[] schema = dest.getSchema();
+		
 		int rlen = dest.getNumRows();
 		int clen = dest.getNumColumns();
 		
@@ -129,8 +129,8 @@ public class FrameReaderTextCell extends FrameReader
 					dest.getColumnMetadata(col).setMvValue(TfUtils.desanitizeSpaces(st.nextToken()));
 				else if( row == -2 )
 					dest.getColumnMetadata(col).setNumDistinct(st.nextLong());
-				else
-					dest.set(row, col, UtilFunctions.stringToObject(schema[col], st.nextToken()));
+				else if( row >= 0 )
+					dest.set(row, col, st.nextToken());
 			}
 		}
 		catch(Exception ex) 

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriter.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriter.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 
@@ -39,14 +38,4 @@ public abstract class FrameWriter {
 	public abstract void writeFrameToHDFS( FrameBlock src, String fname, long rlen, long clen )
 		throws IOException, DMLRuntimeException;
 
-	public static FrameBlock[] createFrameBlocksForReuse( ValueType[] schema, String[] names, long rlen ) {
-		FrameBlock frameBlock[] = new FrameBlock[1];
-		frameBlock[0] = new FrameBlock(schema, names);
-		return frameBlock;
-	}
-
-	public static FrameBlock getFrameBlockForReuse( FrameBlock[] blocks) //TODO do we need this function?
-	{
-		return blocks[ 0 ];
-	}
 }

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriterBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriterBinaryBlock.java
@@ -25,105 +25,94 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.SequenceFile.Writer;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.util.HDFSTool;
 
-
 /**
  * Single-threaded frame binary block writer.
  * 
  */
 public class FrameWriterBinaryBlock extends FrameWriter {
-	// protected static final Log LOG = LogFactory.getLog(FrameWriterBinaryBlock.class.getName());
 
 	@Override
-	public final void writeFrameToHDFS( FrameBlock src, String fname, long rlen, long clen )
+	public final void writeFrameToHDFS(FrameBlock src, String fname, long rlen, long clen)
 		throws IOException, DMLRuntimeException {
-		//prepare file access
+		// prepare file access
 		JobConf job = new JobConf(ConfigurationManager.getCachedJobConf());
-		Path path = new Path( fname );
+		Path path = new Path(fname);
 
-		//if the file already exists on HDFS, remove it.
-		HDFSTool.deleteFileIfExistOnHDFS( fname );
+		// if the file already exists on HDFS, remove it.
+		HDFSTool.deleteFileIfExistOnHDFS(fname);
 
-		//bound check for src block
-		if( src.getNumRows() > rlen || src.getNumColumns() > clen ) {
-			throw new IOException("Frame block [1:"+src.getNumRows()+",1:"+src.getNumColumns()+"] " +
-					              "out of overall frame range [1:"+rlen+",1:"+clen+"].");
+		// bound check for src block
+		if(src.getNumRows() > rlen || src.getNumColumns() > clen) {
+			throw new IOException("Frame block [1:" + src.getNumRows() + ",1:" + src.getNumColumns() + "] "
+				+ "out of overall frame range [1:" + rlen + ",1:" + clen + "].");
 		}
-		
-		//write binary block to hdfs (sequential/parallel)
-		writeBinaryBlockFrameToHDFS( path, job, src, rlen, clen );
+
+		// write binary block to hdfs (sequential/parallel)
+		writeBinaryBlockFrameToHDFS(path, job, src, rlen, clen);
 	}
 
-	protected void writeBinaryBlockFrameToHDFS( Path path, JobConf job, FrameBlock src, long rlen, long clen )
-			throws IOException, DMLRuntimeException
-	{
+	protected void writeBinaryBlockFrameToHDFS(Path path, JobConf job, FrameBlock src, long rlen, long clen)
+		throws IOException, DMLRuntimeException {
 		FileSystem fs = IOUtilFunctions.getFileSystem(path);
 		int blen = ConfigurationManager.getBlocksize();
-		
-		//sequential write to single file
-		writeBinaryBlockFrameToSequenceFile(path, job, fs, src, blen, 0, (int)rlen);
+
+		// sequential write to single file
+		writeBinaryBlockFrameToSequenceFile(path, job, fs, src, blen, 0, (int) rlen);
 		IOUtilFunctions.deleteCrcFilesFromLocalFileSystem(fs, path);
 	}
 
 	/**
-	 * Internal primitive to write a block-aligned row range of a frame to a single sequence file, 
-	 * which is used for both single- and multi-threaded writers (for consistency). 
+	 * Internal primitive to write a block-aligned row range of a frame to a single sequence file, which is used for both
+	 * single- and multi-threaded writers (for consistency).
 	 * 
 	 * @param path file path
-	 * @param job job configuration
-	 * @param fs file system
-	 * @param src frame block
+	 * @param job  job configuration
+	 * @param fs   file system
+	 * @param src  frame block
 	 * @param blen block length
-	 * @param rl lower row
-	 * @param ru upper row
+	 * @param rl   lower row
+	 * @param ru   upper row
 	 * @throws IOException if IOException occurs
 	 */
-	@SuppressWarnings("deprecation")
-	protected static void writeBinaryBlockFrameToSequenceFile( Path path, JobConf job, FileSystem fs, FrameBlock src, int blen, int rl, int ru ) 
-		throws IOException
-	{
-		//1) create sequence file writer 
-		SequenceFile.Writer writer = null;
-		writer = new SequenceFile.Writer(fs, job, path, LongWritable.class, FrameBlock.class);
-		
-		try
-		{
-			//2) reblock and write
+	protected static void writeBinaryBlockFrameToSequenceFile(Path path, JobConf job, FileSystem fs, FrameBlock src,
+		int blen, int rl, int ru) throws IOException {
+		// 1) create sequence file writer
+		SequenceFile.Writer writer = SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
+			Writer.blockSize(4096), Writer.keyClass(LongWritable.class), Writer.valueClass(FrameBlock.class),
+			Writer.compression(SequenceFile.CompressionType.NONE), Writer.replication((short) 1));
+
+		final int rlen = src.getNumRows();
+		final int clen = src.getNumColumns();
+		try {
+			// 2) reblock and write
 			LongWritable index = new LongWritable();
 
-			if( src.getNumRows() <= blen ) //opt for single block
-			{
-				//directly write single block
+			if(rlen <= blen) { // single block
 				index.set(1);
 				writer.append(index, src);
 			}
-			else //general case
-			{
-				//initialize blocks for reuse (at most 4 different blocks required)
-				FrameBlock[] blocks = createFrameBlocksForReuse(src.getSchema(), src.getColumnNames(), src.getNumRows());  
-				
-				//create and write subblocks of frame
+			else { // multi block
 				for(int bi = rl; bi < ru; bi += blen) {
-					int len = Math.min(blen,  src.getNumRows()-bi);
-					
-					//get reuse frame block and copy subpart to block (incl meta on first)
-					FrameBlock block = getFrameBlockForReuse(blocks);
-					src.slice( bi, bi+len-1, 0, src.getNumColumns()-1, block );
-					if( bi==0 ) //first block
+					int len = Math.min(blen, rlen - bi);
+					// get reuse frame block and copy subpart to block (incl meta on first)
+					FrameBlock block = src.slice(bi, bi + len - 1, 0, clen - 1); // full width?
+					if(bi == 0) // first block
 						block.setColumnMetadata(src.getColumnMetadata());
-					//append block to sequence file
-					index.set(bi+1);
+					// append block to sequence file
+					index.set(bi + 1);
 					writer.append(index, block);
 				}
 			}
 		}
 		finally {
 			IOUtilFunctions.closeSilently(writer);
-		}		
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriterProto.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriterProto.java
@@ -70,6 +70,9 @@ public class FrameWriterProto extends FrameWriter {
 			Iterator<String[]> stringRowIterator = IteratorFactory.getStringRowIterator(src, lowerRowBound, upperRowBound);
 			while(stringRowIterator.hasNext()) {
 				String[] row = stringRowIterator.next();
+				for(int i = 0; i < row.length; i++)
+					if(row[i] == null)
+						row[i] = "";
 				frameBuilder.addRowsBuilder().addAllColumnData(Arrays.asList(row));
 			}
 			frameBuilder.build().writeTo(outputStream);

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriterTextCell.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriterTextCell.java
@@ -27,10 +27,12 @@ import java.util.Iterator;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
+import org.apache.sysds.runtime.frame.data.lib.FrameUtil;
 import org.apache.sysds.runtime.util.HDFSTool;
 
 /**
@@ -107,14 +109,15 @@ public class FrameWriterTextCell extends FrameWriter
 						sb.setLength(0);
 					}
 			}
-			
+			ValueType[] schema = src.getSchema();
 			//write frame row range to output
 			Iterator<String[]> iter = IteratorFactory.getStringRowIterator(src, rl, ru);
+
 			for( int i=rl; iter.hasNext(); i++ ) { //for all rows
 				String rowIndex = Integer.toString(i+1);
 				String[] row = iter.next();
 				for( int j=0; j<cols; j++ ) {
-					if( row[j] != null ) {
+					if( !FrameUtil.isDefault(row[j], schema[j]) ) {
 						sb.append( rowIndex );
 						sb.append(' ');
 						sb.append( j+1 );

--- a/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
+++ b/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
@@ -21,6 +21,8 @@ package org.apache.sysds.runtime.io;
 
 import java.io.IOException;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 /**
@@ -30,8 +32,9 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
  * for creating format-specific writers. 
  * 
  */
-public abstract class MatrixWriter 
-{
+public abstract class MatrixWriter {
+	protected static final Log LOG = LogFactory.getLog(MatrixWriter.class.getName());
+	
 	public void writeMatrixToHDFS( MatrixBlock src, String fname, long rlen, long clen, int blen, long nnz ) throws IOException {
 		writeMatrixToHDFS(src, fname, rlen, clen, blen, nnz, false);
 	}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/EncoderFactory.java
@@ -19,7 +19,18 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
+import static org.apache.sysds.runtime.util.CollectionUtils.except;
+import static org.apache.sysds.runtime.util.CollectionUtils.unionDistinct;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -32,16 +43,8 @@ import org.apache.sysds.utils.stats.TransformStatistics;
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map.Entry;
-
-import static org.apache.sysds.runtime.util.CollectionUtils.except;
-import static org.apache.sysds.runtime.util.CollectionUtils.unionDistinct;
-
 public class EncoderFactory {
+	protected static final Log LOG = LogFactory.getLog(EncoderFactory.class.getName());
 
 	public static MultiColumnEncoder createEncoder(String spec, String[] colnames, int clen, FrameBlock meta) {
 		return createEncoder(spec, colnames, UtilFunctions.nCopies(clen, ValueType.STRING), meta);
@@ -155,11 +158,13 @@ public class EncoderFactory {
 			// initialize meta data w/ robustness for superset of cols
 			if(meta != null) {
 				String[] colnames2 = meta.getColumnNames();
+
 				if(!TfMetaUtils.isIDSpec(jSpec) && colnames != null && colnames2 != null &&
 					!ArrayUtils.isEquals(colnames, colnames2)) {
 					HashMap<String, Integer> colPos = getColumnPositions(colnames2);
 					// create temporary meta frame block w/ shallow column copy
 					FrameBlock meta2 = new FrameBlock(meta.getSchema(), colnames2);
+
 					for(int i = 0; i < colnames.length; i++) {
 						if(!colPos.containsKey(colnames[i])) {
 							throw new DMLRuntimeException("Column name not found in meta data: " + colnames[i]

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -338,6 +338,9 @@ public class MultiColumnEncoder implements Encoder {
 				+ "has a encoder or slice the input accordingly");
 		// TODO smart checks
 		// Block allocation for MT access
+		if(in.getNumRows() == 0)
+			throw new DMLRuntimeException("Invalid input with wrong number or rows");
+
 		boolean hasDC = false;
 		for(ColumnEncoderComposite columnEncoder : _columnEncoders)
 			hasDC = columnEncoder.hasEncoder(ColumnEncoderDummycode.class);

--- a/src/main/java/org/apache/sysds/runtime/util/FastBufferedDataInputStream.java
+++ b/src/main/java/org/apache/sysds/runtime/util/FastBufferedDataInputStream.java
@@ -122,7 +122,9 @@ public class FastBufferedDataInputStream extends FilterInputStream implements Da
 
 	@Override
 	public float readFloat() throws IOException {
-		throw new IOException("Not supported.");
+		readFully(_buff, 0, 4);
+		int tmp = baToInt(_buff, 0);
+		return Float.intBitsToFloat(tmp);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/util/FastBufferedDataOutputStream.java
+++ b/src/main/java/org/apache/sysds/runtime/util/FastBufferedDataOutputStream.java
@@ -139,6 +139,15 @@ public class FastBufferedDataOutputStream extends FilterOutputStream implements 
 	}
 
 	@Override
+	public void writeFloat(float v) throws IOException {
+		if (_count+4 > _bufflen)
+			flushBuffer();
+		int tmp = Float.floatToIntBits(v);
+		intToBa(tmp, _buff, _count);
+		_count += 8;
+	}
+
+	@Override
 	public void writeByte(int v) throws IOException {
 		if (_count+1 > _bufflen)
 			flushBuffer();
@@ -165,11 +174,6 @@ public class FastBufferedDataOutputStream extends FilterOutputStream implements 
 
 	@Override
 	public void writeChars(String s) throws IOException {
-		throw new IOException("Not supported.");
-	}
-	
-	@Override
-	public void writeFloat(float v) throws IOException {
 		throw new IOException("Not supported.");
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/util/HDFSTool.java
+++ b/src/main/java/org/apache/sysds/runtime/util/HDFSTool.java
@@ -415,6 +415,11 @@ public class HDFSTool
 		writeMetaDataFile(mtdfile, vt, null, DataType.MATRIX, dc, fmt, formatProperties, privacyConstraint);
 	}
 	
+	public static void writeMetaDataFileFrame(String mtdfile, ValueType[] schema,  DataCharacteristics dc,
+		FileFormat fmt) throws IOException {
+		writeMetaDataFile(mtdfile, ValueType.UNKNOWN, schema, DataType.FRAME, dc, fmt, (FileFormatProperties) null);
+	}
+
 	public static void writeMetaDataFile(String mtdfile, ValueType vt, ValueType[] schema, DataType dt, DataCharacteristics dc,
 			FileFormat fmt, FileFormatProperties formatProperties) 
 		throws IOException 

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -1797,12 +1797,13 @@ public abstract class AutomatedTestBase {
 		sb.append("\nException : " + e.getClass());
 		sb.append("\nMessage   : " + e.getMessage());
 		for(StackTraceElement ste : e.getStackTrace()) {
-			if(ste.toString().contains("org.junit")) {
-				sb.append("\n   >  ... Stopping Stack Trace at JUnit");
+			String steS = ste.toString();
+			if(steS.contains("org.junit") || steS.contains("jdk.internal.reflect")) {
+				sb.append("\n ... Stopping Stack Trace at JUnit Or JDK");
 				break;
 			}
 			else {
-				sb.append("\n" + level + "  >  " + ste);
+				sb.append("\n  at " + steS);
 			}
 		}
 		if(e.getCause() == null) {

--- a/src/test/java/org/apache/sysds/test/component/codegen/CPlanVectorPrimitivesTest.java
+++ b/src/test/java/org/apache/sysds/test/component/codegen/CPlanVectorPrimitivesTest.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.util.StringUtils;
 public class CPlanVectorPrimitivesTest extends AutomatedTestBase 
 {
 	private static final int m = 3;
-	private static final int n = 1191;
+	private static final int n = 132;
 	private static final double sparsity1 = 0.9;
 	private static final double sparsity2 = 0.09;
 	private static final double eps = Math.pow(10, -10);

--- a/src/test/java/org/apache/sysds/test/component/compress/io/IOCompressionTestUtils.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/io/IOCompressionTestUtils.java
@@ -34,9 +34,12 @@ public class IOCompressionTestUtils {
 
 	static final AtomicInteger id = new AtomicInteger(0);
 
-	protected static void deleteDirectory(File file) {
+	public static void deleteDirectory(File file) {
 		synchronized(IOCompressionTestUtils.lock) {
-			for(File subfile : file.listFiles()) {
+			File[] files = file.listFiles();
+			if(files == null)
+				return;
+			for(File subfile :files) {
 				if(subfile.isDirectory())
 					deleteDirectory(subfile);
 				subfile.delete();

--- a/src/test/java/org/apache/sysds/test/component/frame/DataCorruptionTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/DataCorruptionTest.java
@@ -41,6 +41,8 @@ public class DataCorruptionTest
 	private List<Integer> stringpos;
 	private List<Integer> swappable;
 	
+	private static final int nRow = 350; 
+
 	// Set input frame
 	@BeforeClass
 	public static void init() {
@@ -52,7 +54,7 @@ public class DataCorruptionTest
 			"Austria", "Spain", "France", "United Kingdom"};
 		Random rand = new Random();
 		
-		for(int i = 0; i<1000; i++) {
+		for(int i = 0; i<nRow; i++) {
 			Object[] row = new Object[4];
 			row[0] = strings[rand.nextInt(strings.length)];
 			row[1] = strings2[rand.nextInt(strings2.length)];

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameAppendTest_Old.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameAppendTest_Old.java
@@ -31,7 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class FrameAppendTest_Old extends AutomatedTestBase {
-	private final static int rows = 1593;
+	private final static int rows = 132;
 	private final static ValueType[] schemaStrings = new ValueType[] {ValueType.STRING, ValueType.STRING,
 		ValueType.STRING};
 	private final static ValueType[] schemaMixed = new ValueType[] {ValueType.STRING, ValueType.FP64, ValueType.INT64,

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameApplySchema.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameApplySchema.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.component.frame;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -38,7 +39,7 @@ public class FrameApplySchema {
 
 			FrameBlock fb = genStringContainingBoolean(10, 2);
 			ValueType[] schema = new ValueType[] {ValueType.BOOLEAN, ValueType.BOOLEAN};
-			FrameBlock ret = fb.applySchema(schema);
+			FrameBlock ret = FrameLibApplySchema.applySchema(fb, schema);
 			assertTrue(ret.getColumn(0).getValueType() == ValueType.BOOLEAN);
 			assertTrue(ret.getColumn(1).getValueType() == ValueType.BOOLEAN);
 		}
@@ -53,7 +54,7 @@ public class FrameApplySchema {
 		try {
 			FrameBlock fb = genStringContainingInteger(10, 2);
 			ValueType[] schema = new ValueType[] {ValueType.INT32, ValueType.INT32};
-			FrameBlock ret = fb.applySchema(schema);
+			FrameBlock ret = FrameLibApplySchema.applySchema(fb, schema);
 			assertTrue(ret.getColumn(0).getValueType() == ValueType.INT32);
 			assertTrue(ret.getColumn(1).getValueType() == ValueType.INT32);
 		}
@@ -68,7 +69,7 @@ public class FrameApplySchema {
 		try {
 			FrameBlock fb = genStringContainingInteger(10, 1);
 			ValueType[] schema = new ValueType[] {ValueType.INT32};
-			FrameBlock ret = fb.applySchema(schema);
+			FrameBlock ret = FrameLibApplySchema.applySchema(fb, schema);
 			assertTrue(ret.getColumn(0).getValueType() == ValueType.INT32);
 		}
 		catch(Exception e) {
@@ -109,7 +110,6 @@ public class FrameApplySchema {
 		}
 	}
 
-
 	@Test
 	public void testApplySchemaStringToIntDirectCallMultiThreadSingleCol() {
 		try {
@@ -133,11 +133,12 @@ public class FrameApplySchema {
 		FrameLibApplySchema.applySchema(fb, schema, 3);
 	}
 
-	@Test(expected = DMLRuntimeException.class)
-	public void testInvalidInput2() {
+	@Test
+	public void testUnkownColumnDefaultToString() {
 		FrameBlock fb = genStringContainingInteger(10, 3);
 		ValueType[] schema = new ValueType[] {ValueType.UNKNOWN, ValueType.INT32, ValueType.INT32};
-		FrameLibApplySchema.applySchema(fb, schema, 3);
+		fb = FrameLibApplySchema.applySchema(fb, schema, 3);
+		assertEquals(ValueType.UNKNOWN, fb.getSchema()[0]);
 	}
 
 	private FrameBlock genStringContainingInteger(int row, int col) {

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameCastingTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameCastingTest.java
@@ -31,7 +31,7 @@ import org.apache.sysds.test.TestUtils;
 
 public class FrameCastingTest extends AutomatedTestBase
 {
-	private final static int rows = 2891;
+	private final static int rows = 312;
 	private final static ValueType[] schemaStrings = new ValueType[]{ValueType.STRING, ValueType.STRING, ValueType.STRING};	
 	private final static ValueType[] schemaMixed = new ValueType[]{ValueType.STRING, ValueType.FP64, ValueType.INT64, ValueType.BOOLEAN};	
 	

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameCopyTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameCopyTest.java
@@ -30,7 +30,7 @@ import org.apache.sysds.test.TestUtils;
 
 public class FrameCopyTest extends AutomatedTestBase
 {
-	private final static int rows = 1593;
+	private final static int rows = 342;
 	private final static ValueType[] schemaStrings = new ValueType[]{ValueType.STRING, ValueType.STRING, ValueType.STRING};	
 	private final static ValueType[] schemaMixed = new ValueType[]{ValueType.STRING, ValueType.FP64, ValueType.INT64, ValueType.BOOLEAN};	
 	

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameCreationTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameCreationTest.java
@@ -1,0 +1,22 @@
+package org.apache.sysds.test.component.frame;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.junit.Test;
+
+public class FrameCreationTest {
+	@Test
+	public void createEmptyRow() {
+		FrameBlock a = createEmptyRow(new ValueType[] {ValueType.STRING, ValueType.STRING});
+		assertEquals(null, a.get(0, 0));
+		assertEquals(null, a.get(0, 1));
+	}
+
+	private FrameBlock createEmptyRow(ValueType[] schema) {
+		String[][] arr = new String[1][];
+		arr[0] = new String[schema.length];
+		return new FrameBlock(schema, null, arr);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameEvictionTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameEvictionTest.java
@@ -40,7 +40,7 @@ import org.apache.sysds.test.TestUtils;
 @net.jcip.annotations.NotThreadSafe
 public class FrameEvictionTest extends AutomatedTestBase
 {
-	private final static int rows = 1593;
+	private final static int rows = 262;
 	private final static double sparsity1 = 0.9;
 	private final static double sparsity2 = 0.1;
 	

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameGetSetTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameGetSetTest.java
@@ -29,7 +29,7 @@ import org.apache.sysds.test.TestUtils;
 
 public class FrameGetSetTest extends AutomatedTestBase
 {
-	private final static int rows = 3254;
+	private final static int rows = 131;
 	private final static ValueType[] schemaStrings = new ValueType[]{ValueType.STRING, ValueType.STRING, ValueType.STRING};	
 	private final static ValueType[] schemaMixed = new ValueType[]{ValueType.STRING, ValueType.FP64, ValueType.INT64, ValueType.BOOLEAN};	
 	

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmpty.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmpty.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.frame;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.junit.Test;
+
+public class FrameRemoveEmpty {
+	protected static final Log LOG = LogFactory.getLog(FrameRemoveEmpty.class.getName());
+
+	@Test
+	public void removeEmptyCols() {
+		FrameBlock in = getTestCase0();
+		FrameBlock out = in.removeEmptyOperations(false, false, null);
+		assertEquals(out.getNumColumns(), 0);
+	}
+
+	@Test
+	public void removeEmptyColsWithNames() {
+		FrameBlock in = getTestCase1();
+		in.setColumnName(0, "Special Column");
+		FrameBlock out = in.removeEmptyOperations(false, false, null);
+		assertEquals(1, out.getNumColumns());
+		assertEquals("Special Column", out.getColumnName(0));
+	}
+
+	@Test
+	public void removeEmptyColsNoEmptyReturn() {
+		FrameBlock in = getTestCase1();
+		FrameBlock out = in.removeEmptyOperations(false, true, null);
+		assertEquals(1, out.getNumColumns());
+		assertEquals(null, out.get(0, 0));
+		assertEquals(null, out.get(1, 0));
+	}
+
+	@Test
+	public void removeEmptyColsNotEmpty() {
+		FrameBlock in = getTestCase1();
+		FrameBlock out = in.removeEmptyOperations(false, false, null);
+		assertEquals(1, out.getNumColumns());
+		assertEquals(null, out.get(0, 0));
+		assertEquals(null, out.get(1, 0));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelect() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(1, 2, new double[] {0, 1});
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(false, false, select);
+		assertEquals(1, out.getNumColumns());
+		assertEquals("You", out.get(4, 0));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectAll() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(1, 2, new double[] {1, 1});
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(false, false, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals("Hi", out.get(3, 0));
+		assertEquals("You", out.get(4, 1));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectAllNamedCol() {
+		FrameBlock in = getTestCase2();
+		in.setColumnName(1, "MEEE");
+		MatrixBlock select = new MatrixBlock(1, 2, new double[] {1, 1});
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(false, false, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals("Hi", out.get(3, 0));
+		assertEquals("You", out.get(4, 1));
+		assertEquals("MEEE", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectNamedCol() {
+		FrameBlock in = getTestCase2();
+		in.setColumnName(1, "MEEE");
+		MatrixBlock select = new MatrixBlock(1, 2, new double[] {0, 1});
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(false, false, select);
+		assertEquals(1, out.getNumColumns());
+		assertEquals("You", out.get(4, 0));
+		assertEquals("MEEE", out.getColumnName(0));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectNamedColEmptyReturn() {
+		FrameBlock in = getTestCase2();
+		in.setColumnName(1, "MEEE");
+		MatrixBlock select = new MatrixBlock(1, 2, new double[] {0, 0});
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(false, true, select);
+		assertEquals(1, out.getNumColumns());
+		assertEquals("C1", out.getColumnName(0));
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidCols_1() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(1, 3, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(false, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidCols_2() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(1, 1, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(false, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidCols_3() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(2, 1, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(false, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidCols_4() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(2, 2, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(false, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidRows_1() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(2, 2, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(true, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidRows_2() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(10, 2, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(true, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidRows_3() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(1, 10, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(true, true, select);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void removeEmptyInvalidRows_4() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(2, 10, false);
+		select.setNonZeros(0);
+		in.removeEmptyOperations(true, true, select);
+	}
+
+	@Test
+	public void removeEmptyRowsEmptySelect() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(10, 1, false);
+		FrameBlock out = in.removeEmptyOperations(true, true, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(1, out.getNumRows());
+		assertEquals(null, out.get(0, 0));
+	}
+
+	@Test
+	public void removeEmptyRowsSelect() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(10, 1, false);
+		select.setValue(3, 0, 1);
+		FrameBlock out = in.removeEmptyOperations(true, true, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(1, out.getNumRows());
+		assertEquals("Hi", out.get(0, 0));
+	}
+
+	@Test
+	public void removeEmptyRowsSelect_2() {
+		FrameBlock in = getTestCase2();
+		MatrixBlock select = new MatrixBlock(10, 1, false);
+		select.setValue(3, 0, 1);
+		select.setValue(4, 0, 1);
+		FrameBlock out = in.removeEmptyOperations(true, true, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(2, out.getNumRows());
+		assertEquals("Hi", out.get(0, 0));
+		assertEquals("You", out.get(1, 1));
+	}
+
+	@Test
+	public void removeEmptyRows() {
+		FrameBlock in = getTestCase2();
+		FrameBlock out = in.removeEmptyOperations(true, true, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(2, out.getNumRows());
+		assertEquals("Hi", out.get(0, 0));
+		assertEquals("You", out.get(1, 1));
+	}
+
+	@Test
+	public void removeEmptyRowsEmptyIn() {
+		FrameBlock in = getTestCase0();
+		FrameBlock out = in.removeEmptyOperations(true, true, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(1, out.getNumRows());
+	}
+
+	@Test
+	public void removeEmptyRowsEmptyInNotEmptyReturn() {
+		FrameBlock in = getTestCase0();
+		FrameBlock out = in.removeEmptyOperations(true, false, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(0, out.getNumRows());
+	}
+
+	@Test
+	public void removeEmptyRowsEmptyInColumnName() {
+		FrameBlock in = getTestCase0();
+		in.setColumnName(1, "HelloThere");
+		FrameBlock out = in.removeEmptyOperations(true, true, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(1, out.getNumRows());
+		assertEquals("HelloThere", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyRowsEmptySelectAll() {
+		FrameBlock in = getTestCase0();
+		in.setColumnName(1, "HelloThere");
+		MatrixBlock select = new MatrixBlock(10, 1, 1.0);
+		select.recomputeNonZeros();
+		FrameBlock out = in.removeEmptyOperations(true, true, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(10, out.getNumRows());
+		assertEquals("HelloThere", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyRowsEmptyAll() {
+		FrameBlock in = getTestCase3();
+		in.setColumnName(1, "HelloThere");
+		FrameBlock out = in.removeEmptyOperations(true, true, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(10, out.getNumRows());
+		assertEquals("HelloThere", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyRowsSomeColumnsWithName() {
+		FrameBlock in = getTestCase2();
+		in.setColumnName(1, "HelloThere");
+		FrameBlock out = in.removeEmptyOperations(true, true, null);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(2, out.getNumRows());
+		assertEquals("HelloThere", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyRowsSelectAlmostAll() {
+		FrameBlock in = getTestCase2();
+		in.setColumnName(1, "HelloThere");
+		MatrixBlock select = new MatrixBlock(10, 1, 1.0);
+		select.setValue(0, 0, 0);
+		FrameBlock out = in.removeEmptyOperations(true, true, select);
+		assertEquals(2, out.getNumColumns());
+		assertEquals(9, out.getNumRows());
+		assertEquals("HelloThere", out.getColumnName(1));
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectNone() {
+		try {
+			FrameBlock in = getTestCase2();
+			MatrixBlock select = new MatrixBlock(1, 2, new double[] {0, 0});
+			select.recomputeNonZeros();
+			FrameBlock out = in.removeEmptyOperations(false, false, select);
+			assertEquals(0, out.getNumColumns());
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void removeEmptyColsWithSelectNoneEmptyReturn() {
+		try {
+			FrameBlock in = getTestCase2();
+			MatrixBlock select = new MatrixBlock(1, 2, new double[] {0, 0});
+			select.recomputeNonZeros();
+			FrameBlock out = in.removeEmptyOperations(false, true, select);
+			assertEquals(1, out.getNumColumns());
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	private static FrameBlock getTestCase0() {
+		FrameBlock in = new FrameBlock();
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10));
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10));
+		return in;
+	}
+
+	private static FrameBlock getTestCase1() {
+		FrameBlock in = new FrameBlock();
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10));
+		in.set(3, 0, "Hi");
+		return in;
+	}
+
+	private static FrameBlock getTestCase2() {
+		FrameBlock in = new FrameBlock();
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10));
+		in.set(3, 0, "Hi");
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10));
+		in.set(4, 1, "You");
+		return in;
+	}
+
+	private static FrameBlock getTestCase3() {
+		FrameBlock in = new FrameBlock();
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10, "Hi"));
+		in.appendColumn(ArrayFactory.allocate(ValueType.STRING, 10, "You"));
+		return in;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmpty.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameRemoveEmpty.java
@@ -251,12 +251,19 @@ public class FrameRemoveEmpty {
 
 	@Test
 	public void removeEmptyRowsEmptyInColumnName() {
-		FrameBlock in = getTestCase0();
-		in.setColumnName(1, "HelloThere");
-		FrameBlock out = in.removeEmptyOperations(true, true, null);
-		assertEquals(2, out.getNumColumns());
-		assertEquals(1, out.getNumRows());
-		assertEquals("HelloThere", out.getColumnName(1));
+		try{
+
+			FrameBlock in = getTestCase0();
+			in.setColumnName(1, "HelloThere");
+			FrameBlock out = in.removeEmptyOperations(true, true, null);
+			assertEquals(2, out.getNumColumns());
+			assertEquals(1, out.getNumRows());
+			assertEquals("HelloThere", out.getColumnName(1));
+		}
+		catch(Exception e){
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysds/test/component/frame/FrameUtilTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/FrameUtilTest.java
@@ -97,12 +97,10 @@ public class FrameUtilTest {
 		assertEquals(ValueType.BOOLEAN, FrameUtil.isType("FALSE", ValueType.UNKNOWN));
 	}
 
-
 	@Test
 	public void testIsTypeMinimumString_1() {
 		assertEquals(ValueType.STRING, FrameUtil.isType("FALSEE", ValueType.UNKNOWN));
 	}
-
 
 	@Test
 	public void testIsTypeMinimumString_2() {
@@ -119,9 +117,126 @@ public class FrameUtilTest {
 		assertEquals(ValueType.STRING, FrameUtil.isType("AAGss", ValueType.UNKNOWN));
 	}
 
-
 	@Test
 	public void testIsTypeMinimumString_5() {
 		assertEquals(ValueType.STRING, FrameUtil.isType("ttrue", ValueType.UNKNOWN));
+	}
+
+	@Test
+	public void testIsIntLongString() {
+		assertEquals(ValueType.STRING, FrameUtil.isType("11111111111111111111111111111"));
+	}
+
+	@Test
+	public void testInfinite() {
+		assertEquals(ValueType.FP64, FrameUtil.isType("infinity"));
+	}
+
+	@Test
+	public void testMinusInfinite() {
+		assertEquals(ValueType.FP64, FrameUtil.isType("-infinity"));
+	}
+
+	@Test
+	public void testNan() {
+		assertEquals(ValueType.FP64, FrameUtil.isType("nan"));
+	}
+
+	@Test
+	public void testEmptyString() {
+		assertEquals(ValueType.UNKNOWN, FrameUtil.isType(""));
+	}
+
+	@Test
+	public void testMinType() {
+		for(ValueType v : ValueType.values())
+			assertEquals(ValueType.STRING, FrameUtil.isType("asbdapjuawijpasu2139591asd", v));
+	}
+
+	@Test
+	public void testNull() {
+		for(ValueType v : ValueType.values())
+			assertEquals(ValueType.UNKNOWN, FrameUtil.isType(null, v));
+	}
+
+	@Test
+	public void testInteger() {
+		assertEquals(ValueType.INT32, FrameUtil.isType("1324"));
+	}
+
+	@Test
+	public void testIntegerMax() {
+		assertEquals(ValueType.INT32, FrameUtil.isType(Integer.MAX_VALUE + ""));
+	}
+
+	@Test
+	public void testIntegerMaxPlus1() {
+		assertEquals(ValueType.INT64, FrameUtil.isType(((long) Integer.MAX_VALUE + 1) + ""));
+	}
+
+	@Test
+	public void testIntegerMin() {
+		assertEquals(ValueType.INT32, FrameUtil.isType(Integer.MIN_VALUE + ""));
+	}
+
+
+	@Test
+	public void testIntegerMinComma() {
+		assertEquals(ValueType.INT32, FrameUtil.isType(Integer.MIN_VALUE + ".0"));
+	}
+
+	@Test
+	public void testIntegerMinMinus1() {
+		assertEquals(ValueType.INT64, FrameUtil.isType(((long) Integer.MIN_VALUE - 1L) + ""));
+	}
+
+	@Test
+	public void testLong() {
+		assertEquals(ValueType.INT64, FrameUtil.isType("3333333333"));
+	}
+
+	@Test
+	public void testCharacter() {
+		assertEquals(ValueType.CHARACTER, FrameUtil.isType("i"));
+	}
+
+	@Test
+	public void testCharacter_2() {
+		assertEquals(ValueType.CHARACTER, FrameUtil.isType("@"));
+	}
+
+	@Test
+	public void testDoubleIsType_1() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType(0.0));
+	}
+
+	@Test
+	public void testDoubleIsType_2() {
+		assertEquals(ValueType.BOOLEAN, FrameUtil.isType(1.0));
+	}
+
+	@Test
+	public void testDoubleIsType_3() {
+		assertEquals(ValueType.INT32, FrameUtil.isType(15.0));
+	}
+
+	@Test
+	public void testDoubleIsType_4() {
+		assertEquals(ValueType.INT32, FrameUtil.isType(-15.0));
+	}
+
+	@Test
+	public void testDoubleIsType_5() {
+		assertEquals(ValueType.INT64, FrameUtil.isType(3333333333.0));
+	}
+
+	@Test
+	public void testDoubleIsType_6() {
+		assertEquals(ValueType.FP32, FrameUtil.isType(33.3));
+	}
+
+	@Test
+	public void testDoubleIsType_7() {
+		assertEquals(ValueType.FP64, FrameUtil.isType(33.231425155253));
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.frame.data.columns.Array;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
 import org.apache.sysds.runtime.frame.data.columns.BitSetArray;
 import org.apache.sysds.runtime.frame.data.columns.BooleanArray;
@@ -106,85 +107,133 @@ public class CustomArrayTests {
 	@Test
 	public void analyzeValueTypeStringBoolean() {
 		StringArray a = ArrayFactory.create(new String[] {"1", "0", "0"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.BOOLEAN);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.BOOLEAN, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringBoolean_withPointZero() {
 		StringArray a = ArrayFactory.create(new String[] {"1.0", "0", "0"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.BOOLEAN);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.BOOLEAN, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringBoolean_withPointZero_2() {
 		StringArray a = ArrayFactory.create(new String[] {"1.00", "0", "0"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.BOOLEAN);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.BOOLEAN, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringBoolean_withPointZero_3() {
 		StringArray a = ArrayFactory.create(new String[] {"1.00000000000", "0", "0"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.BOOLEAN);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.BOOLEAN, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringInt32() {
 		StringArray a = ArrayFactory.create(new String[] {"13", "131", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.INT32);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT32, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringInt32_withPointZero() {
 		StringArray a = ArrayFactory.create(new String[] {"13.0", "131", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.INT32);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT32, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringInt32_withPointZero_2() {
 		StringArray a = ArrayFactory.create(new String[] {"13.0000", "131", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.INT32);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT32, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringInt32_withPointZero_3() {
 		StringArray a = ArrayFactory.create(new String[] {"13.00000000000000", "131", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.INT32);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT32, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringInt64() {
 		StringArray a = ArrayFactory.create(new String[] {"" + (((long) Integer.MAX_VALUE) + 10L), "131", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.INT64);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT64, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringFP32() {
 		StringArray a = ArrayFactory.create(new String[] {"132", "131.1", "-142"});
-		ValueType t = a.analyzeValueType();
+		ValueType t = a.analyzeValueType().getKey();
 		assertEquals(ValueType.FP32, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringFP64() {
 		StringArray a = ArrayFactory.create(new String[] {"132", "131.0012345678912345", "-142"});
-		ValueType t = a.analyzeValueType();
-		assertTrue(t == ValueType.FP64);
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.FP64, t);
 	}
 
 	@Test
 	public void analyzeValueTypeStringFP32_string() {
 		StringArray a = ArrayFactory.create(new String[] {"\"132\"", "131.1", "-142"});
-		ValueType t = a.analyzeValueType();
+		ValueType t = a.analyzeValueType().getKey();
 		assertEquals(ValueType.STRING, t);
+	}
+
+	@Test
+	public void analyzeValueTypeCharacter() {
+		StringArray a = ArrayFactory.create(new String[] {"1", "g", "1", "3"});
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.CHARACTER, t);
+	}
+
+	@Test
+	public void analyzeValueTypeCharacterWithNull() {
+		StringArray a = ArrayFactory.create(new String[] {"1", "g", null, "3"});
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.CHARACTER, t);
+	}
+
+	@Test
+	public void analyzeValueTypeInteger() {
+		StringArray a = ArrayFactory.create(new String[] {"1", "2", null, "3"});
+		ValueType t = a.analyzeValueType().getKey();
+		assertEquals(ValueType.INT32, t);
+	}
+
+	@Test
+	public void getNulls() {
+		StringArray a = ArrayFactory.create(new String[] {"1", "2", null, "3"});
+		Array<Boolean> n = a.getNulls();
+		verifyNulls(a, n);
+	}
+
+	@Test
+	public void getNulls_2() {
+		StringArray a = ArrayFactory.create(new String[] {"1", "2", "null", "3"});
+		Array<Boolean> n = a.getNulls();
+		verifyNulls(a, n);
+	}
+
+	@Test
+	public void getNulls_3() {
+		StringArray a = ArrayFactory.create(new String[] {null, null, null, "3"});
+		Array<Boolean> n = a.getNulls();
+		verifyNulls(a, n);
+	}
+
+	private static void verifyNulls(Array<?> a, Array<Boolean> n) {
+		for(int i = 0; i < a.size(); i++)
+			assertTrue((a.get(i) == null && !n.get(i)) //
+				|| (a.get(i) != null && n.get(i)));
 	}
 
 	@Test
@@ -551,4 +600,21 @@ public class CustomArrayTests {
 			assertTrue(a.get(i));
 	}
 
+	@Test
+	public void testAppendDifferentTypes_1() {
+		Array<String> a = new StringArray(new String[] {"1", "2", "3"});
+		Array<Integer> b = new IntegerArray(new int[] {4, 5, 6});
+		Array<String> c = ArrayFactory.append(a, b);
+		for(int i = 0; i < c.size(); i++)
+			assertEquals(i + 1, Integer.parseInt(c.get(i)));
+	}
+
+	@Test
+	public void testAppendDifferentTypes_2() {
+		Array<Integer> a = new IntegerArray(new int[] {1, 2, 3});
+		Array<String> b = new StringArray(new String[] {"4", "5", "6"});
+		Array<String> c = ArrayFactory.append(a, b);
+		for(int i = 0; i < c.size(); i++)
+			assertEquals(i + 1, Integer.parseInt(c.get(i)));
+	}
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayTests.java
@@ -105,7 +105,13 @@ public class FrameArrayTests {
 			tests.add(new Object[] {ArrayFactory.create(generateRandom01chars(150, 221)), FrameArrayType.CHARACTER});
 			// Long to int
 			tests.add(new Object[] {ArrayFactory.create(new long[] {3214, 424, 13, 22, 111, 134}), FrameArrayType.INT64});
-		}
+
+			tests.add(new Object[] {ArrayFactory.create(new double[] {//
+				Double.NaN, 424, 13, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 134}), FrameArrayType.FP64});
+			tests.add(new Object[] {ArrayFactory.create(new float[] {//
+				Float.NaN, 424, 13, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, 134}), FrameArrayType.FP32});
+
+			}
 		catch(Exception e) {
 			e.printStackTrace();
 			fail("failed constructing tests");
@@ -376,10 +382,10 @@ public class FrameArrayTests {
 	public void testSetRange(int start, int end, int otherSize, int seed) {
 		try {
 			Array<?> other = create(a.getFrameArrayType(), otherSize, seed);
-			try{
+			try {
 				other = other.changeTypeWithNulls(a.getValueType());
 			}
-			catch(DMLRuntimeException e){
+			catch(DMLRuntimeException e) {
 				return;// all good.
 			}
 
@@ -941,6 +947,19 @@ public class FrameArrayTests {
 		}
 	}
 
+	@Test
+	public void testFindEmpty() {
+		boolean[] select = new boolean[a.size()];
+		a.findEmpty(select);
+		Object d = ArrayFactory.defaultNullValue(a.getValueType());
+		final String errStart = a.getClass().getSimpleName() + " ";
+		for(int i = 0; i < select.length; i++) {
+			if(!select[i])
+				assertTrue(errStart + a.get(i), //
+					(a.get(i) == null) || a.get(i).equals(d) || a.get(i).equals("0"));
+		}
+	}
+
 	protected static void compare(Array<?> a, Array<?> b) {
 		int size = a.size();
 		String err = a.getClass().getSimpleName() + " " + a.getValueType() + " " + b.getClass().getSimpleName() + " "
@@ -1148,7 +1167,6 @@ public class FrameArrayTests {
 		}
 		return ret;
 	}
-
 
 	protected static Double[] generateRandomDoubleOpt(int size, int seed) {
 		Random r = new Random(seed);

--- a/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
@@ -27,6 +27,13 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.columns.Array;
 import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
 import org.apache.sysds.runtime.frame.data.columns.BitSetArray;
+import org.apache.sysds.runtime.frame.data.columns.BooleanArray;
+import org.apache.sysds.runtime.frame.data.columns.CharArray;
+import org.apache.sysds.runtime.frame.data.columns.DoubleArray;
+import org.apache.sysds.runtime.frame.data.columns.FloatArray;
+import org.apache.sysds.runtime.frame.data.columns.IntegerArray;
+import org.apache.sysds.runtime.frame.data.columns.LongArray;
+import org.apache.sysds.runtime.frame.data.columns.OptionalArray;
 import org.apache.sysds.runtime.frame.data.columns.StringArray;
 import org.junit.Test;
 
@@ -117,4 +124,48 @@ public class NegativeArrayTests {
 		new BitSetArray(new long[10], 10);
 	}
 
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationBoolean() {
+		new BooleanArray(new boolean[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationBitSet() {
+		new BitSetArray(new boolean[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationChar() {
+		new CharArray(new char[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationDouble() {
+		new DoubleArray(new double[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationFloat() {
+		new FloatArray(new float[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationInteger() {
+		new IntegerArray(new int[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationLong() {
+		new LongArray(new long[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationOptional() {
+		new OptionalArray<>(new Integer[0]);
+	}
+
+	@Test(expected = DMLRuntimeException.class)
+	public void zLenAllocationString() {
+		new StringArray(new String[0]);
+	}
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/NegativeArrayTests.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.test.component.frame.array;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -30,9 +32,11 @@ import org.junit.Test;
 
 public class NegativeArrayTests {
 
-	@Test(expected = DMLRuntimeException.class)
+	@Test
+	@SuppressWarnings("unchecked")
 	public void testAllocateInvalidArray() {
-		ArrayFactory.allocate(ValueType.UNKNOWN, 1324);
+		Array<String> s = (Array<String>) ArrayFactory.allocate(ValueType.UNKNOWN, 42);
+		assertEquals(null, s.get(3));
 	}
 
 	@Test(expected = DMLRuntimeException.class)
@@ -40,16 +44,30 @@ public class NegativeArrayTests {
 		ArrayFactory.getInMemorySize(ValueType.UNKNOWN, 0);
 	}
 
-	@Test(expected = DMLRuntimeException.class)
+	@Test
+	@SuppressWarnings("unchecked")
 	public void testChangeTypeToInvalid() {
 		Array<?> a = ArrayFactory.create(new int[] {1, 2, 3});
-		a.changeType(ValueType.UNKNOWN);
+		Array<String> s = (Array<String>) a.changeType(ValueType.UNKNOWN);
+		s.toString();
 	}
 
 	@Test(expected = NotImplementedException.class)
 	public void testChangeTypeToUInt8() {
 		Array<?> a = ArrayFactory.create(new int[] {1, 2, 3});
 		a.changeType(ValueType.UINT8);
+	}
+
+	@Test(expected = NotImplementedException.class)
+	public void testChangeTypeToUInt8WithNull_noNull() {
+		Array<?> a = ArrayFactory.create(new int[] {1, 2, 3});
+		a.changeTypeWithNulls(ValueType.UINT8);
+	}
+
+	@Test(expected = NotImplementedException.class)
+	public void testChangeTypeToUInt8WithNull() {
+		Array<?> a = ArrayFactory.create(new String[] {"1", "2", null});
+		a.changeTypeWithNulls(ValueType.UINT8);
 	}
 
 	@Test(expected = DMLRuntimeException.class)
@@ -77,27 +95,26 @@ public class NegativeArrayTests {
 
 	@Test(expected = DMLRuntimeException.class)
 	public void changeTypeBoolean_4() {
-		String[] s = new String[100]; 
+		String[] s = new String[100];
 		s[0] = "1";
 		s[1] = "10";
 		StringArray a = ArrayFactory.create(s);
 		a.changeType(ValueType.BOOLEAN);
 	}
 
-
 	@Test(expected = DMLRuntimeException.class)
-	public void invalidConstructionBitArrayToSmall(){
-		new BitSetArray(new long[0], 10 );
-	}
-	
-	@Test(expected = DMLRuntimeException.class)
-	public void invalidConstructionBitArrayToSmall_2(){
-		new BitSetArray(new long[1], 80 );
+	public void invalidConstructionBitArrayToSmall() {
+		new BitSetArray(new long[0], 10);
 	}
 
 	@Test(expected = DMLRuntimeException.class)
-	public void invalidConstructionBitArrayToBig(){
-		new BitSetArray(new long[10], 10 );
+	public void invalidConstructionBitArrayToSmall_2() {
+		new BitSetArray(new long[1], 80);
 	}
-	
+
+	@Test(expected = DMLRuntimeException.class)
+	public void invalidConstructionBitArrayToBig() {
+		new BitSetArray(new long[10], 10);
+	}
+
 }

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockAlignment.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockAlignment.java
@@ -38,8 +38,8 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockAlignment extends AutomatedTestBase 
 {
-	private final static int rows = 878;
-	private final static int cols = 393;	
+	private final static int rows = 324;
+	private final static int cols = 132;	
 	private final static double sparsity1 = 0.09;
 	private final static double sparsity2 = 0.19;
 	private final static double sparsity3 = 0.29;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockAppendSort.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockAppendSort.java
@@ -40,8 +40,8 @@ import java.util.Iterator;
  */
 public class SparseBlockAppendSort extends AutomatedTestBase 
 {
-	private final static int rows = 632;
-	private final static int cols = 454;	
+	private final static int rows = 304;
+	private final static int cols = 132;	
 	private final static double sparsity1 = 0.11;
 	private final static double sparsity2 = 0.21;
 	private final static double sparsity3 = 0.31;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockDelete.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockDelete.java
@@ -41,10 +41,10 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockDelete extends AutomatedTestBase 
 {
-	private final static int rows = 662;
-	private final static int cols = 444;	
-	private final static int cl = 145;
-	private final static int cu = 225;
+	private final static int rows = 132;
+	private final static int cols = 98;	
+	private final static int cl = 32;
+	private final static int cu = 44;
 	private final static double sparsity1 = 0.12;
 	private final static double sparsity2 = 0.22;
 	private final static double sparsity3 = 0.32;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockGetSet.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockGetSet.java
@@ -42,8 +42,8 @@ import java.util.Iterator;
  */
 public class SparseBlockGetSet extends AutomatedTestBase 
 {
-	private final static int rows = 732;
-	private final static int cols = 354;	
+	private final static int rows = 132;
+	private final static int cols = 60;	
 	private final static double sparsity1 = 0.1;
 	private final static double sparsity2 = 0.2;
 	private final static double sparsity3 = 0.3;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockIterator.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockIterator.java
@@ -41,8 +41,8 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockIterator extends AutomatedTestBase 
 {
-	private final static int rows = 772;
-	private final static int cols = 394;	
+	private final static int rows = 324;
+	private final static int cols = 100;	
 	private final static int rlPartial = 134;
 	private final static double sparsity1 = 0.1;
 	private final static double sparsity2 = 0.2;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockMemEstimate.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockMemEstimate.java
@@ -34,8 +34,8 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockMemEstimate extends AutomatedTestBase 
 {
-	private final static int rows = 662;
-	private final static int cols = 444;
+	private final static int rows = 320;
+	private final static int cols = 130;
 	private final static double sparsity1 = 0.39;
 	private final static double sparsity2 = 0.0001;
 	

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockScan.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockScan.java
@@ -38,8 +38,8 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockScan extends AutomatedTestBase 
 {
-	private final static int rows = 871;
-	private final static int cols = 295;	
+	private final static int rows = 324;
+	private final static int cols = 131;	
 	private final static double sparsity1 = 0.09;
 	private final static double sparsity2 = 0.19;
 	private final static double sparsity3 = 0.29;

--- a/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockSize.java
+++ b/src/test/java/org/apache/sysds/test/component/sparse/SparseBlockSize.java
@@ -39,12 +39,12 @@ import org.apache.sysds.test.TestUtils;
  */
 public class SparseBlockSize extends AutomatedTestBase 
 {
-	private final static int rows = 762;
-	private final static int cols = 649;
+	private final static int rows = 324;
+	private final static int cols = 123;
 	private final static int rl = 31;
-	private final static int ru = 345;
-	private final static int cl = 345;
-	private final static int cu = 525;
+	private final static int ru = 100;
+	private final static int cl = 30;
+	private final static int cu = 80;
 	private final static double sparsity1 = 0.12;
 	private final static double sparsity2 = 0.22;
 	private final static double sparsity3 = 0.32;

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinMeanImputationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinMeanImputationTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.sysds.test.functions.builtin.part2;
 
+import java.util.HashMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
@@ -26,9 +30,9 @@ import org.apache.sysds.test.TestUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.HashMap;
-
 public class BuiltinMeanImputationTest extends AutomatedTestBase {
+	protected static final Log LOG = LogFactory.getLog(BuiltinMeanImputationTest.class.getName());
+	
 	private final static String TEST_NAME1 = "meanImputation";
 	private final static String TEST_NAME2 = "medianImputation";
 	private final static String TEST_DIR = "functions/builtin/";
@@ -77,12 +81,13 @@ public class BuiltinMeanImputationTest extends AutomatedTestBase {
 			rCmd = "Rscript" + " " + fullRScriptName + " " + DATASET_DIR+"Salaries.csv" + " " + expectedDir();
 
 
-			runTest(true, false, null, -1);
+			LOG.error(runTest(null));
 			runRScript(true);
 
 			//compare matrices
 			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("B");
 			HashMap<MatrixValue.CellIndex, Double> rfile  = readRMatrixFromExpectedDir("B");
+
 			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
 		}
 		finally {

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedConstructionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedConstructionTest.java
@@ -136,7 +136,7 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 		// Run reference dml script with normal matrix
 		fullDMLScriptName = HOME + testFile + "Reference.dml";
 		programArgs = new String[] {"-args", input(inputIdentifier), expected("B")};
-		runTest(true, false, null, -1);
+		runTest(null);
 
 		// reference file should not be written to hdfs
 		rtplatform = execMode;
@@ -147,7 +147,7 @@ public class FederatedConstructionTest extends AutomatedTestBase {
 		programArgs = new String[] {"-nvargs", "in=" + TestUtils.federatedAddress(port, input(inputIdentifier)),
 			"rows=" + rows, "cols=" + cols, "out=" + output("B")};
 
-		runTest(true, false, null, -1);
+		runTest(null);
 		// compare via files
 		if(schema != null)
 			compareResults(schema);

--- a/src/test/java/org/apache/sysds/test/functions/frame/ApplySchemaTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/ApplySchemaTest.java
@@ -121,7 +121,6 @@ public class ApplySchemaTest extends AutomatedTestBase {
 				String detected = detectedSchema.get(0, i).toString();
 				String applied = changedFrame.getSchema()[i].toString();
 				Assert.assertEquals("Wrong result column : " + i + ".", detected, applied);
-				// System.out.println(detetctedSchema.get(0, i).toString() +" "+changedFrame.getSchema()[i].toString());
 			}
 
 		}

--- a/src/test/java/org/apache/sysds/test/functions/frame/DetectSchemaTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/DetectSchemaTest.java
@@ -114,8 +114,6 @@ public class DetectSchemaTest extends AutomatedTestBase {
 
 			runTest(null);
 			FrameBlock frame2 = readDMLFrameFromHDFS("B", FileFormat.BINARY);
-			// LOG.error(frame1);
-			// LOG.error(frame2);
 
 			// verify output schema
 			for(int i = 0; i < schema.length; i++) {

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameConverterTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameConverterTest.java
@@ -380,17 +380,16 @@ public class FrameConverterTest extends AutomatedTestBase
 	}
 	
 	private static void verifyFrameMatrixData(FrameBlock frame, MatrixBlock matrix) {
-		for ( int i=0; i<frame.getNumRows(); i++ )
-			for( int j=0; j<frame.getNumColumns(); j++ ) {
-				Object val1 = UtilFunctions.doubleToObject(frame.getSchema()[j],
-								UtilFunctions.objectToDouble(frame.getSchema()[j], frame.get(i, j)));
-				Object val2 = UtilFunctions.doubleToObject(frame.getSchema()[j], matrix.getValue(i, j));
-				if(( UtilFunctions.compareTo(frame.getSchema()[j], val1, val2)) != 0)
-					Assert.fail("Frame value for cell ("+ i + "," + j + ") is " + val1 + 
-							", is not same as matrix value " + val2);
+		for(int i = 0; i < matrix.getNumRows(); i++)
+			for(int j = 0; j < matrix.getNumColumns(); j++) {
+				double v1 = frame.getDouble(i, j);
+				double v2 = matrix.getDouble(i, j);
+				double diff = Math.abs(v2 - v1);
+				if(diff > 0.000001d)
+					Assert.fail("Frame value for cell (" + i + "," + j + ") is " + v1 + ", is not same as matrix " + v2);
 			}
 	}
-	
+
 	@SuppressWarnings({ "unchecked"})
 	private static void runConverter(ConvType type, MatrixCharacteristics mc, MatrixCharacteristics mcMatrix,
 		List<ValueType> schema, String fnameIn, String fnameOut) throws IOException

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameDropInvalidTypeTest.java
@@ -208,7 +208,7 @@ public class FrameDropInvalidTypeTest extends AutomatedTestBase {
 			writer.writeFrameToHDFS(frame2, input("M"), 1, schema.length);
 			runTest(null);
 			FrameBlock frameout = readDMLFrameFromHDFS("B", FileFormat.BINARY);
-			LOG.error(frameout);
+		
 			//read output data and compare results
 			ArrayList<Object> data = new ArrayList<>();
 			for (int i = 0; i < frameout.getNumRows(); i++)

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameMapTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameMapTest.java
@@ -38,7 +38,7 @@ public class FrameMapTest extends AutomatedTestBase {
 	private final static String TEST_DIR = "functions/binary/frame/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + FrameMapTest.class.getSimpleName() + "/";
 
-	private final static int rows = 100005;
+	private final static int rows = 3124;
 	private final static int rows2 = 10;
 	private final static Types.ValueType[] schemaStrings1 = {Types.ValueType.STRING};
 

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameMatrixReblockTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameMatrixReblockTest.java
@@ -21,11 +21,12 @@ package org.apache.sysds.test.functions.frame;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
-import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.common.Types.ExecType;
+import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.io.FrameWriter;
 import org.apache.sysds.runtime.io.FrameWriterFactory;
@@ -36,14 +37,16 @@ import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
 
-public class FrameMatrixReblockTest extends AutomatedTestBase
-{
+public class FrameMatrixReblockTest extends AutomatedTestBase{
+
+	private static final Log LOG = LogFactory.getLog(FrameMatrixReblockTest.class.getName());
 	private final static String TEST_DIR = "functions/frame/";
 	private final static String TEST_NAME1 = "FrameMatrixReblock";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FrameMatrixReblockTest.class.getSimpleName() + "/";
 
-	private final static int rows = 2593;
+	private final static int rows = 1200;
 	private final static int cols1 = 372;
 	private final static int cols2 = 1102;
 	private final static double sparsity1 = 0.9;
@@ -198,7 +201,7 @@ public class FrameMatrixReblockTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain","-args", input("A"), String.valueOf(rows), 
+			programArgs = new String[]{"-args", input("A"), String.valueOf(rows), 
 					String.valueOf(cols), output("B"), ofmt };
 			
 			//generate input data
@@ -206,7 +209,7 @@ public class FrameMatrixReblockTest extends AutomatedTestBase
 			writeFrameInput(input("A"), ofmt, A, rows, cols);
 			
 			//run testcase
-			runTest(true, false, null, -1);
+			LOG.debug(runTest(null));
 			
 			//compare matrices
 			double[][] B = readMatrixOutput(output("B"), ofmt, rows, cols);

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameMatrixWriteTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameMatrixWriteTest.java
@@ -150,6 +150,7 @@ public class FrameMatrixWriteTest extends AutomatedTestBase
 			TestUtils.compareMatrices(A, B, rows, cols, 0);
 		}
 		catch(Exception ex) {
+			ex.printStackTrace();
 			throw new RuntimeException(ex);
 		}
 		finally {

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameRemoveEmptyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameRemoveEmptyTest.java
@@ -21,6 +21,8 @@ package org.apache.sysds.test.functions.frame;
 
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
@@ -28,6 +30,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -37,7 +40,7 @@ import org.junit.Test;
 
 public class FrameRemoveEmptyTest extends AutomatedTestBase {
 
-	private static final Log LOG = LogFactory.getLog(FrameRemoveEmptyTest.class.getName());
+	protected static final Log LOG = LogFactory.getLog(FrameRemoveEmptyTest.class.getName());
 
 	private final static String TEST_NAME1 = "removeEmpty1";
 	private final static String TEST_NAME2 = "removeEmpty2";
@@ -163,9 +166,10 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[] {"-explain", "-args", input("V"), input("I"), margin, output("R")};
+			programArgs = new String[] {"-args", input("V"), input("I"), margin, output("R")};
 
-			Pair<MatrixBlock, MatrixBlock> data = createInputMatrix(margin, bSelectIndex, fullSelect, rows, cols, sparsity);
+			Pair<MatrixBlock, MatrixBlock> data = createInputMatrix(margin, bSelectIndex, fullSelect, rows, cols,
+				sparsity);
 
 			MatrixBlock in = data.getKey();
 			MatrixBlock select = data.getValue();
@@ -174,16 +178,14 @@ public class FrameRemoveEmptyTest extends AutomatedTestBase {
 
 			MatrixBlock expected = fullSelect ? in : in.removeEmptyOperations(new MatrixBlock(), margin.equals("rows"),
 				false, select);
-
-			double[][] out = TestUtils.convertHashMapToDoubleArray(readDMLMatrixFromOutputDir("R"));
-
-			LOG.debug(expected.getNumRows() + "  " + out.length);
+			HashMap<CellIndex, Double> m = readDMLMatrixFromOutputDir("R");
+			double[][] out = TestUtils.convertHashMapToDoubleArray(m, expected.getNumRows(), expected.getNumColumns());
 
 			TestUtils.compareMatrices(expected, out, 0, "");
 		}
 		catch(Exception e) {
 			e.printStackTrace();
-			fail("Failed test because of exception " + e);
+			fail("Failed test because of exception " + e.getMessage());
 		}
 		finally {
 			// reset platform for additional tests

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameReplaceTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameReplaceTest.java
@@ -19,9 +19,12 @@
 
 package org.apache.sysds.test.functions.frame;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
@@ -29,11 +32,10 @@ import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FrameReplaceTest extends AutomatedTestBase {
-	// private static final Log LOG = LogFactory.getLog(FrameReplaceTest.class.getName());
+	protected static final Log LOG = LogFactory.getLog(FrameReplaceTest.class.getName());
 	private final static String TEST_DIR = "functions/frame/";
 	private final static String TEST_NAME = "ReplaceTest";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FrameReplaceTest.class.getSimpleName() + "/";
@@ -50,7 +52,6 @@ public class FrameReplaceTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void testParforFrameIntermediatesSpark() {
 		runReplaceTest(ExecType.SPARK);
 	}

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameSchemaReadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameSchemaReadTest.java
@@ -119,7 +119,7 @@ public class FrameSchemaReadTest extends AutomatedTestBase
 			setOutputBuffering(true);
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain","-args", input("A"), getSchemaString(schema, wildcard), 
+			programArgs = new String[]{"-args", input("A"), getSchemaString(schema, wildcard), 
 					Integer.toString(rows), Integer.toString(schema.length), output("B") };
 			
 			//data generation

--- a/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/json/FrameReaderWriterJSONLTest.java
@@ -19,60 +19,65 @@
 
 package org.apache.sysds.test.functions.io.json;
 
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Random;
+
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.wink.json4j.JSONException;
-import org.junit.Test;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.io.FrameReaderJSONL;
 import org.apache.sysds.runtime.io.FrameWriterJSONL;
 import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.test.TestUtils;
+import org.apache.wink.json4j.JSONException;
+import org.junit.Test;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Random;
-
-public class FrameReaderWriterJSONLTest
-{
+public class FrameReaderWriterJSONLTest {
 	private static final String FILENAME_SINGLE = "target/testTemp/functions/data/FrameJSONLTest/testFrameBlock.json";
 
 	@Test
 	public void testWriteReadFrameBlockSingleSingleFromHDFS() throws IOException, JSONException {
-		testWriteReadFrameBlockComplete(1,1, 4669201);
+		testWriteReadFrameBlockComplete(1, 1, 4669201);
 	}
 
 	@Test
 	public void testWriteReadFrameBlockSingleMultipleFromHDFS() throws IOException, JSONException {
-		testWriteReadFrameBlockComplete(1,23, 4669201);
+		testWriteReadFrameBlockComplete(1, 23, 4669201);
 	}
 
 	@Test
 	public void testWriteReadFrameBlockMultipleSingleFromHDFS() throws IOException, JSONException {
-		testWriteReadFrameBlockComplete(21,1, 4669201);
+		testWriteReadFrameBlockComplete(21, 1, 4669201);
 	}
 
 	@Test
 	public void testWriteReadFrameBlockMultipleMultipleFromHDFS() throws IOException, JSONException {
-		testWriteReadFrameBlockComplete(42,35, 4669201);
+		testWriteReadFrameBlockComplete(42, 35, 4669201);
 	}
 
 	@Test
 	public void testWriteReadFrameBlockMultipleMultipleSmallFromHDFS() throws IOException, JSONException {
-		testWriteReadFrameBlockComplete(694,164, 4669201);
+		testWriteReadFrameBlockComplete(694, 164, 4669201);
 	}
 
 	public void testWriteReadFrameBlockComplete(int rows, int cols, long seed) throws IOException, JSONException {
-		Pair<FrameBlock, FrameBlock> writeReadPair = testWriteReadFullFrameBlockFromHDFS(rows, cols, seed);
-		String[][] strWriteBlock = DataConverter.convertToStringFrame(writeReadPair.getLeft());
-		String[][] strReadBlock = DataConverter.convertToStringFrame(writeReadPair.getRight());
-		TestUtils.compareFrames(strWriteBlock, strReadBlock, rows, cols);
+		try {
+			Pair<FrameBlock, FrameBlock> writeReadPair = testWriteReadFullFrameBlockFromHDFS(rows, cols, seed);
+			String[][] strWriteBlock = DataConverter.convertToStringFrame(writeReadPair.getLeft());
+			String[][] strReadBlock = DataConverter.convertToStringFrame(writeReadPair.getRight());
+			TestUtils.compareFrames(strWriteBlock, strReadBlock, rows, cols);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
-	public Pair<FrameBlock,FrameBlock> testWriteReadFullFrameBlockFromHDFS(int rows, int cols,
-		Types.ValueType[] schema, Map<String, Integer> schemaMap, Random random)
-			throws IOException, JSONException
-	{
+	public Pair<FrameBlock, FrameBlock> testWriteReadFullFrameBlockFromHDFS(int rows, int cols, Types.ValueType[] schema,
+		Map<String, Integer> schemaMap, Random random) throws IOException, JSONException {
 		FrameWriterJSONL frameWriterJSONL = new FrameWriterJSONL();
 		FrameReaderJSONL frameReaderJSONL = new FrameReaderJSONL();
 
@@ -80,7 +85,7 @@ public class FrameReaderWriterJSONLTest
 		FrameBlock writeBlock = TestUtils.generateRandomFrameBlock(rows, schema, random);
 
 		// Write FrameBlock
-		frameWriterJSONL.writeFrameToHDFS(writeBlock, FILENAME_SINGLE, schemaMap, rows,cols);
+		frameWriterJSONL.writeFrameToHDFS(writeBlock, FILENAME_SINGLE, schemaMap, rows, cols);
 
 		// Read FrameBlock
 		FrameBlock readBlock = frameReaderJSONL.readFrameFromHDFS(FILENAME_SINGLE, schema, schemaMap, rows, cols);
@@ -88,8 +93,8 @@ public class FrameReaderWriterJSONLTest
 		return Pair.of(writeBlock, readBlock);
 	}
 
-	public Pair<FrameBlock,FrameBlock> testWriteReadFullFrameBlockFromHDFS(int rows, int cols, long seed)
-			throws IOException, JSONException {
+	public Pair<FrameBlock, FrameBlock> testWriteReadFullFrameBlockFromHDFS(int rows, int cols, long seed)
+		throws IOException, JSONException {
 		Random random = new Random(seed);
 		Map<String, Integer> schemaMap = TestUtils.generateRandomSchemaMap(cols, random);
 		Types.ValueType[] schema = TestUtils.generateRandomSchema(cols, random);

--- a/src/test/java/org/apache/sysds/test/functions/iogen/GenerateReaderFrameTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/iogen/GenerateReaderFrameTest.java
@@ -152,7 +152,7 @@ public abstract class GenerateReaderFrameTest extends AutomatedTestBase {
 				generateRandomNumeric(nrows, types[rnt],min,max,naStrings, sparsity,data,i);
 			}
 	}
-	@SuppressWarnings("unused")
+
 	protected void runGenerateReaderTest() {
 
 		Types.ExecMode oldPlatform = rtplatform;
@@ -180,7 +180,7 @@ public abstract class GenerateReaderFrameTest extends AutomatedTestBase {
 			GenerateReader.GenerateReaderFrame gr = new GenerateReader.GenerateReaderFrame(sampleRaw, sampleFrame);
 
 			FrameReader fr= gr.getReader();
-			FrameBlock grFrame = fr.readFrameFromHDFS(dataPath,schema,names,data.length, clen);
+			fr.readFrameFromHDFS(dataPath,schema,names,data.length, clen);
 		}
 		catch(Exception exception) {
 			exception.printStackTrace();

--- a/src/test/java/org/apache/sysds/test/functions/nary/NaryListTestAdvanced.java
+++ b/src/test/java/org/apache/sysds/test/functions/nary/NaryListTestAdvanced.java
@@ -27,39 +27,28 @@ import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
 
 public class NaryListTestAdvanced extends AutomatedTestBase {
-    private final static String TEST_NAME = "NaryListAdvanced";
-    private final static String TEST_DIR = "functions/nary/";
-    private final static String TEST_CLASS_DIR = TEST_DIR + NaryListTestAdvanced.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "NaryListAdvanced";
+	private final static String TEST_DIR = "functions/nary/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + NaryListTestAdvanced.class.getSimpleName() + "/";
 
-    @Override
-    public void setUp() {
-        TestUtils.clearAssertionInformation();
-        addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
-    }
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+	}
 
-    @Test
-    public void test() {
-        TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME);
-        loadTestConfiguration(config);
+	@Test
+	public void test() {
+		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME);
+		loadTestConfiguration(config);
 
-        String RI_HOME = SCRIPT_DIR + TEST_DIR;
-        fullDMLScriptName = RI_HOME + TEST_NAME + ".dml";
-        programArgs = new String[] {""};
+		String RI_HOME = SCRIPT_DIR + TEST_DIR;
+		fullDMLScriptName = RI_HOME + TEST_NAME + ".dml";
+		programArgs = new String[] {""};
 
-        String out = runTest(true, false, null, -1).toString();
-        assertTrue("Output: " + out,
-            out.contains(String.join("\n",
-                "[1, Im, ",
-                "Matrix:",
-                "1.000 1.000",
-                "1.000 1.000",
-                ", ",
-                "# FRAME: nrow = 2, ncol = 2",
-                "# C1 C2",
-                "# FP64 FP64",
-                "1.000 1.000",
-                "1.000 1.000",
-                "]")));
-    }
+		String out = runTest(true, false, null, -1).toString();
+		assertTrue("Output: " + out, out.contains(String.join("\n", "[1, Im, ", "Matrix:", "1.000 1.000", "1.000 1.000",
+			", ", "# FRAME: nrow = 2, ncol = 2", "# C1 C2", "# BOOLEAN BOOLEAN", "TRUE TRUE", "TRUE TRUE", "]")));
+	}
 
 }

--- a/src/test/java/org/apache/sysds/test/functions/parfor/misc/ParForListFrameResultVarsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/parfor/misc/ParForListFrameResultVarsTest.java
@@ -19,14 +19,17 @@
 
 package org.apache.sysds.test.functions.parfor.misc;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class ParForListFrameResultVarsTest extends AutomatedTestBase 
-{
+public class ParForListFrameResultVarsTest extends AutomatedTestBase {
+	protected static final Log LOG = LogFactory.getLog(ParForListFrameResultVarsTest.class.getName());
+
 	private final static String TEST_DIR = "functions/parfor/";
 	private final static String TEST_NAME1 = "parfor_listResults";
 	private final static String TEST_NAME2 = "parfor_frameResults";
@@ -64,10 +67,10 @@ public class ParForListFrameResultVarsTest extends AutomatedTestBase
 		
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		fullDMLScriptName = HOME + testName + ".dml";
-		programArgs = new String[]{"-explain","-args",
+		programArgs = new String[]{"-args",
 			String.valueOf(rows), String.valueOf(cols), output("R") };
 
-		runTest(true, false, null, -1);
+		LOG.debug(runTest(null));
 		Assert.assertEquals(Double.valueOf(7),
 			readDMLMatrixFromOutputDir("R").get(new CellIndex(1,1)));
 	}

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinFitPipelineTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinFitPipelineTest.java
@@ -51,6 +51,8 @@ public class BuiltinFitPipelineTest extends AutomatedTestBase {
 	private void evalPip(double split, String cv, String path, Types.ExecMode et) {
 		String HOME = SCRIPT_DIR+"functions/pipelines/";
 		Types.ExecMode modeOld = setExecMode(et);
+
+		setOutputBuffering(true);
 		try {
 			loadTestConfiguration(getTestConfiguration(TEST_NAME1));
 			fullDMLScriptName = HOME + TEST_NAME1 + ".dml";

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageCutoutTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageCutoutTest.java
@@ -66,6 +66,7 @@ public class BuiltinImageCutoutTest extends AutomatedTestBase {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
 
+		setOutputBuffering(true);
 		int rows = random.nextInt(1000) + 1;
 		int cols = random.nextInt(1000) + 1;
 		int x = random.nextInt(cols);

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageInvertTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageInvertTest.java
@@ -66,6 +66,7 @@ public class BuiltinImageInvertTest extends AutomatedTestBase {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
 
+		setOutputBuffering(true);
 		int rows = random.nextInt(1000) + 1;
 		int cols = random.nextInt(1000) + 1;
 

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageMirrorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageMirrorTest.java
@@ -66,6 +66,7 @@ public class BuiltinImageMirrorTest extends AutomatedTestBase
 	{
 		ExecMode platformOld = setExecMode(instType);
 		
+		setOutputBuffering(true);
 		try
 		{
 			loadTestConfiguration(getTestConfiguration(TEST_NAME));

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImagePosterizeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImagePosterizeTest.java
@@ -85,6 +85,7 @@ public class BuiltinImagePosterizeTest extends AutomatedTestBase {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
 
+		setOutputBuffering(true);
 		int rows = random.nextInt(1000) + 1;
 		int cols = random.nextInt(1000) + 1;
 		int bits = random.nextInt(7) + 1;

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageRotateTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageRotateTest.java
@@ -44,6 +44,7 @@ public class BuiltinImageRotateTest extends AutomatedTestBase {
 	@Test
 	public void testImageRotateZero() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final int w = 500, h = 135;
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", h, w);
@@ -63,6 +64,7 @@ public class BuiltinImageRotateTest extends AutomatedTestBase {
 	@Test
 	public void testImageRotateComplete() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final int w = 500, h = 135;
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", h, w);
@@ -82,6 +84,7 @@ public class BuiltinImageRotateTest extends AutomatedTestBase {
 	@Test
 	public void testImageRotatePillow() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final int w = 500, h = 135;
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", h, w);

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageSamplePairingTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageSamplePairingTest.java
@@ -67,6 +67,7 @@ public class BuiltinImageSamplePairingTest extends AutomatedTestBase {
 	private void runImageSamplePairingTest(boolean sparse, ExecType instType) {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
+		setOutputBuffering(true);
 
 		int rows = random.nextInt(1000) + 1;
 		int cols = random.nextInt(1000) + 1;

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageShearTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageShearTest.java
@@ -46,6 +46,7 @@ public class BuiltinImageShearTest extends AutomatedTestBase {
 	@Test
 	public void testImageShearZero() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", rows, cols);
 		double[][] reference = input;
 		String HOME = SCRIPT_DIR + TEST_DIR;
@@ -63,6 +64,7 @@ public class BuiltinImageShearTest extends AutomatedTestBase {
 	@Test
 	public void testImageShearPillowX() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", rows, cols);
 		double[][] reference = TestUtils.readExpectedResource("ImageTransformShearedX.csv", rows, cols);
@@ -81,6 +83,7 @@ public class BuiltinImageShearTest extends AutomatedTestBase {
 	@Test
 	public void testImageShearPillowY() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", rows, cols);
 		double[][] reference = TestUtils.readExpectedResource("ImageTransformShearedY.csv", rows, cols);

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageTransformTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageTransformTest.java
@@ -77,6 +77,7 @@ public class BuiltinImageTransformTest extends AutomatedTestBase {
 	@Test
 	public void testImageTranslatePillow() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final int w = 500, h = 135, out_w = 550, out_h = 330;
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", h, w);
@@ -97,6 +98,7 @@ public class BuiltinImageTransformTest extends AutomatedTestBase {
 	private void runImageTransformTest(boolean sparse, ExecType instType) {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
+		setOutputBuffering(true);
 
 		try {
 			loadTestConfiguration(getTestConfiguration(TEST_NAME));

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageTranslateTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinImageTranslateTest.java
@@ -67,6 +67,7 @@ public class BuiltinImageTranslateTest extends AutomatedTestBase {
 	@Test
 	public void testImageTranslatePillow() throws Exception {
 		loadTestConfiguration(getTestConfiguration(TEST_NAME));
+		setOutputBuffering(true);
 		final int w = 500, h = 135, out_w = 510, out_h = 125, offset_x = 39, offset_y = -13;
 		final double fill_value = 128.0;
 		double[][] input = TestUtils.readExpectedResource("ImageTransformInput.csv", h, w);
@@ -87,6 +88,7 @@ public class BuiltinImageTranslateTest extends AutomatedTestBase {
 	private void runImageTranslateTest(boolean sparse, ExecType instType) {
 		ExecMode platformOld = setExecMode(instType);
 		disableOutAndExpectedDeletion();
+		setOutputBuffering(true);
 
 		try {
 			loadTestConfiguration(getTestConfiguration(TEST_NAME));

--- a/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinTopkCleaningClassificationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/pipelines/BuiltinTopkCleaningClassificationTest.java
@@ -74,6 +74,7 @@ public class BuiltinTopkCleaningClassificationTest extends AutomatedTestBase {
 		double split, Types.ExecMode et) {
 
 		Types.ExecMode modeOld = setExecMode(et);
+		setOutputBuffering(true);
 		String HOME = SCRIPT_DIR + TEST_DIR;
 		try {
 			loadTestConfiguration(getTestConfiguration(TEST_NAME));

--- a/src/test/java/org/apache/sysds/test/functions/transform/TokenizeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TokenizeTest.java
@@ -201,7 +201,7 @@ public class TokenizeTest extends AutomatedTestBase  {
 //                    new FrameReaderTextCSVParallel( new FileFormatPropertiesCSV() ) :
 //                    new FrameReaderTextCSV( new FileFormatPropertiesCSV()  );
 //            FrameBlock fb2 = reader2.readFrameFromHDFS(output("R"), -1L, -1L);
-//            System.out.println(DataConverter.toString(fb2));
+
         }
         catch(Exception ex) {
             throw new RuntimeException(ex);

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
@@ -106,12 +106,12 @@ public class TransformEncodeDecodeTest extends AutomatedTestBase
 			writer.writeFrameToHDFS(FA, input("F"), rows, cols);
 			
 			fullDMLScriptName = SCRIPT_DIR+TEST_DIR+TEST_NAME1 + ".dml";
-			programArgs = new String[]{"-explain","-args", input("F"), fmt, 
+			programArgs = new String[]{"-args", input("F"), fmt, 
 					String.valueOf(rows), String.valueOf(cols), 
 					SCRIPT_DIR+TEST_DIR+SPEC, output("FO") };
 			
 			//run test
-			runTest(true, false, null, -1); 
+			runTest(null); 
 			
 			//compare matrices (values recoded to identical codes)
 			FrameReader reader = FrameReaderFactory.createFrameReader(FileFormat.safeValueOf(fmt));

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
@@ -22,27 +22,32 @@ package org.apache.sysds.test.functions.transform;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
 import org.apache.sysds.runtime.io.FrameReader;
 import org.apache.sysds.runtime.io.FrameReaderFactory;
 import org.apache.sysds.runtime.io.FrameWriter;
 import org.apache.sysds.runtime.io.FrameWriterFactory;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.DataConverter;
+import org.apache.sysds.runtime.util.HDFSTool;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * 
- */
-public class TransformEncodeDecodeTest extends AutomatedTestBase 
-{
+public class TransformEncodeDecodeTest extends AutomatedTestBase {
+	protected static final Log LOG = LogFactory.getLog(TransformEncodeDecodeTest.class.getName());
+
 	private static final String TEST_NAME1 = "TransformEncodeDecode";
 	private static final String TEST_DIR = "functions/transform/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + TransformEncodeDecodeTest.class.getSimpleName() + "/";
@@ -102,6 +107,8 @@ public class TransformEncodeDecodeTest extends AutomatedTestBase
 			//generate and write input data
 			double[][] A = TestUtils.round(getRandomMatrix(rows, cols, 1, 15, sparse ? sparsity2 : sparsity1, 7)); 
 			FrameBlock FA = DataConverter.convertToFrameBlock(DataConverter.convertToMatrixBlock(A));  
+			DataCharacteristics dc = new MatrixCharacteristics(rows,cols); 
+			HDFSTool.writeMetaDataFileFrame(input("F")+".mtd", FA.getSchema(), dc, FileFormat.safeValueOf(fmt));
 			FrameWriter writer = FrameWriterFactory.createFrameWriter(FileFormat.safeValueOf(fmt));
 			writer.writeFrameToHDFS(FA, input("F"), rows, cols);
 			
@@ -111,7 +118,7 @@ public class TransformEncodeDecodeTest extends AutomatedTestBase
 					SCRIPT_DIR+TEST_DIR+SPEC, output("FO") };
 			
 			//run test
-			runTest(null); 
+			LOG.error(runTest(null)); 
 			
 			//compare matrices (values recoded to identical codes)
 			FrameReader reader = FrameReaderFactory.createFrameReader(FileFormat.safeValueOf(fmt));

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformEncodeDecodeTest.java
@@ -24,11 +24,9 @@ import java.util.Iterator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
-import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
 import org.apache.sysds.runtime.io.FrameReader;
@@ -51,86 +49,83 @@ public class TransformEncodeDecodeTest extends AutomatedTestBase {
 	private static final String TEST_NAME1 = "TransformEncodeDecode";
 	private static final String TEST_DIR = "functions/transform/";
 	private static final String TEST_CLASS_DIR = TEST_DIR + TransformEncodeDecodeTest.class.getSimpleName() + "/";
-	
+
 	private static final String SPEC = "TransformEncodeDecodeSpec.json";
-	
+
 	private static final int rows = 1234;
 	private static final int cols = 2;
 	private static final double sparsity1 = 0.9;
 	private static final double sparsity2 = 0.1;
-	
+
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1,new String[]{"FO"}));
+		addTestConfiguration(TEST_NAME1, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"FO"}));
 	}
-	
+
 	@Test
 	public void runTestCSVDenseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, false, "csv");
 	}
-	
+
 	@Test
 	public void runTestCSVSparseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, true, "csv");
 	}
-	
+
 	@Test
 	public void runTestTextcellDenseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, false, "text");
 	}
-	
+
 	@Test
 	public void runTestTextcellSparseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, true, "text");
 	}
-	
+
 	@Test
 	public void runTestBinaryDenseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, false, "binary");
 	}
-	
+
 	@Test
 	public void runTestBinarySparseCP() {
 		runTransformEncodeDecodeTest(ExecType.CP, true, "binary");
 	}
-	
-	private void runTransformEncodeDecodeTest( ExecType et, boolean sparse, String fmt)
-	{
-		ExecMode platformOld = rtplatform;
-		rtplatform = ExecMode.HYBRID; //only CP supported
 
-		try
-		{
+	private void runTransformEncodeDecodeTest(ExecType et, boolean sparse, String fmt) {
+		ExecMode platformOld = rtplatform;
+		rtplatform = ExecMode.HYBRID; // only CP supported
+
+		try {
 			getAndLoadTestConfiguration(TEST_NAME1);
-			
-			//generate and write input data
-			double[][] A = TestUtils.round(getRandomMatrix(rows, cols, 1, 15, sparse ? sparsity2 : sparsity1, 7)); 
-			FrameBlock FA = DataConverter.convertToFrameBlock(DataConverter.convertToMatrixBlock(A));  
-			DataCharacteristics dc = new MatrixCharacteristics(rows,cols); 
-			HDFSTool.writeMetaDataFileFrame(input("F")+".mtd", FA.getSchema(), dc, FileFormat.safeValueOf(fmt));
+
+			// generate and write input data
+			double[][] A = TestUtils.round(getRandomMatrix(rows, cols, 1, 15, sparse ? sparsity2 : sparsity1, 7));
+			FrameBlock FA = DataConverter.convertToFrameBlock(DataConverter.convertToMatrixBlock(A));
+			DataCharacteristics dc = new MatrixCharacteristics(rows, cols);
+			HDFSTool.writeMetaDataFileFrame(input("F") + ".mtd", FA.getSchema(), dc, FileFormat.safeValueOf(fmt));
+
 			FrameWriter writer = FrameWriterFactory.createFrameWriter(FileFormat.safeValueOf(fmt));
 			writer.writeFrameToHDFS(FA, input("F"), rows, cols);
-			
-			fullDMLScriptName = SCRIPT_DIR+TEST_DIR+TEST_NAME1 + ".dml";
-			programArgs = new String[]{"-args", input("F"), fmt, 
-					String.valueOf(rows), String.valueOf(cols), 
-					SCRIPT_DIR+TEST_DIR+SPEC, output("FO") };
-			
-			//run test
-			LOG.error(runTest(null)); 
-			
-			//compare matrices (values recoded to identical codes)
+
+			fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME1 + ".dml";
+			programArgs = new String[] {"-args", input("F"), fmt, String.valueOf(rows), String.valueOf(cols),
+				SCRIPT_DIR + TEST_DIR + SPEC, output("FO")};
+
+			// run test
+			LOG.error(runTest(null));
+
+			// compare matrices (values recoded to identical codes)
 			FrameReader reader = FrameReaderFactory.createFrameReader(FileFormat.safeValueOf(fmt));
 			FrameBlock FO = reader.readFrameFromHDFS(output("FO"), 16, 2);
-			HashMap<String,Long> cFA = getCounts(FA, 1);
+			HashMap<String, Long> cFA = getCounts(FA, 1);
 			Iterator<String[]> iterFO = IteratorFactory.getStringRowIterator(FO);
-			while( iterFO.hasNext() ) {
+			while(iterFO.hasNext()) {
 				String[] row = iterFO.next();
-				Double expected = (double)cFA.get(row[1]);
-				Double val = (row[0]!=null)?Double.valueOf(row[0]) : 0;
-				Assert.assertEquals("Output aggregates don't match: "+
-						expected+" vs "+val, expected, val);
+				Double expected = (double) cFA.get(row[1]);
+				Double val = (row[0] != null) ? Double.valueOf(row[0]) : 0;
+				Assert.assertEquals("Output aggregates don't match: " + expected + " vs " + val, expected, val);
 			}
 		}
 		catch(Exception ex) {
@@ -140,14 +135,14 @@ public class TransformEncodeDecodeTest extends AutomatedTestBase {
 		finally {
 			rtplatform = platformOld;
 		}
-	}	
-	
+	}
+
 	private static HashMap<String, Long> getCounts(FrameBlock input, int groupBy) {
 		HashMap<String, Long> ret = new HashMap<>();
-		for( int i=0; i<input.getNumRows(); i++ ) {
+		for(int i = 0; i < input.getNumRows(); i++) {
 			String key = input.get(i, groupBy).toString();
 			Long tmp = ret.get(key);
-			ret.put(key, (tmp!=null)?tmp+1:1);
+			ret.put(key, (tmp != null) ? tmp + 1 : 1);
 		}
 		return ret;
 	}

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeColmapTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeColmapTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.sysds.test.functions.transform;
 
-import org.junit.Test;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.FileFormat;
@@ -27,13 +28,13 @@ import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
 import org.apache.sysds.runtime.io.FrameReader;
 import org.apache.sysds.runtime.io.FrameReaderFactory;
-import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
 
-public class TransformFrameEncodeColmapTest extends AutomatedTestBase 
-{
+public class TransformFrameEncodeColmapTest extends AutomatedTestBase {
+	protected static final Log LOG = LogFactory.getLog(TransformFrameEncodeColmapTest.class.getName());
 	private final static String TEST_NAME1 = "TransformFrameEncodeColmap1";
 	private final static String TEST_NAME2 = "TransformFrameEncodeColmap2";
 	
@@ -109,19 +110,20 @@ public class TransformFrameEncodeColmapTest extends AutomatedTestBase
 		if( !ofmt.equals("csv") )
 			throw new RuntimeException("Unsupported test output format");
 		
+		setOutputBuffering(true);	
 		try
 		{
 			getAndLoadTestConfiguration(testname);
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + testname + ".dml";
-			programArgs = new String[]{"-explain","-nvargs", 
+			programArgs = new String[]{"-nvargs", 
 				"DATA=" + DATASET_DIR + DATASET,
 				"TFSPEC=" + DATASET_DIR + SPEC,
 				"TFDATA=" + output("tfout"), 
 				"OFMT=" + ofmt, "OSEP=," };
 			
-			runTest(true, false, null, -1); 
+			runTest(null);
 			
 			//read input/output and compare
 			FrameReader reader1 = FrameReaderFactory.createFrameReader(FileFormat.CSV, 
@@ -129,11 +131,10 @@ public class TransformFrameEncodeColmapTest extends AutomatedTestBase
 			FrameBlock fb1 = reader1.readFrameFromHDFS(DATASET_DIR + DATASET, -1L, -1L);
 			FrameReader reader2 = FrameReaderFactory.createFrameReader(FileFormat.CSV);
 			FrameBlock fb2 = reader2.readFrameFromHDFS(output("tfout"), -1L, -1L);
-			String[][] R1 = DataConverter.convertToStringFrame(fb1);
-			String[][] R2 = DataConverter.convertToStringFrame(fb2);
-			TestUtils.compareFrames(R1, R2, R1.length, R1[0].length);
+			TestUtils.compareFrames(fb1, fb2, false);
 		}
 		catch(Exception ex) {
+			ex.printStackTrace();
 			throw new RuntimeException(ex);
 		}
 		finally {

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformFrameEncodeMultithreadedTest.java
@@ -270,6 +270,7 @@ public class TransformFrameEncodeMultithreadedTest extends AutomatedTestBase {
 			}
 		}
 		catch(Exception ex) {
+			ex.printStackTrace();
 			throw new RuntimeException(ex);
 		}
 	}

--- a/src/test/scripts/functions/builtin/meanImputation.dml
+++ b/src/test/scripts/functions/builtin/meanImputation.dml
@@ -22,6 +22,7 @@
 X = read($1, data_type="frame", format="csv", header=TRUE, 
   naStrings= ["19"]);
 X = as.matrix(cbind(X[,4],X[,5]))
+print(toString(X))
 Y = imputeByMean(X = X, mask = matrix("1 0", rows=1, cols=2))
 
 write(Y, $2)

--- a/src/test/scripts/functions/frame/FrameMatrixReblock.dml
+++ b/src/test/scripts/functions/frame/FrameMatrixReblock.dml
@@ -20,6 +20,5 @@
 #-------------------------------------------------------------
 
 A = read($1, rows=$2, cols=$3, data_type="frame", schema="double", format=$5);
-
 B = as.matrix(A);
 write(B, $4, format=$5);

--- a/src/test/scripts/functions/frame/removeEmpty1.dml
+++ b/src/test/scripts/functions/frame/removeEmpty1.dml
@@ -23,4 +23,5 @@
 A = read($1, naStrings= ["NA", "null","  ","NaN", "nan", "", "?", "99999"])
 V = as.frame(A)
 Vp = removeEmpty(target=V, margin=$3)
-write(Vp, $4);
+Vm = as.matrix(Vp)
+write(Vm, $4);

--- a/src/test/scripts/functions/frame/removeEmpty2.dml
+++ b/src/test/scripts/functions/frame/removeEmpty2.dml
@@ -23,4 +23,5 @@
 A = read($1, naStrings= ["NA", "null","  ","NaN", "nan", "", "?", "99999"])
 V = as.frame(A)
 Vp = removeEmpty(target=V, margin=$3, select=read($2))
-write(Vp, $4);
+Vm = as.matrix(Vp)
+write(Vm, $4);

--- a/src/test/scripts/functions/parfor/parfor_frameResults.dml
+++ b/src/test/scripts/functions/parfor/parfor_frameResults.dml
@@ -19,14 +19,15 @@
 #
 #-------------------------------------------------------------
 
-F = as.frame(matrix(0,7,1));
-
+# 1 makes the frame a boolean frame that does not allow one to
+# assign other values than 1 and 0
+F = as.frame(matrix(2,7,1));
 parfor(i in 1:nrow(F))
   F[i,1] = as.frame(rowMeans(as.matrix(F[i]))+i);
 
 R1 = matrix(0,0,1)
 for(i in 1:length(F))
-  R1 = rbind(R1, as.matrix(F[i,1]));
+  R1 = rbind(R1, as.matrix(F[i,1]) - 2);
 
 R = as.matrix(sum(R1==seq(1,7)));
 write(R, $3);

--- a/src/test/scripts/functions/pipelines/fit_pipelineTest.dml
+++ b/src/test/scripts/functions/pipelines/fit_pipelineTest.dml
@@ -94,7 +94,7 @@ return(Matrix[Double] output, Matrix[Double] error)
     paramRanges = list(seq(0, 2, 1), 10^seq(1,-3), 10^seq(1,-5), 10^seq(1,3));
     trainArgs = list(X=X, y=Y, icpt=-1, reg=-1, tol=1e-9, maxi=100, maxii=-1, verbose=FALSE);
     [B1,opt] = gridSearch(X=X, y=Y, train="multiLogReg", predict="accuracy", numB=(ncol(X)+1)*(nc-1),
-      params=params, paramValues=paramRanges, trainArgs=trainArgs, cv=TRUE, cv=3, verbose=TRUE);
+      params=params, paramValues=paramRanges, trainArgs=trainArgs, cv=TRUE, cv=3, verbose=FALSE);
     evalFunHp = as.matrix(opt) 
   }
   if(min(Y) == max(Y))

--- a/src/test/scripts/functions/pipelines/intermediates/regression/applyFunc.csv
+++ b/src/test/scripts/functions/pipelines/intermediates/regression/applyFunc.csv
@@ -1,5 +1,0 @@
-imputeByMedianApply,scaleApply,imputeByMedianApply,normalizeApply,forward_fill,dummycodingApply,0,0,0,0,0,0,0,0,0,0,0,0
-imputeByMedianApply,scaleApply,imputeByMedianApply,normalizeApply,forward_fill,dummycodingApply,0,0,0,0,0,0,0,0,0,0,0,0
-imputeByMedianApply,scaleApply,imputeByMedianApply,normalizeApply,forward_fill,dummycodingApply,0,0,0,0,0,0,0,0,0,0,0,0
-imputeByMedianApply,scaleApply,imputeByMedianApply,normalizeApply,forward_fill,dummycodingApply,0,0,0,0,0,0,0,0,0,0,0,0
-imputeByMedianApply,scaleApply,imputeByMedianApply,normalizeApply,forward_fill,dummycodingApply,0,0,0,0,0,0,0,0,0,0,0,0

--- a/src/test/scripts/functions/pipelines/topkcleaningClassificationTest.dml
+++ b/src/test/scripts/functions/pipelines/topkcleaningClassificationTest.dml
@@ -123,7 +123,7 @@ return(Matrix[Double] output, Matrix[Double] error)
     trainArgs = list(X=X, Y=Y, intercept=-1, reg=-1, epsilon=-1, maxIterations=1000,  verbose=FALSE);
     dataArgs = list("X", "Y");
     [B1,opt] = gridSearch(X=X, y=Y, train="msvm", predict="accuracyMSVM", numB=(ncol(X)+1)*(nc),
-      params=params, paramValues=paramRanges, dataArgs=dataArgs, trainArgs=trainArgs, cv=TRUE, cvk=3, verbose=TRUE);
+      params=params, paramValues=paramRanges, dataArgs=dataArgs, trainArgs=trainArgs, cv=TRUE, cvk=3, verbose=FALSE);
     evalFunHp = as.matrix(opt) # opt #
     # opt = matrix("2 10 0.001", rows=1, cols=3)
     # evalFunHp = opt

--- a/src/test/scripts/functions/pipelines/topkcleaningRegressionTest.dml
+++ b/src/test/scripts/functions/pipelines/topkcleaningRegressionTest.dml
@@ -74,11 +74,11 @@ return(Matrix[Double] output)
     params = list("icpt","reg", "tol");
     paramRanges = list(seq(0,2,1),10^seq(0,-4), 10^seq(-6,-12));
     [B1, opt] = gridSearch(X=X, y=Y, train="lm", predict="wmape",
-      numB=ncol(X)+1, params=params, paramValues=paramRanges, cv=TRUE, cvk=3, verbose=TRUE);
+      numB=ncol(X)+1, params=params, paramValues=paramRanges, cv=TRUE, cvk=3, verbose=FALSE);
     evalFunHp = as.matrix(opt)  
   }
   beta = lm(X=X, y=Y, icpt=as.scalar(evalFunHp[1,1]), reg=as.scalar(evalFunHp[1,2]), tol=as.scalar(evalFunHp[1,3]), 
-    maxi=1000);
+    maxi=1000, verbose=FALSE);
   acc = wmape(Xtest, Ytest, beta)
   accuracy = (1 - acc)
   output = cbind(accuracy, evalFunHp)
@@ -94,7 +94,7 @@ return(Matrix[Double] output)
 wmape = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B) return (Matrix[Double] loss) {
   # loss = as.matrix(sum((y - X%*%B)^2));
   pred = lmPredict(X=X, B=B, ytest=y);
-  print("WMAPO: "+(1 - (sum(abs((pred - y)/(pred + y)))/nrow(y))))
+  # print("WMAPO: "+(1 - (sum(abs((pred - y)/(pred + y)))/nrow(y))))
   WMAPE = 1 - (sum(abs((pred - y)/(pred + y)))/nrow(y)) #this will give the lose into range of [0,1]
   loss = ifelse(is.na(as.matrix(WMAPE)), as.matrix(0), as.matrix(WMAPE))  
 }

--- a/src/test/scripts/functions/transform/TransformEncodeDecode.dml
+++ b/src/test/scripts/functions/transform/TransformEncodeDecode.dml
@@ -21,9 +21,11 @@
 
 F1 = read($1, data_type="frame", format=$2, rows=$3, cols=$4);
 jspec = read($5, data_type="scalar", value_type="string");
-
+print(toString(F1))
+print(jspec)
 [X, M] = transformencode(target=F1, spec=jspec);
-
+print(toString(X))
+while(FALSE){}
 A = aggregate(target=X[,1], groups=X[,2], fn="count");
 Ag = cbind(A, seq(1,nrow(A)));
 


### PR DESCRIPTION
This PR add a new type of array that allows the primitive types of arrays to contain null values by allocating a BitSet along with the primitive array, to indicate where nulls are placed.
The cost of this ends up at  1 bit extra per value in the column.