### PR TITLE
[SYSTEMDS-3469] Bug fixes, new tests and extensions

### DIFF
--- a/src/main/java/org/apache/sysds/lops/BinaryM.java
+++ b/src/main/java/org/apache/sysds/lops/BinaryM.java
@@ -76,6 +76,13 @@ public class BinaryM extends Lop
 		return " Operation: " + _operation;
 	}
 
+	@Override
+	public Lop getBroadcastInput() {
+		if (getExecType() != ExecType.SPARK)
+			return null;
+		return inputs.get(1);
+	}
+
 	public OpOp2 getOperationType() {
 		return _operation;
 	}

--- a/src/main/java/org/apache/sysds/lops/FunctionCallCP.java
+++ b/src/main/java/org/apache/sysds/lops/FunctionCallCP.java
@@ -81,6 +81,10 @@ public class FunctionCallCP extends Lop
 	public ArrayList<Lop> getFunctionOutputs() {
 		return _outputLops;
 	}
+
+	public String getFnamespace() {
+		return _fnamespace;
+	}
 	
 	public boolean requiresOutputCreateVar() {
 		return !_fname.equalsIgnoreCase(Builtins.REMOVE.getName());

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -423,13 +423,13 @@ public class SparkExecutionContext extends ExecutionContext
 			rdd = mo.getRDDHandle().getRDD();
 		}
 		//CASE 2: dirty in memory data or cached result of rdd operations
-		else if( mo.isDirty() || mo.isCached(false) || mo.isFederated() )
+		else if( mo.isDirty() || mo.isCached(false) || mo.isFederated() || mo instanceof MatrixObjectFuture)
 		{
 			//get in-memory matrix block and parallelize it
 			//w/ guarded parallelize (fallback to export, rdd from file if too large)
 			DataCharacteristics dc = mo.getDataCharacteristics();
 			boolean fromFile = false;
-			if( !mo.isFederated() && (!OptimizerUtils.checkSparkCollectMemoryBudget(dc, 0)
+			if( !mo.isFederated() && !(mo instanceof MatrixObjectFuture) && (!OptimizerUtils.checkSparkCollectMemoryBudget(dc, 0)
 				|| !_parRDDs.reserve(OptimizerUtils.estimatePartitionedSizeExactSparsity(dc)))) {
 				if( mo.isDirty() || !mo.isHDFSFileExists() ) //write if necessary
 					mo.exportData();

--- a/src/test/java/org/apache/sysds/test/functions/async/MaxParallelizeOrderTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/MaxParallelizeOrderTest.java
@@ -37,7 +37,7 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 
 	protected static final String TEST_DIR = "functions/async/";
 	protected static final String TEST_NAME = "MaxParallelizeOrder";
-	protected static final int TEST_VARIANTS = 4;
+	protected static final int TEST_VARIANTS = 5;
 	protected static String TEST_CLASS_DIR = TEST_DIR + MaxParallelizeOrderTest.class.getSimpleName() + "/";
 
 	@Override
@@ -65,6 +65,12 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 	@Test
 	public void testSparkTransformations() {
 		runTest(TEST_NAME+"4");
+	}
+
+	@Test
+	public void testPCAlm() {
+		//eigen is an internal function. Outputs of eigen are not in the lop list
+		runTest(TEST_NAME+"5");
 	}
 
 	public void runTest(String testname) {
@@ -101,9 +107,9 @@ public class MaxParallelizeOrderTest extends AutomatedTestBase {
 			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = true;
 
 			//compare matrices
-			boolean matchVal = TestUtils.compareMatrices(R, R_mp, 1e-6, "Origin", "withPrefetch");
+			boolean matchVal = TestUtils.compareMatrices(R, R_mp, 1e-6, "Origin", "withMaxParallelize");
 			if (!matchVal)
-				System.out.println("Value w/o Prefetch "+R+" w/ Prefetch "+R_mp);
+				System.out.println("Value w/ depth first"+R+" w/ Max Parallelize"+R_mp);
 		} finally {
 			resetExecMode(oldPlatform);
 			InfrastructureAnalyzer.setLocalMaxMemory(oldmem);

--- a/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
@@ -39,7 +39,7 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 	
 	protected static final String TEST_DIR = "functions/async/";
 	protected static final String TEST_NAME = "PrefetchRDD";
-	protected static final int TEST_VARIANTS = 3;
+	protected static final int TEST_VARIANTS = 4;
 	protected static String TEST_CLASS_DIR = TEST_DIR + PrefetchRDDTest.class.getSimpleName() + "/";
 	
 	@Override
@@ -66,10 +66,14 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 		//SP binary consumer, followed by an action. No Prefetch.
 		runTest(TEST_NAME+"3");
 	}
-	
+
+	@Test
+	public void testAsyncSparkOPs4() {
+		//SP consumer. Collect to broadcast to the SP consumer. Prefetch.
+		runTest(TEST_NAME+"4");
+	}
+
 	public void runTest(String testname) {
-		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
-		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
 		boolean old_trans_exec_type = OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE;
 		ExecMode oldPlatform = setExecMode(ExecMode.HYBRID);
 		
@@ -78,8 +82,6 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 		InfrastructureAnalyzer.setLocalMaxMemory(mem);
 		
 		try {
-			//OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
-			//OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
 			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = false;
 			getAndLoadTestConfiguration(testname);
 			fullDMLScriptName = getScript();
@@ -114,8 +116,6 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 			//long successPF = SparkStatistics.getAsyncPrefetchCount();
 			//Assert.assertTrue("Violated successful Prefetch count: "+successPF, successPF == expected_successPF);
 		} finally {
-			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
-			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;
 			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = old_trans_exec_type;
 			resetExecMode(oldPlatform);
 			InfrastructureAnalyzer.setLocalMaxMemory(oldmem);

--- a/src/test/scripts/functions/async/MaxParallelizeOrder5.dml
+++ b/src/test/scripts/functions/async/MaxParallelizeOrder5.dml
@@ -1,0 +1,59 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+checkR2 = function(Matrix[double] X, Matrix[double] y, Matrix[double] y_p,
+          Matrix[double] beta, Integer icpt) return (Double R2_ad)
+{
+  n = nrow(X);
+  m = ncol(X);
+  m_ext = m;
+  if (icpt == 1|icpt == 2)
+      m_ext = m+1; #due to extra column ones
+  avg_tot = sum(y)/n;
+  ss_tot = sum(y^2);
+  ss_avg_tot = ss_tot - n*avg_tot^2;
+  y_res = y - y_p;
+  avg_res = sum(y - y_p)/n;
+  ss_res = sum((y - y_p)^2);
+  R2 = 1 - ss_res/ss_avg_tot;
+  dispersion = ifelse(n>m_ext, ss_res/(n-m_ext), NaN);
+  R2_ad = ifelse(n>m_ext, 1-dispersion/(ss_avg_tot/(n-1)), NaN);
+}
+
+# Get the dataset
+M = 4000;
+A = rand(rows=M, cols=500, seed=42);
+y = rand(rows=M, cols=1, seed=43);
+R = matrix(0, rows=1, cols=20);
+
+K = floor(ncol(A) * 0.1);
+nComb = 5; #10
+
+for (i in 1:nComb) {
+  [newA1, Mout] = pca(X=A, K=K+i);
+  beta1 = lmDS(X=newA1, y=y, icpt=1, reg=0.0001, verbose=FALSE);
+  y_predict1 = lmPredict(X=newA1, B=beta1, icpt=1);
+  R2_ad1 = checkR2(newA1, y, y_predict1, beta1, 1);
+  R[,i] = R2_ad1;
+}
+
+R = sum(R);
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/async/PrefetchRDD4.dml
+++ b/src/test/scripts/functions/async/PrefetchRDD4.dml
@@ -1,0 +1,37 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+X = rand(rows=10000, cols=200, seed=42); #sp_rand
+v = rand(rows=200, cols=1, seed=42); #cp_rand
+
+# Spark transformation operations 
+sp1 = X + ceil(X);
+sp2 = sp1 %*% v; #output fits in local
+
+# CP instructions
+v = ((v + v) * 1 - v) / (1+1);
+v = ((v + v) * 2 - v) / (2+1);
+
+# Collect sp2 result to local and broadcast for map+
+sp3 = X + sp2; #map+
+cp = sp3 + sum(v);
+# Trigger the DAG of SP operations
+R = sum(cp);
+write(R, $1, format="text");


### PR DESCRIPTION
This patch fixes bugs in the max_parallelize operator ordering logic, adds extensions such as finding and defining operators with collect for broadcast as triggering Spark roots and an asynchronous Zipmm implementation. This patch as well adds new tests.