### PR TITLE
[SYSTEMDS-???] Specialized ColumnIndexes in CLA

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ArrayIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ArrayIndex.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.utils.MemoryEstimates;
+
+public class ArrayIndex implements IColIndex {
+	private final int[] cols;
+
+	public ArrayIndex(int[] cols) {
+		this.cols = cols;
+	}
+
+	@Override
+	public int size() {
+		return cols.length;
+	}
+
+	@Override
+	public int get(int i) {
+		return cols[i];
+	}
+
+	@Override
+	public IColIndex shift(int i) {
+		int[] ret = new int[cols.length];
+		for(int j = 0; j < cols.length; j++)
+			ret[j] = cols[j] + i;
+		return new ArrayIndex(ret);
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		out.writeByte(ColIndexType.ARRAY.ordinal());
+		out.writeInt(cols.length);
+		for(int i = 0; i < cols.length; i++)
+			out.writeInt(cols[i]);
+	}
+
+	public static ArrayIndex read(DataInput in) throws IOException {
+		int size = in.readInt();
+		int[] cols = new int[size];
+		for(int i = 0; i < size; i++)
+			cols[i] = in.readInt();
+		return new ArrayIndex(cols);
+	}
+
+	@Override
+	public long getExactSizeOnDisk() {
+		return 1 + 4 + 4 * cols.length;
+	}
+
+	@Override
+	public long estimateInMemorySize() {
+		return 16 + (long) MemoryEstimates.intArrayCost(cols.length);
+	}
+
+	@Override
+	public IIterate iterator() {
+		throw new NotImplementedException();
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ArrayIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ArrayIndex.java
@@ -23,7 +23,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.utils.MemoryEstimates;
 
 public class ArrayIndex implements IColIndex {
@@ -79,6 +78,20 @@ public class ArrayIndex implements IColIndex {
 
 	@Override
 	public IIterate iterator() {
-		throw new NotImplementedException();
+		return new ArrayIterator();
+	}
+
+	protected class ArrayIterator implements IIterate {
+		int id = 0;
+
+		@Override
+		public int next() {
+			return cols[id++];
+		}
+
+		@Override
+		public boolean hasNext() {
+			return id < cols.length;
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex.ColIndexType;
+
+public interface ColIndexFactory {
+
+	public static IColIndex read(DataInput in) throws IOException {
+		final ColIndexType t = ColIndexType.values()[in.readByte()];
+		switch(t) {
+			case SINGLE:
+				return new SingleIndex(in.readInt());
+			case TWO:
+				return new TwoIndex(in.readInt(), in.readInt());
+			default:
+				throw new DMLCompressionException("Failed reading column index of type: " + t);
+		}
+	}
+
+	public static IColIndex create(int[] indexes) {
+		if(indexes.length == 1)
+			return new SingleIndex(indexes[0]);
+		else if(indexes.length == 2)
+			return new TwoIndex(indexes[0], indexes[1]);
+		throw new NotImplementedException();
+	}
+
+	public static IColIndex create(int l, int u) {
+		if(u - 1 == l)
+			return new SingleIndex(l);
+		throw new NotImplementedException();
+	}
+
+	public static IColIndex create(int nCol) {
+		if(nCol == 1)
+			return new SingleIndex(0);
+		throw new NotImplementedException();
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
@@ -54,14 +54,12 @@ public interface ColIndexFactory {
 			return new ArrayIndex(indexes);
 	}
 
-	
-
 	public static IColIndex create(int l, int u) {
 		if(u - 1 == l)
 			return new SingleIndex(l);
 		else if(u - 2 == l)
 			return new TwoIndex(l, l + 1);
-		else 
+		else
 			return new RangeIndex(l, u);
 	}
 
@@ -69,7 +67,7 @@ public interface ColIndexFactory {
 		if(nCol == 1)
 			return new SingleIndex(0);
 		else if(nCol == 2)
-			return new TwoIndex(0,1);
+			return new TwoIndex(0, 1);
 		else
 			return new RangeIndex(nCol);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
@@ -35,6 +35,8 @@ public interface ColIndexFactory {
 				return new SingleIndex(in.readInt());
 			case TWO:
 				return new TwoIndex(in.readInt(), in.readInt());
+			case ARRAY:
+				return ArrayIndex.read(in);
 			default:
 				throw new DMLCompressionException("Failed reading column index of type: " + t);
 		}
@@ -45,12 +47,16 @@ public interface ColIndexFactory {
 			return new SingleIndex(indexes[0]);
 		else if(indexes.length == 2)
 			return new TwoIndex(indexes[0], indexes[1]);
-		throw new NotImplementedException();
+		else
+			return new ArrayIndex(indexes);
 	}
 
 	public static IColIndex create(int l, int u) {
 		if(u - 1 == l)
 			return new SingleIndex(l);
+		else if(u - 2 == l)
+			return new TwoIndex(l, l + 1);
+
 		throw new NotImplementedException();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/ColIndexFactory.java
@@ -22,7 +22,6 @@ package org.apache.sysds.runtime.compress.colgroup.indexes;
 import java.io.DataInput;
 import java.io.IOException;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex.ColIndexType;
 
@@ -37,6 +36,8 @@ public interface ColIndexFactory {
 				return new TwoIndex(in.readInt(), in.readInt());
 			case ARRAY:
 				return ArrayIndex.read(in);
+			case RANGE:
+				return RangeIndex.read(in);
 			default:
 				throw new DMLCompressionException("Failed reading column index of type: " + t);
 		}
@@ -47,22 +48,29 @@ public interface ColIndexFactory {
 			return new SingleIndex(indexes[0]);
 		else if(indexes.length == 2)
 			return new TwoIndex(indexes[0], indexes[1]);
+		else if(RangeIndex.isValidRange(indexes))
+			return new RangeIndex(indexes[0], indexes[0] + indexes.length);
 		else
 			return new ArrayIndex(indexes);
 	}
+
+	
 
 	public static IColIndex create(int l, int u) {
 		if(u - 1 == l)
 			return new SingleIndex(l);
 		else if(u - 2 == l)
 			return new TwoIndex(l, l + 1);
-
-		throw new NotImplementedException();
+		else 
+			return new RangeIndex(l, u);
 	}
 
 	public static IColIndex create(int nCol) {
 		if(nCol == 1)
 			return new SingleIndex(0);
-		throw new NotImplementedException();
+		else if(nCol == 2)
+			return new TwoIndex(0,1);
+		else
+			return new RangeIndex(nCol);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IColIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IColIndex.java
@@ -23,23 +23,24 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 /**
- * Class to contain column indexes for the Compression column groups.
+ * Class to contain column indexes for the compression column groups.
  */
 public interface IColIndex {
 
 	public static enum ColIndexType {
-		SINGLE, TWO, ARRAY;
+		SINGLE, TWO, ARRAY, RANGE, UNKNOWN;
 	}
 
 	/**
 	 * Get the size of the index aka, how many columns is contained
 	 * 
-	 * @return The size
+	 * @return The size of the array
 	 */
 	public int size();
 
 	/**
-	 * Get the index at a specific location
+	 * Get the index at a specific location, Note that many of the underlying implementations does not throw exceptions
+	 * on indexes that are completely wrong, so all implementations that use this index should always be well behaved.
 	 * 
 	 * @param i The index to get
 	 * @return the column index at the index.
@@ -56,10 +57,26 @@ public interface IColIndex {
 	 */
 	public IColIndex shift(int i);
 
+	/**
+	 * Write out the IO representation of this column index
+	 * 
+	 * @param out The Output to write into
+	 * @throws IOException IO exceptions in case of for instance not enough disk space
+	 */
 	public void write(DataOutput out) throws IOException;
 
+	/**
+	 * Get the exact size on disk to enable preallocation of the disk output buffer sizes
+	 * 
+	 * @return The exact disk representation size
+	 */
 	public long getExactSizeOnDisk();
 
+	/**
+	 * Get the in memory size of this object.
+	 * 
+	 * @return The memory size of this object
+	 */
 	public long estimateInMemorySize();
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IColIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IColIndex.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Class to contain column indexes for the Compression column groups.
+ */
+public interface IColIndex {
+
+	public static enum ColIndexType {
+		SINGLE, TWO, ARRAY;
+	}
+
+	/**
+	 * Get the size of the index aka, how many columns is contained
+	 * 
+	 * @return The size
+	 */
+	public int size();
+
+	/**
+	 * Get the index at a specific location
+	 * 
+	 * @param i The index to get
+	 * @return the column index at the index.
+	 */
+	public int get(int i);
+
+	/**
+	 * Return a new column index where the values are shifted by the specified amount.
+	 * 
+	 * It is returning a new instance of the index.
+	 * 
+	 * @param i The amount to shift
+	 * @return the new instance of an index.
+	 */
+	public IColIndex shift(int i);
+
+	public void write(DataOutput out) throws IOException;
+
+	public long getExactSizeOnDisk();
+
+	public long estimateInMemorySize();
+
+	/**
+	 * A Iterator of the indexes see the iterator interface for details.
+	 * 
+	 * @return A iterator for the indexes contained.
+	 */
+	public IIterate iterator();
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IIterate.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/IIterate.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+/**
+ * Class to iterate through the columns of a IColIndex.
+ * 
+ * When initialized it should be at index -1 and then at the call to next you get the first value
+ */
+public interface IIterate {
+	/**
+	 * Get next index
+	 * 
+	 * @return the index.
+	 */
+	public int next();
+
+	/**
+	 * Get if the index has a next index.
+	 * 
+	 * @return the next index.
+	 */
+	public boolean hasNext();
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class SingleIndex implements IColIndex {
+	private final int idx;
+
+	public SingleIndex(int idx) {
+		this.idx = idx;
+	}
+
+	@Override
+	public int size() {
+		return 1;
+	}
+
+	@Override
+	public int get(int i) {
+		if(i == 0)
+			return idx;
+		else
+			throw new ArrayIndexOutOfBoundsException("Out of bounds at " + i);
+	}
+
+	@Override
+	public SingleIndex shift(int i) {
+		return new SingleIndex(i + idx);
+	}
+
+	@Override
+	public IIterate iterator() {
+		return new SingleIterator();
+	}
+
+	public void write(DataOutput out) throws IOException {
+		out.writeByte(ColIndexType.SINGLE.ordinal());
+		out.writeInt(idx);
+	}
+
+	@Override
+	public long getExactSizeOnDisk() {
+		return 1 + 4;
+	}
+
+	@Override
+	public long estimateInMemorySize() {
+		return 16 + 4 + 4; // object, int, and padding
+	}
+
+	protected class SingleIterator implements IIterate {
+		boolean taken = false;
+
+		@Override
+		public int next() {
+			taken = true;
+			return idx;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return !taken;
+		}
+	}
+
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
@@ -36,10 +36,7 @@ public class SingleIndex implements IColIndex {
 
 	@Override
 	public int get(int i) {
-		if(i == 0)
-			return idx;
-		else
-			throw new ArrayIndexOutOfBoundsException("Out of bounds at " + i);
+		return idx;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/TwoIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/TwoIndex.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.colgroup.indexes;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class TwoIndex implements IColIndex {
+	private final int id1;
+	private final int id2;
+
+	public TwoIndex(int id1, int id2) {
+		this.id1 = id1;
+		this.id2 = id2;
+	}
+
+	@Override
+	public int size() {
+		return 2;
+	}
+
+	@Override
+	public int get(int i) {
+		if(i == 0)
+			return id1;
+		else if(i == 1)
+			return id2;
+		else
+			throw new ArrayIndexOutOfBoundsException("Out of bounds at " + i);
+	}
+
+	@Override
+	public TwoIndex shift(int i) {
+		return new TwoIndex(id1 + i, id2 + i);
+	}
+
+	@Override
+	public IIterate iterator() {
+		return new TwoIterator();
+	}
+
+	public void write(DataOutput out) throws IOException {
+		out.writeByte(ColIndexType.TWO.ordinal());
+		out.writeInt(id1);
+		out.writeInt(id2);
+	}
+
+	@Override
+	public long getExactSizeOnDisk() {
+		return 1 + 4 + 4;
+	}
+
+	@Override
+	public long estimateInMemorySize() {
+		return 16 + 8; // object, 2x int
+	}
+
+	protected class TwoIterator implements IIterate {
+		int id = 0;
+
+		@Override
+		public int next() {
+			if(id++ == 0)
+				return id1;
+			else
+				return id2;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return id < 2;
+		}
+	}
+
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.indexes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IIterate;
+import org.apache.sysds.runtime.compress.colgroup.indexes.SingleIndex;
+import org.apache.sysds.runtime.compress.colgroup.indexes.TwoIndex;
+import org.apache.sysds.utils.MemoryEstimates;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class IndexesTest {
+
+	private final int[] expected;
+	private final IColIndex actual;
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		List<Object[]> tests = new ArrayList<>();
+
+		try {
+			// single
+			tests.add(new Object[] {new int[] {0}, new SingleIndex(0)});
+			tests.add(new Object[] {new int[] {334}, ColIndexFactory.create(334, 335)});
+			tests.add(new Object[] {new int[] {0}, ColIndexFactory.create(1)});
+			tests.add(new Object[] {new int[] {0}, ColIndexFactory.create(new int[] {0})});
+			tests.add(new Object[] {new int[] {320}, ColIndexFactory.create(new int[] {320})});
+
+			// two
+			tests.add(new Object[] {new int[] {0, 1}, new TwoIndex(0, 1)});
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("failed constructing tests");
+		}
+
+		return tests;
+	}
+
+	public IndexesTest(int[] expected, IColIndex actual) {
+		this.expected = expected;
+		this.actual = actual;
+	}
+
+	@Test
+	public void testGet() {
+		for(int i = 0; i < expected.length; i++) {
+			assertEquals(expected[i], actual.get(i));
+		}
+	}
+
+	@Test
+	public void testSerialize() {
+		try {
+			// Serialize out
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			DataOutputStream fos = new DataOutputStream(bos);
+			actual.write(fos);
+
+			// Serialize in
+			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+			DataInputStream fis = new DataInputStream(bis);
+
+			IColIndex n = ColIndexFactory.read(fis);
+
+			compare(actual, n);
+		}
+		catch(IOException e) {
+			throw new RuntimeException("Error in io", e);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+	}
+
+	@Test
+	public void testSerializeSize() {
+		try {
+			// Serialize out
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			DataOutputStream fos = new DataOutputStream(bos);
+			actual.write(fos);
+
+			long actualSize = bos.size();
+			long expectedSize = actual.getExactSizeOnDisk();
+
+			assertEquals(expectedSize, actualSize);
+		}
+		catch(IOException e) {
+			throw new RuntimeException("Error in io", e);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			throw e;
+		}
+	}
+
+	@Test
+	public void testSize() {
+		assertEquals(expected.length, actual.size());
+	}
+
+	@Test(expected = ArrayIndexOutOfBoundsException.class)
+	public void outOfBounds() {
+		actual.get(expected.length);
+	}
+
+	@Test(expected = ArrayIndexOutOfBoundsException.class)
+	public void negative() {
+		actual.get(-1);
+	}
+
+	@Test
+	public void iterator() {
+		compare(expected, actual.iterator());
+	}
+
+	@Test
+	public void factoryCreate() {
+		compare(expected, ColIndexFactory.create(expected));
+	}
+
+	@Test
+	public void shift() {
+		shift(5);
+	}
+
+	@Test
+	public void shift2() {
+		shift(1342);
+	}
+
+	@Test
+	public void estimateInMemorySizeIsNotToBig() {
+		assertTrue(MemoryEstimates.intArrayCost(expected.length) > actual.estimateInMemorySize() - 16);
+	}
+
+	private void shift(int i) {
+		compare(expected, actual.shift(i), i);
+	}
+
+	private static void compare(int[] expected, IColIndex actual) {
+		assertEquals(expected.length, actual.size());
+		for(int i = 0; i < expected.length; i++)
+			assertEquals(expected[i], actual.get(i));
+	}
+
+	private static void compare(int[] expected, IColIndex actual, int off) {
+		assertEquals(expected.length, actual.size());
+		for(int i = 0; i < expected.length; i++)
+			assertEquals(expected[i] + off, actual.get(i));
+	}
+
+	private static void compare(IColIndex expected, IColIndex actual) {
+		assertEquals(expected.size(), actual.size());
+		for(int i = 0; i < expected.size(); i++)
+			assertEquals(expected.get(i), actual.get(i));
+	}
+
+	private static void compare(int[] expected, IIterate actual) {
+		for(int i = 0; i < expected.length; i++) {
+			assertTrue(actual.hasNext());
+			assertEquals(expected[i], actual.next());
+		}
+		assertFalse(actual.hasNext());
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
@@ -68,9 +68,31 @@ public class IndexesTest {
 			tests.add(new Object[] {new int[] {3214, 44444}, new TwoIndex(3214, 44444)});
 			tests.add(new Object[] {new int[] {3214, 44444}, ColIndexFactory.create(new int[] {3214, 44444})});
 			tests.add(new Object[] {new int[] {3214, 3215}, ColIndexFactory.create(3214, 3216)});
+			tests.add(new Object[] {new int[] {0, 1}, ColIndexFactory.create(2)});
 
 			// array
 			tests.add(create(32, 14));
+			tests.add(create(40, 21));
+			tests.add(new Object[] {//
+				new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, //
+				ColIndexFactory.create(0, 10)});
+
+			tests.add(new Object[] {//
+				new int[] {0, 1, 2, 3}, //
+				ColIndexFactory.create(0, 4)});
+
+			tests.add(new Object[] {//
+				new int[] {0, 1, 2, 3}, //
+				ColIndexFactory.create(4)});
+
+			tests.add(new Object[] {//
+				new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, //
+				ColIndexFactory.create(10)});
+
+			tests.add(new Object[] {//
+				new int[] {4, 5, 6, 7, 8, 9}, //
+				ColIndexFactory.create(4, 10)});
+
 		}
 		catch(Exception e) {
 			e.printStackTrace();
@@ -144,15 +166,6 @@ public class IndexesTest {
 		assertEquals(expected.length, actual.size());
 	}
 
-	@Test(expected = ArrayIndexOutOfBoundsException.class)
-	public void outOfBounds() {
-		actual.get(expected.length);
-	}
-
-	@Test(expected = ArrayIndexOutOfBoundsException.class)
-	public void negative() {
-		actual.get(-1);
-	}
 
 	@Test
 	public void iterator() {

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
@@ -64,6 +65,12 @@ public class IndexesTest {
 
 			// two
 			tests.add(new Object[] {new int[] {0, 1}, new TwoIndex(0, 1)});
+			tests.add(new Object[] {new int[] {3214, 44444}, new TwoIndex(3214, 44444)});
+			tests.add(new Object[] {new int[] {3214, 44444}, ColIndexFactory.create(new int[] {3214, 44444})});
+			tests.add(new Object[] {new int[] {3214, 3215}, ColIndexFactory.create(3214, 3216)});
+
+			// array
+			tests.add(create(32, 14));
 		}
 		catch(Exception e) {
 			e.printStackTrace();
@@ -169,7 +176,7 @@ public class IndexesTest {
 
 	@Test
 	public void estimateInMemorySizeIsNotToBig() {
-		assertTrue(MemoryEstimates.intArrayCost(expected.length) > actual.estimateInMemorySize() - 16);
+		assertTrue(MemoryEstimates.intArrayCost(expected.length) >= actual.estimateInMemorySize() - 16);
 	}
 
 	private void shift(int i) {
@@ -200,5 +207,15 @@ public class IndexesTest {
 			assertEquals(expected[i], actual.next());
 		}
 		assertFalse(actual.hasNext());
+	}
+
+	private static Object[] create(int size, int seed) {
+		int[] cols = new int[size];
+		Random r = new Random(seed);
+		cols[0] = r.nextInt(1000) + 1;
+		for(int i = 1; i < size; i++) {
+			cols[i] = cols[i - 1] + r.nextInt(1000) + 1;
+		}
+		return new Object[] {cols, ColIndexFactory.create(cols)};
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/NegativeIndexTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/NegativeIndexTest.java
@@ -1,0 +1,32 @@
+package org.apache.sysds.test.component.compress.indexes;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex.ColIndexType;
+import org.junit.Test;
+
+public class NegativeIndexTest {
+	@Test(expected = DMLCompressionException.class)
+	public void notValidRead() {
+		try {
+
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			DataOutputStream fos = new DataOutputStream(bos);
+			fos.writeByte(ColIndexType.UNKNOWN.ordinal());
+			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+			DataInputStream fis = new DataInputStream(bis);
+			ColIndexFactory.read(fis);
+		}
+		catch(IOException e) {
+			fail("Wrong type of exception");
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/NegativeIndexTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/NegativeIndexTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysds.test.component.compress.indexes;
 
 import static org.junit.Assert.fail;


### PR DESCRIPTION
Specialized indexes for columns inside CLA.

Previously the indexes were simple arrays, this PR makes the implementation of specialized objects,
for better in memory representations of the column indexes. to better support the transform encode
containing potentially 1k - 100k columns in one compressed column group.