### PR TITLE
[SYSTEMDS-3497] Refactor to add LOP rewrite step in compilation

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -455,8 +455,11 @@ public class DMLScript
 		
 		//Step 6: construct lops (incl exec type and op selection)
 		dmlt.constructLops(prog);
+
+		//Step 7: rewrite LOP DAGs (incl adding new LOPs s.a. prefetch, broadcast)
+		dmlt.rewriteLopDAG(prog);
 		
-		//Step 7: generate runtime program, incl codegen
+		//Step 8: generate runtime program, incl codegen
 		Program rtprog = dmlt.getRuntimeProgram(prog, ConfigurationManager.getDMLConfig());
 		
 		//Step 9: prepare statistics [and optional explain output]

--- a/src/main/java/org/apache/sysds/lops/Lop.java
+++ b/src/main/java/org/apache/sysds/lops/Lop.java
@@ -401,6 +401,10 @@ public abstract class Lop
 	public long getID() {
 		return lps.getID();
 	}
+
+	public void setNewID() {
+		lps.setNewID();
+	}
 	
 	public int getLevel() {
 		return lps.getLevel();

--- a/src/main/java/org/apache/sysds/lops/LopProperties.java
+++ b/src/main/java/org/apache/sysds/lops/LopProperties.java
@@ -54,6 +54,7 @@ public class LopProperties
 	}
 	
 	public long getID() { return ID; }
+	public void setNewID() { ID = UniqueLopID.getNextID(); }
 	public int getLevel() { return level; }
 	public void setLevel( int l ) { level = l; }
 	

--- a/src/main/java/org/apache/sysds/lops/OperatorOrderingUtils.java
+++ b/src/main/java/org/apache/sysds/lops/OperatorOrderingUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.parser.DMLProgram;
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class OperatorOrderingUtils
+{
+	// Return a list representation of all the lops in a SB
+	public static ArrayList<Lop> getLopList(StatementBlock sb) {
+		ArrayList<Lop> lops = null;
+		if (sb.getLops() != null && !sb.getLops().isEmpty()) {
+			lops = new ArrayList<>();
+			for (Lop root : sb.getLops())
+				addToLopList(lops, root);
+		}
+		return lops;
+	}
+
+	// Determine if a lop is root of a DAG
+	public static boolean isLopRoot(Lop lop) {
+		if (lop.getOutputs().isEmpty())
+			return true;
+		//TODO: Handle internal builtins (e.g. eigen)
+		if (lop instanceof FunctionCallCP &&
+			((FunctionCallCP) lop).getFnamespace().equalsIgnoreCase(DMLProgram.INTERNAL_NAMESPACE)) {
+			return true;
+		}
+		return false;
+	}
+
+	// Gather the Spark operators which return intermediates to local (actions/single_block)
+	// In addition count the number of Spark OPs underneath every Operator
+	public static int collectSparkRoots(Lop root, Map<Long, Integer> sparkOpCount, List<Lop> sparkRoots) {
+		if (sparkOpCount.containsKey(root.getID())) //visited before
+			return sparkOpCount.get(root.getID());
+
+		// Aggregate #Spark operators in the child DAGs
+		int total = 0;
+		for (Lop input : root.getInputs())
+			total += collectSparkRoots(input, sparkOpCount, sparkRoots);
+
+		// Check if this node is Spark
+		total = root.isExecSpark() ? total + 1 : total;
+		sparkOpCount.put(root.getID(), total);
+
+		// Triggering point: Spark action/operator with all CP consumers
+		if (isSparkTriggeringOp(root)) {
+			sparkRoots.add(root);
+			root.setAsynchronous(true); //candidate for async. execution
+		}
+
+		return total;
+	}
+
+	// Dictionary of Spark operators which are expensive enough to be
+	// benefited from persisting if shared among jobs.
+	public static boolean isPersistableSparkOp(Lop lop) {
+		return lop.isExecSpark() && (lop instanceof MapMult
+			|| lop instanceof MMCJ || lop instanceof MMRJ
+			|| lop instanceof MMZip);
+	}
+
+	private static boolean isSparkTriggeringOp(Lop lop) {
+		boolean rightSpLop = lop.isExecSpark() && (lop.getAggType() == AggBinaryOp.SparkAggType.SINGLE_BLOCK
+			|| lop.getDataType() == Types.DataType.SCALAR || lop instanceof MapMultChain
+			|| lop instanceof PickByCount || lop instanceof MMZip || lop instanceof CentralMoment
+			|| lop instanceof CoVariance || lop instanceof MMTSJ || lop.isAllOutputsCP());
+		boolean isPrefetched = lop.getOutputs().size() == 1
+			&& lop.getOutputs().get(0) instanceof UnaryCP
+			&& ((UnaryCP) lop.getOutputs().get(0)).getOpCode().equalsIgnoreCase("prefetch");
+		boolean col2Bc = isCollectForBroadcast(lop);
+		boolean prefetch = (lop instanceof UnaryCP) &&
+			((UnaryCP) lop).getOpCode().equalsIgnoreCase("prefetch");
+		return (rightSpLop || col2Bc || prefetch) && !isPrefetched;
+	}
+
+	// Determine if the result of this operator is collected to
+	// broadcast for the next operator (e.g. mapmm --> map+)
+	public static boolean isCollectForBroadcast(Lop lop) {
+		boolean isSparkOp = lop.isExecSpark();
+		boolean isBc = lop.getOutputs().stream()
+			.allMatch(out -> (out.getBroadcastInput() == lop));
+		//TODO: Handle Lops with mixed Spark (broadcast) CP consumers
+		return isSparkOp && isBc && (lop.getDataType() == Types.DataType.MATRIX);
+	}
+
+	private static boolean addNode(ArrayList<Lop> lops, Lop node) {
+		if (lops.contains(node))
+			return false;
+		lops.add(node);
+		return true;
+	}
+
+	private static void addToLopList(ArrayList<Lop> lops, Lop lop) {
+		if (addNode(lops, lop))
+			for (Lop in : lop.getInputs())
+				addToLopList(lops, in);
+	}
+
+}

--- a/src/main/java/org/apache/sysds/lops/UnaryCP.java
+++ b/src/main/java/org/apache/sysds/lops/UnaryCP.java
@@ -66,7 +66,7 @@ public class UnaryCP extends Lop {
 		return "Operation: " + getInstructions("", "");
 	}
 	
-	private String getOpCode() {
+	public String getOpCode() {
 		return operation.toString();
 	}
 

--- a/src/main/java/org/apache/sysds/lops/rewrite/LopRewriteRule.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/LopRewriteRule.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.List;
+
+public abstract class LopRewriteRule
+{
+	public abstract List<StatementBlock> rewriteLOPinStatementBlock(StatementBlock sb);
+	public abstract List<StatementBlock> rewriteLOPinStatementBlocks(List<StatementBlock> sb);
+}

--- a/src/main/java/org/apache/sysds/lops/rewrite/LopRewriter.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/LopRewriter.java
@@ -1,0 +1,134 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+	* or more contributor license agreements.  See the NOTICE file
+	* distributed with this work for additional information
+	* regarding copyright ownership.  The ASF licenses this file
+	* to you under the Apache License, Version 2.0 (the
+	* "License"); you may not use this file except in compliance
+	* with the License.  You may obtain a copy of the License at
+	*
+	*   http://www.apache.org/licenses/LICENSE-2.0
+	*
+	* Unless required by applicable law or agreed to in writing,
+	* software distributed under the License is distributed on an
+	* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	* KIND, either express or implied.  See the License for the
+	* specific language governing permissions and limitations
+	* under the License.
+	*/
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.lops.Lop;
+import org.apache.sysds.parser.DMLProgram;
+import org.apache.sysds.parser.ForStatement;
+import org.apache.sysds.parser.ForStatementBlock;
+import org.apache.sysds.parser.FunctionStatement;
+import org.apache.sysds.parser.FunctionStatementBlock;
+import org.apache.sysds.parser.IfStatement;
+import org.apache.sysds.parser.IfStatementBlock;
+import org.apache.sysds.parser.StatementBlock;
+import org.apache.sysds.parser.WhileStatement;
+import org.apache.sysds.parser.WhileStatementBlock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LopRewriter
+{
+	private ArrayList<LopRewriteRule> _lopSBRuleSet = null;
+
+	public LopRewriter() {
+		_lopSBRuleSet = new ArrayList<>();
+		// Add rewrite rules (single and multi-statement block)
+		_lopSBRuleSet.add(new RewriteAddPrefetchLop());
+		_lopSBRuleSet.add(new RewriteAddBroadcastLop());
+		_lopSBRuleSet.add(new RewriteAddChkpointLop());
+		// TODO: A rewrite pass to remove less effective chkpoints
+		// Last rewrite to reset Lop IDs in a depth-first manner
+		_lopSBRuleSet.add(new RewriteFixIDs());
+	}
+
+	public void rewriteProgramLopDAGs(DMLProgram dmlp) {
+		for (String namespaceKey : dmlp.getNamespaces().keySet())
+			// for each namespace, handle function statement blocks
+			for (String fname : dmlp.getFunctionStatementBlocks(namespaceKey).keySet()) {
+				FunctionStatementBlock fsblock = dmlp.getFunctionStatementBlock(namespaceKey,fname);
+				rewriteLopDAGsFunction(fsblock);
+			}
+
+		if (!_lopSBRuleSet.isEmpty()) {
+			ArrayList<StatementBlock> sbs = rRewriteLops(dmlp.getStatementBlocks());
+			dmlp.setStatementBlocks(sbs);
+		}
+	}
+
+	public void rewriteLopDAGsFunction(FunctionStatementBlock fsb) {
+		if( !_lopSBRuleSet.isEmpty() )
+			rRewriteLop(fsb);
+	}
+
+	public ArrayList<Lop> rewriteLopDAG(ArrayList<Lop> lops) {
+		StatementBlock sb = new StatementBlock();
+		sb.setLops(lops);
+		return rRewriteLop(sb).get(0).getLops();
+	}
+
+	public ArrayList<StatementBlock> rRewriteLops(ArrayList<StatementBlock> sbs) {
+		// Apply rewrite rules to the lops of the list of statement blocks
+		List<StatementBlock> tmp = sbs;
+		for(LopRewriteRule r : _lopSBRuleSet)
+			tmp = r.rewriteLOPinStatementBlocks(tmp);
+
+		// Recursively rewrite lops in statement blocks
+		List<StatementBlock> tmp2 = new ArrayList<>();
+		for( StatementBlock sb : tmp )
+			tmp2.addAll(rRewriteLop(sb));
+
+		// Prepare output list
+		sbs.clear();
+		sbs.addAll(tmp2);
+		return sbs;
+	}
+
+	public ArrayList<StatementBlock> rRewriteLop(StatementBlock sb) {
+		ArrayList<StatementBlock> ret = new ArrayList<>();
+		ret.add(sb);
+
+		// Recursive invocation
+		if (sb instanceof FunctionStatementBlock) {
+			FunctionStatementBlock fsb = (FunctionStatementBlock)sb;
+			FunctionStatement fstmt = (FunctionStatement)fsb.getStatement(0);
+			fstmt.setBody(rRewriteLops(fstmt.getBody()));
+		}
+		else if (sb instanceof WhileStatementBlock) {
+			WhileStatementBlock wsb = (WhileStatementBlock) sb;
+			WhileStatement wstmt = (WhileStatement)wsb.getStatement(0);
+			wstmt.setBody(rRewriteLops(wstmt.getBody()));
+		}
+		else if (sb instanceof IfStatementBlock) {
+			IfStatementBlock isb = (IfStatementBlock) sb;
+			IfStatement istmt = (IfStatement)isb.getStatement(0);
+			istmt.setIfBody(rRewriteLops(istmt.getIfBody()));
+			istmt.setElseBody(rRewriteLops(istmt.getElseBody()));
+		}
+		else if (sb instanceof ForStatementBlock) { //incl parfor
+			//TODO: parfor statement blocks
+			ForStatementBlock fsb = (ForStatementBlock) sb;
+			ForStatement fstmt = (ForStatement)fsb.getStatement(0);
+			fstmt.setBody(rRewriteLops(fstmt.getBody()));
+		}
+
+		// Apply rewrite rules to individual statement blocks
+		for(LopRewriteRule r : _lopSBRuleSet) {
+			ArrayList<StatementBlock> tmp = new ArrayList<>();
+			for( StatementBlock sbc : ret )
+				tmp.addAll( r.rewriteLOPinStatementBlock(sbc) );
+
+			// Take over set of rewritten sbs
+			ret.clear();
+			ret.addAll(tmp);
+		}
+
+		return ret;
+	}
+}

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddBroadcastLop.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddBroadcastLop.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.lops.Lop;
+import org.apache.sysds.lops.OperatorOrderingUtils;
+import org.apache.sysds.lops.UnaryCP;
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RewriteAddBroadcastLop extends LopRewriteRule
+{
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlock(StatementBlock sb)
+	{
+		if (!ConfigurationManager.isBroadcastEnabled())
+			return List.of(sb);
+
+		ArrayList<Lop> lops = OperatorOrderingUtils.getLopList(sb);
+		if (lops == null)
+			return List.of(sb);
+
+		ArrayList<Lop> nodesWithBroadcast = new ArrayList<>();
+		for (Lop l : lops) {
+			nodesWithBroadcast.add(l);
+			if (isBroadcastNeeded(l)) {
+				List<Lop> oldOuts = new ArrayList<>(l.getOutputs());
+				// Construct a Broadcast lop that takes this Spark node as an input
+				UnaryCP bc = new UnaryCP(l, Types.OpOp1.BROADCAST, l.getDataType(), l.getValueType(), Types.ExecType.CP);
+				bc.setAsynchronous(true);
+				//FIXME: Wire Broadcast only with the necessary outputs
+				for (Lop outCP : oldOuts) {
+					// Rewire l -> outCP to l -> Broadcast -> outCP
+					bc.addOutput(outCP);
+					outCP.replaceInput(l, bc);
+					l.removeOutput(outCP);
+					//FIXME: Rewire _inputParams when needed (e.g. GroupedAggregate)
+				}
+				//Place it immediately after the Spark lop in the node list
+				nodesWithBroadcast.add(bc);
+			}
+		}
+		// New node is added inplace in the Lop DAG
+		return Arrays.asList(sb);
+	}
+
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlocks(List<StatementBlock> sbs) {
+		return sbs;
+	}
+
+	private static boolean isBroadcastNeeded(Lop lop) {
+		// Asynchronously broadcast a matrix if that is produced by a CP instruction,
+		// and at least one Spark parent needs to broadcast this intermediate (eg. mapmm)
+		boolean isBc = lop.getOutputs().stream()
+			.anyMatch(out -> (out.getBroadcastInput() == lop));
+		//TODO: Early broadcast objects that are bigger than a single block
+		boolean isCP = lop.getExecType() == Types.ExecType.CP;
+		return isCP && isBc && lop.getDataType() == Types.DataType.MATRIX;
+	}
+}

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddChkpointLop.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddChkpointLop.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.lops.Checkpoint;
+import org.apache.sysds.lops.Lop;
+import org.apache.sysds.lops.OperatorOrderingUtils;
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RewriteAddChkpointLop extends LopRewriteRule
+{
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlock(StatementBlock sb)
+	{
+		if (!ConfigurationManager.isCheckpointEnabled())
+			return List.of(sb);
+
+		ArrayList<Lop> lops = OperatorOrderingUtils.getLopList(sb);
+		if (lops == null)
+			return List.of(sb);
+
+		// Collect the Spark roots and #Spark instructions in each subDAG
+		List<Lop> sparkRoots = new ArrayList<>();
+		Map<Long, Integer> sparkOpCount = new HashMap<>();
+		List<Lop> roots = lops.stream().filter(OperatorOrderingUtils::isLopRoot).collect(Collectors.toList());
+		roots.forEach(r -> OperatorOrderingUtils.collectSparkRoots(r, sparkOpCount, sparkRoots));
+		if (sparkRoots.isEmpty())
+			return List.of(sb);
+
+		// Add Chkpoint lops after the expensive Spark operators, which are
+		// shared among multiple Spark jobs. Only consider operators with
+		// Spark consumers for now.
+		Map<Long, Integer> operatorJobCount = new HashMap<>();
+		markPersistableSparkOps(sparkRoots, operatorJobCount);
+		// TODO: A rewrite pass to remove less effective chkpoints
+		List<Lop> nodesWithChkpt = addChkpointLop(lops, operatorJobCount);
+		//New node is added inplace in the Lop DAG
+		return List.of(sb);
+	}
+
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlocks(List<StatementBlock> sbs) {
+		return sbs;
+	}
+
+	private static List<Lop> addChkpointLop(List<Lop> nodes, Map<Long, Integer> operatorJobCount) {
+		List<Lop> nodesWithChkpt = new ArrayList<>();
+
+		for (Lop l : nodes) {
+			nodesWithChkpt.add(l);
+			if(operatorJobCount.containsKey(l.getID()) && operatorJobCount.get(l.getID()) > 1) {
+				// This operation is expensive and shared between Spark jobs
+				List<Lop> oldOuts = new ArrayList<>(l.getOutputs());
+				// Construct a chkpoint lop that takes this Spark node as a input
+				Lop chkpoint = new Checkpoint(l, l.getDataType(), l.getValueType(),
+					Checkpoint.getDefaultStorageLevelString(), false);
+				for (Lop out : oldOuts) {
+					//Rewire l -> out to l -> chkpoint -> out
+					chkpoint.addOutput(out);
+					out.replaceInput(l, chkpoint);
+					l.removeOutput(out);
+				}
+				// Place it immediately after the Spark lop in the node list
+				nodesWithChkpt.add(chkpoint);
+			}
+		}
+		return nodesWithChkpt;
+	}
+
+	// Count the number of jobs a Spark operator is part of
+	private static void markPersistableSparkOps(List<Lop> sparkRoots, Map<Long, Integer> operatorJobCount) {
+		for (Lop root : sparkRoots) {
+			collectPersistableSparkOps(root, operatorJobCount);
+			root.resetVisitStatus();
+		}
+	}
+
+	private static void collectPersistableSparkOps(Lop root, Map<Long, Integer> operatorJobCount) {
+		if (root.isVisited())
+			return;
+
+		for (Lop input : root.getInputs())
+			if (root.getBroadcastInput() != input)
+				collectPersistableSparkOps(input, operatorJobCount);
+
+		// Increment the job counter if this node benefits from persisting
+		// and reachable from multiple job roots
+		if (OperatorOrderingUtils.isPersistableSparkOp(root))
+			operatorJobCount.merge(root.getID(), 1, Integer::sum);
+
+		root.setVisited();
+	}
+}

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddPrefetchLop.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddPrefetchLop.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.hops.AggBinaryOp;
+import org.apache.sysds.lops.CSVReBlock;
+import org.apache.sysds.lops.CentralMoment;
+import org.apache.sysds.lops.Checkpoint;
+import org.apache.sysds.lops.CoVariance;
+import org.apache.sysds.lops.DataGen;
+import org.apache.sysds.lops.GroupedAggregate;
+import org.apache.sysds.lops.GroupedAggregateM;
+import org.apache.sysds.lops.Lop;
+import org.apache.sysds.lops.MMTSJ;
+import org.apache.sysds.lops.MMZip;
+import org.apache.sysds.lops.MapMultChain;
+import org.apache.sysds.lops.OperatorOrderingUtils;
+import org.apache.sysds.lops.ParameterizedBuiltin;
+import org.apache.sysds.lops.PickByCount;
+import org.apache.sysds.lops.ReBlock;
+import org.apache.sysds.lops.SpoofFused;
+import org.apache.sysds.lops.UAggOuterChain;
+import org.apache.sysds.lops.UnaryCP;
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RewriteAddPrefetchLop extends LopRewriteRule
+{
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlock(StatementBlock sb)
+	{
+		if (!ConfigurationManager.isPrefetchEnabled())
+			return List.of(sb);
+
+		ArrayList<Lop> lops = OperatorOrderingUtils.getLopList(sb);
+		if (lops == null)
+			return List.of(sb);
+
+		ArrayList<Lop> nodesWithPrefetch = new ArrayList<>();
+		//Find the Spark nodes with all CP outputs
+		for (Lop l : lops) {
+			nodesWithPrefetch.add(l);
+			if (isPrefetchNeeded(l)) {
+				List<Lop> oldOuts = new ArrayList<>(l.getOutputs());
+				//Construct a Prefetch lop that takes this Spark node as a input
+				UnaryCP prefetch = new UnaryCP(l, Types.OpOp1.PREFETCH, l.getDataType(), l.getValueType(), Types.ExecType.CP);
+				prefetch.setAsynchronous(true);
+				//Reset asynchronous flag for the input if already set (e.g. mapmm -> prefetch)
+				l.setAsynchronous(false);
+				for (Lop outCP : oldOuts) {
+					//Rewire l -> outCP to l -> Prefetch -> outCP
+					prefetch.addOutput(outCP);
+					outCP.replaceInput(l, prefetch);
+					l.removeOutput(outCP);
+					//FIXME: Rewire _inputParams when needed (e.g. GroupedAggregate)
+				}
+				//Place it immediately after the Spark lop in the node list
+				nodesWithPrefetch.add(prefetch);
+			}
+		}
+		//New node is added inplace in the Lop DAG
+		return Arrays.asList(sb);
+	}
+
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlocks(List<StatementBlock> sbs) {
+		return sbs;
+	}
+
+	private boolean isPrefetchNeeded(Lop lop) {
+		// Run Prefetch for a Spark instruction if the instruction is a Transformation
+		// and the output is consumed by only CP instructions.
+		boolean transformOP = lop.getExecType() == Types.ExecType.SPARK && lop.getAggType() != AggBinaryOp.SparkAggType.SINGLE_BLOCK
+			// Always Action operations
+			&& !(lop.getDataType() == Types.DataType.SCALAR)
+			&& !(lop instanceof MapMultChain) && !(lop instanceof PickByCount)
+			&& !(lop instanceof MMZip) && !(lop instanceof CentralMoment)
+			&& !(lop instanceof CoVariance)
+			// Not qualified for prefetching
+			&& !(lop instanceof Checkpoint) && !(lop instanceof ReBlock)
+			&& !(lop instanceof CSVReBlock) && !(lop instanceof DataGen)
+			// Cannot filter Transformation cases from Actions (FIXME)
+			&& !(lop instanceof MMTSJ) && !(lop instanceof UAggOuterChain)
+			&& !(lop instanceof ParameterizedBuiltin) && !(lop instanceof SpoofFused);
+
+		//FIXME: Rewire _inputParams when needed (e.g. GroupedAggregate)
+		boolean hasParameterizedOut = lop.getOutputs().stream()
+			.anyMatch(out -> ((out instanceof ParameterizedBuiltin)
+				|| (out instanceof GroupedAggregate)
+				|| (out instanceof GroupedAggregateM)));
+		//TODO: support non-matrix outputs
+		return transformOP && !hasParameterizedOut
+			&& (lop.isAllOutputsCP() || OperatorOrderingUtils.isCollectForBroadcast(lop))
+			&& lop.getDataType() == Types.DataType.MATRIX;
+	}
+}

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteFixIDs.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteFixIDs.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.lops.rewrite;
+
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.lops.Lop;
+import org.apache.sysds.parser.StatementBlock;
+
+import java.util.List;
+
+public class RewriteFixIDs extends LopRewriteRule
+{
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlock(StatementBlock sb)
+	{
+		// Skip if no new Lop nodes are added
+		if (!ConfigurationManager.isPrefetchEnabled() && !ConfigurationManager.isBroadcastEnabled()
+			&& !ConfigurationManager.isCheckpointEnabled())
+			return List.of(sb);
+
+		// Reset the IDs in a depth-first manner
+		if (sb.getLops() != null && !sb.getLops().isEmpty()) {
+			for (Lop root : sb.getLops())
+				assignNewID(root);
+			sb.getLops().forEach(Lop::resetVisitStatus);
+		}
+		return List.of(sb);
+	}
+
+	@Override
+	public List<StatementBlock> rewriteLOPinStatementBlocks(List<StatementBlock> sbs) {
+		return sbs;
+	}
+
+	private void assignNewID(Lop lop) {
+		if (lop.isVisited())
+			return;
+
+		if (lop.getInputs().isEmpty()) {  //leaf node
+			lop.setNewID();
+			lop.setVisited();
+			return;
+		}
+		for (Lop input : lop.getInputs())
+			assignNewID(input);
+
+		lop.setNewID();
+		lop.setVisited();
+	}
+}

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -78,6 +78,7 @@ import org.apache.sysds.hops.rewrite.ProgramRewriter;
 import org.apache.sysds.lops.Lop;
 import org.apache.sysds.lops.LopsException;
 import org.apache.sysds.lops.compile.Dag;
+import org.apache.sysds.lops.rewrite.LopRewriter;
 import org.apache.sysds.parser.PrintStatement.PRINTTYPE;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.BasicProgramBlock;
@@ -312,6 +313,11 @@ public class DMLTranslator
 				codgenHopsDAG(dmlp);
 		}
 	}
+
+	public void rewriteLopDAG(DMLProgram dmlp) {
+		LopRewriter rewriter = new LopRewriter();
+		rewriter.rewriteProgramLopDAGs(dmlp);
+	}
 	
 	public void codgenHopsDAG(DMLProgram dmlp) {
 		SpoofCompiler.generateCode(dmlp);
@@ -482,7 +488,7 @@ public class DMLTranslator
 	}
 	
 	public ProgramBlock createRuntimeProgramBlock(Program prog, StatementBlock sb, DMLConfig config) {
-		Dag<Lop> dag = null; 
+		Dag<Lop> dag = null;
 		Dag<Lop> pred_dag = null;
 
 		ArrayList<Instruction> instruct;

--- a/src/test/java/org/apache/sysds/test/functions/async/AsyncBroadcastTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/AsyncBroadcastTest.java
@@ -71,8 +71,6 @@ public class AsyncBroadcastTest extends AutomatedTestBase {
 		InfrastructureAnalyzer.setLocalMaxMemory(mem);
 		
 		try {
-			//OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = false;
-			//OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = false;
 			OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE = false;
 			getAndLoadTestConfiguration(testname);
 			fullDMLScriptName = getScript();
@@ -88,11 +86,9 @@ public class AsyncBroadcastTest extends AutomatedTestBase {
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
 
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
 			OptimizerUtils.ASYNC_BROADCAST_SPARK = true;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			OptimizerUtils.ASYNC_BROADCAST_SPARK = false;
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = false;
 			HashMap<MatrixValue.CellIndex, Double> R_bc = readDMLScalarFromOutputDir("R");
 
 			//compare matrices

--- a/src/test/java/org/apache/sysds/test/functions/async/CheckpointSharedOpsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/CheckpointSharedOpsTest.java
@@ -79,11 +79,11 @@ public class CheckpointSharedOpsTest extends AutomatedTestBase {
 			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
 			long numCP = Statistics.getCPHeavyHitterCount("sp_chkpoint");
 
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
+			OptimizerUtils.ASYNC_CHECKPOINT_SPARK = true;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R_mp = readDMLScalarFromOutputDir("R");
 			long numCP_maxp = Statistics.getCPHeavyHitterCount("sp_chkpoint");
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = false;
+			OptimizerUtils.ASYNC_CHECKPOINT_SPARK = false;
 
 			//compare matrices
 			boolean matchVal = TestUtils.compareMatrices(R, R_mp, 1e-6, "Origin", "withPrefetch");

--- a/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/PrefetchRDDTest.java
@@ -97,7 +97,6 @@ public class PrefetchRDDTest extends AutomatedTestBase {
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			HashMap<MatrixValue.CellIndex, Double> R = readDMLScalarFromOutputDir("R");
 
-			OptimizerUtils.MAX_PARALLELIZE_ORDER = true;
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = true;
 			runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 			OptimizerUtils.ASYNC_PREFETCH_SPARK = false;


### PR DESCRIPTION
This patch adds a new step in the compilation (and recompilation) steps to rewrite Lop DAGs (single and multi-statement block). Current rewrite passes include adding prefetch, broadcast and checkpoint nodes. This refactoring allows us easily add new rewrite rules and separate the Lop rewrites from operator ordering.