### PR TITLE
[SYSTEMDS-2947] Remove background eviction of GPU lineage cache

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/CPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/CPInstruction.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.runtime.instructions.cp;
 
-import java.util.concurrent.Executors;
 
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.DataType;
@@ -32,10 +31,7 @@ import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.CPInstructionParser;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.fed.FEDInstructionUtils;
-import org.apache.sysds.runtime.instructions.gpu.context.GPUContextPool;
-import org.apache.sysds.runtime.instructions.gpu.context.GPUMemoryEviction;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig;
-import org.apache.sysds.runtime.lineage.LineageGPUCacheEviction;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.privacy.propagation.PrivacyPropagator;
 
@@ -108,29 +104,17 @@ public abstract class CPInstruction extends Instruction
 		}
 		
 		tmp = PrivacyPropagator.preprocessInstruction(tmp, ec);
-		
-		//Submit a task for the eviction thread. The stopping criteria are a passed
-		//eviction count and STOPBACKGROUNDEVICTION flag. STOPBACKGROUNDEVICTION flag
-		//is set to true in the post processing of CPU instruction to stop eviction.
-		if (!LineageCacheConfig.ReuseCacheType.isNone() && DMLScript.USE_ACCELERATOR
-			&& LineageCacheConfig.CONCURRENTGPUEVICTION && ec.getNumGPUContexts()>0 
-			&& !(tmp instanceof VariableCPInstruction) && !(tmp instanceof FunctionCallCPInstruction)) {
-			long availableMem = ec.getGPUContext(0).getAvailableMemory(); //TODO: multi-gpu
-			long almostFull = (long) (0.2 * GPUContextPool.initialGPUMemBudget());
-
-			if (availableMem < almostFull) { //80% full
-				if (LineageGPUCacheEviction.gpuEvictionThread == null)
-					LineageGPUCacheEviction.gpuEvictionThread = Executors.newSingleThreadExecutor();
-				LineageCacheConfig.STOPBACKGROUNDEVICTION = false;
-				LineageGPUCacheEviction.gpuEvictionThread.submit(new GPUMemoryEviction());
-			}
-		}
-		
 		return tmp;
 	}
 
 	@Override 
 	public abstract void processInstruction(ExecutionContext ec);
+
+	@Override
+	public void postprocessInstruction(ExecutionContext ec) {
+		if (DMLScript.LINEAGE_DEBUGGER)
+			ec.maintainLineageDebuggerInfo(this);
+	}
 	
 	/**
 	 * Takes a delimited string of instructions, and replaces ALL placeholder labels 
@@ -156,17 +140,7 @@ public abstract class CPInstruction extends Instruction
 		}
 		return updateInstList.toString();
 	}
-	@Override
-	public void postprocessInstruction(ExecutionContext ec) {
-		//Stop the eviction thread if not done yet evicting the given count.
-		if (!LineageCacheConfig.ReuseCacheType.isNone() && DMLScript.USE_ACCELERATOR
-			&& LineageCacheConfig.CONCURRENTGPUEVICTION)
-			LineageCacheConfig.STOPBACKGROUNDEVICTION = true;
-		
-		if (DMLScript.LINEAGE_DEBUGGER)
-			ec.maintainLineageDebuggerInfo(this);
-	}
-	
+
 	/** 
 	 * Replaces ALL placeholder strings (such as ##mVar2## and ##Var5##) in a single instruction.
 	 *  

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
@@ -1064,8 +1064,10 @@ public class GPUObject {
 	 * @throws DMLRuntimeException if error occurs
 	 */
 	synchronized public void clearData(String opcode, boolean eager) throws DMLRuntimeException {
-		if (isLineageCached)
+		if (isLineageCached) {
+			setDirty(false);
 			return;
+		}
 
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("GPU : clearData on " + this + ", GPUContext=" + getGPUContext());

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -126,6 +126,7 @@ public class LineageCacheConfig
 	private static LineageCachePolicy _cachepolicy = null;
 	// Weights for scoring components (computeTime/size, LRU timestamp, DAG height)
 	protected static double[] WEIGHTS = {1, 0, 0};
+	public static boolean GPU2HOSTEVICTION = false;
 	public static boolean CONCURRENTGPUEVICTION = false;
 	public static volatile boolean STOPBACKGROUNDEVICTION = false;
 

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
@@ -45,6 +45,7 @@ public class LineageCacheStatistics {
 	private static final LongAdder _numHitsGpu      = new LongAdder();
 	private static final LongAdder _numAsyncEvictGpu= new LongAdder();
 	private static final LongAdder _numSyncEvictGpu = new LongAdder();
+	private static final LongAdder _evtimeGpu       = new LongAdder();
 	// Below entries are specific to Spark instructions
 	private static final LongAdder _numHitsRdd      = new LongAdder();
 	private static final LongAdder _numHitsSparkActions = new LongAdder();
@@ -65,6 +66,7 @@ public class LineageCacheStatistics {
 		_ctimeFSWrite.reset();
 		_ctimeSaved.reset();
 		_ctimeMissed.reset();
+		_evtimeGpu.reset();
 		_numHitsGpu.reset();
 		_numAsyncEvictGpu.reset();
 		_numSyncEvictGpu.reset();
@@ -204,6 +206,11 @@ public class LineageCacheStatistics {
 		_numSyncEvictGpu.increment();
 	}
 
+	public static void incrementEvictTimeGpu(long delta) {
+		// Total time spent on evicting from GPU to main memory or deleting from GPU lineage cache
+		_evtimeGpu.add(delta);
+	}
+
 	public static void incrementRDDHits() {
 		// Number of times a locally cached (but not persisted) RDD are reused.
 		_numHitsRdd.increment();
@@ -278,6 +285,12 @@ public class LineageCacheStatistics {
 		sb.append(_numAsyncEvictGpu.longValue());
 		sb.append("/");
 		sb.append(_numSyncEvictGpu.longValue());
+		return sb.toString();
+	}
+
+	public static String displayGpuEvictTime() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(String.format("%.3f", ((double)_evtimeGpu.longValue())/1000000000)); //in sec
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageGPUCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageGPUCacheEviction.java
@@ -152,4 +152,10 @@ public class LineageGPUCacheEviction
 		updateSize(size, false);
 	}
 
+	public static void removeFromDeviceCache(LineageCacheEntry entry, String instName, boolean alreadyCopied) {
+		long size = entry.getGPUObject().getSizeOnDevice();
+		LineageCache.removeEntry(entry._key);
+		updateSize(size, false);
+	}
+
 }

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -639,6 +639,7 @@ public class Statistics
 				sb.append("LinCache hits (Mem/FS/Del): \t" + LineageCacheStatistics.displayHits() + ".\n");
 				sb.append("LinCache MultiLevel (Ins/SB/Fn):" + LineageCacheStatistics.displayMultiLevelHits() + ".\n");
 				sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
+				sb.append("LinCache GPU evict time: \t" + LineageCacheStatistics.displayGpuEvictTime() + " sec.\n");
 				sb.append("LinCache Spark (Col/Loc/Dist): \t" + LineageCacheStatistics.displaySparkStats() + ".\n");
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");
 				sb.append("LinCache FStimes (Rd/Wr): \t" + LineageCacheStatistics.displayFSTime() + " sec.\n");

--- a/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -79,6 +80,8 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		
 		// reset clears the lineage cache held memory from the last run
 		Lineage.resetInternalState();
+		boolean gpu2Mem = LineageCacheConfig.GPU2HOSTEVICTION;
+		LineageCacheConfig.GPU2HOSTEVICTION = true;
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		HashMap<MatrixValue.CellIndex, Double> R_orig = readDMLMatrixFromOutputDir("R");
@@ -95,6 +98,7 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		AutomatedTestBase.TEST_GPU = false;
+		LineageCacheConfig.GPU2HOSTEVICTION = gpu2Mem;
 		HashMap<MatrixValue.CellIndex, Double> R_reused = readDMLMatrixFromOutputDir("R");
 
 		//compare results 

--- a/src/test/scripts/functions/lineage/GPUCacheEviction1.dml
+++ b/src/test/scripts/functions/lineage/GPUCacheEviction1.dml
@@ -27,7 +27,7 @@ X1 = X;
 y1 = y;
 S1 = 0;
 # fill half of the cache
-for (i in 1:15) {
+for (i in 1:20) {
   R = X1 * y1;
   X1 = cbind(X1, rand(rows=10000, cols=1, seed=42));
   y1 = cbind(y1, rand(rows=10000, cols=1, seed=42));
@@ -40,7 +40,7 @@ X2 = X;
 y2 = y;
 S2 = 0;
 # reuse (saves cache pollution)
-for (i in 1:15) {
+for (i in 1:20) {
   R = X2 * y2;
   X2 = cbind(X2, rand(rows=10000, cols=1, seed=42));
   y2 = cbind(y2, rand(rows=10000, cols=1, seed=42));
@@ -50,7 +50,7 @@ for (i in 1:15) {
 S[,2] = S2;
 
 # generate eviction
-for (i in 1:15) {
+for (i in 1:20) {
   R = X1 * y1;
   X1 = cbind(X1, rand(rows=10000, cols=1, seed=42));
   y1 = cbind(y1, rand(rows=10000, cols=1, seed=42));

--- a/src/test/scripts/functions/lineage/GPUCacheEviction2.dml
+++ b/src/test/scripts/functions/lineage/GPUCacheEviction2.dml
@@ -25,7 +25,7 @@ S = matrix(0, rows=1, cols=1);
 
 S1 = 0;
 # fill the cache and generate eviction
-for (i in 1:30) {
+for (i in 1:40) {
   R = X * y;
   X = cbind(X, rand(rows=10000, cols=1, seed=42));
   y = cbind(y, rand(rows=10000, cols=1, seed=42));


### PR DESCRIPTION
This patch removes the asynchronous eviction of lineage cache entries from the GPU to main memory. Background eviction needs a compiler-assisted approach. A full runtime asynchronous eviction leads to synchronization issues. This patch also adds a flag to delete cache entries in GPU instead of coping to host.
Currently, for a mini-batch workload with limited reuse opportunities, enabling reuse in GPU slows down the execution by 10x with eviction (copy to host) and 4x with delete.