### PR TITLE
[SYSTEMDS-3510] Recycling pointers from GPU lineage cache

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -790,9 +790,6 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 			for (GPUObject gObj : _gpuObjects.values())
 				if (gObj != null) {
 					gObj.clearData(null, DMLScript.EAGER_CUDA_FREE);
-					if (gObj.isLinCached())
-						// set rmVarPending which helps detecting liveness
-						gObj.setrmVarPending(true);
 				}
 		}
 		

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -51,7 +51,9 @@ import org.apache.sysds.runtime.instructions.gpu.context.CSRPointer;
 import org.apache.sysds.runtime.instructions.gpu.context.GPUContext;
 import org.apache.sysds.runtime.instructions.gpu.context.GPUObject;
 import org.apache.sysds.runtime.lineage.Lineage;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.runtime.lineage.LineageDebugger;
+import org.apache.sysds.runtime.lineage.LineageGPUCacheEviction;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.Pair;
@@ -183,7 +185,11 @@ public class ExecutionContext {
 	 */
 	public void setGPUContexts(List<GPUContext> gpuContexts){
 		_gpuContexts = gpuContexts;
+		// Set the single-GPU context in the lineage cache
+		if (!LineageCacheConfig.ReuseCacheType.isNone())
+			LineageGPUCacheEviction.setGPUContext(gpuContexts.get(0));
 	}
+
 
 	/**
 	 * Gets the list of GPUContexts

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUContext.java
@@ -283,15 +283,6 @@ public class GPUContext {
 		GPUObject ret = new GPUObject(this, source, mo);
 		getMemoryManager().getGPUMatrixMemoryManager().addGPUObject(ret);
 
-		// Maintain the linked list of GPUObjects that point to same memory region
-		if (!LineageCacheConfig.ReuseCacheType.isNone()) {
-			if (source.lineageCachedChainHead == null)
-				source.lineageCachedChainHead = source;
-			if (source.nextLineageCachedEntry != null)
-				ret.nextLineageCachedEntry = source.nextLineageCachedEntry;
-			source.nextLineageCachedEntry = ret;
-			ret.lineageCachedChainHead = source;
-		}
 		return ret;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMatrixMemoryManager.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMatrixMemoryManager.java
@@ -120,12 +120,11 @@ public class GPUMatrixMemoryManager {
 	 * Get pointers from the first memory sections "Matrix Memory"
 	 * @param locked return locked pointers if true
 	 * @param dirty return dirty pointers if true
-	 * @param lineageCached return cached pointer if true
 	 * @return set of pointers
 	 */
-	Set<Pointer> getPointers(boolean locked, boolean dirty, boolean lineageCached) {
+	Set<Pointer> getPointers(boolean locked, boolean dirty) {
 		return gpuObjects.stream()
-			.filter(gObj -> gObj.isLocked() == locked && gObj.isDirty() == dirty || gObj.isLinCached() == lineageCached)
+			.filter(gObj -> gObj.isLocked() == locked && gObj.isDirty() == dirty)
 			.flatMap(gObj -> getPointers(gObj).stream()).collect(Collectors.toSet());
 	}
 	
@@ -137,7 +136,7 @@ public class GPUMatrixMemoryManager {
 	 */
 	void clearAllUnlocked(String opcode) throws DMLRuntimeException {
 		Set<GPUObject> unlockedGPUObjects = gpuObjects.stream()
-				.filter(gpuObj -> !gpuObj.isLocked() && !gpuObj.isLinCached()).collect(Collectors.toSet());
+				.filter(gpuObj -> !gpuObj.isLocked()).collect(Collectors.toSet());
 		if(unlockedGPUObjects.size() > 0) {
 			if(LOG.isWarnEnabled())
 				LOG.warn("Clearing all unlocked matrices (count=" + unlockedGPUObjects.size() + ").");

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryEviction.java
@@ -50,7 +50,7 @@ public class GPUMemoryEviction implements Runnable
 		// Stop if 1) Evicted the request number of entries, 2) The parallel
 		// CPU instruction is ended, and 3) No non-live entries left in the cache.
 		long t0 =  DMLScript.STATISTICS ? System.nanoTime() : 0;
-		while (!LineageGPUCacheEviction.isGPUCacheEmpty()) 
+		/*while (!LineageGPUCacheEviction.isGPUCacheEmpty())
 		{
 			if (LineageCacheConfig.STOPBACKGROUNDEVICTION)
 				// This logic reduces #evictions if the cpu instructions is so small
@@ -135,7 +135,7 @@ public class GPUMemoryEviction implements Runnable
 				LineageCacheStatistics.incrementGpuAsyncEvicts();
 			}
 			count++;
-		}
+		}*/
 
 		// Add the locked entries back to the eviction queue
 		if (!lockedOrLiveEntries.isEmpty())

--- a/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
@@ -81,7 +81,7 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		// reset clears the lineage cache held memory from the last run
 		Lineage.resetInternalState();
 		boolean gpu2Mem = LineageCacheConfig.GPU2HOSTEVICTION;
-		LineageCacheConfig.GPU2HOSTEVICTION = true;
+		//LineageCacheConfig.GPU2HOSTEVICTION = true;
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		HashMap<MatrixValue.CellIndex, Double> R_orig = readDMLMatrixFromOutputDir("R");


### PR DESCRIPTION
This patch reworks the GPU cache eviction (deletion). The free pointer cache stays empty when lineage cache is enabled. This patch allows recycling the cached pointers. We maintain two lists for live and free pointers in the cache. When the GPU memory is full, we poll the first entry from the free list (weighted queue) and recycle the pointer if the size matches the requested size, otherwise we deallocate the cached pointers till enough space is available.