### PR TITLE
[SYSTEMDS-3510] Size-oriented free lists in GPU lineage cache

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryEviction.java
@@ -135,13 +135,13 @@ public class GPUMemoryEviction implements Runnable
 				LineageCacheStatistics.incrementGpuAsyncEvicts();
 			}
 			count++;
-		}*/
+		}
 
 		// Add the locked entries back to the eviction queue
 		if (!lockedOrLiveEntries.isEmpty())
 			LineageGPUCacheEviction.addEntryList(lockedOrLiveEntries);
 		
 		if (DMLScript.STATISTICS) //TODO: dedicated statistics for lineage
-			GPUStatistics.cudaEvictTime.add(System.nanoTime() - t0);
+			GPUStatistics.cudaEvictTime.add(System.nanoTime() - t0); */
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
@@ -45,6 +45,8 @@ public class LineageCacheStatistics {
 	private static final LongAdder _numHitsGpu      = new LongAdder();
 	private static final LongAdder _numAsyncEvictGpu= new LongAdder();
 	private static final LongAdder _numSyncEvictGpu = new LongAdder();
+	private static final LongAdder _numRecycleGpu   = new LongAdder();
+	private static final LongAdder _numDelGpu       = new LongAdder();
 	private static final LongAdder _evtimeGpu       = new LongAdder();
 	// Below entries are specific to Spark instructions
 	private static final LongAdder _numHitsRdd      = new LongAdder();
@@ -70,6 +72,8 @@ public class LineageCacheStatistics {
 		_numHitsGpu.reset();
 		_numAsyncEvictGpu.reset();
 		_numSyncEvictGpu.reset();
+		_numRecycleGpu.reset();
+		_numDelGpu.reset();
 		_numHitsRdd.reset();
 		_numHitsSparkActions.reset();
 		_numHitsRddPersist.reset();
@@ -206,6 +210,16 @@ public class LineageCacheStatistics {
 		_numSyncEvictGpu.increment();
 	}
 
+	public static void incrementGpuRecycle() {
+		// Number of gpu cached pointers recycled
+		_numRecycleGpu.increment();
+	}
+
+	public static void incrementGpuDel() {
+		// Number of gpu cached pointers deleted to make space
+		_numDelGpu.increment();
+	}
+
 	public static void incrementEvictTimeGpu(long delta) {
 		// Total time spent on evicting from GPU to main memory or deleting from GPU lineage cache
 		_evtimeGpu.add(delta);
@@ -285,6 +299,14 @@ public class LineageCacheStatistics {
 		sb.append(_numAsyncEvictGpu.longValue());
 		sb.append("/");
 		sb.append(_numSyncEvictGpu.longValue());
+		return sb.toString();
+	}
+
+	public static String displayGpuPointerStats() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(_numRecycleGpu.longValue());
+		sb.append("/");
+		sb.append(_numDelGpu.longValue());
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -639,6 +639,7 @@ public class Statistics
 				sb.append("LinCache hits (Mem/FS/Del): \t" + LineageCacheStatistics.displayHits() + ".\n");
 				sb.append("LinCache MultiLevel (Ins/SB/Fn):" + LineageCacheStatistics.displayMultiLevelHits() + ".\n");
 				sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
+				sb.append("LinCache GPU (Recyc/Del): \t" + LineageCacheStatistics.displayGpuPointerStats() + ".\n");
 				sb.append("LinCache GPU evict time: \t" + LineageCacheStatistics.displayGpuEvictTime() + " sec.\n");
 				sb.append("LinCache Spark (Col/Loc/Dist): \t" + LineageCacheStatistics.displaySparkStats() + ".\n");
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");


### PR DESCRIPTION
This patch splits the weighted queue of the free pointers in the GPU cache into multiple free lists, one for each allocated size. The entries in the free lists are ordered by a scoring function of compute time. When malloc is called, we recycle one free pointer with less reuse potential. We also extended the statistics to report recycling count.