### PR TITLE
[SYSTEMDS-3510] Cache data characteristics with GPU pointer

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUContext.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUContext.java
@@ -37,7 +37,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
-import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.utils.GPUStatistics;
 
 import jcuda.Pointer;

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
@@ -333,6 +333,8 @@ public class GPUMemoryManager {
 					// TODO: else evict to the host cache
 					if (freedSize > size)
 						A = cudaMallocNoWarn(tmpA, size, "recycle non-exact match of lineage cache");
+					// Else, deallocate another free pointer. We are calling pollFistFreeNotExact with
+					// the same size (not with freedSize-size) to reduce potentials for creating holes
 				}
 			}
 			if (DMLScript.STATISTICS)

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUObject.java
@@ -101,7 +101,7 @@ public class GPUObject {
 	 * Shadow buffer instance
 	 */
 	final ShadowBuffer shadowBuffer;
-	
+
 	// ----------------------------------------------------------------------
 	// Methods used to access, set and check jcudaDenseMatrixPtr
 	
@@ -791,6 +791,7 @@ public class GPUObject {
 		setSparseMatrixCudaPointer(tmp);
 	}
 
+	// Method to find the estimated size of this GPU Object in the device
 	public long getSizeOnDevice() {
 		long GPUSize = 0;
 		long rlen = mat.getNumRows();
@@ -803,6 +804,11 @@ public class GPUObject {
 			GPUSize = getDatatypeSizeOf(rlen * clen);
 		}
 		return GPUSize;
+	}
+
+	// Method to find the allocated size of this GPU Object in the device
+	public long getAllocatedSize() {
+		return gpuContext.getMemoryManager().getSizeAllocatedGPUPointer(getDensePointer());
 	}
 
 	void copyFromHostToDevice(String opcode) {


### PR DESCRIPTION
This patch enables caching the metadata along with the GPU pointers in the lineage cache. The data characteristics are required to evict cached entries from the device cache to the host cache. Also, sometime the output dimensions are not known before execution.