### PR TITLE
[SYSTEMDS-2947] Re-enable lineage cache eviction from GPU to host

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/CSRPointer.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/CSRPointer.java
@@ -178,9 +178,6 @@ public class CSRPointer {
 	 */
 	public static void copyToDevice(GPUContext gCtx, CSRPointer dest, int rows, long nnz, int[] rowPtr, int[] colInd, double[] values) {
 		CSRPointer r = dest;
-		long t0 = 0;
-		if (DMLScript.STATISTICS)
-			t0 = System.nanoTime();
 		r.nnz = nnz;
 		if(rows < 0) throw new DMLRuntimeException("Incorrect input parameter: rows=" + rows);
 		if(nnz < 0) throw new DMLRuntimeException("Incorrect input parameter: nnz=" + nnz);
@@ -190,10 +187,10 @@ public class CSRPointer {
 		LibMatrixCUDA.cudaSupportFunctions.hostToDevice(gCtx, values, r.val, null);
 		cudaMemcpy(r.rowPtr, Pointer.to(rowPtr), getIntSizeOf(rows + 1), cudaMemcpyHostToDevice);
 		cudaMemcpy(r.colInd, Pointer.to(colInd), getIntSizeOf(nnz), cudaMemcpyHostToDevice);
-		if (DMLScript.STATISTICS)
-			GPUStatistics.cudaToDevTime.add(System.nanoTime() - t0);
-		if (DMLScript.STATISTICS)
-			GPUStatistics.cudaToDevCount.add(3);
+		//if (DMLScript.STATISTICS)
+		//	GPUStatistics.cudaToDevTime.add(System.nanoTime() - t0);
+		//if (DMLScript.STATISTICS)
+		//	GPUStatistics.cudaToDevCount.add(3);
 	}
 	
 	/**

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -106,7 +106,7 @@ public class LineageCacheConfig
 	public static double FSREAD_SPARSE = 400;
 	public static double FSWRITE_DENSE = 450;
 	public static double FSWRITE_SPARSE = 225;
-	public static double D2HCOPY = 1500;
+	public static double D2HCOPYBANDWIDTH = 1500; //MB/sec
 	public static double D2HMAXBANDWIDTH = 8192;
 	
 	private enum CachedItemHead {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
@@ -183,6 +183,12 @@ public class LineageCacheEntry {
 		return _gpuPointer!= null;
 	}
 
+	public synchronized boolean isDensePointer() {
+		if (!isGPUObject())
+			return false;
+		return _gpuPointer.isDensepointer();
+	}
+
 	public boolean isSerializedBytes() {
 		return _dt.isUnknown() && _key.getOpcode().equals(LineageItemUtils.SERIALIZATION_OPCODE);
 	}
@@ -342,6 +348,11 @@ public class LineageCacheEntry {
 
 		protected DataCharacteristics getDataCharacteristics() {
 			return _metadata.getDataCharacteristics();
+		}
+
+		protected boolean isDensepointer() {
+			return true;
+			// TODO: Support sparse pointer caching
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/lineage/GPUFullReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/GPUFullReuseTest.java
@@ -84,6 +84,7 @@ public class GPUFullReuseTest extends AutomatedTestBase{
 
 		AutomatedTestBase.TEST_GPU = true;  //adds '-gpu'
 		List<String> proArgs = new ArrayList<>();
+		proArgs.add("-explain");
 		proArgs.add("-stats");
 		proArgs.add("-args");
 		proArgs.add(output("R"));
@@ -94,7 +95,8 @@ public class GPUFullReuseTest extends AutomatedTestBase{
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		HashMap<MatrixValue.CellIndex, Double> R_orig = readDMLMatrixFromOutputDir("R");
-		
+
+		proArgs.clear();
 		proArgs.add("-stats");
 		proArgs.add("-lineage");
 		proArgs.add(LineageCacheConfig.ReuseCacheType.REUSE_MULTILEVEL.name().toLowerCase());


### PR DESCRIPTION
This patch adds code to be able to copy a cached pointer to a cached matrix block. The plan is to conditionally evict cached entries to host based of the score (compute time and #hits, #misses) while recycling. Currently, the eviction is disabled as we do not have a way to measure the elapsed time of the GPU kernels due to their asynchronous nature.