### PR TITLE
[SYSTEMDS-3518] Eviction of lineage-cached RDDs from Spark storage

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
@@ -28,6 +28,7 @@ public abstract class LineageObject
 {
 	//basic lineage information
 	protected int _numRef = -1;
+	protected int _maxNumRef = -1;
 	protected boolean _lineageCached = false;
 	protected final List<LineageObject> _childs;
 	
@@ -62,10 +63,18 @@ public abstract class LineageObject
 	
 	public void incrementNumReferences() {
 		_numRef++;
+
+		// Maintain the maximum reference count. Higher reference
+		// count indicates higher importance to persist (in lineage cache)
+		_maxNumRef = Math.max(_numRef, _maxNumRef);
 	}
 	
 	public void decrementNumReferences() {
 		_numRef--;
+	}
+
+	public int getMaxReferenceCount() {
+		return _maxNumRef;
 	}
 	
 	public List<LineageObject> getLineageChilds() {

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
@@ -40,6 +40,10 @@ public class RDDObject extends LineageObject
 	public JavaPairRDD<?,?> getRDD() {
 		return _rddHandle;
 	}
+
+	public void setRDD(JavaPairRDD<?,?> rddHandle) {
+		_rddHandle = rddHandle;
+	}
 	
 	public void setCheckpointRDD( boolean flag ) {
 		_checkpointed = flag;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEviction.java
@@ -90,7 +90,7 @@ public class LineageCacheEviction
 		// FIXME: avoid when called from partial reuse methods
 		if (LineageCacheConfig.isCostNsize()) {
 			if (weightedQueue.remove(entry)) {
-				entry.updateScore();
+				entry.updateScore(true);
 				weightedQueue.add(entry);
 			}
 		}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
@@ -52,6 +52,8 @@ public class LineageCacheStatistics {
 	private static final LongAdder _numHitsRdd      = new LongAdder();
 	private static final LongAdder _numHitsSparkActions = new LongAdder();
 	private static final LongAdder _numHitsRddPersist   = new LongAdder();
+	private static final LongAdder _numRddPersist   = new LongAdder();
+	private static final LongAdder _numRddUnpersist   = new LongAdder();
 
 	public static void reset() {
 		_numHitsMem.reset();
@@ -77,6 +79,8 @@ public class LineageCacheStatistics {
 		_numHitsRdd.reset();
 		_numHitsSparkActions.reset();
 		_numHitsRddPersist.reset();
+		_numRddPersist.reset();
+		_numRddUnpersist.reset();
 	}
 	
 	public static void incrementMemHits() {
@@ -241,6 +245,16 @@ public class LineageCacheStatistics {
 		_numHitsRddPersist.increment();
 	}
 
+	public static void incrementRDDPersists() {
+		// Number of RDDs marked for persistence
+		_numRddPersist.increment();
+	}
+
+	public static void incrementRDDUnpersists() {
+		// Number of RDDs unpersisted due the due to memory pressure
+		_numRddUnpersist.increment();
+	}
+
 	public static String displayHits() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(_numHitsMem.longValue());
@@ -316,7 +330,13 @@ public class LineageCacheStatistics {
 		return sb.toString();
 	}
 
-	public static String displaySparkStats() {
+	public static boolean ifGpuStats() {
+		return (_numHitsGpu.longValue() + _numAsyncEvictGpu.longValue()
+			+ _numSyncEvictGpu.longValue() + _numRecycleGpu.longValue()
+			+ _numDelGpu.longValue() + _evtimeGpu.longValue()) != 0;
+	}
+
+	public static String displaySparkHits() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(_numHitsSparkActions.longValue());
 		sb.append("/");
@@ -324,5 +344,18 @@ public class LineageCacheStatistics {
 		sb.append("/");
 		sb.append(_numHitsRddPersist.longValue());
 		return sb.toString();
+	}
+
+	public static String displaySparkPersist() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(_numRddPersist.longValue());
+		sb.append("/");
+		sb.append(_numRddUnpersist.longValue());
+		return sb.toString();
+	}
+
+	public static boolean ifSparkStats() {
+		return (_numHitsSparkActions.longValue() + _numHitsRdd.longValue()
+		+ _numHitsRddPersist.longValue() + _numRddUnpersist.longValue()) != 0;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.lineage;
+
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig.LineageCacheStatus;
+
+import java.util.Map;
+import java.util.TreeSet;
+
+public class LineageSparkCacheEviction
+{
+	private static long SPARK_STORAGE_LIMIT = 0; //60% (upper limit of Spark unified memory)
+	private static long _sparkStorageSize = 0; //current size
+	private static TreeSet<LineageCacheEntry> weightedQueue = new TreeSet<>(LineageCacheConfig.LineageCacheComparator);
+
+	protected static void resetEviction() {
+		_sparkStorageSize = 0;
+		weightedQueue.clear();
+	}
+
+	//--------------- CACHE MAINTENANCE & LOOKUP FUNCTIONS --------------//
+
+	// This method is called at the first cache hit.
+	protected static void addEntry(LineageCacheEntry entry, long estimatedSize) {
+		if (entry.isNullVal())
+			// Placeholders shouldn't participate in eviction cycles.
+			return;
+
+		entry.initiateScoreSpark(LineageCacheEviction._removelist, estimatedSize);
+		weightedQueue.add(entry);
+	}
+
+	protected static void maintainOrder(LineageCacheEntry entry) {
+		// Reset the timestamp to maintain the LRU component of the scoring function
+		if (LineageCacheConfig.isTimeBased()) {
+			if (weightedQueue.remove(entry)) {
+				entry.updateTimestamp();
+				weightedQueue.add(entry);
+			}
+		}
+		// Scale score of the sought entry after every cache hit
+		// FIXME: avoid when called from partial reuse methods
+		if (LineageCacheConfig.isCostNsize()) {
+			// Exists in weighted queue only if already marked for persistent
+			if (weightedQueue.remove(entry)) {
+				// Score stays same if not persisted (i.e. size == 0)
+				entry.updateScore(true);
+				weightedQueue.add(entry);
+			}
+		}
+	}
+
+	protected static void removeSingleEntry(Map<LineageItem, LineageCacheEntry> cache, LineageCacheEntry e) {
+		// Keep in cache. Just change the status to be persisted on the next hit
+		e.setCacheStatus(LineageCacheStatus.TOPERSISTRDD);
+		// Mark for lazy unpersisting
+		JavaPairRDD<?,?> rdd = e.getRDDObject().getRDD();
+		rdd.unpersist(false);
+		// Maintain the current size
+		_sparkStorageSize -= e.getSize();
+		// Maintain miss count to increase the score if the item enters the cache again
+		LineageCacheEviction._removelist.merge(e._key, 1, Integer::sum);
+
+		if (DMLScript.STATISTICS)
+			LineageCacheStatistics.incrementRDDUnpersists();
+		// NOTE: The caller of this method maintains the eviction queue.
+	}
+
+	private static void removeEntry(Map<LineageItem, LineageCacheEntry> cache, LineageCacheEntry e) {
+		if (e._origItem == null) {
+			// Single entry. Remove.
+			removeSingleEntry(cache, e);
+			return;
+		}
+
+		// Defer the eviction till all the entries with the same intermediate are evicted.
+		e.setCacheStatus(LineageCacheStatus.TODELETE);
+
+		boolean del = false;
+		LineageCacheEntry tmp = cache.get(e._origItem);
+		while (tmp != null) {
+			if (tmp.getCacheStatus() != LineageCacheStatus.TODELETE)
+				return; //do nothing
+			del |= (tmp.getCacheStatus() == LineageCacheStatus.TODELETE);
+			tmp = tmp._nextEntry;
+		}
+		if (del) {
+			tmp = cache.get(e._origItem);
+			while (tmp != null) {
+				removeSingleEntry(cache, tmp);
+				tmp = tmp._nextEntry;
+			}
+		}
+	}
+
+	//---------------- CACHE SPACE MANAGEMENT METHODS -----------------//
+
+	private static void setSparkStorageLimit() {
+		// Set the limit only during the first RDD caching to avoid context creation
+		if (SPARK_STORAGE_LIMIT == 0)
+			SPARK_STORAGE_LIMIT = (long) SparkExecutionContext.getDataMemoryBudget(false, true); //FIXME
+	}
+
+	protected static double getSparkStorageLimit() {
+		if (SPARK_STORAGE_LIMIT == 0)
+			setSparkStorageLimit();
+		return SPARK_STORAGE_LIMIT;
+	}
+
+	protected static void updateSize(long space, boolean addspace) {
+		_sparkStorageSize += addspace ? space : -space;
+		// NOTE: this doesn't represent the true size as we maintain total size based on estimations
+	}
+
+	protected static boolean isBelowThreshold(long estimateSize) {
+		boolean available = (estimateSize + _sparkStorageSize) <= getSparkStorageLimit();
+		if (!available)
+			// Get exact storage used (including checkpoints from outside of lineage)
+			_sparkStorageSize = SparkExecutionContext.getStorageSpaceUsed();
+
+		return  (estimateSize + _sparkStorageSize) <= getSparkStorageLimit();
+	}
+
+	protected static void makeSpace(Map<LineageItem, LineageCacheEntry> cache, long estimatedSize) {
+		// Cost-based eviction
+		while ((estimatedSize + _sparkStorageSize) > getSparkStorageLimit()) {
+			LineageCacheEntry e = weightedQueue.pollFirst();
+			if (e == null)
+				// Nothing to evict.
+				break;
+
+			removeEntry(cache, e);
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -2564,6 +2564,10 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 			return estimateSizeDenseInMemory(nrows, ncols);
 	}
 
+	public static long estimateSizeInMemory(DataCharacteristics dc) {
+		return estimateSizeInMemory(dc.getRows(), dc.getCols(), dc.getSparsity());
+	}
+
 	public long estimateSizeDenseInMemory() {
 		return estimateSizeDenseInMemory(rlen, clen);
 	}

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -638,10 +638,15 @@ public class Statistics
 			if (DMLScript.LINEAGE && !ReuseCacheType.isNone()) {
 				sb.append("LinCache hits (Mem/FS/Del): \t" + LineageCacheStatistics.displayHits() + ".\n");
 				sb.append("LinCache MultiLevel (Ins/SB/Fn):" + LineageCacheStatistics.displayMultiLevelHits() + ".\n");
-				sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
-				sb.append("LinCache GPU (Recyc/Del): \t" + LineageCacheStatistics.displayGpuPointerStats() + ".\n");
-				sb.append("LinCache GPU evict time: \t" + LineageCacheStatistics.displayGpuEvictTime() + " sec.\n");
-				sb.append("LinCache Spark (Col/Loc/Dist): \t" + LineageCacheStatistics.displaySparkStats() + ".\n");
+				if (LineageCacheStatistics.ifGpuStats()) {
+					sb.append("LinCache GPU (Hit/Async/Sync): \t" + LineageCacheStatistics.displayGpuStats() + ".\n");
+					sb.append("LinCache GPU (Recyc/Del): \t" + LineageCacheStatistics.displayGpuPointerStats() + ".\n");
+					sb.append("LinCache GPU evict time: \t" + LineageCacheStatistics.displayGpuEvictTime() + " sec.\n");
+				}
+				if (LineageCacheStatistics.ifSparkStats()) {
+					sb.append("LinCache Spark (Col/Loc/Dist): \t" + LineageCacheStatistics.displaySparkHits() + ".\n");
+					sb.append("LinCache Spark (Per/Unper): \t" + LineageCacheStatistics.displaySparkPersist() + ".\n");
+				}
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");
 				sb.append("LinCache FStimes (Rd/Wr): \t" + LineageCacheStatistics.displayFSTime() + " sec.\n");
 				sb.append("LinCache Computetime (S/M): \t" + LineageCacheStatistics.displayComputeTime() + " sec.\n");

--- a/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
@@ -74,8 +74,6 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 	}
 
 	public void runTest(String testname, ExecMode execMode, int testId) {
-		setOutputBuffering(true);
-		
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
 		boolean old_trans_exec_type = OptimizerUtils.ALLOW_TRANSITIVE_SPARK_EXEC_TYPE;


### PR DESCRIPTION
This patch extends the lineage cache eviction policies to support RDDs persisted at the executors.
- We checkpoint a RDD on the second cache hit (reduce cache pollution).
- While checkpointing, we rely on the worst case size estimations and later update the eviction data structures with actual size once the RDDs are persisted.
- We split the Spark operators into two groups, one for expensive, shuffle-based operations, and another for map-based operations. For the scoring function, we assume the first set is 2x more expensive
- We also track the reference counts of RDDs and use that in the scoring. More references (many consumers) indicates higher importance.
- We reduce the score by one hit count if we collect a persisted RDD. This is to evict the intermediates which are cached at multiple locations.