### PR TITLE
[SYSTEMDS-3562] Save multi-statementblock checkpoints for recompiler

### DIFF
--- a/src/main/java/org/apache/sysds/hops/recompile/Recompiler.java
+++ b/src/main/java/org/apache/sysds/hops/recompile/Recompiler.java
@@ -404,8 +404,8 @@ public class Recompiler {
 		}
 
 		// dynamic lop rewrites for the updated hop DAGs
-		if (rewrittenHops)
-			_lopRewriter.get().rewriteLopDAG(lops);
+		if (rewrittenHops && sb != null)
+			_lopRewriter.get().rewriteLopDAG(sb, lops);
 
 		Dag<Lop> dag = new Dag<>();
 		for (Lop l : lops)

--- a/src/main/java/org/apache/sysds/lops/rewrite/LopRewriter.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/LopRewriter.java
@@ -69,8 +69,8 @@ public class LopRewriter
 			rRewriteLop(fsb);
 	}
 
-	public ArrayList<Lop> rewriteLopDAG(ArrayList<Lop> lops) {
-		StatementBlock sb = new StatementBlock();
+	public ArrayList<Lop> rewriteLopDAG(StatementBlock sb, ArrayList<Lop> lops) {
+		//StatementBlock sb = new StatementBlock();
 		sb.setLops(lops);
 		return rRewriteLop(sb).get(0).getLops();
 	}

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddChkpointInLoop.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddChkpointInLoop.java
@@ -81,7 +81,7 @@ public class RewriteAddChkpointInLoop extends LopRewriteRule
 			return List.of(sb);
 
 		// Add checkpoint Lops after the shared operators
-		addChkpointLop(lops, operatorJobCount);
+		addChkpointLop(lops, operatorJobCount, csb);
 		// TODO: A rewrite pass to remove less effective checkpoints
 		return List.of(sb);
 	}
@@ -91,7 +91,7 @@ public class RewriteAddChkpointInLoop extends LopRewriteRule
 		return sbs;
 	}
 
-	private void addChkpointLop(List<Lop> nodes, Map<Long, Integer> operatorJobCount) {
+	private void addChkpointLop(List<Lop> nodes, Map<Long, Integer> operatorJobCount, StatementBlock sb) {
 		for (Lop l : nodes) {
 			if(operatorJobCount.containsKey(l.getID()) && operatorJobCount.get(l.getID()) > 1) {
 				// TODO: Check if this lop leads to one of those variables
@@ -106,6 +106,8 @@ public class RewriteAddChkpointInLoop extends LopRewriteRule
 					out.replaceInput(l, checkpoint);
 					l.removeOutput(out);
 				}
+				// Save the checkpoint position for the recompiler
+				sb.setCheckpointPosition(l, oldOuts);
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysds/parser/StatementBlock.java
+++ b/src/main/java/org/apache/sysds/parser/StatementBlock.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -64,6 +65,7 @@ public class StatementBlock extends LiveVariableAnalysis implements ParseInfo
 	private boolean _requiresRecompile = false;
 	private boolean _splitDag = false;
 	private boolean _nondeterministic = false;
+	private HashMap<Lop.Type, List<Lop.Type>> _checkpointPositions = null;
 
 	protected double repetitions = 1;
 	public final static double DEFAULT_LOOP_REPETITIONS = 10;
@@ -1392,5 +1394,21 @@ public class StatementBlock extends LiveVariableAnalysis implements ParseInfo
 	
 	public boolean isNondeterministic() {
 		return _nondeterministic;
+	}
+
+	public void setCheckpointPosition(Lop input, List<Lop> outputs) {
+		// FIXME: Type is not the best key as many Lops may have the same types
+		Lop.Type inputT = input.getType();
+		List<Lop.Type> outputsT = outputs.stream().map(Lop::getType).collect(Collectors.toList());
+
+		if (_checkpointPositions == null)
+			_checkpointPositions = new HashMap<>();
+		if (!_checkpointPositions.containsKey(inputT)) {
+			_checkpointPositions.put(inputT, outputsT);
+		}
+	}
+
+	public HashMap<Lop.Type, List<Lop.Type>> getCheckpointPositions() {
+		return _checkpointPositions;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/async/CheckpointSharedOpsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/CheckpointSharedOpsTest.java
@@ -96,8 +96,7 @@ public class CheckpointSharedOpsTest extends AutomatedTestBase {
 			if (!matchVal)
 				System.out.println("Value w/o Checkpoint "+R+" w/ Checkpoint "+R_mp);
 			//compare checkpoint instruction count
-			if (!testname.equalsIgnoreCase(TEST_NAME+"2"))
-				Assert.assertTrue("Violated checkpoint count: " + numCP + " < " + numCP_maxp, numCP < numCP_maxp);
+			Assert.assertTrue("Violated checkpoint count: " + numCP + " < " + numCP_maxp, numCP < numCP_maxp);
 		} finally {
 			resetExecMode(oldPlatform);
 			InfrastructureAnalyzer.setLocalMaxMemory(oldmem);


### PR DESCRIPTION
This patch adds a temporary fix to save the position of the checkpoint instructions placed in a loop body during compilation and again place those in there during recompilation. A better fix would be to enable recompilation for that loop or the function.