### PR TITLE
[SYSTEMDS-3585] Reuse lineage traces from lineage cache

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/ExecutionContext.java
@@ -167,6 +167,7 @@ public class ExecutionContext {
 	}
 
 	/**
+	 *
 	 * Get the i-th GPUContext
 	 * @param index index of the GPUContext
 	 * @return a valid GPUContext or null if the indexed GPUContext does not exist.
@@ -923,6 +924,18 @@ public class ExecutionContext {
 		if( _lineage == null )
 			throw new DMLRuntimeException("Lineage Trace unavailable.");
 		return _lineage.getOrCreate(input);
+	}
+
+	public void replaceLineageItem(String varname, LineageItem li) {
+		if (!LineageCacheConfig.isLineageTraceReuse())
+			return;
+		if( _lineage == null )
+			throw new DMLRuntimeException("Lineage Trace unavailable.");
+		if (_lineage.get(varname) == null)
+			throw new DMLRuntimeException("Lineage item does not exist for "+varname);
+		//Passed lineage trace should be equivalent to the live lineage trace
+		//corresponding to varname. Replacing reduces memory and probing overheads.
+		_lineage.set(varname, li);
 	}
 	
 	private static String getNonExistingVarError(String varname) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/Lineage.java
@@ -132,6 +132,7 @@ public class Lineage {
 	public void initializeDedupBlock(ProgramBlock pb, ExecutionContext ec) {
 		if( !(pb instanceof ForProgramBlock || pb instanceof WhileProgramBlock) )
 			throw new DMLRuntimeException("Invalid deduplication block: "+ pb.getClass().getSimpleName());
+		LineageCacheConfig.setReuseLineageTraces(false);
 		if (!_dedupBlocks.containsKey(pb)) {
 			// valid only if doesn't contain a nested loop
 			boolean valid = LineageDedupUtils.isValidDedupBlock(pb, false);

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -50,11 +50,11 @@ public class LineageCacheConfig
 	private static final String[] OPCODES = new String[] {
 		"tsmm", "ba+*", "*", "/", "+", "||", "nrow", "ncol", "round", "exp", "log",
 		"rightIndex", "leftIndex", "groupedagg", "r'", "solve", "spoof",
-		"uamean", "max", "min", "ifelse", "-", "sqrt", ">", "uak+", "<=",
+		"uamean", "max", "min", "ifelse", "-", "sqrt", "<", ">", "uak+", "<=",
 		"^", "uamax", "uark+", "uacmean", "eigen", "ctableexpand", "replace",
-		"^2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort", 
+		"^2", "*2", "uack+", "tak+*", "uacsqk+", "uark+", "n+", "uarimax", "qsort",
 		"qpick", "transformapply", "uarmax", "n+", "-*", "castdtm", "lowertri",
-		"prefetch", "mapmm"
+		"prefetch", "mapmm", "contains", "mmchain", "mapmmchain", "+*"
 		//TODO: Reuse everything.
 	};
 
@@ -70,7 +70,7 @@ public class LineageCacheConfig
 
 	// Relatively inexpensive instructions.
 	private static final String[] PERSIST_OPCODES2 = new String[] {
-		"mapmm"
+		"mapmm,"
 	};
 
 	private static String[] REUSE_OPCODES  = new String[] {};
@@ -104,6 +104,7 @@ public class LineageCacheConfig
 	private static CachedItemTail _itemT = null;
 	private static boolean _compilerAssistedRW = false;
 	private static boolean _onlyEstimate = false;
+	private static boolean _reuseLineageTraces = true;
 
 	//-------------DISK SPILLING RELATED CONFIGURATIONS--------------//
 
@@ -366,6 +367,14 @@ public class LineageCacheConfig
 	
 	public static boolean getCompAssRW() {
 		return _compilerAssistedRW;
+	}
+
+	public static void setReuseLineageTraces(boolean reuseTrace) {
+		_reuseLineageTraces = reuseTrace;
+	}
+
+	public static boolean isLineageTraceReuse() {
+		return _reuseLineageTraces;
 	}
 
 	public static void setCachePolicy(LineageCachePolicy policy) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheStatistics.java
@@ -41,6 +41,7 @@ public class LineageCacheStatistics {
 	private static final LongAdder _ctimeFSWrite    = new LongAdder();
 	private static final LongAdder _ctimeSaved      = new LongAdder();
 	private static final LongAdder _ctimeMissed     = new LongAdder();
+	private static final LongAdder _ctimeProbe      = new LongAdder();
 	// Bellow entries are specific to gpu lineage cache
 	private static final LongAdder _numHitsGpu      = new LongAdder();
 	private static final LongAdder _numAsyncEvictGpu= new LongAdder();
@@ -70,6 +71,7 @@ public class LineageCacheStatistics {
 		_ctimeFSWrite.reset();
 		_ctimeSaved.reset();
 		_ctimeMissed.reset();
+		_ctimeProbe.reset();
 		_evtimeGpu.reset();
 		_numHitsGpu.reset();
 		_numAsyncEvictGpu.reset();
@@ -191,6 +193,10 @@ public class LineageCacheStatistics {
 		_ctimeMissed.add(delta);
 	}
 
+	public static void incrementProbeTime(long delta) {
+		_ctimeProbe.add(delta);
+	}
+
 	public static long getMultiLevelFnHits() {
 		return _numHitsFunc.longValue();
 	}
@@ -303,6 +309,8 @@ public class LineageCacheStatistics {
 		sb.append(String.format("%.3f", ((double)_ctimeSaved.longValue())/1000000000)); //in sec
 		sb.append("/");
 		sb.append(String.format("%.3f", ((double)_ctimeMissed.longValue())/1000000000)); //in sec
+		sb.append("/");
+		sb.append(String.format("%.3f", ((double)_ctimeProbe.longValue())/1000000000)); //in sec
 		return sb.toString();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
+import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.parfor.util.IDSequence;
 import org.apache.sysds.runtime.util.UtilFunctions;
@@ -269,8 +270,8 @@ public class LineageItem {
 		Stack<LineageItem> s2 = new Stack<>();
 		s1.push(this);
 		s2.push(that);
-		//boolean ret = false;
 		boolean ret = true;
+		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		while (!s1.empty() && !s2.empty()) {
 			LineageItem li1 = s1.pop();
 			LineageItem li2 = s2.pop();
@@ -356,6 +357,8 @@ public class LineageItem {
 				}
 			li1.setVisited();
 		}
+		if (DMLScript.STATISTICS) //increment probing time
+			LineageCacheStatistics.incrementProbeTime(System.nanoTime() - t0);
 		return ret;
 	}
 	

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -649,7 +649,7 @@ public class Statistics
 				}
 				sb.append("LinCache writes (Mem/FS/Del): \t" + LineageCacheStatistics.displayWtrites() + ".\n");
 				sb.append("LinCache FStimes (Rd/Wr): \t" + LineageCacheStatistics.displayFSTime() + " sec.\n");
-				sb.append("LinCache Computetime (S/M): \t" + LineageCacheStatistics.displayComputeTime() + " sec.\n");
+				sb.append("LinCache Computetime (S/M/P): \t" + LineageCacheStatistics.displayComputeTime() + " sec.\n");
 				sb.append("LinCache Rewrites:    \t\t" + LineageCacheStatistics.displayRewrites() + ".\n");
 			}
 


### PR DESCRIPTION
This commits adds a small but useful extension to lineage-base reuse. We now also reuse the lineage traces corresponding to the reused intermediates by replacing the live lineage traces with the cached ones. This change increases the use of same lineage items in many lineage DAGs, which in turn reduces probing cost and memory overhead. This extension is disabled for parfor and deduplicated lineage traces. Integrating with those require more thoughts.