### PR TITLE
[SYSTEMDS-3594] Multi-level reuse of RDDs

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/RDDObject.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.instructions.spark.data;
 
 import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
 
 public class RDDObject extends LineageObject
 {
@@ -31,6 +32,7 @@ public class RDDObject extends LineageObject
 	private String  _hdfsFname = null;     //hdfs filename, if created from hdfs.  
 	private boolean _parRDD = false;       //is a parallelized rdd at driver
 	private boolean _pending = true;       //is a pending rdd operation
+	private DataCharacteristics _dc = null;
 	
 	public RDDObject( JavaPairRDD<?,?> rddvar) {
 		super();
@@ -83,6 +85,14 @@ public class RDDObject extends LineageObject
 	
 	public boolean isPending() {
 		return _pending;
+	}
+
+	public void setDataCharacteristics(DataCharacteristics dc) {
+		_dc = dc;
+	}
+
+	public DataCharacteristics getDataCharacteristics() {
+		return _dc;
 	}
 	
 

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheConfig.java
@@ -70,7 +70,7 @@ public class LineageCacheConfig
 
 	// Relatively inexpensive instructions.
 	private static final String[] PERSIST_OPCODES2 = new String[] {
-		"mapmm,"
+		"mapmm"
 	};
 
 	private static String[] REUSE_OPCODES  = new String[] {};
@@ -300,8 +300,8 @@ public class LineageCacheConfig
 		return insttype && rightOp;
 	}
 
-	protected static boolean isShuffleOp(Instruction inst) {
-		return ArrayUtils.contains(PERSIST_OPCODES1, inst.getOpcode());
+	protected static boolean isShuffleOp(String opcode) {
+		return ArrayUtils.contains(PERSIST_OPCODES1, opcode);
 	}
 
 	protected static int getComputeGroup(String opcode) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
@@ -254,7 +254,7 @@ public class LineageCacheEntry {
 		_gpuPointer = src._gpuPointer;
 		_rddObject = src._rddObject;
 		_computeTime = src._computeTime;
-		_status = isNullVal() ? LineageCacheStatus.EMPTY : LineageCacheStatus.CACHED;
+		_status = src._status; //requires for multi-level reuse of RDDs
 		// resume all threads waiting for val
 		notifyAll();
 	}

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
@@ -117,8 +117,11 @@ public class LineageSparkCacheEviction
 
 	private static void setSparkStorageLimit() {
 		// Set the limit only during the first RDD caching to avoid context creation
-		if (SPARK_STORAGE_LIMIT == 0)
-			SPARK_STORAGE_LIMIT = (long) SparkExecutionContext.getDataMemoryBudget(false, true); //FIXME
+		// Cache size = 70% of unified Spark memory = 0.7 * 0.6 = 42%.
+		if (SPARK_STORAGE_LIMIT == 0) {
+			long unifiedSparkMem = (long) SparkExecutionContext.getDataMemoryBudget(false, true);
+			SPARK_STORAGE_LIMIT = (long)(unifiedSparkMem * 0.7d);
+		}
 	}
 
 	protected static double getSparkStorageLimit() {

--- a/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
@@ -41,7 +41,7 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 
 	protected static final String TEST_DIR = "functions/async/";
 	protected static final String TEST_NAME = "LineageReuseSpark";
-	protected static final int TEST_VARIANTS = 3;
+	protected static final int TEST_VARIANTS = 4;
 	protected static String TEST_CLASS_DIR = TEST_DIR + LineageReuseSparkTest.class.getSimpleName() + "/";
 
 	@Override
@@ -73,6 +73,12 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 		runTest(TEST_NAME+"3", ExecMode.SPARK, 3);
 	}
 
+	@Test
+	public void testlmdsMultiLevel() {
+		// Cache RDD and matrix block function returns and reuse
+		runTest(TEST_NAME+"4", ExecMode.HYBRID, 4);
+	}
+
 	public void runTest(String testname, ExecMode execMode, int testId) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		boolean old_sum_product = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
@@ -92,7 +98,6 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 
 			//proArgs.add("-explain");
 			proArgs.add("-stats");
-			proArgs.add("-explain");
 			proArgs.add("-args");
 			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);
@@ -109,7 +114,7 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 			//proArgs.add("recompile_runtime");
 			proArgs.add("-stats");
 			proArgs.add("-lineage");
-			proArgs.add(LineageCacheConfig.ReuseCacheType.REUSE_FULL.name().toLowerCase());
+			proArgs.add(LineageCacheConfig.ReuseCacheType.REUSE_MULTILEVEL.name().toLowerCase());
 			proArgs.add("-args");
 			proArgs.add(output("R"));
 			programArgs = proArgs.toArray(new String[proArgs.size()]);

--- a/src/test/scripts/functions/async/LineageReuseSpark4.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark4.dml
@@ -1,0 +1,57 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N) 
+return (Matrix[double] A, Matrix[double] b)
+{
+  # Reuse sp_tsmm and sp_mapmm if not future-based
+  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  while(FALSE){}
+  b = t(X) %*% y;
+}
+
+no_lamda = 2;
+
+stp = (0.1 - 0.0001)/no_lamda;
+lamda = 0.0001;
+lim = 0.1;
+
+X = rand(rows=1500, cols=1500, seed=42);
+y = rand(rows=1500, cols=1, seed=43);
+N = ncol(X);
+R = matrix(0, rows=N, cols=no_lamda+2);
+
+[A, b] = SimlinRegDS(X, y, lamda, N);
+beta = solve(A, b);
+R[,1] = beta;
+
+# Reuse function call
+[A, b] = SimlinRegDS(X, y, lamda, N);
+beta = solve(A, b);
+R[,2] = beta;
+
+[A, b] = SimlinRegDS(X, y, lamda, N);
+beta = solve(A, b);
+R[,3] = beta;
+
+R = sum(R);
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch extends the multi-level reuse framework to support functions and statement blocks returning RDDs. Similar to instruction-level reuse, we persist the function outputs on the second call. Based on if the original instruction is shuffle-based, we also reuse the function output locally.