### PR TITLE
[MINOR] Support Non-Literals in Federated Reshape Instruction

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReshapeFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReshapeFEDInstruction.java
@@ -120,7 +120,7 @@ public class ReshapeFEDInstruction extends UnaryFEDInstruction {
 			mo1.getFedMapping().execute(getTID(), true, fr1, new FederatedRequest[0]);
 
 			// set new fed map
-			FederationMap reshapedFedMap = mo1.getFedMapping();
+			FederationMap reshapedFedMap = mo1.getFedMapping().copyWithNewID(fr1[0].getID());
 			for(int i = 0; i < reshapedFedMap.getFederatedRanges().length; i++) {
 				long cells = reshapedFedMap.getFederatedRanges()[i].getSize();
 				long row = byRow.getBooleanValue() ? cells / cols : rows;
@@ -141,7 +141,7 @@ public class ReshapeFEDInstruction extends UnaryFEDInstruction {
 			//derive output federated mapping
 			MatrixObject out = ec.getMatrixObject(output);
 			out.getDataCharacteristics().set(rows, cols, (int) mo1.getBlocksize(), mo1.getNnz());
-			out.setFedMapping(reshapedFedMap.copyWithNewID(fr1[0].getID()));
+			out.setFedMapping(reshapedFedMap);
 		}
 		else {
 			// TODO support tensor out, frame and list

--- a/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/io/FederatedReaderTest.java
@@ -40,7 +40,7 @@ import org.junit.runners.Parameterized;
 public class FederatedReaderTest extends AutomatedTestBase {
 
 	private static final Log LOG = LogFactory.getLog(FederatedReaderTest.class.getName());
-	private final static String TEST_DIR = "functions/federated/ioR/";
+	private final static String TEST_DIR = "functions/federated/io/";
 	private final static String TEST_NAME = "FederatedReaderTest";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedReaderTest.class.getSimpleName() + "/";
 	private final static int blocksize = 1024;
@@ -50,8 +50,6 @@ public class FederatedReaderTest extends AutomatedTestBase {
 	public int cols;
 	@Parameterized.Parameter(2)
 	public boolean rowPartitioned;
-	@Parameterized.Parameter(3)
-	public int fedCount;
 
 	@Override
 	public void setUp() {
@@ -62,7 +60,7 @@ public class FederatedReaderTest extends AutomatedTestBase {
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {
 		// number of rows or cols has to be >= number of federated locations.
-		return Arrays.asList(new Object[][] {{10, 13, true, 2}});
+		return Arrays.asList(new Object[][] {{10, 13, true}});
 	}
 
 	@Test
@@ -111,11 +109,11 @@ public class FederatedReaderTest extends AutomatedTestBase {
 			// Run reference dml script with normal matrix
 
 			if(workerCount == 1) {
-				fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME + "1Reference.dml";
+				fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME + "1Reference.dml";
 				programArgs = new String[] {"-stats", "-args", input("X1")};
 			}
 			else {
-				fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME
+				fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME
 					+ (rowPartitioned ? "Row" : "Col") + "2Reference.dml";
 				programArgs = new String[] {"-stats", "-args", input("X1"), input("X2")};
 			}
@@ -125,7 +123,7 @@ public class FederatedReaderTest extends AutomatedTestBase {
 			LOG.debug(refOut);
 			
 			// Run federated
-			fullDMLScriptName = SCRIPT_DIR + "functions/federated/io/" + TEST_NAME + ".dml";
+			fullDMLScriptName = SCRIPT_DIR + TEST_DIR + TEST_NAME + ".dml";
 			programArgs = new String[] {"-stats", "-args", input("X.json")};
 			String out = runTest(null).toString();
 

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedMisAlignedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/FederatedMisAlignedTest.java
@@ -205,10 +205,10 @@ public class FederatedMisAlignedTest extends AutomatedTestBase {
 			c = cols;
 		}
 
-		double[][] X1 = getRandomMatrix(r, c, 3, 3, 1, 3);
-		double[][] X2 = getRandomMatrix(r, c, 3, 3, 1, 7);
-		double[][] X3 = getRandomMatrix(r, c, 3, 3, 1, 8);
-		double[][] X4 = getRandomMatrix(r, c, 3, 3, 1, 9);
+		double[][] X1 = getRandomMatrix(r, c, 3, 4, 1, 3);
+		double[][] X2 = getRandomMatrix(r, c, 3, 4, 1, 7);
+		double[][] X3 = getRandomMatrix(r, c, 3, 4, 1, 8);
+		double[][] X4 = getRandomMatrix(r, c, 3, 4, 1, 9);
 
 		MatrixCharacteristics mc = new MatrixCharacteristics(r, c, blocksize, r * c);
 		writeInputMatrixWithMTD("X1", X1, false, mc);

--- a/src/test/scripts/functions/federated/FederatedReshapeTest.dml
+++ b/src/test/scripts/functions/federated/FederatedReshapeTest.dml
@@ -27,5 +27,10 @@ A = federated(addresses=list($in_X1, $in_X2, $in_X3, $in_X4),
     ranges=list(list(0, 0), list(2, 12), list(2, 0), list(4, $cols),
     list(4, 0), list(10, $cols), list(10, 0), list(12, $cols)));
 
-s = matrix(A, rows=$r_rows, cols=$r_cols);
+# materialize the scalar input (non-literal)
+reshape_cols = $r_cols;
+while(FALSE) {}
+reshape_cols = reshape_cols;
+
+s = matrix(A, rows=$r_rows, cols=reshape_cols);
 write(s, $out_S);


### PR DESCRIPTION
Hi,
This PR adds support for non-literal parameters _rows_ and _cols_ in _ReshapeFEDInstruction_ by simply constructing a literal operand for the respective scalar and replacing the corresponding operand of the instruction string. I also changed the DML script of the _FederatedReshapeTest_  such that we materialize one of these parameters as a non-literal.
This PR implicitly also includes the removal of unused variables inside the _FederatedReaderTest_ and the change of value range of the random matrices in _FederatedMisAlignedTest_.

Thanks for review :)