### PR TITLE
[SYSTEMDS-3599] Cleanup child RDDs, broadcasts from driver and executors

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1503,7 +1503,6 @@ public class SparkExecutionContext extends ExecutionContext
 		}
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private void rCleanupLineageObject(LineageObject lob)
 		throws IOException
 	{
@@ -1522,12 +1521,30 @@ public class SparkExecutionContext extends ExecutionContext
 
 		//cleanup current lineage object (from driver/executors)
 		//incl deferred hdfs file removal (only if metadata set by cleanup call)
+		cleanupSingleLineageObject(lob);
+
+		//recursively process lineage children
+		for( LineageObject c : lob.getLineageChilds() ){
+			c.decrementNumReferences();
+			rCleanupLineageObject(c);
+		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static void cleanupSingleLineageObject(LineageObject lob) {
+		//cleanup current lineage object (from driver/executors)
+		//incl deferred hdfs file removal (only if metadata set by cleanup call)
 		if( lob instanceof RDDObject ) {
 			RDDObject rdd = (RDDObject)lob;
 			int rddID = rdd.getRDD().id();
 			cleanupRDDVariable(rdd.getRDD());
 			if( rdd.getHDFSFilename()!=null ) { //deferred file removal
-				HDFSTool.deleteFileWithMTDIfExistOnHDFS(rdd.getHDFSFilename());
+				try {
+					HDFSTool.deleteFileWithMTDIfExistOnHDFS(rdd.getHDFSFilename());
+				}
+				catch(IOException e) {
+					throw new DMLRuntimeException(e);
+				}
 			}
 			if( rdd.isParallelizedRDD() )
 				_parRDDs.deregisterRDD(rddID);
@@ -1547,12 +1564,6 @@ public class SparkExecutionContext extends ExecutionContext
 					cleanupBroadcastVariable(bc);
 			}
 			CacheableData.addBroadcastSize(-bob.getSize());
-		}
-
-		//recursively process lineage children
-		for( LineageObject c : lob.getLineageChilds() ){
-			c.decrementNumReferences();
-			rCleanupLineageObject(c);
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/CheckpointSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/CheckpointSPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.instructions.spark;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.storage.StorageLevel;
+import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.hops.OptimizerUtils;
@@ -41,6 +42,7 @@ import org.apache.sysds.runtime.instructions.spark.functions.CopyFrameBlockFunct
 import org.apache.sysds.runtime.instructions.spark.functions.CreateSparseBlockFunction;
 import org.apache.sysds.runtime.instructions.spark.utils.SparkUtils;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig;
+import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.operators.Operator;
@@ -99,6 +101,7 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 			//add a dummy entry to the input, which will be immediately overwritten by the null output.
 			sec.setVariable( input1.getName(), new BooleanObject(false));
 			sec.setVariable( output.getName(), new BooleanObject(false));
+			replaceLineage(ec);
 			return;
 		}
 
@@ -107,6 +110,7 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 			// Do nothing if the RDD is already checkpointed
 			sec.setVariable(output.getName(), sec.getCacheableData(input1.getName()));
 			Statistics.decrementNoOfExecutedSPInst();
+			replaceLineage(ec);
 			return;
 		}
 		//-------
@@ -121,6 +125,7 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 			//available in memory
 			sec.setVariable(output.getName(), obj);
 			Statistics.decrementNoOfExecutedSPInst();
+			replaceLineage(ec);
 			return;
 		}
 		
@@ -187,6 +192,7 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 		}
 		else {
 			out = in; //pass-through
+			replaceLineage(ec);
 		}
 		
 		// Step 3: In-place update of input matrix/frame rdd handle and set as output
@@ -207,5 +213,18 @@ public class CheckpointSPInstruction extends UnarySPInstruction {
 			cd.setRDDHandle(outro);
 		}
 		sec.setVariable( output.getName(), cd);
+		//TODO: remove lineage tracing of chkpoint to allow
+		//  reuse across loops and basic blocks
+		//replaceLineage(ec);
+	}
+
+	private void replaceLineage(ExecutionContext ec) {
+		// Copy the lineage trace of the input to the output
+		// to prevent unnecessary chkpoint lineage entry, which wrongly
+		// reduces reuse opportunities for nested loop bodies.
+		if (DMLScript.LINEAGE) {
+			LineageItem inputLi = ec.getLineageItem(input1.getName());
+			ec.getLineage().set(output.getName(), inputLi);
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/data/LineageObject.java
@@ -85,4 +85,8 @@ public abstract class LineageObject
 		lob.incrementNumReferences();
 		_childs.add( lob );
 	}
+
+	public void removeAllChild() {
+		_childs.clear();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEntry.java
@@ -240,6 +240,13 @@ public class LineageCacheEntry {
 		notifyAll();
 	}
 
+	public synchronized void setRDDValue(RDDObject rdd) {
+		_rddObject = rdd;
+		_status = isNullVal() ? LineageCacheStatus.EMPTY : LineageCacheStatus.TOPERSISTRDD;
+		//resume all threads waiting for val
+		notifyAll();
+	}
+
 	public synchronized void setValue(byte[] serialBytes, long computetime) {
 		_serialBytes = serialBytes;
 		_computeTime = computetime;

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCacheEviction.java
@@ -58,9 +58,9 @@ public class LineageCacheEviction
 			return;
 
 		double exectime = ((double) entry._computeTime) / 1000000; // in milliseconds
-		if (!entry.isMatrixValue() && exectime >= LineageCacheConfig.MIN_SPILL_TIME_ESTIMATE)
+		if (!entry.isMatrixValue() && (exectime >= LineageCacheConfig.MIN_SPILL_TIME_ESTIMATE || entry._origItem != null))
 			// Pin the entries having scalar values and with higher computation time
-			// to memory, to save those from eviction. Scalar values are
+			// to memory or function output, to save those from eviction. Scalar values are
 			// not spilled to disk and are just deleted. Scalar entries associated 
 			// with high computation time might contain function outputs. Pinning them
 			// will increase chances of multilevel reuse.

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageSparkCacheEviction.java
@@ -22,20 +22,28 @@ package org.apache.sysds.runtime.lineage;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysds.runtime.instructions.spark.data.LineageObject;
+import org.apache.sysds.runtime.instructions.spark.data.RDDObject;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig.LineageCacheStatus;
+import org.apache.sysds.runtime.util.CommonThreadPool;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.Executors;
 
 public class LineageSparkCacheEviction
 {
 	private static long SPARK_STORAGE_LIMIT = 0; //60% (upper limit of Spark unified memory)
 	private static long _sparkStorageSize = 0; //current size
 	private static TreeSet<LineageCacheEntry> weightedQueue = new TreeSet<>(LineageCacheConfig.LineageCacheComparator);
+	protected static final Map<LineageItem, Integer> RDDHitCountLocal = new HashMap<>();
 
 	protected static void resetEviction() {
 		_sparkStorageSize = 0;
 		weightedQueue.clear();
+		RDDHitCountLocal.clear();
 	}
 
 	//--------------- CACHE MAINTENANCE & LOOKUP FUNCTIONS --------------//
@@ -153,6 +161,75 @@ public class LineageSparkCacheEviction
 				break;
 
 			removeEntry(cache, e);
+		}
+	}
+
+	//---------------- LOCAL CLEANUP METHODS -----------------//
+
+	protected static void cleanupChildRDDs(LineageCacheEntry e) {
+		if (e.getCacheStatus() == LineageCacheStatus.PERSISTEDRDD) {
+			// Persisted at Spark. Cleanup the child RDDs and broadcast vars
+			for( LineageObject c : e.getRDDObject().getLineageChilds() ){
+				c.decrementNumReferences();
+				rCleanupChildRDDs(c);
+			}
+			// Also detach the child RDDs to be GCed
+			e.getRDDObject().removeAllChild();
+		}
+		// TODO: Cleanup the child RDDs of the persisted RDDs
+		//  which are never reused after the second hit.
+	}
+
+	protected static void rCleanupChildRDDs(LineageObject lob) {
+		// Abort recursive cleanup if still consumers
+		if( lob.getNumReferences() > 0 )
+			return;
+
+		// Abort if still reachable through live matrix object
+		if( lob.hasBackReference() )
+			return;
+
+		// Abort if the RDD is yet to be persisted
+		if (lob instanceof RDDObject && lob.isInLineageCache()
+			&& SparkExecutionContext.isRDDCached(((RDDObject)lob).getRDD().id()))
+			return;
+
+		// Cleanup current lineage object (from driver/executors)
+		SparkExecutionContext.cleanupSingleLineageObject(lob);
+
+		//recursively process lineage children
+		for (LineageObject c : lob.getLineageChilds()) {
+			c.decrementNumReferences();
+			rCleanupChildRDDs(c);
+		}
+	}
+
+	// RDDs that are marked for persistence, reused more than three times,
+	// but never actually persisted in the executors. Asynchronously move
+	// them to Spark by triggering a Spark job. The next reuse will clean up
+	// The next reuse will clean up the child RDDs and broadcast variables.
+	protected static void moveToSpark(LineageCacheEntry e) {
+		RDDHitCountLocal.merge(e._key, 1, Integer::sum);
+		int localHitCount = RDDHitCountLocal.get(e._key);
+		if (localHitCount > 3) {
+			RDDHitCountLocal.remove(e._key);
+			if (CommonThreadPool.triggerRemoteOPsPool == null)
+				CommonThreadPool.triggerRemoteOPsPool = Executors.newCachedThreadPool();
+			CommonThreadPool.triggerRemoteOPsPool.submit(new TriggerRemoteTask(e.getRDDObject().getRDD()));
+		}
+	}
+
+	private static class TriggerRemoteTask implements Runnable {
+		JavaPairRDD<?, ?> rdd;
+
+		public TriggerRemoteTask(JavaPairRDD<?,?> persistRDD) {
+			rdd = persistRDD;
+		}
+
+		@Override
+		public void run() {
+			// Trigger a Spark job
+			long ret = rdd.count();
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/async/LineageReuseSparkTest.java
@@ -29,6 +29,7 @@ import org.apache.sysds.hops.recompile.Recompiler;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysds.runtime.lineage.Lineage;
 import org.apache.sysds.runtime.lineage.LineageCacheConfig;
+import org.apache.sysds.runtime.lineage.LineageCacheStatistics;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -41,7 +42,7 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 
 	protected static final String TEST_DIR = "functions/async/";
 	protected static final String TEST_NAME = "LineageReuseSpark";
-	protected static final int TEST_VARIANTS = 4;
+	protected static final int TEST_VARIANTS = 6;
 	protected static String TEST_CLASS_DIR = TEST_DIR + LineageReuseSparkTest.class.getSimpleName() + "/";
 
 	@Override
@@ -70,7 +71,7 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 
 	@Test
 	public void testL2svm() {
-		runTest(TEST_NAME+"3", ExecMode.SPARK, 3);
+		runTest(TEST_NAME+"3", ExecMode.HYBRID, 3);
 	}
 
 	@Test
@@ -78,6 +79,17 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 		// Cache RDD and matrix block function returns and reuse
 		runTest(TEST_NAME+"4", ExecMode.HYBRID, 4);
 	}
+
+	@Test
+	public void testEnsemble() {
+		runTest(TEST_NAME+"5", ExecMode.HYBRID, 5);
+	}
+
+	//FIXME: Collecting a persisted RDD still needs the broadcast vars. Debug.
+	/*@Test
+	public void testHyperband() {
+		runTest(TEST_NAME+"6", ExecMode.HYBRID, 6);
+	}*/
 
 	public void runTest(String testname, ExecMode execMode, int testId) {
 		boolean old_simplification = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
@@ -130,12 +142,17 @@ public class LineageReuseSparkTest extends AutomatedTestBase {
 			boolean matchVal = TestUtils.compareMatrices(R, R_reused, 1e-6, "Origin", "withPrefetch");
 			if (!matchVal)
 				System.out.println("Value w/o reuse "+R+" w/ reuse "+R_reused);
-			if (testId == 1 || testId == 3) {
+			if (testId == 1) {
 				Assert.assertTrue("Violated sp_tsmm reuse count: " + numTsmm_r + " < " + numTsmm, numTsmm_r < numTsmm);
 				Assert.assertTrue("Violated sp_mapmm reuse count: " + numMapmm_r + " < " + numMapmm, numMapmm_r < numMapmm);
 			}
+			if (testId == 3)
+				Assert.assertTrue("Violated sp_mapmm reuse count: " + numMapmm_r + " < " + numMapmm, numMapmm_r < numMapmm);
 			if (testId == 2)
 				Assert.assertTrue("Violated sp_rmm reuse count: " + numRmm_r + " < " + numRmm, numRmm_r < numRmm);
+			if (testId == 4 || testId == 5) { // fn/SB reuse
+				Assert.assertTrue((LineageCacheStatistics.getMultiLevelFnHits() + LineageCacheStatistics.getMultiLevelSBHits()) > 1);
+			}
 		} finally {
 			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = old_simplification;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = old_sum_product;

--- a/src/test/scripts/functions/async/LineageReuseSpark4.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark4.dml
@@ -19,16 +19,16 @@
 #
 #-------------------------------------------------------------
 
-SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y, Double lamda, Integer N) 
+SimlinRegDS = function(Matrix[Double] X, Matrix[Double] y) 
 return (Matrix[double] A, Matrix[double] b)
 {
   # Reuse sp_tsmm and sp_mapmm if not future-based
-  A = (t(X) %*% X) + diag(matrix(lamda, rows=N, cols=1));
+  A = (t(X) %*% X); 
   while(FALSE){}
   b = t(X) %*% y;
 }
 
-no_lamda = 2;
+no_lamda = 5;
 
 stp = (0.1 - 0.0001)/no_lamda;
 lamda = 0.0001;
@@ -38,19 +38,35 @@ X = rand(rows=1500, cols=1500, seed=42);
 y = rand(rows=1500, cols=1, seed=43);
 N = ncol(X);
 R = matrix(0, rows=N, cols=no_lamda+2);
+i = 1;
 
-[A, b] = SimlinRegDS(X, y, lamda, N);
-beta = solve(A, b);
+while (lamda < lim)
+{
+  [A, b] = SimlinRegDS(X, y);
+  A_diag = A + diag(matrix(lamda, rows=N, cols=1));
+  beta = solve(A_diag, b);
+  R[,i] = beta;
+  lamda = lamda + stp;
+  i = i + 1;
+}
+
+/*[A, b] = SimlinRegDS(X, y);
+A_diag = A + diag(matrix(lamda, rows=N, cols=1));
+beta = solve(A_diag, b);
 R[,1] = beta;
+lamda = lamda + stp;
 
 # Reuse function call
-[A, b] = SimlinRegDS(X, y, lamda, N);
-beta = solve(A, b);
+[A, b] = SimlinRegDS(X, y);
+A_diag = A + diag(matrix(lamda, rows=N, cols=1));
+beta = solve(A_diag, b);
 R[,2] = beta;
+lamda = lamda + stp;
 
-[A, b] = SimlinRegDS(X, y, lamda, N);
-beta = solve(A, b);
-R[,3] = beta;
+[A, b] = SimlinRegDS(X, y);
+A_diag = A + diag(matrix(lamda, rows=N, cols=1));
+beta = solve(A_diag, b);
+R[,3] = beta;*/
 
 R = sum(R);
 write(R, $1, format="text");

--- a/src/test/scripts/functions/async/LineageReuseSpark5.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark5.dml
@@ -1,0 +1,56 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+M = 10000;
+N = 200;
+sp = 1.0; #1.0
+nweights = 10; #3000
+
+X = rand(rows=M, cols=N, sparsity=sp, seed=42);
+y = rand(rows=M, cols=1, min=0, max=2, seed=42);
+y = ceil(y);
+
+model_svm = l2svm(X=X, Y=y, intercept=TRUE, epsilon=1e-12,
+ reg=0.001, maxIterations=20, verbose=FALSE);
+model_mlr = multiLogReg(X=X, Y=y, icpt=2, tol=1e-6, reg=0.001, maxi=20, maxii=20, verbose=FALSE);
+
+# Assign random weights and grid search top-k models
+bestAcc = 0;
+weights = rand(rows=2, cols=nweights, min=0, max=1, seed=42);
+nclass = 2;
+k = 2;
+for (wi in 1:nweights) {
+  weightedClassProb = matrix(0, M, 2);
+  for (i in 1:k) {
+    [yRaw, yPred] = l2svmPredict(X=X, W=model_svm, verbose=FALSE);
+    probs_svm = yRaw / rowSums(yRaw);
+    [prob_mlr, Y_mlr, acc] = multiLogRegPredict(X=X, B=model_mlr, Y=y, verbose=FALSE);
+    weightedClassProb = weightedClassProb + as.scalar(weights[1,wi])*probs_svm + as.scalar(weights[2,wi])*prob_mlr;
+    y_voted = rowIndexMax(weightedClassProb);
+    acc = sum(y_voted == y) / M * 100;
+    if (acc > bestAcc) {
+      bestWeights = weights;
+      bestAcc = acc;
+    }
+  }
+}
+R = bestAcc;
+write(R, $1, format="text");
+

--- a/src/test/scripts/functions/async/LineageReuseSpark6.dml
+++ b/src/test/scripts/functions/async/LineageReuseSpark6.dml
@@ -1,0 +1,101 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+randRegSample = function(Matrix[Double] lamdas, Double ratio)
+return (Matrix[Double] samples) {
+  temp = rand(rows=nrow(lamdas), cols=1, min=0, max=1, seed=42) < ratio;
+  samples = removeEmpty(target=lamdas, margin="rows", select=temp);
+}
+
+l2norm = function(Matrix[Double] X, Matrix[Double] y, Matrix[Double] B)
+return (Double accuracy) {
+  #loss = as.matrix(sum((y - X%*%B)^2));
+  [yRaw, yPred] = l2svmPredict(X=X, W=B, verbose=FALSE);
+  accuracy = sum((yPred - y) == 0) / nrow(y) * 100;
+}
+
+M = 10000;
+N = 200;
+sp = 1.0; #1.0
+no_bracket = 2; #5
+
+X = rand(rows=M, cols=N, sparsity=sp, seed=42);
+y = rand(rows=M, cols=1, min=0, max=2, seed=42);
+y = ceil(y);
+
+no_lamda = 25; #starting combintaions = 25 * 4 = 100 HPs
+stp = (0.1 - 0.0001)/no_lamda;
+HPlamdas = seq(0.0001, 0.1, stp);
+maxIter = 10; #starting interation count = 100 * 10 = 1k
+
+for (r in 1:no_bracket) {
+  i = 1;
+  svmModels = matrix(0, rows=no_lamda, cols=ncol(X)+2); #first col is accuracy
+  mlrModels = matrix(0, rows=no_lamda, cols=ncol(X)+2); #first col is accuracy
+  # Optimize for regularization parameters
+  print("#lamda = "+no_lamda+", maxIterations = "+maxIter);
+  for (l in 1:no_lamda)
+  {
+    #print("lamda = "+as.scalar(HPlamdas[i,1])+", maxIterations = "+maxIter);
+    #Run L2svm with intercept true
+    beta = l2svm(X=X, Y=y, intercept=TRUE, epsilon=1e-12,
+      reg = as.scalar(HPlamdas[i,1]), maxIterations=maxIter, verbose=FALSE);
+    svmModels[i,1] = l2norm(X, y, beta); #1st column
+    svmModels[i,2:nrow(beta)+1] = t(beta);
+
+    #Run L2svm with intercept false
+    beta = l2svm(X=X, Y=y, intercept=FALSE, epsilon=1e-12,
+      reg = as.scalar(HPlamdas[i,1]), maxIterations=maxIter, verbose=FALSE);
+    svmModels[i,1] = l2norm(X, y, beta); #1st column
+    svmModels[i,2:nrow(beta)+1] = t(beta);
+
+    #Run multilogreg with intercept true
+    beta = multiLogReg(X=X, Y=y, icpt=2, tol=1e-6, reg=as.scalar(HPlamdas[i,1]),
+      maxi=maxIter, maxii=20, verbose=FALSE);
+    [prob_mlr, Y_mlr, acc] = multiLogRegPredict(X=X, B=beta, Y=y, verbose=FALSE);
+    mlrModels[i,1] = acc; #1st column
+    mlrModels[i,2:nrow(beta)+1] = t(beta);
+
+    #Run multilogreg with intercept false
+    beta = multiLogReg(X=X, Y=y, icpt=1, tol=1e-6, reg=as.scalar(HPlamdas[i,1]),
+      maxi=maxIter, maxii=20, verbose=FALSE);
+    [prob_mlr, Y_mlr, acc] = multiLogRegPredict(X=X, B=beta, Y=y, verbose=FALSE);
+    mlrModels[i,1] = acc; #1st column
+    mlrModels[i,2:nrow(beta)+1] = t(beta);
+
+    i = i + 1;
+  }
+  #Sort the models based on accuracy
+  svm_order = order(target=svmModels, by=1);
+  bestAccSvm = svm_order[1,1];
+  print(toString(bestAccSvm));
+  mlr_order = order(target=mlrModels, by=1);
+  bestAccMlr = mlr_order[1,1];
+  print(toString(bestAccMlr));
+
+  #double the iteration count and half the HPs
+  maxIter = maxIter * 2;
+  HPlamdas = randRegSample(HPlamdas, 0.5);
+  #TODO: select the models with highest accruacies
+  no_lamda = nrow(HPlamdas);
+}
+R = sum(bestAccSvm) + sum(bestAccMlr);
+write(R, $1, format="text");
+


### PR DESCRIPTION
This patch adds methods to clean up the child RDDs of lineage cached RDDs. On the first hit, we marked the RDD but let it and its child RDDs get cleaned up by the rmVar logic. On the second hit, we call persist while putting that RDD in the cache. On a later hit, if the RDD is already persisted, we clean up the child RDDs including the checkpointed and broadcast variables. If still not persisted, we asynchronously move the RDD to Spark by triggering a job after a few local reuse. A future reuse then cleans up the child RDDs.