### PR TITLE
[SYSTEMDS-3610] BuiltinSwitch Aggregate Skip

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/functionobjects/Builtin.java
+++ b/src/main/java/org/apache/sysds/runtime/functionobjects/Builtin.java
@@ -115,7 +115,7 @@ public class Builtin extends ValueFunction
 		String2BuiltinCode.put( "applySchema", BuiltinCode.APPLY_SCHEMA);
 	}
 	
-	private Builtin(BuiltinCode bf) {
+	protected Builtin(BuiltinCode bf) {
 		bFunc = bf;
 	}
 	
@@ -142,6 +142,10 @@ public class Builtin extends ValueFunction
 	public static Builtin getBuiltinFnObject(BuiltinCode code) {
 		if ( code == null ) 
 			return null; 
+		if(code == BuiltinCode.MAX)
+			return Max.getMaxFnObject();
+		else if (code == BuiltinCode.MIN)
+			return Min.getMinFnObject();
 		return new Builtin(code);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/functionobjects/Max.java
+++ b/src/main/java/org/apache/sysds/runtime/functionobjects/Max.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.functionobjects;
+
+public class Max extends Builtin {
+	private static Max singleObj = null;
+
+	private Max() {
+		super(BuiltinCode.MAX);
+		// nothing to do here.
+	}
+
+	private static final long serialVersionUID = 6529946102263905602L;
+
+	public static Max getMaxFnObject() {
+		if(singleObj == null)
+			singleObj = new Max();
+		return singleObj;
+	}
+
+	@Override
+	public boolean execute(boolean in1, boolean in2) {
+		return in1 || in2;
+	}
+
+	@Override
+	public double execute(long in1, long in2) {
+		return Math.max(in1, in2);
+	}
+
+	@Override
+	public double execute(double in1, double in2) {
+		return Math.max(in1, in2);
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/functionobjects/Min.java
+++ b/src/main/java/org/apache/sysds/runtime/functionobjects/Min.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.functionobjects;
+
+public class Min extends Builtin {
+	private static Min singleObj = null;
+
+	private Min() {
+		super(BuiltinCode.MIN);
+		// nothing to do here.
+	}
+
+	private static final long serialVersionUID = 6529946102263905602L;
+
+	public static Min getMinFnObject() {
+		if(singleObj == null)
+			singleObj = new Min();
+		return singleObj;
+	}
+
+	@Override
+	public boolean execute(boolean in1, boolean in2) {
+		return !(!in1 || !in2);
+	}
+
+	@Override
+	public double execute(long in1, long in2) {
+		return Math.min(in1, in2);
+	}
+
+	@Override
+	public double execute(double in1, double in2) {
+		return Math.min(in1, in2);
+	}
+}


### PR DESCRIPTION
I have observed depending on JVM the switch case in the builtin objects is taking a long time. we can remove this by having dedicated objects.
