### PR TITLE
[MINOR] Refine internal sparse printing

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
@@ -888,14 +888,14 @@ public class SparseBlockCSR extends SparseBlock
 			final int pos = pos(i);
 			final int len = size(i);
 			if(pos < pos + len) {
-				sb.append(String.format("row %0"+rowDigits+"d -- ", i));
+				sb.append(String.format("%0"+rowDigits+"d ", i));
 				for(int j = pos; j < pos + len; j++) {
 					if(_values[j] == (long) _values[j])
 						sb.append(String.format("%"+rowDigits+"d:%d", _indexes[j], (long)_values[j]));
 					else
 						sb.append(String.format("%"+rowDigits+"d:%s", _indexes[j], Double.toString(_values[j])));
 					if(j + 1 < pos + len)
-						sb.append(", ");
+						sb.append(" ");
 				}
 				sb.append("\n");
 			}

--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlockMCSR.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlockMCSR.java
@@ -87,8 +87,12 @@ public class SparseBlockMCSR extends SparseBlock
 		}
 	}
 	
-	public SparseBlockMCSR(int rlen, int clen) {
+	public SparseBlockMCSR(int rlen){
 		_rows = new SparseRow[rlen];
+	}
+
+	public SparseBlockMCSR(int rlen, int clen) {
+		this(rlen);
 	}
 	
 	/**
@@ -436,7 +440,7 @@ public class SparseBlockMCSR extends SparseBlock
 		for( int i=0; i<nRow; i++ ) {
 			if(isEmpty(i))
 				continue;
-			sb.append(String.format("row %0"+rowDigits+"d -- %s\n", i, _rows[i].toString()));
+			sb.append(String.format("%0"+rowDigits+"d %s\n", i, _rows[i].toString()));
 		}
 		
 		return sb.toString();

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
@@ -148,7 +148,7 @@ public abstract class SparseRow implements Serializable
 			else
 				sb.append(String.format("%"+rowDigits+"d:%s", indexes[i], Double.toString(values[i])));
 			if(i + 1 < s)
-				sb.append(", ");
+				sb.append(" ");
 		}
 		
 		return sb.toString();


### PR DESCRIPTION
This commit change the internal printing of sparse matrices to print in LIBSVM format. The change happens because I realized that I accidentally made the internal writer print something very close to LIBSVM. I could therefore not help myself not to make a minor refinement to make it LIBSVM.