### PR TITLE
[MINOR] Parallel NNz count MatrixBlock

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/Pair.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/Pair.java
@@ -17,54 +17,46 @@
  * under the License.
  */
 
-
 package org.apache.sysds.runtime.matrix.data;
 
-public class Pair<K, V> 
-{
-	
+public class Pair<K, V> {
+
 	private K key;
 	private V value;
-	
-	public Pair()
-	{
-		key=null;
-		value=null;
+
+	public Pair() {
+		key = null;
+		value = null;
 	}
-	
-	public Pair(K k, V v)
-	{
-		set(k, v);
+
+	public Pair(K k, V v) {
+		key = k;
+		value = v;
 	}
-	
-	public void setKey(K k)
-	{
-		key=k;
+
+	public final void setKey(K k) {
+		key = k;
 	}
-	
-	public void setValue(V v)
-	{
-		value=v;
+
+	public final void setValue(V v) {
+		value = v;
 	}
-	
-	public void set(K k, V v)
-	{
-		key=k;
-		value=v;
+
+	public final void set(K k, V v) {
+		key = k;
+		value = v;
 	}
-	
-	public K getKey()
-	{
+
+	public final K getKey() {
 		return key;
 	}
-	
-	public V getValue()
-	{
+
+	public final V getValue() {
 		return value;
 	}
 
 	@Override
-	public String toString(){
+	public String toString() {
 		return key + ":" + value;
 	}
 }

--- a/src/test/java/org/apache/sysds/performance/simple/NNZ.java
+++ b/src/test/java/org/apache/sysds/performance/simple/NNZ.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.performance.simple;
+
+import org.apache.sysds.runtime.controlprogram.parfor.stat.Timing;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+
+public class NNZ {
+    public static void main(String[] args) {
+        MatrixBlock mb = TestUtils.generateTestMatrixBlock(10000, 1000, 0, 103, 0.7, 421);
+        Timing t = new Timing();
+        t.start();
+        for(int i = 0; i < 1000; i++) {
+            mb.recomputeNonZeros();
+        }
+        System.out.println("single:   " + t.stop()/ 1000);
+        t.start();
+        for(int i = 0; i < 1000; i++) {
+
+            mb.recomputeNonZeros(16);
+        }
+
+        System.out.println("par:      " + t.stop()/ 1000);
+        t.start();
+        for(int i = 0; i < 1000; i++) {
+            mb.recomputeNonZeros();
+        }
+        System.out.println("single:   " + t.stop()/ 1000);
+        t.start();
+        for(int i = 0; i < 1000; i++) {
+
+            mb.recomputeNonZeros(16);
+        }
+
+        System.out.println("par:      " + t.stop()/ 1000);
+    }
+}


### PR DESCRIPTION
This commit adds another method to count the nnz values in a MatrixBlock in parallel. This gives no improvement in performance for sparseBlocks and therefore defaults to our default nnz count in that case. For a dense: i see improvements of 7.9 ms to 3.4 ms on a 10k by 1k matrix.