### PR TITLE
[SYSTEMDS-3619] IO save Encoded

### DIFF
--- a/scripts/builtin/auc.dml
+++ b/scripts/builtin/auc.dml
@@ -19,7 +19,7 @@
 #
 #-------------------------------------------------------------
 
-# This builting function computes the area under the ROC curve (AUC)
+# This builtin function computes the area under the ROC curve (AUC)
 # for binary classifiers.
 #
 # INPUT:

--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -70,6 +70,7 @@ public class DMLConfig
 	public static final String DEFAULT_BLOCK_SIZE   = "sysds.defaultblocksize";
 	public static final String CP_PARALLEL_OPS      = "sysds.cp.parallel.ops";
 	public static final String CP_PARALLEL_IO       = "sysds.cp.parallel.io";
+	public static final String IO_COMPRESSION_CODEC = "sysds.io.compression.encoding";
 	public static final String PARALLEL_ENCODE      = "sysds.parallel.encode";  // boolean: enable multi-threaded transformencode and apply
 	public static final String PARALLEL_ENCODE_STAGED = "sysds.parallel.encode.staged";
 	public static final String PARALLEL_ENCODE_APPLY_BLOCKS = "sysds.parallel.encode.applyBlocks";
@@ -154,6 +155,7 @@ public class DMLConfig
 		_defaultVals.put(DEFAULT_BLOCK_SIZE,     String.valueOf(OptimizerUtils.DEFAULT_BLOCKSIZE) );
 		_defaultVals.put(CP_PARALLEL_OPS,        "true" );
 		_defaultVals.put(CP_PARALLEL_IO,         "true" );
+		_defaultVals.put(IO_COMPRESSION_CODEC,   "none");
 		_defaultVals.put(PARALLEL_TOKENIZE,      "false");
 		_defaultVals.put(PARALLEL_TOKENIZE_NUM_BLOCKS, "64");
 		_defaultVals.put(PARALLEL_ENCODE,        "true" );
@@ -463,7 +465,7 @@ public class DMLConfig
 			FLOATING_POINT_PRECISION, GPU_EVICTION_POLICY, LOCAL_SPARK_NUM_THREADS, EVICTION_SHADOW_BUFFERSIZE,
 			GPU_MEMORY_ALLOCATOR, GPU_MEMORY_UTILIZATION_FACTOR, USE_SSL_FEDERATED_COMMUNICATION,
 			DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT, FEDERATED_TIMEOUT, FEDERATED_MONITOR_FREQUENCY, FEDERATED_COMPRESSION,
-			ASYNC_PREFETCH, ASYNC_SPARK_BROADCAST, ASYNC_SPARK_CHECKPOINT
+			ASYNC_PREFETCH, ASYNC_SPARK_BROADCAST, ASYNC_SPARK_CHECKPOINT, IO_COMPRESSION_CODEC
 		}; 
 		
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/hops/FunctionOp.java
+++ b/src/main/java/org/apache/sysds/hops/FunctionOp.java
@@ -24,12 +24,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.lops.Compression;
+import org.apache.sysds.lops.Data;
+import org.apache.sysds.lops.DeCompression;
 import org.apache.sysds.lops.FunctionCallCP;
 import org.apache.sysds.lops.Lop;
 import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.parser.DMLProgram;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.compress.SingletonLookupHashMap;
 import org.apache.sysds.runtime.controlprogram.Program;
 import org.apache.sysds.runtime.controlprogram.parfor.opt.CostEstimatorHops;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
@@ -295,18 +299,42 @@ public class FunctionOp extends Hop
 			tmp.add( in.constructLops() );
 		
 		//construct function call
-		Lop fcall = new FunctionCallCP(tmp, _fnamespace, _fname, _inputNames, _outputNames, _outputHops, _opt, et);
+		FunctionCallCP fcall = new FunctionCallCP(tmp, _fnamespace, _fname, _inputNames, _outputNames, _outputHops, _opt, et);
 		setLineNumbers(fcall);
 		setLops(fcall);
 		
 		//note: no reblock lop because outputs directly bound
+		constructAndSetCompressionLopFunctionalIfRequired(et);
 
 		return getLops();
 	}
 
+	protected void constructAndSetCompressionLopFunctionalIfRequired(ExecType et) {
+		if((requiresCompression()) && ((FunctionCallCP) getLops()).getFunctionName().equalsIgnoreCase("transformencode")){ // xor
+			
+			// Lop matrixOut = lop.getFunctionOutputs().get(0);
+			Lop compressionInstruction = null;
+		
+			if(_compressedWorkloadTree != null) {
+				SingletonLookupHashMap m = SingletonLookupHashMap.getMap();
+				int singletonID = m.put(_compressedWorkloadTree);
+				compressionInstruction = new Compression(getLops(), DataType.MATRIX, ValueType.FP64, et, singletonID);
+			}
+			else
+				compressionInstruction = new Compression(getLops(), DataType.MATRIX, ValueType.FP64, et, 0);
+			
+
+			setOutputDimensions( compressionInstruction );
+			setLineNumbers( compressionInstruction );
+			setLops( compressionInstruction );
+
+		}
+	}
+
+
 	@Override
 	public String getOpString() {
-		return OPCODE;
+		return OPCODE + " " + _fnamespace  + " " + _fname;
 	}
 
 	@Override
@@ -385,8 +413,4 @@ public class FunctionOp extends Hop
 		return false;
 	}
 
-	@Override
-	public String toString(){
-		return getOpString();
-	}
 }

--- a/src/main/java/org/apache/sysds/hops/LiteralOp.java
+++ b/src/main/java/org/apache/sysds/hops/LiteralOp.java
@@ -287,9 +287,4 @@ public class LiteralOp extends Hop
 	{
 		return false;
 	}
-
-	@Override
-	public String toString(){
-		return getOpString();
-	}
 }

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -21,6 +21,7 @@ package org.apache.sysds.hops;
 
 import java.util.ArrayList;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.AggOp;
 import org.apache.sysds.common.Types.DataType;
@@ -158,11 +159,13 @@ public class UnaryOp extends MultiThreadedHop
 					}
 					else { // general case MATRIX
 						ExecType et = optFindExecType();
-
 						// special handling cumsum/cumprod/cummin/cumsum
 						if(isCumulativeUnaryOperation() && !(et == ExecType.CP || et == ExecType.GPU)) {
 							// TODO additional physical operation if offsets fit in memory
 							ret = constructLopsSparkCumulativeUnary();
+						}
+						else if(_op == OpOp1.CAST_AS_FRAME && getInput().size() == 2) {
+							throw new NotImplementedException();
 						}
 						else {// default unary
 							final boolean inplace = OptimizerUtils.ALLOW_UNARY_UPDATE_IN_PLACE &&

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteCompressedReblock.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteCompressedReblock.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.AggOp;
+import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.OpOp1;
 import org.apache.sysds.common.Types.OpOp2;
 import org.apache.sysds.common.Types.OpOp3;
@@ -35,6 +36,7 @@ import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.AggBinaryOp;
 import org.apache.sysds.hops.FunctionOp;
 import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.LiteralOp;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.lops.Compression.CompressConfig;
 import org.apache.sysds.parser.DMLProgram;
@@ -92,12 +94,18 @@ public class RewriteCompressedReblock extends StatementBlockRewriteRule {
 	}
 
 	private static void injectCompressionDirective(Hop hop, CompressConfig compress, DMLProgram prog) {
-		if(hop.isVisited() || hop.requiresCompression() || hop.hasCompressedInput())
+		if(hop.isVisited() || hop.requiresCompression())
 			return;
 
-		// recursively process children
+		// recursion for inputs.
 		for(Hop hi : hop.getInput())
 			injectCompressionDirective(hi, compress, prog);
+		
+		// filter candidates.
+		if((HopRewriteUtils.isData(hop, OpOpData.PERSISTENTREAD, DataType.SCALAR))//
+			|| HopRewriteUtils.isData(hop, OpOpData.TRANSIENTREAD, OpOpData.TRANSIENTWRITE)//
+			|| hop instanceof LiteralOp)
+			return;
 
 		// check for compression conditions
 		switch(compress) {
@@ -128,29 +136,41 @@ public class RewriteCompressedReblock extends StatementBlockRewriteRule {
 		if(hop.getDim2() >= 1) {
 			final long x = hop.getDim1();
 			final long y = hop.getDim2();
-			return 
+			final boolean ret = 
 				// If the Cube of the number of rows is greater than multiplying the number of columns by 1024.
 				y << 10 <= x * x
 				// is very sparse and at least 100 rows.
 				|| (hop.getSparsity() < 0.0001 && y > 100);
+			return ret;
 		}
-		return false;
+		else if(hop.getDim1() >= 1){
+			// known rows. but not cols;
+			boolean ret = hop.getDim1() > 10000;
+			return ret;
+		}
+		else{
+			return true; // unknown dimensions lets always try.
+		}
 	}
 
 	public static boolean satisfiesCompressionCondition(Hop hop) {
 		boolean satisfies = false;
-		if(satisfiesSizeConstraintsForCompression(hop))
+		if(satisfiesSizeConstraintsForCompression(hop)){
 			satisfies |= HopRewriteUtils.isData(hop, OpOpData.PERSISTENTREAD);
-
+			satisfies |= HopRewriteUtils.isTransformEncode(hop);
+		}
 		return satisfies;
 	}
 
 	public static boolean satisfiesAggressiveCompressionCondition(Hop hop) {
 		//size-independent conditions (robust against unknowns)
-		boolean satisfies = HopRewriteUtils.isTernary(hop, OpOp3.CTABLE) //matrix (no vector) ctable
-			&& hop.getInput(0).getDataType().isMatrix() && hop.getInput(1).getDataType().isMatrix();
+		boolean satisfies = false;
 		//size-dependent conditions
 		if(satisfiesSizeConstraintsForCompression(hop)) {
+			//matrix (no vector) ctable
+			satisfies |= HopRewriteUtils.isTernary(hop, OpOp3.CTABLE) 
+				&& hop.getInput(0).getDataType().isMatrix() 
+				&& hop.getInput(1).getDataType().isMatrix();
 			satisfies |= HopRewriteUtils.isData(hop, OpOpData.PERSISTENTREAD);
 			satisfies |= HopRewriteUtils.isUnary(hop, OpOp1.ROUND, OpOp1.FLOOR, OpOp1.NOT, OpOp1.CEIL);
 			satisfies |= HopRewriteUtils.isBinary(hop, OpOp2.EQUAL, OpOp2.NOTEQUAL, OpOp2.LESS,

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteRemovePersistentReadWrite.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteRemovePersistentReadWrite.java
@@ -100,8 +100,7 @@ public class RewriteRemovePersistentReadWrite extends HopRewriteRule
 			rule_RemovePersistentDataOp( inputs.get(i) );
 
 		//remove cast if unnecessary
-		if( hop instanceof DataOp )
-		{
+		if( hop instanceof DataOp ) {
 			DataOp dop = (DataOp) hop;
 			OpOpData dotype = dop.getOp();
 			

--- a/src/main/java/org/apache/sysds/lops/Compression.java
+++ b/src/main/java/org/apache/sysds/lops/Compression.java
@@ -61,9 +61,21 @@ public class Compression extends Lop {
 		sb.append(Lop.OPERAND_DELIMITOR);
 		sb.append(OPCODE);
 		sb.append(OPERAND_DELIMITOR);
-		sb.append(getInputs().get(0).prepInputOperand(input1));
+		if(getInputs().get(0) instanceof FunctionCallCP &&
+			((FunctionCallCP)getInputs().get(0)).getFunctionName().equalsIgnoreCase("transformencode") ){
+			sb.append(getInputs().get(0).getOutputs().get(0).getOutputParameters().getLabel());
+		}
+		else{
+			sb.append(getInputs().get(0).prepInputOperand(input1));
+		}
 		sb.append(OPERAND_DELIMITOR);
-		sb.append(prepOutputOperand(output));
+		if(getInputs().get(0) instanceof FunctionCallCP && 
+			((FunctionCallCP)getInputs().get(0)).getFunctionName().equalsIgnoreCase("transformencode") ){
+			sb.append(getInputs().get(0).getOutputs().get(0).getOutputParameters().getLabel());
+		}
+		else{
+			sb.append(prepOutputOperand(output));
+		}
 		if(_singletonLookupKey != 0){
 			sb.append(OPERAND_DELIMITOR);
 			sb.append(_singletonLookupKey);

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -396,24 +396,28 @@ public class CompressedMatrixBlockFactory {
 				compSettings.transposed = false;
 				break;
 			default:
-				if(mb.isInSparseFormat()) {
-					if(mb.getNumColumns() > 10000)
-						// many sparse columns we have to...
-						compSettings.transposed = true;
-					else if(mb.getNonZeros() < 1000)
-						// low nnz trivial to transpose
-						compSettings.transposed = true;
-					else {
-						// is enough rows to make it usable
-						boolean isAboveRowNumbers = mb.getNumRows() > 500000;
-						// Make sure that it is not more efficient to extract the rows.
-						boolean isAboveThreadToColumnRatio = compressionGroups.getNumberColGroups() > mb.getNumColumns() / 30;
-						compSettings.transposed = isAboveRowNumbers && isAboveThreadToColumnRatio;
-					}
-				}
-				else
-					compSettings.transposed = false;
+				compSettings.transposed = transposeHeuristics(compressionGroups.getNumberColGroups() , mb);
 		}
+	}
+
+	public static boolean transposeHeuristics(int nGroups, MatrixBlock mb) {
+		if(mb.isInSparseFormat()) {
+			if(mb.getNumColumns() > 10000 || mb.getNumRows() > 10000)
+				// many sparse columns or rows we have to...
+				return true;
+			else if(mb.getNonZeros() < 1000)
+				// low nnz trivial to transpose
+				return true;
+			else {
+				// is enough rows to make it usable
+				boolean isAboveRowNumbers = mb.getNumRows() > 500000;
+				// Make sure that it is not more efficient to extract the rows.
+				boolean isAboveThreadToColumnRatio = nGroups > mb.getNumColumns() / 30;
+				return isAboveRowNumbers && isAboveThreadToColumnRatio;
+			}
+		}
+		else
+			return false;
 	}
 
 	private void compressPhase() {

--- a/src/main/java/org/apache/sysds/runtime/compress/bitmap/BitmapEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/bitmap/BitmapEncoder.java
@@ -73,7 +73,8 @@ public class BitmapEncoder {
 		final int numRows = transposed ? rawBlock.getNumColumns() : rawBlock.getNumRows();
 		final int estimatedNumber = Math.max(estimatedNumberOfUniques, 8);
 		if(colIndices.size() == 1)
-			return extractBitmapSingleColumn(colIndices.get(0), rawBlock, numRows, transposed, estimatedNumber, sortedEntries);
+			return extractBitmapSingleColumn(colIndices.get(0), rawBlock, numRows, transposed, estimatedNumber,
+				sortedEntries);
 		else
 			return extractBitmapMultiColumns(colIndices, rawBlock, numRows, transposed, estimatedNumber, sortedEntries);
 	}
@@ -165,10 +166,18 @@ public class BitmapEncoder {
 		boolean transposed, int estimatedUnique, boolean sort) {
 		final DblArrayIntListHashMap map = new DblArrayIntListHashMap(estimatedUnique);
 		final ReaderColumnSelection reader = ReaderColumnSelection.createReader(rawBlock, colIndices, transposed);
-
 		DblArray cellVals = null;
-		while((cellVals = reader.nextRow()) != null)
-			map.appendValue(cellVals, reader.getCurrentRowIndex());
+		try {
+			DblArray empty = new DblArray(new double[colIndices.size()]);
+			while((cellVals = reader.nextRow()) != null) {
+				if(!cellVals.equals(empty))
+					map.appendValue(cellVals, reader.getCurrentRowIndex());
+			}
+
+		}
+		catch(Exception e) {
+			throw new RuntimeException("failed extracting bitmap and adding. " + map + "  \n " + cellVals, e);
+		}
 
 		return makeMultiColBitmap(map, numRows, colIndices.size(), sort);
 	}

--- a/src/main/java/org/apache/sysds/runtime/compress/cocode/CoCodeGreedy.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/cocode/CoCodeGreedy.java
@@ -32,6 +32,7 @@ import org.apache.sysds.runtime.compress.cost.ACostEstimate;
 import org.apache.sysds.runtime.compress.estim.AComEst;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfo;
 import org.apache.sysds.runtime.compress.estim.CompressedSizeInfoColGroup;
+import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 
 public class CoCodeGreedy extends AColumnCoCoder {
@@ -43,8 +44,7 @@ public class CoCodeGreedy extends AColumnCoCoder {
 		mem = new Memorizer(sizeEstimator);
 	}
 
-	protected CoCodeGreedy(AComEst sizeEstimator, ACostEstimate costEstimator, CompressionSettings cs,
-		Memorizer mem) {
+	protected CoCodeGreedy(AComEst sizeEstimator, ACostEstimate costEstimator, CompressionSettings cs, Memorizer mem) {
 		super(sizeEstimator, costEstimator, cs);
 		this.mem = mem;
 	}
@@ -64,7 +64,7 @@ public class CoCodeGreedy extends AColumnCoCoder {
 	private List<CompressedSizeInfoColGroup> coCodeBruteForce(List<CompressedSizeInfoColGroup> inputColumns, int k) {
 
 		final List<ColIndexes> workSet = new ArrayList<>(inputColumns.size());
-
+		k = k <= 0 ? InfrastructureAnalyzer.getLocalParallelism() : k;
 		final ExecutorService pool = CommonThreadPool.get(k);
 		for(int i = 0; i < inputColumns.size(); i++) {
 			CompressedSizeInfoColGroup g = inputColumns.get(i);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -178,7 +178,9 @@ public abstract class AColGroup implements Serializable {
 	 * @throws IOException if IOException occurs
 	 */
 	protected void write(DataOutput out) throws IOException {
-		out.writeByte(getColGroupType().ordinal());
+		final byte[] o = new byte[1];
+		o[0] = (byte) getColGroupType().ordinal();
+		out.write(o);
 		_colIndexes.write(out);
 	}
 
@@ -622,10 +624,12 @@ public abstract class AColGroup implements Serializable {
 	 * If it is not possible or very inefficient null is returned.
 	 * 
 	 * @param groups The groups to combine.
+	 * @param blen   The normal number of rows in the groups
+	 * @param rlen   The total number of rows of all combined.
 	 * @return A combined column group or null
 	 */
-	public static AColGroup appendN(AColGroup[] groups) {
-		return groups[0].appendNInternal(groups);
+	public static AColGroup appendN(AColGroup[] groups, int blen, int rlen) {
+		return groups[0].appendNInternal(groups, blen, rlen);
 	}
 
 	/**
@@ -636,9 +640,11 @@ public abstract class AColGroup implements Serializable {
 	 * If it is not possible or very inefficient null is returned.
 	 * 
 	 * @param groups The groups to combine.
+	 * @param blen   The normal number of rows in the groups
+	 * @param rlen   The total number of rows of all combined.
 	 * @return A combined column group or null
 	 */
-	protected abstract AColGroup appendNInternal(AColGroup[] groups);
+	protected abstract AColGroup appendNInternal(AColGroup[] groups, int blen, int rlen);
 
 	/**
 	 * Get the compression scheme for this column group to enable compression of other data.
@@ -713,7 +719,7 @@ public abstract class AColGroup implements Serializable {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(String.format("%15s", "Type: "));
+		sb.append(String.format("\n%15s", "Type: "));
 		sb.append(this.getClass().getSimpleName());
 		sb.append(String.format("\n%15s", "Columns: "));
 		sb.append(_colIndexes);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -544,7 +544,7 @@ public class ColGroupDDC extends APreAgg implements IMapToDataGroup {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
 		for(int i = 1; i < g.length; i++) {
 			if(!_colIndexes.equals(g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending DDC\n" + _colIndexes + "\n\n" + g[i]._colIndexes);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
@@ -452,8 +452,8 @@ public class ColGroupDDCFOR extends AMorphingMMColGroup implements IFrameOfRefer
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -24,11 +24,16 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.ADictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IIterate;
+import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
+import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
+import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
+import org.apache.sysds.runtime.compress.colgroup.offset.OffsetEmpty;
 import org.apache.sysds.runtime.compress.colgroup.scheme.EmptyScheme;
 import org.apache.sysds.runtime.compress.colgroup.scheme.ICLAScheme;
 import org.apache.sysds.runtime.compress.cost.ComputationCostEstimator;
@@ -47,7 +52,8 @@ import org.apache.sysds.runtime.matrix.operators.CMOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 
-public class ColGroupEmpty extends AColGroupCompressed implements IContainADictionary, IContainDefaultTuple {
+public class ColGroupEmpty extends AColGroupCompressed
+	implements IContainADictionary, IContainDefaultTuple, AOffsetsGroup ,IMapToDataGroup{
 	private static final long serialVersionUID = -2307677253622099958L;
 
 	/**
@@ -332,10 +338,16 @@ public class ColGroupEmpty extends AColGroupCompressed implements IContainADicti
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		for(int i = 0; i < g.length; i++)
-			if(!_colIndexes.equals(g[i]._colIndexes))
-				return null;
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		for(int i = 0; i < g.length; i++) {
+			final AColGroup gs = g[i];
+			if(!_colIndexes.equals(gs._colIndexes))
+				throw new DMLCompressionException("Invalid columns not matching " + gs._colIndexes + " " + _colIndexes);
+			if(gs instanceof ColGroupEmpty)
+				continue;
+			else
+				return gs.appendNInternal(g, blen, rlen);
+		}
 		return this;
 	}
 
@@ -379,6 +391,16 @@ public class ColGroupEmpty extends AColGroupCompressed implements IContainADicti
 	@Override
 	protected AColGroup fixColIndexes(IColIndex newColIndex, int[] reordering) {
 		return new ColGroupEmpty(newColIndex);
+	}
+
+	@Override
+	public AOffset getOffsets() {
+		return new OffsetEmpty();
+	}
+
+	@Override
+	public AMapToData getMapToData() {
+		return MapToFactory.create(0, 0);
 	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
@@ -674,8 +674,8 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -665,8 +665,8 @@ public class ColGroupOLE extends AColGroupOffset {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -977,8 +977,8 @@ public class ColGroupRLE extends AColGroupOffset {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		return null;
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -26,10 +26,11 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
-import org.apache.sysds.runtime.compress.colgroup.dictionary.IDictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.DictionaryFactory;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.IDictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.PlaceHolderDict;
 import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
 import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
@@ -67,6 +68,8 @@ public class ColGroupSDC extends ASDC implements IMapToDataGroup {
 	protected ColGroupSDC(IColIndex colIndices, int numRows, IDictionary dict, double[] defaultTuple, AOffset offsets,
 		AMapToData data, int[] cachedCounts) {
 		super(colIndices, numRows, dict, offsets, cachedCounts);
+		_data = data;
+		_defaultTuple = defaultTuple;
 		if(data.getUnique() != dict.getNumberOfValues(colIndices.size())) {
 			if(data.getUnique() != data.getMax())
 				throw new DMLCompressionException(
@@ -77,8 +80,6 @@ public class ColGroupSDC extends ASDC implements IMapToDataGroup {
 		if(defaultTuple.length != colIndices.size())
 			throw new DMLCompressionException("Invalid construction of SDC group");
 
-		_data = data;
-		_defaultTuple = defaultTuple;
 	}
 
 	public static AColGroup create(IColIndex colIndices, int numRows, IDictionary dict, double[] defaultTuple,
@@ -596,30 +597,33 @@ public class ColGroupSDC extends ASDC implements IMapToDataGroup {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = getNumRows();
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
 		for(int i = 1; i < g.length; i++) {
-			if(!_colIndexes.equals(g[i]._colIndexes)) {
-				LOG.warn("Not same columns therefore not appending \n" + _colIndexes + "\n\n" + g[i]._colIndexes);
-				return null;
-			}
+			final AColGroup gs = g[i];
+			if(!_colIndexes.equals(gs._colIndexes))
+				throw new DMLCompressionException(
+					"Not same columns therefore not appending \n" + _colIndexes + "\n\n" + gs._colIndexes);
 
-			if(!(g[i] instanceof ColGroupSDC)) {
-				LOG.warn("Not SDC but " + g[i].getClass().getSimpleName());
-				return null;
-			}
+			if(!(gs instanceof AOffsetsGroup))
+				throw new DMLCompressionException("Not SDC but " + gs.getClass().getSimpleName());
 
-			final ColGroupSDC gc = (ColGroupSDC) g[i];
-			if(!gc._dict.equals(_dict)) {
-				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
-				return null;
+			if(gs instanceof ColGroupSDC) {
+				final ColGroupSDC gc = (ColGroupSDC) gs;
+				if(!gc._dict.equals(_dict))
+					throw new DMLCompressionException(
+						"Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
 			}
-			sumRows += gc.getNumRows();
+			else if(gs instanceof ColGroupConst) {
+				final ColGroupConst gc = (ColGroupConst) gs;
+				if(!(gc._dict instanceof PlaceHolderDict) && gc._dict.equals(_defaultTuple))
+					throw new DMLCompressionException("Not same default values therefore not appending:\n" + gc._dict
+						+ "\n\n" + Arrays.toString(_defaultTuple));
+			}
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, IMapToDataGroup[].class));
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
 
-		return create(_colIndexes, sumRows, _dict, _defaultTuple, no, nd, null);
+		return create(_colIndexes, rlen, _dict, _defaultTuple, no, nd, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -461,8 +461,7 @@ public class ColGroupSDCFOR extends ASDC implements IMapToDataGroup, IFrameOfRef
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = getNumRows();
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
 		for(int i = 1; i < g.length; i++) {
 			if(!_colIndexes.equals(g[i]._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + _colIndexes + "\n\n" + g[i]._colIndexes);
@@ -479,11 +478,10 @@ public class ColGroupSDCFOR extends ASDC implements IMapToDataGroup, IFrameOfRef
 				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
 				return null;
 			}
-			sumRows += gc.getNumRows();
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, IMapToDataGroup[].class));
 		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
-		return create(_colIndexes, sumRows, _dict, no, nd, null, _reference);
+		return create(_colIndexes, rlen, _dict, no, nd, null, _reference);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -766,30 +766,32 @@ public class ColGroupSDCZeros extends ASDCZero implements IMapToDataGroup {
 	}
 
 	@Override
-	public AColGroup appendNInternal(AColGroup[] g) {
-		int sumRows = getNumRows();
+	public AColGroup appendNInternal(AColGroup[] g, int blen, int rlen) {
+		
 		for(int i = 1; i < g.length; i++) {
-			if(!_colIndexes.equals(g[i]._colIndexes)) {
+			final AColGroup gs = g[i];
+			if(!_colIndexes.equals(gs._colIndexes)) {
 				LOG.warn("Not same columns therefore not appending \n" + _colIndexes + "\n\n" + g[i]._colIndexes);
 				return null;
 			}
 
-			if(!(g[i] instanceof ColGroupSDCZeros)) {
-				LOG.warn("Not SDCFOR but " + g[i].getClass().getSimpleName());
+			if(!(gs instanceof AOffsetsGroup )) {
+				LOG.warn("Not valid OffsetGroup but " + gs.getClass().getSimpleName());
 				return null;
 			}
 
-			final ColGroupSDCZeros gc = (ColGroupSDCZeros) g[i];
-			if(!gc._dict.equals(_dict)) {
-				LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
-				return null;
+			if( gs instanceof ColGroupSDCZeros){
+				final ColGroupSDCZeros gc = (ColGroupSDCZeros) gs;
+				if(!gc._dict.equals(_dict)) {
+					LOG.warn("Not same Dictionaries therefore not appending \n" + _dict + "\n\n" + gc._dict);
+					return null;
+				}
 			}
-			sumRows += gc.getNumRows();
 		}
 		AMapToData nd = _data.appendN(Arrays.copyOf(g, g.length, IMapToDataGroup[].class));
-		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), getNumRows());
+		AOffset no = _indexes.appendN(Arrays.copyOf(g, g.length, AOffsetsGroup[].class), blen);
 
-		return create(_colIndexes, sumRows, _dict, no, nd, null);
+		return create(_colIndexes, rlen, _dict, no, nd, null);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/ADictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/ADictionary.java
@@ -52,6 +52,11 @@ public abstract class ADictionary implements IDictionary, Serializable {
 		return false;
 	}
 
+	@Override
+	public final boolean equals(double[] v) {
+		return equals(new Dictionary(v));
+	}
+
 	/**
 	 * Make a double into a string, if the double is a whole number then return it without decimal points
 	 * 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
@@ -1079,15 +1079,16 @@ public class Dictionary extends ADictionary {
 	}
 
 	@Override
-	public void TSMMToUpperTriangleSparseScaling(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight,
-		int[] scale, MatrixBlock result) {
+	public void TSMMToUpperTriangleSparseScaling(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
+		MatrixBlock result) {
 		DictLibMatrixMult.TSMMToUpperTriangleSparseDenseScaling(left, _values, rowsLeft, colsRight, scale, result);
 	}
 
 	@Override
 	public boolean equals(IDictionary o) {
-		if(o instanceof Dictionary)
+		if(o instanceof Dictionary) {
 			return Arrays.equals(_values, ((Dictionary) o)._values);
+		}
 		else if(o instanceof MatrixBlockDictionary) {
 			final MatrixBlock mb = ((MatrixBlockDictionary) o).getMatrixBlock();
 			if(mb.isInSparseFormat())
@@ -1099,7 +1100,7 @@ public class Dictionary extends ADictionary {
 	}
 
 	@Override
-	public IDictionary cbind(IDictionary that, int nCol){
+	public IDictionary cbind(IDictionary that, int nCol) {
 		int nRowThat = that.getNumberOfValues(nCol);
 		int nColThis = _values.length / nRowThat;
 		MatrixBlockDictionary mbd = getMBDict(nColThis);
@@ -1107,12 +1108,12 @@ public class Dictionary extends ADictionary {
 	}
 
 	@Override
-	public IDictionary reorder(int[] reorder){
+	public IDictionary reorder(int[] reorder) {
 		double[] retV = new double[_values.length];
 		Dictionary ret = new Dictionary(retV);
 		int nRows = _values.length / reorder.length;
 
-		for(int r = 0; r < nRows; r++){
+		for(int r = 0; r < nRows; r++) {
 			int off = r * reorder.length;
 			for(int c = 0; c < reorder.length; c++)
 				retV[off + c] = _values[off + reorder[c]];

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
@@ -75,8 +75,8 @@ public interface IDictionary {
 	public long getInMemorySize();
 
 	/**
-	 * Aggregate all the contained values, useful in value only computations where the operation is iterating through
-	 * all values contained in the dictionary.
+	 * Aggregate all the contained values, useful in value only computations where the operation is iterating through all
+	 * values contained in the dictionary.
 	 * 
 	 * @param init The initial Value, in cases such as Max value, this could be -infinity
 	 * @param fn   The Function to apply to values
@@ -572,8 +572,7 @@ public interface IDictionary {
 	/**
 	 * Allocate a new dictionary where the tuple given is subtracted from all tuples in the previous dictionary.
 	 * 
-	 * @param tuple a double list representing a tuple, it is given that the tuple with is the same as this
-	 *              dictionaries.
+	 * @param tuple a double list representing a tuple, it is given that the tuple with is the same as this dictionaries.
 	 * @return a new instance of dictionary with the tuple subtracted.
 	 */
 	public IDictionary subtractTuple(double[] tuple);
@@ -788,8 +787,8 @@ public interface IDictionary {
 	public double getSparsity();
 
 	/**
-	 * Multiply the v value with the dictionary entry at dictIdx and add it to the ret matrix at the columns specified
-	 * in the int array.
+	 * Multiply the v value with the dictionary entry at dictIdx and add it to the ret matrix at the columns specified in
+	 * the int array.
 	 * 
 	 * @param v       Value to multiply
 	 * @param ret     Output dense double array location
@@ -869,8 +868,7 @@ public interface IDictionary {
 	 * @param colsRight Offset cols on the right
 	 * @param result    The output matrix block
 	 */
-	public void TSMMToUpperTriangleSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight,
-		MatrixBlock result);
+	public void TSMMToUpperTriangleSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result);
 
 	/**
 	 * Matrix multiplication but allocate output in upper triangle and twice if on diagonal, note this is left
@@ -924,6 +922,14 @@ public interface IDictionary {
 	 * @return If they are equal
 	 */
 	public boolean equals(Object o);
+
+	/**
+	 * Indicate if this object is equal to the given array of doubles.
+	 * 
+	 * @param v The list of double values
+	 * @return If they are equal to this.
+	 */
+	public boolean equals(double[] v);
 
 	/**
 	 * Indicate if the other dictionary is equal to this.

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
@@ -29,6 +29,7 @@ import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.instructions.cp.CM_COV_Object;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
@@ -36,467 +37,474 @@ import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 
 public class PlaceHolderDict implements IDictionary, Serializable {
 
-    private static final long serialVersionUID = 9176356558592L;
-
-    private static final String errMessage = "PlaceHolderDict does not support Operations, and is purely intended for serialization";
-
-    /** The number of values supposed to be contained in this dictionary */
-    private final int nVal;
-
-    public PlaceHolderDict(int nVal) {
-        this.nVal = nVal;
-    }
-
-    @Override
-    public double[] getValues() {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double getValue(int i) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double getValue(int r, int col, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public long getInMemorySize() {
-        return 16 + 4;
-    }
-
-    @Override
-    public double aggregate(double init, Builtin fn) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double aggregateWithReference(double init, Builtin fn, double[] reference, boolean def) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] aggregateRows(Builtin fn, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] aggregateRowsWithDefault(Builtin fn, double[] defaultTuple) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] aggregateRowsWithReference(Builtin fn, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void aggregateCols(double[] c, Builtin fn, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void aggregateColsWithReference(double[] c, Builtin fn, IColIndex colIndexes, double[] reference,
-        boolean def) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyScalarOp(ScalarOperator op) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyScalarOpAndAppend(ScalarOperator op, double v0, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyUnaryOp(UnaryOperator op) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyUnaryOpAndAppend(UnaryOperator op, double v0, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyScalarOpWithReference(ScalarOperator op, double[] reference, double[] newReference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary applyUnaryOpWithReference(UnaryOperator op, double[] reference, double[] newReference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpLeft(BinaryOperator op, double[] v, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpLeftAndAppend(BinaryOperator op, double[] v, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpLeftWithReference(BinaryOperator op, double[] v, IColIndex colIndexes, double[] reference,
-        double[] newReference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpRight(BinaryOperator op, double[] v, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpRightAndAppend(BinaryOperator op, double[] v, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpRight(BinaryOperator op, double[] v) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary binOpRightWithReference(BinaryOperator op, double[] v, IColIndex colIndexes, double[] reference,
-        double[] newReference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        out.writeByte(DictionaryFactory.Type.PLACE_HOLDER.ordinal());
-        out.writeInt(nVal);
-    }
-
-    public static PlaceHolderDict read(DataInput in) throws IOException {
-        int nVals = in.readInt();
-        return new PlaceHolderDict(nVals);
-    }
-
-    @Override
-    public long getExactSizeOnDisk() {
-        return 1 + 4;
-    }
-
-    @Override
-    public DictType getDictType() {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public int getNumberOfValues(int ncol) {
-        return nVal;
-    }
-
-    @Override
-    public double[] sumAllRowsToDouble(int nrColumns) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] sumAllRowsToDoubleWithDefault(double[] defaultTuple) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] sumAllRowsToDoubleWithReference(double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] sumAllRowsToDoubleSq(int nrColumns) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] sumAllRowsToDoubleSqWithDefault(double[] defaultTuple) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] sumAllRowsToDoubleSqWithReference(double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] productAllRowsToDouble(int nrColumns) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] productAllRowsToDoubleWithDefault(double[] defaultTuple) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double[] productAllRowsToDoubleWithReference(double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void colSum(double[] c, int[] counts, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void colSumSq(double[] c, int[] counts, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void colSumSqWithReference(double[] c, int[] counts, IColIndex colIndexes, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double sum(int[] counts, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double sumSq(int[] counts, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double sumSqWithReference(int[] counts, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public String getString(int colIndexes) {
-        return ""; // get string empty
-    }
-
-    @Override
-    public IDictionary sliceOutColumnRange(int idxStart, int idxEnd, int previousNumberOfColumns) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public boolean containsValue(double pattern) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public boolean containsValueWithReference(double pattern, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public long getNumberNonZeros(int[] counts, int nCol) {
-        return -1;
-    }
-
-    @Override
-    public long getNumberNonZerosWithReference(int[] counts, double[] reference, int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void addToEntry(double[] v, int fr, int to, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void addToEntry(double[] v, int fr, int to, int nCol, int rep) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void addToEntryVectorized(double[] v, int f1, int f2, int f3, int f4, int f5, int f6, int f7, int f8, int t1,
-        int t2, int t3, int t4, int t5, int t6, int t7, int t8, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary subtractTuple(double[] tuple) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public MatrixBlockDictionary getMBDict(int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary scaleTuples(int[] scaling, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary preaggValuesFromDense(int numVals, IColIndex colIndexes, IColIndex aggregateColumns, double[] b,
-        int cut) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary replace(double pattern, double replace, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary replaceWithReference(double pattern, double replace, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void product(double[] ret, int[] counts, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void productWithDefault(double[] ret, int[] counts, double[] def, int defCount) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void productWithReference(double[] ret, int[] counts, double[] reference, int refCount) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void colProduct(double[] res, int[] counts, IColIndex colIndexes) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void colProductWithReference(double[] res, int[] counts, IColIndex colIndexes, double[] reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMoment(ValueFunction fn, int[] counts, int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMoment(CM_COV_Object ret, ValueFunction fn, int[] counts, int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMomentWithDefault(ValueFunction fn, int[] counts, double def, int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMomentWithDefault(CM_COV_Object ret, ValueFunction fn, int[] counts, double def,
-        int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMomentWithReference(ValueFunction fn, int[] counts, double reference, int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public CM_COV_Object centralMomentWithReference(CM_COV_Object ret, ValueFunction fn, int[] counts, double reference,
-        int nRows) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary rexpandCols(int max, boolean ignore, boolean cast, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary rexpandColsWithReference(int max, boolean ignore, boolean cast, int reference) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public double getSparsity() {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void multiplyScalar(double v, double[] ret, int off, int dictIdx, IColIndex cols) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMWithScaling(int[] counts, IColIndex rows, IColIndex cols, MatrixBlock ret) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void MMDict(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void MMDictDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void MMDictSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangle(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangleDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangleSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight,
-        MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangleScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
-        MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangleDenseScaling(double[] left, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
-        MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public void TSMMToUpperTriangleSparseScaling(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
-        MatrixBlock result) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary cbind(IDictionary that, int nCol) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public boolean equals(IDictionary o) {
-        return o instanceof PlaceHolderDict;
-    }
-
-    @Override
-    public IDictionary reorder(int[] reorder) {
-        throw new RuntimeException(errMessage);
-    }
-
-    @Override
-    public IDictionary clone() {
-        return new PlaceHolderDict(nVal);
-    }
+	private static final long serialVersionUID = 9176356558592L;
+
+	private static final String errMessage = "PlaceHolderDict does not support Operations, and is purely intended for serialization";
+
+	/** The number of values supposed to be contained in this dictionary */
+	private final int nVal;
+
+	public PlaceHolderDict(int nVal) {
+		this.nVal = nVal;
+	}
+
+	@Override
+	public double[] getValues() {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double getValue(int i) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double getValue(int r, int col, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public long getInMemorySize() {
+		return 16 + 4;
+	}
+
+	@Override
+	public double aggregate(double init, Builtin fn) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double aggregateWithReference(double init, Builtin fn, double[] reference, boolean def) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] aggregateRows(Builtin fn, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] aggregateRowsWithDefault(Builtin fn, double[] defaultTuple) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] aggregateRowsWithReference(Builtin fn, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void aggregateCols(double[] c, Builtin fn, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void aggregateColsWithReference(double[] c, Builtin fn, IColIndex colIndexes, double[] reference,
+		boolean def) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyScalarOp(ScalarOperator op) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyScalarOpAndAppend(ScalarOperator op, double v0, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyUnaryOp(UnaryOperator op) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyUnaryOpAndAppend(UnaryOperator op, double v0, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyScalarOpWithReference(ScalarOperator op, double[] reference, double[] newReference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary applyUnaryOpWithReference(UnaryOperator op, double[] reference, double[] newReference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpLeft(BinaryOperator op, double[] v, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpLeftAndAppend(BinaryOperator op, double[] v, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpLeftWithReference(BinaryOperator op, double[] v, IColIndex colIndexes, double[] reference,
+		double[] newReference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpRight(BinaryOperator op, double[] v, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpRightAndAppend(BinaryOperator op, double[] v, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpRight(BinaryOperator op, double[] v) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary binOpRightWithReference(BinaryOperator op, double[] v, IColIndex colIndexes, double[] reference,
+		double[] newReference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void write(DataOutput out) throws IOException {
+		byte[] o = new byte[5];
+		o[0] = (byte) DictionaryFactory.Type.PLACE_HOLDER.ordinal();
+		IOUtilFunctions.intToBa(nVal, o, 1);
+		out.write(o);
+	}
+
+	public static PlaceHolderDict read(DataInput in) throws IOException {
+		int nVals = in.readInt();
+		return new PlaceHolderDict(nVals);
+	}
+
+	@Override
+	public long getExactSizeOnDisk() {
+		return 1 + 4;
+	}
+
+	@Override
+	public DictType getDictType() {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public int getNumberOfValues(int ncol) {
+		return nVal;
+	}
+
+	@Override
+	public double[] sumAllRowsToDouble(int nrColumns) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] sumAllRowsToDoubleWithDefault(double[] defaultTuple) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] sumAllRowsToDoubleWithReference(double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] sumAllRowsToDoubleSq(int nrColumns) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] sumAllRowsToDoubleSqWithDefault(double[] defaultTuple) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] sumAllRowsToDoubleSqWithReference(double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] productAllRowsToDouble(int nrColumns) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] productAllRowsToDoubleWithDefault(double[] defaultTuple) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double[] productAllRowsToDoubleWithReference(double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void colSum(double[] c, int[] counts, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void colSumSq(double[] c, int[] counts, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void colSumSqWithReference(double[] c, int[] counts, IColIndex colIndexes, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double sum(int[] counts, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double sumSq(int[] counts, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double sumSqWithReference(int[] counts, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public String getString(int colIndexes) {
+		return ""; // get string empty
+	}
+
+	@Override
+	public IDictionary sliceOutColumnRange(int idxStart, int idxEnd, int previousNumberOfColumns) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public boolean containsValue(double pattern) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public boolean containsValueWithReference(double pattern, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public long getNumberNonZeros(int[] counts, int nCol) {
+		return -1;
+	}
+
+	@Override
+	public long getNumberNonZerosWithReference(int[] counts, double[] reference, int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void addToEntry(double[] v, int fr, int to, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void addToEntry(double[] v, int fr, int to, int nCol, int rep) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void addToEntryVectorized(double[] v, int f1, int f2, int f3, int f4, int f5, int f6, int f7, int f8, int t1,
+		int t2, int t3, int t4, int t5, int t6, int t7, int t8, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary subtractTuple(double[] tuple) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public MatrixBlockDictionary getMBDict(int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary scaleTuples(int[] scaling, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary preaggValuesFromDense(int numVals, IColIndex colIndexes, IColIndex aggregateColumns, double[] b,
+		int cut) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary replace(double pattern, double replace, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary replaceWithReference(double pattern, double replace, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void product(double[] ret, int[] counts, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void productWithDefault(double[] ret, int[] counts, double[] def, int defCount) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void productWithReference(double[] ret, int[] counts, double[] reference, int refCount) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void colProduct(double[] res, int[] counts, IColIndex colIndexes) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void colProductWithReference(double[] res, int[] counts, IColIndex colIndexes, double[] reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMoment(ValueFunction fn, int[] counts, int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMoment(CM_COV_Object ret, ValueFunction fn, int[] counts, int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMomentWithDefault(ValueFunction fn, int[] counts, double def, int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMomentWithDefault(CM_COV_Object ret, ValueFunction fn, int[] counts, double def,
+		int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMomentWithReference(ValueFunction fn, int[] counts, double reference, int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public CM_COV_Object centralMomentWithReference(CM_COV_Object ret, ValueFunction fn, int[] counts, double reference,
+		int nRows) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary rexpandCols(int max, boolean ignore, boolean cast, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary rexpandColsWithReference(int max, boolean ignore, boolean cast, int reference) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public double getSparsity() {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void multiplyScalar(double v, double[] ret, int off, int dictIdx, IColIndex cols) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMWithScaling(int[] counts, IColIndex rows, IColIndex cols, MatrixBlock ret) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void MMDict(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void MMDictDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void MMDictSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangle(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangleDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangleSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight,
+		MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangleScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
+		MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangleDenseScaling(double[] left, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
+		MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void TSMMToUpperTriangleSparseScaling(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, int[] scale,
+		MatrixBlock result) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary cbind(IDictionary that, int nCol) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public boolean equals(IDictionary o) {
+		return o instanceof PlaceHolderDict;
+	}
+
+	@Override
+	public final boolean equals(double[] v) {
+		return false;
+	}
+
+	@Override
+	public IDictionary reorder(int[] reorder) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public IDictionary clone() {
+		return new PlaceHolderDict(nVal);
+	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/indexes/SingleIndex.java
@@ -23,6 +23,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
 
 public class SingleIndex extends AColIndex {
 	private final int idx;
@@ -52,8 +53,10 @@ public class SingleIndex extends AColIndex {
 	}
 
 	public void write(DataOutput out) throws IOException {
-		out.writeByte(ColIndexType.SINGLE.ordinal());
-		out.writeInt(idx);
+		byte[] o = new byte[5];
+		o[0] = (byte) ColIndexType.SINGLE.ordinal();
+		IOUtilFunctions.intToBa(idx, o, 1);
+		out.write(o);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToBit.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToBit.java
@@ -412,16 +412,17 @@ public class MapToBit extends AMapToData {
 			p += gd.getMapToData().size();
 		final long[] ret = new long[longSize(p)];
 
-		long[] or = _data;
-		System.arraycopy(or, 0, ret, 0, or.length);
+		long[] or = null;
 
-		p = size();
-		for(int i = 1; i < d.length; i++) {
-			final MapToBit mm = (MapToBit) d[i].getMapToData();
-			final int ms = mm.size();
-			or = mm._data;
-			BitSetArray.setVectorizedLongs(p, p + ms, ret, or);
-			p += ms;
+		p = 0;
+		for(int i = 0; i < d.length; i++) {
+			if(d[i].getMapToData().size() > 0) {
+				final MapToBit mm = (MapToBit) d[i].getMapToData();
+				final int ms = mm.size();
+				or = mm._data;
+				BitSetArray.setVectorizedLongs(p, p + ms, ret, or);
+				p += ms;
+			}
 		}
 
 		BitSet retBS = BitSet.valueOf(ret);
@@ -441,7 +442,7 @@ public class MapToBit extends AMapToData {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
-		sb.append("size: " + _size);
+		sb.append(" size: " + _size);
 		sb.append(" longLength:[");
 		sb.append(_data.length);
 		sb.append("]");

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToByte.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToByte.java
@@ -238,14 +238,16 @@ public class MapToByte extends AMapToData {
 		int p = 0; // pointer
 		for(IMapToDataGroup gd : d)
 			p += gd.getMapToData().size();
-		final byte[] ret = Arrays.copyOf(_data, p);
+		final byte[] ret = new byte[p];
 
-		p = size();
-		for(int i = 1; i < d.length; i++) {
-			final MapToByte mm = (MapToByte) d[i].getMapToData();
-			final int ms = mm.size();
-			System.arraycopy(mm._data, 0, ret, p, ms);
-			p += ms;
+		p = 0;
+		for(int i = 0; i < d.length; i++) {
+			if(d[i].getMapToData().size() > 0) {
+				final MapToByte mm = (MapToByte) d[i].getMapToData();
+				final int ms = mm.size();
+				System.arraycopy(mm._data, 0, ret, p, ms);
+				p += ms;
+			}
 		}
 
 		if(getUnique() < 127)
@@ -255,14 +257,14 @@ public class MapToByte extends AMapToData {
 	}
 
 	@Override
-	public int getMaxPossible(){
+	public int getMaxPossible() {
 		return 256;
 	}
 
 	@Override
 	public boolean equals(AMapToData e) {
 		return e instanceof MapToByte && //
-			e.getUnique() == getUnique() &&//
+			e.getUnique() == getUnique() && //
 			Arrays.equals(((MapToByte) e)._data, _data);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToCharPByte.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToCharPByte.java
@@ -244,7 +244,26 @@ public class MapToCharPByte extends AMapToData {
 
 	@Override
 	public AMapToData appendN(IMapToDataGroup[] d) {
-		throw new NotImplementedException();
+
+		int p = 0; // pointer
+		for(IMapToDataGroup gd : d)
+			p += gd.getMapToData().size();
+		final char[] ret = new char[p];
+		final byte[] retb = new byte[p];
+
+		p = 0;
+		for(int i = 0; i < d.length; i++) {
+			if(d[i].getMapToData().size() > 0) {
+				final MapToCharPByte mm = (MapToCharPByte) d[i].getMapToData();
+				final int ms = mm.size();
+				System.arraycopy(mm._data_c, 0, ret, p, ms);
+				System.arraycopy(mm._data_b, 0, retb, p, ms);
+				p += ms;
+			}
+		}
+
+		return new MapToCharPByte(getUnique(), ret, retb);
+
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToInt.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToInt.java
@@ -259,28 +259,30 @@ public class MapToInt extends AMapToData {
 		int p = 0; // pointer
 		for(IMapToDataGroup gd : d)
 			p += gd.getMapToData().size();
-		final int[] ret = Arrays.copyOf(_data, p);
+		final int[] ret = new int[p];
 
-		p = size();
-		for(int i = 1; i < d.length; i++) {
-			final MapToInt mm = (MapToInt) d[i].getMapToData();
-			final int ms = mm.size();
-			System.arraycopy(mm._data, 0, ret, p, ms);
-			p += ms;
+		p = 0;
+		for(int i = 0; i < d.length; i++) {
+			if(d[i].getMapToData().size() > 0) {
+				final MapToInt mm = (MapToInt) d[i].getMapToData();
+				final int ms = mm.size();
+				System.arraycopy(mm._data, 0, ret, p, ms);
+				p += ms;
+			}
 		}
 
 		return new MapToInt(getUnique(), ret);
 	}
 
 	@Override
-	public int getMaxPossible(){
+	public int getMaxPossible() {
 		return Integer.MAX_VALUE;
 	}
 
 	@Override
 	public boolean equals(AMapToData e) {
 		return e instanceof MapToInt && //
-			e.getUnique() == getUnique() &&//
+			e.getUnique() == getUnique() && //
 			Arrays.equals(((MapToInt) e)._data, _data);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToZero.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/mapping/MapToZero.java
@@ -163,13 +163,23 @@ public class MapToZero extends AMapToData {
 	@Override
 	public AMapToData appendN(IMapToDataGroup[] d) {
 		int p = 0; // pointer
-		for(IMapToDataGroup gd : d)
-			p += gd.getMapToData().size();
+		boolean allZ = true;
+		for(IMapToDataGroup gd : d) {
+			AMapToData m = gd.getMapToData();
+
+			p += m.size();
+			if(!(m instanceof MapToZero))
+				allZ = false;
+		}
+
+		if(!allZ)
+			throw new RuntimeException("Not supported combining different types of map");
+
 		return new MapToZero(p);
 	}
 
 	@Override
-	public int getMaxPossible(){
+	public int getMaxPossible() {
 		return 1;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/AOffset.java
@@ -50,19 +50,19 @@ public abstract class AOffset implements Serializable {
 
 	protected static final Log LOG = LogFactory.getLog(AOffset.class.getName());
 
+	/** The skip list stride size, aka how many indexes skipped for each index. */
+	protected static final int skipStride = 1000;
+
+	/** SoftReference of the skip list to be dematerialized on memory pressure */
+	private volatile SoftReference<OffsetCacheV2[]> skipList = null;
+
 	/** Thread local cache for a single recently used Iterator, this is used for cache blocking */
-	private ThreadLocal<OffsetCache> cacheRow = new ThreadLocal<>() {
+	private volatile ThreadLocal<OffsetCache> cacheRow = new ThreadLocal<>() {
 		@Override
 		protected OffsetCache initialValue() {
 			return null;
 		}
 	};
-
-	/** The skiplist stride size, aka how many indexes skipped for each index. */
-	protected static final int skipStride = 1000;
-
-	/** SoftReference of the skip list to be dematerialized on memory pressure */
-	private SoftReference<OffsetCacheV2[]> skipList = null;
 
 	/**
 	 * Get an iterator of the offsets while also maintaining the data index pointer.
@@ -104,6 +104,17 @@ public abstract class AOffset implements Serializable {
 			return getIteratorLargeOffset(row);
 	}
 
+	private AIterator getIteratorSkipCache(int row){
+		if(row <= getOffsetToFirst())
+			return getIterator();
+		else if(row > getOffsetToLast())
+			return null;
+		else if(getLength() < skipStride)
+			return getIteratorSmallOffset(row);
+		else
+			return getIteratorLargeOffset(row);
+	}
+
 	private AIterator getIteratorSmallOffset(int row) {
 		AIterator it = getIterator();
 		it.skipTo(row);
@@ -111,7 +122,7 @@ public abstract class AOffset implements Serializable {
 		return it;
 	}
 
-	private AIterator getIteratorLargeOffset(int row) {
+	private final AIterator getIteratorLargeOffset(int row) {
 		if(skipList == null || skipList.get() == null)
 			constructSkipList();
 		final OffsetCacheV2[] skip = skipList.get();
@@ -125,22 +136,23 @@ public abstract class AOffset implements Serializable {
 		return it;
 	}
 
-	private synchronized void constructSkipList() {
+	public synchronized void constructSkipList() {
 		if(skipList != null && skipList.get() != null)
 			return;
 
 		// not actual accurate but applicable.
-		final int skipSize = getLength() / skipStride + 1;
+		final int last = getOffsetToLast();
+		final int skipSize = last / skipStride + 1;
 		if(skipSize == 0)
 			return;
 
 		final OffsetCacheV2[] skipListTmp = new OffsetCacheV2[skipSize];
 		final AIterator it = getIterator();
 
-		final int last = getOffsetToLast();
 		int skipListIdx = 0;
-		while(it.value() < last) {
-			for(int i = 0; i < skipStride && it.value() < last; i++)
+		while(it.value() < last && skipListIdx < skipListTmp.length) {
+			int next = skipListIdx * skipStride + skipStride;
+			while(it.value() < next && it.value() < last)
 				it.next();
 			skipListTmp[skipListIdx++] = new OffsetCacheV2(it.value(), it.getDataIndex(), it.getOffsetsIndex());
 		}
@@ -241,8 +253,8 @@ public abstract class AOffset implements Serializable {
 		}
 	}
 
-	protected final void preAggregateDenseMapRow(double[] mV, int off, double[] preAV, int cu, int nVal,
-		AMapToData data, AIterator it) {
+	protected final void preAggregateDenseMapRow(double[] mV, int off, double[] preAV, int cu, int nVal, AMapToData data,
+		AIterator it) {
 		final int last = getOffsetToLast();
 		if(cu <= last)
 			preAggregateDenseMapRowBellowEnd(mV, off, preAV, cu, nVal, data, it);
@@ -250,8 +262,8 @@ public abstract class AOffset implements Serializable {
 			preAggregateDenseMapRowEnd(mV, off, preAV, last, nVal, data, it);
 	}
 
-	protected final void preAggregateDenseMapRowBellowEnd(final double[] mV, final int off, final double[] preAV,
-		int cu, final int nVal, final AMapToData data, final AIterator it) {
+	protected final void preAggregateDenseMapRowBellowEnd(final double[] mV, final int off, final double[] preAV, int cu,
+		final int nVal, final AMapToData data, final AIterator it) {
 		it.offset += off;
 		cu += off;
 		while(it.offset < cu) {
@@ -426,6 +438,11 @@ public abstract class AOffset implements Serializable {
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof AOffset && this.equals((AOffset) o);
+	}
+
 	public boolean equals(AOffset b) {
 		if(getOffsetToLast() == b.getOffsetToLast()) {
 			int last = getOffsetToLast();
@@ -461,7 +478,7 @@ public abstract class AOffset implements Serializable {
 	public abstract int getLength();
 
 	public OffsetSliceInfo slice(int l, int u) {
-		AIterator it = getIterator(l);
+		AIterator it = getIteratorSkipCache(l);
 		if(it == null || it.value() >= u)
 			return new OffsetSliceInfo(-1, -1, new OffsetEmpty());
 		else if(l <= getOffsetToFirst() && u > getOffsetToLast()) {
@@ -470,13 +487,13 @@ public abstract class AOffset implements Serializable {
 			else
 				return new OffsetSliceInfo(0, getSize(), moveIndex(l));
 		}
-		int low = it.getDataIndex();
-		int lowOff = it.getOffsetsIndex();
-		int lowValue = it.value();
+		final int low = it.getDataIndex();
+		final int lowOff = it.getOffsetsIndex();
+		final int lowValue = it.value();
 
-		int high = it.getDataIndex();
-		int highOff = it.getOffsetsIndex();
-		int highValue = it.value();
+		int high = low;
+		int highOff = lowOff;
+		int highValue = lowValue;
 		if(u >= getOffsetToLast()) { // If including the last do not iterate.
 			high = getSize() - 1;
 			highOff = getLength();
@@ -484,22 +501,20 @@ public abstract class AOffset implements Serializable {
 		}
 		else { // Have to iterate through until we find last.
 			while(it.value() < u) {
+				// TODO add previous command that would allow us to simplify this loop.
 				high = it.getDataIndex();
 				highOff = it.getOffsetsIndex();
 				highValue = it.value();
 				it.next();
 			}
 		}
-
-		lowValue -= l;
-		highValue -= l;
-
+		
 		if(low == high)
-			return new OffsetSliceInfo(low, high + 1, new OffsetSingle(lowValue));
+			return new OffsetSliceInfo(low, high + 1, new OffsetSingle(lowValue - l));
 		else if(low + 1 == high)
-			return new OffsetSliceInfo(low, high + 1, new OffsetTwo(lowValue, highValue));
+			return new OffsetSliceInfo(low, high + 1, new OffsetTwo(lowValue - l, highValue - l));
 		else
-			return ((ISliceOffset) this).slice(lowOff, highOff, lowValue, highValue, low, high);
+			return ((ISliceOffset) this).slice(lowOff, highOff, lowValue - l, highValue - l, low, high);
 	}
 
 	/**
@@ -546,18 +561,25 @@ public abstract class AOffset implements Serializable {
 		int ss = 0;
 		for(AOffsetsGroup gs : g) {
 			final AOffset tof = gs.getOffsets();
-			final AOffsetIterator tofit = tof.getOffsetIterator();
-			final int last = tof.getOffsetToLast() + ss;
-			int v = tofit.value() + ss;
-			while(v < last) {
+			if(!(tof instanceof OffsetEmpty)) {
+				final AOffsetIterator tofit = tof.getOffsetIterator();
+				final int last = tof.getOffsetToLast() + ss;
+				int v = tofit.value() + ss;
+				while(v < last) {
+					r.appendValue(v);
+					v = tofit.next() + ss;
+				}
 				r.appendValue(v);
-				v = tofit.next() + ss;
 			}
-			r.appendValue(v);
 			ss += s;
 		}
 
-		return OffsetFactory.createOffset(r);
+		try {
+			return OffsetFactory.createOffset(r);
+		}
+		catch(Exception e) {
+			throw new DMLCompressionException("failed to combine" + Arrays.toString(g) + " with S sizes: " + s);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByte.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByte.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AOffsetsGroup;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
 public class OffsetByte extends AOffsetByte {
@@ -71,11 +72,13 @@ public class OffsetByte extends AOffsetByte {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
-		out.writeByte(OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTE.ordinal());
-		out.writeInt(offsetToFirst);
-		out.writeInt(offsets.length);
-		out.writeInt(offsetToLast);
-		out.writeInt(size);
+		final byte[] its = new byte[4 *4 + 1];
+		its[0] = (byte) OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTE.ordinal();
+		IOUtilFunctions.intToBa(offsetToFirst, its, 1);
+		IOUtilFunctions.intToBa(offsets.length, its, 5);
+		IOUtilFunctions.intToBa(offsetToLast, its, 9);
+		IOUtilFunctions.intToBa(size, its, 13);
+		out.write(its);
 		out.write(offsets);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByteNZ.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByteNZ.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
 public class OffsetByteNZ extends AOffsetByte {
@@ -55,10 +56,12 @@ public class OffsetByteNZ extends AOffsetByte {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
-		out.writeByte(OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTENZ.ordinal());
-		out.writeInt(offsetToFirst);
-		out.writeInt(offsets.length);
-		out.writeInt(offsetToLast);
+		final byte[] its = new byte[4 *3 + 1];
+		its[0] = (byte) OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTENZ.ordinal();
+		IOUtilFunctions.intToBa(offsetToFirst, its, 1);
+		IOUtilFunctions.intToBa(offsets.length, its, 5);
+		IOUtilFunctions.intToBa(offsetToLast, its, 9);
+		out.write(its);
 		out.write(offsets);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByteUNZ.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetByteUNZ.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.io.IOUtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
 public class OffsetByteUNZ extends AOffsetByte {
@@ -55,10 +56,12 @@ public class OffsetByteUNZ extends AOffsetByte {
 
 	@Override
 	public void write(DataOutput out) throws IOException {
-		out.writeByte(OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTEUNZ.ordinal());
-		out.writeInt(offsetToFirst);
-		out.writeInt(offsets.length);
-		out.writeInt(offsetToLast);
+		final byte[] its = new byte[4 * 3 + 1];
+		its[0] = (byte) OffsetFactory.OFF_TYPE_SPECIALIZATIONS.BYTEUNZ.ordinal();
+		IOUtilFunctions.intToBa(offsetToFirst, its, 1);
+		IOUtilFunctions.intToBa(offsets.length, its, 5);
+		IOUtilFunctions.intToBa(offsetToLast, its, 9);
+		out.write(its);
 		out.write(offsets);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetFactory.java
@@ -273,7 +273,6 @@ public final class OffsetFactory {
 		}
 		boolean noOverHalf = getNoOverHalf(offsets);
 		return OffsetByte.create(offsets, offsetToFirst, offsetToLast, alen - apos, noZero, noOverHalf);
-
 	}
 
 	private static int calcSize(int[] indexes, int apos, int alen, int offMax) {

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetTwo.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/offset/OffsetTwo.java
@@ -97,7 +97,9 @@ public class OffsetTwo extends AOffset {
 	@Override
 	public OffsetSliceInfo slice(int l, int u) {
 		if(l <= first) {
-			if(u > last)
+			if(u < first)
+				return new OffsetSliceInfo(-1, -1, new OffsetEmpty());
+			else if(u > last)
 				return new OffsetSliceInfo(0, 2, moveIndex(l));
 			else
 				return new OffsetSliceInfo(0, 1, new OffsetSingle(first - l));

--- a/src/main/java/org/apache/sysds/runtime/compress/estim/EstimationFactors.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/estim/EstimationFactors.java
@@ -36,7 +36,7 @@ public class EstimationFactors {
 	protected final int largestOff;
 	/** The frequencies of the Non zero tuples in the columns */
 	protected final int[] frequencies;
-	/** The Number of values in the collection not Zero , Also refered to as singletons */
+	/** The Number of values in the collection not Zero, also referred to as singletons */
 	protected final int numSingle;
 	/** The Number of rows in the column group */
 	protected final int numRows;

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
@@ -48,6 +48,7 @@ import org.apache.sysds.runtime.functionobjects.MinusMultiply;
 import org.apache.sysds.runtime.functionobjects.Multiply;
 import org.apache.sysds.runtime.functionobjects.Plus;
 import org.apache.sysds.runtime.functionobjects.PlusMultiply;
+import org.apache.sysds.runtime.functionobjects.ValueComparisonFunction;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell.BinaryAccessType;
@@ -355,8 +356,16 @@ public final class CLALibBinaryCellOp {
 		else
 			nnz = binaryMVColMultiThread(m1, m2, op, left, ret);
 
+		if(op.fn instanceof ValueComparisonFunction) {
+			if(nnz == (long) nRows * nCols)
+				return CompressedMatrixBlockFactory.createConstant(nRows, nCols, 1.0);
+
+			else if(nnz == 0)
+				return CompressedMatrixBlockFactory.createConstant(nRows, nCols, 0.0);
+		}
 		ret.setNonZeros(nnz);
 		ret.examSparsity();
+
 		return ret;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCompAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibCompAgg.java
@@ -568,7 +568,7 @@ public final class CLALibCompAgg {
 			_op = op;
 			_rl = rl;
 			_ru = ru;
-			_blklen = Math.max(65536 * 2 / ret.getNumColumns() / filteredGroups.size(), 64);
+			_blklen = Math.max(65536  / ret.getNumColumns() / filteredGroups.size(), 64);
 			_ret = ret;
 			_nCol = nCol;
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibMatrixMult.java
@@ -63,11 +63,11 @@ public final class CLALibMatrixMult {
 			}
 
 			if(!(m1 instanceof CompressedMatrixBlock) && transposeLeft) {
-				m1 = LibMatrixReorg.transpose(m1, k);
+				m1 = LibMatrixReorg.transpose(m1, k, true);
 				transposeLeft = false;
 			}
 			else if(!(m2 instanceof CompressedMatrixBlock) && transposeRight) {
-				m2 = LibMatrixReorg.transpose(m2, k);
+				m2 = LibMatrixReorg.transpose(m2, k, true);
 				transposeRight = false;
 			}
 		}
@@ -87,7 +87,7 @@ public final class CLALibMatrixMult {
 				LOG.warn("Transposing decompression");
 				ret = ((CompressedMatrixBlock) ret).decompress(k);
 			}
-			ret = LibMatrixReorg.transpose(ret, k);
+			ret = LibMatrixReorg.transpose(ret, k, true);
 		}
 
 		return ret;

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSeparator.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSeparator.java
@@ -44,8 +44,8 @@ public interface CLALibSeparator {
 	 * @return A split of the groups and their dictionaries.
 	 */
 	public static SeparatedGroups split(List<AColGroup> gs) {
-		List<IDictionary> dicts = new ArrayList<>();
-		List<AColGroup> indexStructures = new ArrayList<>();
+		List<IDictionary> dicts = new ArrayList<>(gs.size());
+		List<AColGroup> indexStructures = new ArrayList<>(gs.size());
 		for(AColGroup g : gs) {
 			if(g instanceof ADictBasedColGroup) {
 				ADictBasedColGroup dg = (ADictBasedColGroup) g;
@@ -68,24 +68,25 @@ public interface CLALibSeparator {
 	 * @param gs   groups to combine with dictionaries
 	 * @param d    dictionaries to combine back into the groups.
 	 * @param blen The block size.
-	 * @return A combined list of columngroups.
+	 * @return A combined list of column groups.
 	 */
 	public static List<AColGroup> combine(List<AColGroup> gs, Map<Integer, List<IDictionary>> d, int blen) {
 		int gid = 0;
+		int s = 0;
+		for(List<IDictionary> e : d.values())
+			s += e.size();
+
+		if(gs.size() != s)
+			throw new RuntimeException(
+				"Invalid combine of of groups and dictionaries groups:" + gs.size() + " vs  dicts" + s);
 
 		for(int i = 0; i < d.size(); i++) {
 			List<IDictionary> dd = d.get(i);
 			for(int j = 0; j < dd.size(); j++) {
 				IDictionary ddd = dd.get(j);
-				if(!(ddd instanceof PlaceHolderDict)) {
-
-					AColGroup g = gs.get(gid);
-					while(!(g instanceof ADictBasedColGroup)) {
-						gid++;
-						g = gs.get(gid);
-					}
+				AColGroup g = gs.get(gid);
+				if(g instanceof ADictBasedColGroup) {
 					ADictBasedColGroup dg = (ADictBasedColGroup) g;
-
 					gs.set(gid, dg.copyAndSet(ddd));
 				}
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSlice.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSlice.java
@@ -32,8 +32,6 @@ import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupEmpty;
-import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
-import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
@@ -146,7 +144,6 @@ public final class CLALibSlice {
 	public static MatrixBlock sliceRowsCompressed(CompressedMatrixBlock cmb, int rl, int ru) {
 		final List<AColGroup> groups = cmb.getColGroups();
 		final List<AColGroup> newColGroups = new ArrayList<>(groups.size());
-		final List<IColIndex> emptyGroups = new ArrayList<>();
 		final int rue = ru + 1;
 
 		final CompressedMatrixBlock ret = new CompressedMatrixBlock(rue - rl, cmb.getNumColumns());
@@ -156,16 +153,11 @@ public final class CLALibSlice {
 			if(slice != null)
 				newColGroups.add(slice);
 			else
-				emptyGroups.add(grp.getColIndices());
+				newColGroups.add(new ColGroupEmpty(grp.getColIndices()));
 		}
 
 		if(newColGroups.size() == 0)
 			return new MatrixBlock(rue - rl, cmb.getNumColumns(), 0.0);
-
-		if(!emptyGroups.isEmpty()) {
-			IColIndex empties = ColIndexFactory.combineIndexes(emptyGroups);
-			newColGroups.add(new ColGroupEmpty(empties));
-		}
 
 		ret.allocateColGroupList(newColGroups);
 		ret.setNonZeros(-1);

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/ACount.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/ACount.java
@@ -19,7 +19,7 @@
 
 package org.apache.sysds.runtime.compress.utils;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -186,8 +186,7 @@ public abstract class ACount<T> {
 
 		@Override
 		public DCounts inc(Double key, int c, int id) {
-			// return inc((double) key, c, id);
-			throw new NotImplementedException();
+			return inc((double) key, c, id);
 		}
 
 		@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/ACountHashMap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/ACountHashMap.java
@@ -25,254 +25,254 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.utils.ACount.DCounts;
 
 public abstract class ACountHashMap<T> implements Cloneable {
-    protected static final Log LOG = LogFactory.getLog(ACountHashMap.class.getName());
-    protected static final int RESIZE_FACTOR = 2;
-    protected static final float LOAD_FACTOR = 0.80f;
-    protected static final int shortCutSize = 10;
+	protected static final Log LOG = LogFactory.getLog(ACountHashMap.class.getName());
+	protected static final int RESIZE_FACTOR = 2;
+	protected static final float LOAD_FACTOR = 0.80f;
+	protected static final int shortCutSize = 10;
 
-    protected int size;
-    protected ACount<T>[] data;
+	protected int size;
+	protected ACount<T>[] data;
 
-    public ACountHashMap() {
-        data = create(1);
-        size = 0;
-    }
+	public ACountHashMap() {
+		data = create(1);
+		size = 0;
+	}
 
-    public ACountHashMap(int arrSize) {
-        if(arrSize < shortCutSize)
-            data = create(1);
-        else {
-            arrSize = (int) (arrSize * (1.0 / LOAD_FACTOR));
-            arrSize += arrSize % 2 == 0 ? 1 : 0;
-            data = create(arrSize);
-        }
-        size = 0;
-    }
+	public ACountHashMap(int arrSize) {
+		if(arrSize < shortCutSize)
+			data = create(1);
+		else {
+			arrSize = (int) (arrSize * (1.0 / LOAD_FACTOR));
+			arrSize += arrSize % 2 == 0 ? 1 : 0;
+			data = create(arrSize);
+		}
+		size = 0;
+	}
 
-    public int size() {
-        return size;
-    }
+	public int size() {
+		return size;
+	}
 
-    /**
-     * Increment and return the id of the incremeted index.
-     * 
-     * @param key The key to increment
-     * @return The id of the incremented entry.
-     */
-    public final int increment(T key) {
-        return increment(key, 1);
-    }
+	/**
+	 * Increment and return the id of the incremeted index.
+	 * 
+	 * @param key The key to increment
+	 * @return The id of the incremented entry.
+	 */
+	public final int increment(T key) {
+		return increment(key, 1);
+	}
 
-    public final int increment(double key) {
-        return increment(key, 1);
-    }
+	public final int increment(double key) {
+		return increment(key, 1);
+	}
 
-    /**
-     * Increment and return the id of the incremented index.
-     * 
-     * @param key   The key to increment
-     * @param count The number of times to increment the value
-     * @return The Id of the incremented entry.
-     */
-    public int increment(final T key, final int count) {
-        // skip hash if data array is 1 length
-        final int ix = data.length < shortCutSize ? 0 : hash(key) % data.length;
+	/**
+	 * Increment and return the id of the incremented index.
+	 * 
+	 * @param key   The key to increment
+	 * @param count The number of times to increment the value
+	 * @return The Id of the incremented entry.
+	 */
+	public synchronized int increment(final T key, final int count) {
+		// skip hash if data array is 1 length
+		final int ix = data.length < shortCutSize ? 0 : hash(key) % data.length;
 
-        try {
-            return increment(key, ix, count);
-        }
-        catch(ArrayIndexOutOfBoundsException e) {
-            if(ix < 0)
-                return increment(key, 0, count);
-            else
-                throw new RuntimeException(e);
-        }
-    }
+		try {
+			return increment(key, ix, count);
+		}
+		catch(ArrayIndexOutOfBoundsException e) {
+			if(ix < 0)
+				return increment(key, 0, count);
+			else
+				throw new RuntimeException(e);
+		}
+	}
 
-    private final int increment(final T key, final int ix, final int count) throws ArrayIndexOutOfBoundsException {
-        final ACount<T> l = data[ix];
-        if(l == null) {
-            data[ix] = create(key, size);
-            // never try to resize here since we use a new unused bucket.
-            return size++;
-        }
-        else {
-            final ACount<T> v = l.inc(key, count, size);
-            if(v.id == size) {
-                size++;
-                resize();
-                return size - 1;
-            }
-            else {
-                // do not resize if not new.
-                return v.id;
-            }
-        }
-    }
+	private final int increment(final T key, final int ix, final int count) throws ArrayIndexOutOfBoundsException {
+		final ACount<T> l = data[ix];
+		if(l == null) {
+			data[ix] = create(key, size);
+			// never try to resize here since we use a new unused bucket.
+			return size++;
+		}
+		else {
+			final ACount<T> v = l.inc(key, count, size);
+			if(v.id == size) {
+				size++;
+				resize();
+				return size - 1;
+			}
+			else {
+				// do not resize if not new.
+				return v.id;
+			}
+		}
+	}
 
-    public final int increment(final double key, final int count) {
-        // skip hash if data array is 1 length
-        final int ix = data.length < shortCutSize ? 0 : DCounts.hashIndex(key) % data.length;
+	public synchronized final int increment(final double key, final int count) {
+		// skip hash if data array is 1 length
+		final int ix = data.length < shortCutSize ? 0 : DCounts.hashIndex(key) % data.length;
 
-        try {
-            return increment(key, ix, count);
-        }
-        catch(ArrayIndexOutOfBoundsException e) {
-            if(ix < 0)
-                return increment(key, 0, count);
-            else
-                throw new RuntimeException(e);
-        }
-    }
+		try {
+			return increment(key, ix, count);
+		}
+		catch(ArrayIndexOutOfBoundsException e) {
+			if(ix < 0)
+				return increment(key, 0, count);
+			else
+				throw new RuntimeException(e);
+		}
+	}
 
-    private final int increment(final double key, final int ix, final int count) throws ArrayIndexOutOfBoundsException {
-        final ACount<T> l = data[ix];
-        if(l == null) {
-            data[ix] = create(key, size);
-            // never try to resize here since we use a new unused bucket.
-            return size++;
-        }
-        else {
-            final ACount<T> v = l.inc(key, count, size);
-            if(v.id == size) {
-                size++;
-                resize();
-                return size - 1;
-            }
-            else {
-                // do not resize if not new.
-                return v.id;
-            }
-        }
-    }
+	private final int increment(final double key, final int ix, final int count) throws ArrayIndexOutOfBoundsException {
+		final ACount<T> l = data[ix];
+		if(l == null) {
+			data[ix] = create(key, size);
+			// never try to resize here since we use a new unused bucket.
+			return size++;
+		}
+		else {
+			final ACount<T> v = l.inc(key, count, size);
+			if(v.id == size) {
+				size++;
+				resize();
+				return size - 1;
+			}
+			else {
+				// do not resize if not new.
+				return v.id;
+			}
+		}
+	}
 
-    public int get(T key) {
-        return getC(key).count;
-    }
+	public int get(T key) {
+		return getC(key).count;
+	}
 
-    public int getId(T key) {
-        return getC(key).id;
-    }
+	public int getId(T key) {
+		return getC(key).id;
+	}
 
-    public ACount<T> getC(T key) {
-        final int ix = data.length < shortCutSize ? 0 : hash(key) % data.length;
-        try {
-            ACount<T> l = data[ix];
-            return l != null ? l.get(key) : null;
-        }
-        catch(ArrayIndexOutOfBoundsException e) {
-            if(ix < 0) {
-                ACount<T> l = data[0];
-                return l != null ? l.get(key) : null;
-            }
-            else
-                throw new RuntimeException(e);
-        }
-    }
+	public ACount<T> getC(T key) {
+		final int ix = data.length < shortCutSize ? 0 : hash(key) % data.length;
+		try {
+			ACount<T> l = data[ix];
+			return l != null ? l.get(key) : null;
+		}
+		catch(ArrayIndexOutOfBoundsException e) {
+			if(ix < 0) {
+				ACount<T> l = data[0];
+				return l != null ? l.get(key) : null;
+			}
+			else
+				throw new RuntimeException(e);
+		}
+	}
 
-    public int getOrDefault(T key, int def) {
-        ACount<T> e = getC(key);
-        return (e == null) ? def : e.count;
-    }
+	public int getOrDefault(T key, int def) {
+		ACount<T> e = getC(key);
+		return (e == null) ? def : e.count;
+	}
 
-    public final ACount<T>[] extractValues() {
-        final ACount<T>[] ret = create(size);
-        int i = 0;
-        for(ACount<T> e : data) {
-            while(e != null) {
-                ret[i++] = e;
-                e = e.next();
-            }
-        }
-        return ret;
-    }
+	public final ACount<T>[] extractValues() {
+		final ACount<T>[] ret = create(size);
+		int i = 0;
+		for(ACount<T> e : data) {
+			while(e != null) {
+				ret[i++] = e;
+				e = e.next();
+			}
+		}
+		return ret;
+	}
 
-    public T getMostFrequent() {
-        T f = null;
-        int fq = 0;
-        for(ACount<T> e : data) {
-            while(e != null) {
-                if(e.count > fq) {
-                    fq = e.count;
-                    f = e.key();
-                }
-                e = e.next();
-            }
-        }
-        return f;
-    }
+	public T getMostFrequent() {
+		T f = null;
+		int fq = 0;
+		for(ACount<T> e : data) {
+			while(e != null) {
+				if(e.count > fq) {
+					fq = e.count;
+					f = e.key();
+				}
+				e = e.next();
+			}
+		}
+		return f;
+	}
 
-    private void resize() {
-        if(size >= LOAD_FACTOR * data.length && size > shortCutSize)
-            // +1 to make the hash buckets better
-            resize(Math.max(data.length, shortCutSize) * RESIZE_FACTOR + 1);
-    }
+	private void resize() {
+		if(size >= LOAD_FACTOR * data.length && size > shortCutSize)
+			// +1 to make the hash buckets better
+			resize(Math.max(data.length, shortCutSize) * RESIZE_FACTOR + 1);
+	}
 
-    private void resize(int underlying_size) {
+	private void resize(int underlying_size) {
 
-        // resize data array and copy existing contents
-        final ACount<T>[] olddata = data;
-        data = create(underlying_size);
+		// resize data array and copy existing contents
+		final ACount<T>[] olddata = data;
+		data = create(underlying_size);
 
-        // rehash all entries
-        for(ACount<T> e : olddata)
-            appendValue(e);
-    }
+		// rehash all entries
+		for(ACount<T> e : olddata)
+			appendValue(e);
+	}
 
-    protected void appendValue(ACount<T> ent) {
-        if(ent != null) {
-            // take the tail recursively first
-            appendValue(ent.next()); // append tail first
-            ent.setNext(null); // set this tail to null.
-            final int ix = hash(ent.key()) % data.length;
-            try {
-                appendValue(ent, ix);
-            }
-            catch(ArrayIndexOutOfBoundsException e) {
-                if(ix < 0)
-                    appendValue(ent, 0);
-                else
-                    throw new RuntimeException(e);
-            }
-        }
-    }
+	protected void appendValue(ACount<T> ent) {
+		if(ent != null) {
+			// take the tail recursively first
+			appendValue(ent.next()); // append tail first
+			ent.setNext(null); // set this tail to null.
+			final int ix = hash(ent.key()) % data.length;
+			try {
+				appendValue(ent, ix);
+			}
+			catch(ArrayIndexOutOfBoundsException e) {
+				if(ix < 0)
+					appendValue(ent, 0);
+				else
+					throw new RuntimeException(e);
+			}
+		}
+	}
 
-    private void appendValue(ACount<T> ent, int ix) {
-        ACount<T> l = data[ix];
-        data[ix] = ent;
-        ent.setNext(l);
-    }
+	private void appendValue(ACount<T> ent, int ix) {
+		ACount<T> l = data[ix];
+		data[ix] = ent;
+		ent.setNext(l);
+	}
 
-    public void sortBuckets() {
-        if(size > 10)
-            for(int i = 0; i < data.length; i++)
-                if(data[i] != null)
-                    data[i] = data[i].sort();
-    }
+	public void sortBuckets() {
+		if(size > 10)
+			for(int i = 0; i < data.length; i++)
+				if(data[i] != null)
+					data[i] = data[i].sort();
+	}
 
-    public void reset(int size) {
-        this.data = create(size);
-        this.size = 0;
-    }
+	public void reset(int size) {
+		this.data = create(size);
+		this.size = 0;
+	}
 
-    protected abstract ACount<T>[] create(int size);
+	protected abstract ACount<T>[] create(int size);
 
-    protected abstract int hash(T key);
+	protected abstract int hash(T key);
 
-    protected abstract ACount<T> create(T key, int id);
+	protected abstract ACount<T> create(T key, int id);
 
-    protected ACount<T> create(double key, int id) {
-        throw new NotImplementedException();
-    }
+	protected ACount<T> create(double key, int id) {
+		throw new NotImplementedException();
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(this.getClass().getSimpleName());
-        for(int i = 0; i < data.length; i++)
-            if(data[i] != null)
-                sb.append(", " + data[i]);
-        return sb.toString();
-    }
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.getClass().getSimpleName());
+		for(int i = 0; i < data.length; i++)
+			if(data[i] != null)
+				sb.append(", " + data[i]);
+		return sb.toString();
+	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayCountHashMap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayCountHashMap.java
@@ -35,7 +35,7 @@ public final class DblArrayCountHashMap extends ACountHashMap<DblArray> {
 		return new DArrCounts[size];
 	}
 
-	protected int hash(DblArray key) {
+	protected final int hash(DblArray key) {
 		return Math.abs(key.hashCode());
 	}
 
@@ -44,13 +44,12 @@ public final class DblArrayCountHashMap extends ACountHashMap<DblArray> {
 	}
 
 	@Override
-    public DblArrayCountHashMap clone() {
+	public DblArrayCountHashMap clone() {
 		DblArrayCountHashMap ret = new DblArrayCountHashMap(size);
-
-        for(ACount<DblArray> e : data)
-            ret.appendValue(e);
+		for(ACount<DblArray> e : data)
+			ret.appendValue(e);
 		ret.size = size;
 		return ret;
-    }
+	}
 
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayIntListHashMap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/DblArrayIntListHashMap.java
@@ -20,7 +20,6 @@
 package org.apache.sysds.runtime.compress.utils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -35,12 +34,10 @@ public class DblArrayIntListHashMap {
 
 	protected static final int INIT_CAPACITY = 8;
 	protected static final int RESIZE_FACTOR = 2;
-	protected static final float LOAD_FACTOR = 0.5f;
-	public static int hashMissCount = 0;
+	protected static final float LOAD_FACTOR = 0.8f;
 
-	protected int _size = -1;
-
-	protected DArrayIListEntry[] _data = null;
+	protected int _size;
+	protected DArrayIListEntry[] _data;
 
 	public DblArrayIntListHashMap() {
 		_data = new DArrayIListEntry[INIT_CAPACITY];
@@ -57,64 +54,21 @@ public class DblArrayIntListHashMap {
 	}
 
 	public IntArrayList get(DblArray key) {
-		// probe for early abort
-		if(_size == 0)
-			return null;
-		// compute entry index position
-		int hash = key.hashCode();
-		int ix = indexFor(hash, _data.length);
-
-		// find entry
-
-		while(_data[ix] != null && !_data[ix].keyEquals(key)) {
-			hash = Integer.hashCode(hash + 1); // hash of hash
-			ix = indexFor(hash, _data.length);
-			hashMissCount++;
-		}
-		DArrayIListEntry e = _data[ix];
-		if(e != null)
-			return e.value;
-		return null;
-	}
-
-	private void appendValue(DblArray key, IntArrayList value) {
-		// compute entry index position
-		int hash = key.hashCode();
-		int ix = indexFor(hash, _data.length);
-
-		// add new table entry (constant time)
-		while(_data[ix] != null && !_data[ix].keyEquals(key)) {
-			hash = Integer.hashCode(hash + 1); // hash of hash
-			ix = indexFor(hash, _data.length);
-			hashMissCount++;
-		}
-		_data[ix] = new DArrayIListEntry(key, value);
-		_size++;
+		final int hash = key.hashCode();
+		final int ix = indexFor(hash, _data.length);
+		return _data[ix] == null ? null: _data[ix].get(key);
 	}
 
 	public void appendValue(DblArray key, int value) {
 		int hash = key.hashCode();
 		int ix = indexFor(hash, _data.length);
-
-		while(_data[ix] != null && !_data[ix].keyEquals(key)) {
-			hash = Integer.hashCode(hash + 1); // hash of hash
-			ix = indexFor(hash, _data.length);
-			hashMissCount++;
-		}
-
-		DArrayIListEntry e = _data[ix];
-		if(e == null) {
-			final IntArrayList lstPtr = new IntArrayList();
-			lstPtr.appendValue(value);
-			_data[ix] = new DArrayIListEntry(new DblArray(key), lstPtr);
+		if(_data[ix] == null) {
+			_data[ix] = new DArrayIListEntry(new DblArray(key), value);
 			_size++;
 		}
-		else {
-			final IntArrayList lstPtr = e.value;
-			lstPtr.appendValue(value);
-		}
+		else if(_data[ix].add(key, value))
+			_size++;
 
-		// resize if necessary
 		if(_size >= LOAD_FACTOR * _data.length)
 			resize();
 	}
@@ -122,18 +76,17 @@ public class DblArrayIntListHashMap {
 	public List<DArrayIListEntry> extractValues() {
 		List<DArrayIListEntry> ret = new ArrayList<>();
 
-		for(DArrayIListEntry e : _data)
-			if(e != null)
+		for(DArrayIListEntry e : _data) {
+			while(e != null) {
 				ret.add(e);
+				e = e.next;
+			}
+		}
 
-		// Collections.sort(ret);
 		return ret;
 	}
 
 	private void resize() {
-		// check for integer overflow on resize
-		if(_data.length > Integer.MAX_VALUE / RESIZE_FACTOR)
-			return;
 
 		// resize data array and copy existing contents
 		DArrayIListEntry[] olddata = _data;
@@ -141,66 +94,112 @@ public class DblArrayIntListHashMap {
 		_size = 0;
 
 		// rehash all entries
-		for(DArrayIListEntry e : olddata)
-			if(e != null)
-				appendValue(e.key, e.value);
+		for(DArrayIListEntry e : olddata) {
+			while(e != null) {
+				reinsert(e.key, e.value);
+				e = e.next;
+			}
+		}
 	}
 
-	public void reset() {
-		Arrays.fill(_data, null);
-		_size = 0;
-	}
-
-	public void reset(int size) {
-		int newSize = Util.getPow2(size);
-		if(newSize > _data.length) {
-			_data = new DArrayIListEntry[newSize];
+	private void reinsert(DblArray key, IntArrayList value) {
+		// compute entry index position
+		int hash = key.hashCode();
+		int ix = indexFor(hash, _data.length);
+		if(_data[ix] == null) {
+			_data[ix] = new DArrayIListEntry(key, value);
+			_size++;
 		}
 		else {
-			Arrays.fill(_data, null);
-			// only allocate new if the size is smaller than 2x
-			if(size < _data.length / 2)
-				_data = new DArrayIListEntry[newSize];
+			_data[ix].reinsert(key, value);
+			_size++;
 		}
-		_size = 0;
 	}
 
-	protected static int indexFor(int h, int length) {
+	private static int indexFor(int h, int length) {
 		return h & (length - 1);
 	}
 
 	public static class DArrayIListEntry {
-		public DblArray key;
-		public IntArrayList value;
+		public final DblArray key;
+		public final IntArrayList value;
+		private DArrayIListEntry next;
 
-		public DArrayIListEntry(DblArray ekey, IntArrayList evalue) {
-			key = ekey;
-			value = evalue;
+		private DArrayIListEntry(DblArray key, int value) {
+			this.key = key;
+			this.value = new IntArrayList();
+			this.value.appendValue(value);
+			next = null;
 		}
 
-		@Override
-		public String toString() {
-			return key + ":" + value;
+		private DArrayIListEntry(DblArray key, IntArrayList value) {
+			this.key = key;
+			this.value = value;
+			next = null;
 		}
 
-		public boolean keyEquals(DblArray keyThat) {
-			return key.equals(keyThat);
+		private final boolean reinsert(final DblArray key, final IntArrayList value) {
+			DArrayIListEntry e = this;
+			while(e.next != null)
+				e = e.next;
+
+			e.next = new DArrayIListEntry(key, value);
+			return true;
+		}
+
+		private final boolean add(final DblArray key, final int value) {
+			DArrayIListEntry e = this;
+			if(e.key.equals(key)) {
+				this.value.appendValue(value);
+				return false;
+			}
+			while(e.next != null) {
+				e = e.next;
+				if(e.key.equals(key)) {
+					e.value.appendValue(value);
+					return false;
+				}
+			}
+			e.next = new DArrayIListEntry(new DblArray(key), new IntArrayList());
+			e.next.value.appendValue(value);
+			return true;
+		}
+
+		private IntArrayList get(DblArray key) {
+			DArrayIListEntry e = this;
+			boolean eq = e.key.equals(key);
+			while(e.next != null && !eq) {
+				e = e.next;
+				eq = e.key.equals(key);
+			}
+			return eq ? e.value : null;
+		}
+
+		private void toString(StringBuilder sb) {
+			DArrayIListEntry e = this;
+			while(e != null) {
+				sb.append(e.key);
+				sb.append(":");
+				sb.append(e.value);
+				if(e.next != null)
+					sb.append(" -> ");
+				e = e.next;
+			}
 		}
 	}
 
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(this.getClass().getSimpleName() + this.hashCode());
+		sb.append(this.getClass().getSimpleName());
 		sb.append("   " + _size);
 		for(int i = 0; i < _data.length; i++) {
 			DArrayIListEntry ent = _data[i];
 			if(ent != null) {
 
 				sb.append("\n");
-				sb.append("id:" + i);
 				sb.append("[");
-				sb.append(ent);
+				ent.toString(sb);
 				sb.append("]");
 			}
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/DoubleCountHashMap.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/DoubleCountHashMap.java
@@ -48,16 +48,36 @@ public final class DoubleCountHashMap extends ACountHashMap<Double> {
 	}
 
 	public double[] getDictionary() {
+		return getDictionary(size);
+	}
+
+
+	public double[] getDictionary(int size) {
 		double[] ret = new double[size];
 		for(int i = 0; i < data.length; i++) {
 			ACount<Double> e = data[i];
 			while(e != null) {
-				ret[e.id] = e.key();
+				if(e.id >= 0)
+					ret[e.id] = e.key();
+				e = e.next();
+			}
+		}
+		return ret;
+	}
+
+
+	public void replaceWithUIDs(double v) {
+		int i = 0;
+		for(ACount<Double> e : data) {
+			while(e != null) {
+				if(!e.key().equals(v))
+					e.id = i++;
+				else
+					e.id = -1;
 				e = e.next();
 			}
 		}
 
-		return ret;
 	}
 
 	public void replaceWithUIDsNoZero() {

--- a/src/main/java/org/apache/sysds/runtime/compress/utils/IntArrayList.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/utils/IntArrayList.java
@@ -52,12 +52,20 @@ public class IntArrayList {
 
 	public void appendValue(int value) {
 		// allocate or resize array if necessary
-		if(_size + 1 >= _data.length)
+		if(_size + 1 > _data.length)
 			resize();
 
 		// append value
 		_data[_size] = value;
 		_size++;
+	}
+
+	public void appendValue(IntArrayList value) {
+		// allocate or resize array if necessary
+		if(_size + value._size >= _data.length)
+			_data = Arrays.copyOf(_data, _size + value._size);
+		System.arraycopy(value._data, 0, _data, _size, value._size);
+		_size = _size + value._size;
 	}
 
 	/**
@@ -75,20 +83,22 @@ public class IntArrayList {
 	}
 
 	public int[] extractValues(boolean trim) {
-		int[] ret = extractValues();
-		return (trim && _size < ret.length) ? Arrays.copyOfRange(ret, 0, _size) : ret;
+		if(trim ){
+			if(_data.length == _size)
+				return _data;
+			return Arrays.copyOfRange(_data, 0, _size);
+		}
+		else
+			return _data;
 	}
 
 	private void resize() {
-		// check for integer overflow on resize
-		if(_data.length > Integer.MAX_VALUE / RESIZE_FACTOR)
-			throw new RuntimeException("IntArrayList resize leads to integer overflow: size=" + _size);
 
 		// resize data array and copy existing contents
 		_data = Arrays.copyOf(_data, _data.length * RESIZE_FACTOR);
 	}
 
-	public void reset(){
+	public void reset() {
 		_size = 0;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/context/SparkExecutionContext.java
@@ -1769,7 +1769,7 @@ public class SparkExecutionContext extends ExecutionContext
 	 *
 	 * @return spark cluster configuration
 	 */
-	public static SparkClusterConfig getSparkClusterConfig() {
+	public synchronized static SparkClusterConfig getSparkClusterConfig() {
 		//lazy creation of spark cluster config
 		if( _sconf == null )
 			_sconf = new SparkClusterConfig();
@@ -1782,8 +1782,7 @@ public class SparkExecutionContext extends ExecutionContext
 	 * @return broadcast memory budget
 	 */
 	public static double getBroadcastMemoryBudget() {
-		return getSparkClusterConfig()
-			.getBroadcastMemoryBudget();
+		return getSparkClusterConfig().getBroadcastMemoryBudget();
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
@@ -821,29 +821,29 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {
 		
-		if((out instanceof ObjectOutputStream)){
-			ObjectOutputStream oos = (ObjectOutputStream)out;
-			FastBufferedDataOutputStream fos = new FastBufferedDataOutputStream(oos);
-			write(fos); //note: cannot close fos as this would close oos
-			fos.flush();
-		}
-		else{
+		// if((out instanceof ObjectOutputStream)){
+		// 	ObjectOutputStream oos = (ObjectOutputStream)out;
+		// 	FastBufferedDataOutputStream fos = new FastBufferedDataOutputStream(oos);
+		// 	write(fos); //note: cannot close fos as this would close oos
+		// 	fos.flush();
+		// }
+		// else{
 			write(out);
-		}
+		// }
 	}
 
 	@Override
 	public void readExternal(ObjectInput in) throws IOException {
-		if(in instanceof ObjectInputStream) {
-			// fast deserialize of dense/sparse blocks
-			ObjectInputStream ois = (ObjectInputStream) in;
-			FastBufferedDataInputStream fis = new FastBufferedDataInputStream(ois);
-			readFields(fis); // note: cannot close fos as this would close oos
-		}
-		else {
+		// if(in instanceof ObjectInputStream) {
+		// 	// fast deserialize of dense/sparse blocks
+		// 	ObjectInputStream ois = (ObjectInputStream) in;
+		// 	FastBufferedDataInputStream fis = new FastBufferedDataInputStream(ois);
+		// 	readFields(fis); // note: cannot close fos as this would close oos
+		// }
+		// else {
 			// redirect deserialization to writable impl
 			readFields(in);
-		}
+		// }
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -108,7 +108,7 @@ public abstract class Array<T> implements Writable {
 	 */
 	protected Map<T, Long> createRecodeMap() {
 		Map<T, Long> map = new HashMap<>();
-		long id = 0;
+		long id = 1;
 		for(int i = 0; i < size(); i++) {
 			T val = get(i);
 			if(val != null) {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
@@ -102,7 +102,7 @@ public class StringArray extends Array<String> {
 		catch(Exception e) {
 			super.set(rl, ru, value, rlSrc);
 		}
-		finally{
+		finally {
 			materializedSize = -1;
 		}
 	}
@@ -150,18 +150,18 @@ public class StringArray extends Array<String> {
 
 		// final Charset cs = Charset.defaultCharset();
 		for(int i = 0; i < _size; i++)
-		// {
-		// 	if(_data[i] == null){
-		// 		out.writeInt(0);
-		// 	}
-		// 	else{
-		// 		// cs.encode(_data[i]);
-		// 		byte[] bs = _data[i].getBytes(cs);
-		// 		out.writeInt(bs.length);
-		// 		out.write(bs);
-		// 	}
-		// }
-		
+			// {
+			// if(_data[i] == null){
+			// out.writeInt(0);
+			// }
+			// else{
+			// // cs.encode(_data[i]);
+			// byte[] bs = _data[i].getBytes(cs);
+			// out.writeInt(bs.length);
+			// out.write(bs);
+			// }
+			// }
+
 			out.writeUTF((_data[i] != null) ? _data[i] : "");
 	}
 
@@ -172,18 +172,17 @@ public class StringArray extends Array<String> {
 		// byte[] bs = new byte[16];
 		// final Charset cs = Charset.defaultCharset();
 		for(int i = 0; i < _size; i++) {
-
 			// int l = in.readInt();
 			// if(l == 0){
-			// 	_data[i] = null;
+			// _data[i] = null;
 			// }
 			// else{
-			// 	if(l > bs.length)
-			// 		bs = new byte[l];
-			// 	in.readFully(bs, 0, l);
-			// 	String tmp = new String(bs, 0, l, cs);
-			// 	// String tmp = in.readUTF();
-			// 	_data[i] = tmp;
+			// if(l > bs.length)
+			// bs = new byte[l];
+			// in.readFully(bs, 0, l);
+			// String tmp = new String(bs, 0, l, cs);
+			// // String tmp = in.readUTF();
+			// _data[i] = tmp;
 			// }
 			{
 				String tmp = in.readUTF();

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
@@ -147,28 +147,48 @@ public class StringArray extends Array<String> {
 	public void write(DataOutput out) throws IOException {
 		out.writeByte(FrameArrayType.STRING.ordinal());
 		out.writeLong(getInMemorySize());
+
+		// final Charset cs = Charset.defaultCharset();
+		for(int i = 0; i < _size; i++)
+		// {
+		// 	if(_data[i] == null){
+		// 		out.writeInt(0);
+		// 	}
+		// 	else{
+		// 		// cs.encode(_data[i]);
+		// 		byte[] bs = _data[i].getBytes(cs);
+		// 		out.writeInt(bs.length);
+		// 		out.write(bs);
+		// 	}
+		// }
 		
-		for(int i = 0; i < _size; i++){
-			byte[] bs = ((_data[i] != null) ? _data[i] : "").getBytes();
-			out.writeInt(bs.length);
-			out.write(bs);
-		}
-		
-			// out.writeUTF((_data[i] != null) ? _data[i] : "");
+			out.writeUTF((_data[i] != null) ? _data[i] : "");
 	}
 
 	@Override
 	public void readFields(DataInput in) throws IOException {
 		_size = _data.length;
 		materializedSize = in.readLong();
-		byte[] bs = new byte[32];
+		// byte[] bs = new byte[16];
+		// final Charset cs = Charset.defaultCharset();
 		for(int i = 0; i < _size; i++) {
-			int l = in.readInt();
-			if(l > bs.length)
-				bs = new byte[l];
-			in.readFully(bs, 0, l);
-			String tmp = new String(bs, 0, l, Charset.defaultCharset());
-			_data[i] = (!tmp.isEmpty()) ? tmp : null;
+
+			// int l = in.readInt();
+			// if(l == 0){
+			// 	_data[i] = null;
+			// }
+			// else{
+			// 	if(l > bs.length)
+			// 		bs = new byte[l];
+			// 	in.readFully(bs, 0, l);
+			// 	String tmp = new String(bs, 0, l, cs);
+			// 	// String tmp = in.readUTF();
+			// 	_data[i] = tmp;
+			// }
+			{
+				String tmp = in.readUTF();
+				_data[i] = tmp.isEmpty() ? null : tmp;
+			}
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/io/IOUtilFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/io/IOUtilFunctions.java
@@ -22,6 +22,7 @@ package org.apache.sysds.runtime.io;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -49,6 +50,15 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.SequenceFile.Writer;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.DefaultCodec;
+import org.apache.hadoop.io.compress.DeflateCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.io.compress.Lz4Codec;
+import org.apache.hadoop.io.compress.PassthroughCodec;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.ZStandardCodec;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
@@ -57,6 +67,7 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.data.TensorBlock;
 import org.apache.sysds.runtime.data.TensorIndexes;
@@ -66,11 +77,12 @@ import org.apache.sysds.runtime.matrix.data.MatrixCell;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.transform.TfUtils;
 import org.apache.sysds.runtime.util.LocalFileUtils;
-import org.apache.sysds.runtime.util.UtilFunctions;
 
-public class IOUtilFunctions 
-{
-	private static final Log LOG = LogFactory.getLog(UtilFunctions.class.getName());
+import io.airlift.compress.lzo.LzoCodec;
+import io.airlift.compress.lzo.LzopCodec;
+
+public class IOUtilFunctions {
+	private static final Log LOG = LogFactory.getLog(IOUtilFunctions.class.getName());
 
 	public static final PathFilter hiddenFileFilter = new PathFilter(){
 		@Override
@@ -188,7 +200,6 @@ public class IOUtilFunctions
 	{
 		//split by whole separator required for multi-character delimiters, preserve
 		//all tokens required for empty cells and in order to keep cell alignment
-	
 		return StringUtils.splitByWholeSeparatorPreserveAllTokens(str, delim);
 	}
 	
@@ -252,13 +263,22 @@ public class IOUtilFunctions
 	private static String[] splitCSVNonNullWithCache(final String str, final String delim, final String[] cache) {
 		final int len = str.length();
 		final int delimLen = delim.length();
-
+		final boolean containsQuotationMarks = str.contains("\"");
 		int from = 0;
 		int id = 0;
-		while(from < len) { // for all tokens
-			final int to = getTo(str, from, delim);
-			cache[id++] =str.substring(from, to);
-			from = to + delimLen;
+		if(containsQuotationMarks){
+			while(from < len) { // for all tokens
+				final int to = getTo(str, from, delim);
+				cache[id++] = str.substring(from, to);
+				from = to + delimLen;
+			}
+		}
+		else{
+			while(from < len) { // for all tokens
+				final int to = getToNoQuote(str, from, delim);
+				cache[id++] = str.substring(from, to);
+				from = to + delimLen;
+			}
 		}
 
 		if(from == len)
@@ -294,6 +314,21 @@ public class IOUtilFunctions
 				to = str.indexOf(delim, to + 1);
 		}
 		else if(isEmptyMatch(str, from, delim, dLen, len))
+			return to = from; // empty string
+		else // default: unquoted non-empty
+			to = str.indexOf(delim, fromP1);
+
+		// slice out token and advance position
+		return to >= 0 ? to : len;
+	}
+
+	private static int getToNoQuote(final String str, final int from, final String delim) {
+		final int len = str.length();
+		final int dLen = delim.length();
+		final int fromP1 = from + 1;
+		int to;
+
+		if(isEmptyMatch(str, from, delim, dLen, len))
 			return to = from; // empty string
 		else // default: unquoted non-empty
 			to = str.indexOf(delim, fromP1);
@@ -561,32 +596,43 @@ public class IOUtilFunctions
 		return ncol;
 	}
 
-	public static Path[] getSequenceFilePaths( FileSystem fs, Path file ) 
-		throws IOException
-	{
+	public static Path[] getSequenceFilePaths(FileSystem fs, Path file) throws IOException {
 		Path[] ret = null;
 		
-		//Note on object stores: Since the object store file system implementations 
-		//only emulate a file system, the directory of a multi-part file does not
-		//exist physically and hence the isDirectory call returns false. Furthermore,
-		//listStatus call returns all files with the given directory as prefix, which
-		//includes the mtd file which needs to be ignored accordingly.
-		
-		if( fs.getFileStatus(file).isDirectory() 
-			|| IOUtilFunctions.isObjectStoreFileScheme(file) )
-		{
+		// Note on object stores: Since the object store file system implementations
+		// only emulate a file system, the directory of a multi-part file does not
+		// exist physically and hence the isDirectory call returns false. Furthermore,
+		// listStatus call returns all files with the given directory as prefix, which
+		// includes the mtd file which needs to be ignored accordingly.
+
+		if(fs instanceof LocalFileSystem) {
+			java.io.File f = new java.io.File(file.toString());
+			if(f.isDirectory()){
+				java.io.File[] r = new java.io.File(file.toString()).listFiles((a) -> {
+					final String s = a.getName();
+					return !(s.startsWith("_") || (s.endsWith(".crc")) || s.endsWith(".mtd"));
+				});
+				ret = new Path[r.length];
+				for(int i = 0; i < r.length; i++)
+					ret[i] = new Path(r[i].toString());
+			}
+			else{
+				return new Path[]{file};
+			}
+		}
+		else if(fs.getFileStatus(file).isDirectory() || IOUtilFunctions.isObjectStoreFileScheme(file)) {
 			LinkedList<Path> tmp = new LinkedList<>();
 			FileStatus[] dStatus = fs.listStatus(file);
-			for( FileStatus fdStatus : dStatus )
-				if( !fdStatus.getPath().getName().startsWith("_") //skip internal files
-					&& !fdStatus.getPath().toString().equals(file.toString()+".mtd") ) //mtd file
+			for(FileStatus fdStatus : dStatus)
+				if(!fdStatus.getPath().getName().startsWith("_") // skip internal files
+					&& !fdStatus.getPath().toString().equals(file.toString() + ".mtd")) // mtd file
 					tmp.add(fdStatus.getPath());
 			ret = tmp.toArray(new Path[0]);
 		}
 		else {
-			ret = new Path[]{ file };
+			ret = new Path[] {file};
 		}
-		
+
 		return ret;
 	}
 	
@@ -703,6 +749,27 @@ public class IOUtilFunctions
 			throw new DMLRuntimeException(e);
 		}
 	}
+
+	public static boolean isFileCPReadable(String path){
+		try{
+
+			JobConf job = ConfigurationManager.getCachedJobConf();
+			Path p = new Path(path);
+			FileSystem fs = getFileSystem(p,job);
+			if(fs instanceof LocalFileSystem){
+				// fast java path.
+				File f = new File(path);
+				return ! f.isDirectory() && f.length() < Integer.MAX_VALUE;
+			}
+			else{
+				FileStatus fstat = fs.getFileStatus(p);
+				return !fstat.isDirectory() && fstat.getLen() < Integer.MAX_VALUE;
+			}
+		}
+		catch(Exception e){
+			return false;
+		}
+	}
 	
 	public static class CountRowsTask implements Callable<Long> {
 		private final InputSplit _split;
@@ -745,28 +812,69 @@ public class IOUtilFunctions
 	public static Writer getSeqWriter(Path path, Configuration job, int replication) throws IOException {
 		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
 			Writer.replication((short) (replication > 0 ? replication : 1)),
-			Writer.compression(SequenceFile.CompressionType.NONE), Writer.keyClass(MatrixIndexes.class),
+			Writer.compression(getCompressionEncodingType(), getCompressionCodec()), Writer.keyClass(MatrixIndexes.class),
 			Writer.valueClass(MatrixBlock.class));
 	}
 
 	public static Writer getSeqWriterFrame(Path path, Configuration job, int replication) throws IOException {
 		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
 			Writer.keyClass(LongWritable.class), Writer.valueClass(FrameBlock.class),
-			Writer.compression(SequenceFile.CompressionType.NONE),
+			Writer.compression(getCompressionEncodingType(), getCompressionCodec()),
 			Writer.replication((short) (replication > 0 ? replication : 1)));
 	}
 
 	public static Writer getSeqWriterTensor(Path path, Configuration job, int replication) throws IOException {
 		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
 		Writer.replication((short) (replication > 0 ? replication : 1)),
-		Writer.compression(SequenceFile.CompressionType.NONE), Writer.keyClass(TensorIndexes.class),
+		Writer.compression(getCompressionEncodingType(),getCompressionCodec()), Writer.keyClass(TensorIndexes.class),
 		Writer.valueClass(TensorBlock.class));
 	}
 
 	public static Writer getSeqWriterCell(Path path, Configuration job, int replication) throws IOException {
 		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
 			Writer.replication((short) (replication > 0 ? replication : 1)),
-			Writer.compression(SequenceFile.CompressionType.NONE), Writer.keyClass(MatrixIndexes.class),
+			Writer.compression(getCompressionEncodingType(), getCompressionCodec()),
+			Writer.keyClass(MatrixIndexes.class),
 			Writer.valueClass(MatrixCell.class));
 	}
+
+	public static SequenceFile.CompressionType getCompressionEncodingType() {
+		String v = ConfigurationManager.getDMLConfig().getTextValue(DMLConfig.IO_COMPRESSION_CODEC);
+		if(v.equals("none"))
+			return SequenceFile.CompressionType.NONE;
+		else
+			return SequenceFile.CompressionType.RECORD;
+	}
+
+	public static CompressionCodec getCompressionCodec() {
+		String v = ConfigurationManager.getDMLConfig().getTextValue(DMLConfig.IO_COMPRESSION_CODEC);
+
+		switch(v) {
+			case "Lz4":
+				return new Lz4Codec();
+			case "Lzo":
+				return new LzoCodec();
+			case "Lzop":
+				return new LzopCodec();
+			case "Snappy":
+				return new SnappyCodec();
+			case "BZip2":
+				return new BZip2Codec();
+			case "deflate":
+				return new DeflateCodec();
+			case "Gzip":
+				return new GzipCodec();
+			case "pass":
+				return new PassthroughCodec();
+			case "Zstd":
+				return new ZStandardCodec();
+			case "none":
+				return null;
+			case "default":
+			default:
+				return new DefaultCodec();
+		}
+
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/io/ReaderBinaryBlockParallel.java
+++ b/src/main/java/org/apache/sysds/runtime/io/ReaderBinaryBlockParallel.java
@@ -93,10 +93,10 @@ public class ReaderBinaryBlockParallel extends ReaderBinaryBlock
 		if( HDFSTool.USE_BINARYBLOCK_SERIALIZATION )
 			HDFSTool.addBinaryBlockSerializationFramework( job );
 		
+		final ExecutorService pool = CommonThreadPool.get(_numThreads);
 		try 
 		{
 			//create read tasks for all files
-			ExecutorService pool = CommonThreadPool.get(_numThreads);
 			ArrayList<ReadFileTask> tasks = new ArrayList<>();
 			for( Path lpath : IOUtilFunctions.getSequenceFilePaths(fs, path) ){
 				ReadFileTask t = new ReadFileTask(lpath, job, dest, rlen, clen, blen, syncBlock);
@@ -116,10 +116,12 @@ public class ReaderBinaryBlockParallel extends ReaderBinaryBlock
 			if( dest.isInSparseFormat() && clen>blen ) 
 				sortSparseRowsParallel(dest, rlen, _numThreads, pool);
 			
-			pool.shutdown();
 		} 
 		catch (Exception e) {
 			throw new IOException("Failed parallel read of binary block input.", e);
+		}
+		finally{
+			pool.shutdown();
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.data.SparseBlockCSR;
+import org.apache.sysds.runtime.data.SparseBlockMCSR;
+import org.apache.sysds.runtime.data.SparseRowVector;
+import org.apache.sysds.runtime.util.CommonThreadPool;
+import org.apache.sysds.runtime.util.UtilFunctions;
+
+public interface LibMatrixSparseToDense {
+	/**
+	 * Convert the given matrix block to a sparse allocation.
+	 * 
+	 * @param r        The matrix block to modify, and return the sparse block in.
+	 * @param allowCSR If CSR is allowed.
+	 */
+	public static void denseToSparse(MatrixBlock r, boolean allowCSR) {
+		final DenseBlock a = r.getDenseBlock();
+
+		// set target representation, early abort on empty blocks
+		r.sparse = true;
+		if(a == null)
+			return;
+
+		int k = InfrastructureAnalyzer.getLocalParallelism();
+
+		if(k > 1) 
+			denseToSparseParallel(r, k, allowCSR);
+		else if(allowCSR && r.nonZeros <= Integer.MAX_VALUE)
+			denseToSparseCSR(r);
+		else
+			denseToSparseMCSR(r);
+
+		// cleanup dense block
+		r.denseBlock = null;
+	}
+
+	private static void denseToSparseCSR(MatrixBlock r) {
+		final DenseBlock a = r.getDenseBlock();
+		final int m = r.rlen;
+		final int n = r.clen;
+		try {
+			// allocate target in memory-efficient CSR format
+			int lnnz = (int) r.nonZeros;
+			int[] rptr = new int[m + 1];
+			int[] indexes = new int[lnnz];
+			double[] values = new double[lnnz];
+			for(int i = 0, pos = 0; i < m; i++) {
+				double[] avals = a.values(i);
+				int aix = a.pos(i);
+				for(int j = 0; j < n; j++) {
+					double aval = avals[aix + j];
+					if(aval != 0) {
+						indexes[pos] = j;
+						values[pos] = aval;
+						pos++;
+					}
+				}
+				rptr[i + 1] = pos;
+			}
+			r.sparseBlock = new SparseBlockCSR(rptr, indexes, values, lnnz);
+		}
+		catch(ArrayIndexOutOfBoundsException ioobe) {
+			r.sparse = false;
+			// this means something was wrong with the sparse count.
+			final long nnzBefore = r.nonZeros;
+			final long nnzNew = r.recomputeNonZeros();
+
+			// try again.
+			if(nnzBefore != nnzNew)
+				denseToSparse(r, true);
+			else
+				denseToSparse(r, false);
+
+		}
+	}
+
+	private static void denseToSparseMCSR(MatrixBlock r) {
+		final DenseBlock a = r.getDenseBlock();
+
+		final int m = r.rlen;
+		final int n = r.clen;
+		// remember number non zeros.
+		long nnzTemp = r.getNonZeros();
+		// fallback to less-memory efficient MCSR format,
+		// which however allows much larger sparse matrices
+		if(!r.allocateSparseRowsBlock())
+			r.reset(); // reset if not allocated
+		SparseBlockMCSR sblock = (SparseBlockMCSR) r.sparseBlock;
+		toSparseMCSRRange(a, sblock, n, 0, m);
+		r.nonZeros = nnzTemp;
+	}
+
+	private static void toSparseMCSRRange(DenseBlock a, SparseBlockMCSR b, int n, int rl, int ru) {
+		for(int i = rl; i < ru; i++)
+			toSparseMCSRRow(a, b, n, i);
+	}
+
+	private static void toSparseMCSRRow(DenseBlock a, SparseBlockMCSR b, int n, int i) {
+		final double[] avals = a.values(i);
+		final int aix = a.pos(i);
+		// compute nnz per row (not via recomputeNonZeros as sparse allocated)
+		final int lnnz = UtilFunctions.computeNnz(avals, aix, n);
+		if(lnnz <= 0)
+			return;
+
+		final double[] vals = new double[lnnz];
+		final int[] idx = new int[lnnz];
+		// allocate sparse row and append non-zero values
+		// b.allocate(i, lnnz);
+
+		for(int j = 0, o = 0; j < n; j++) {
+			double v = avals[aix + j];
+			if(v != 0.0) {
+				vals[o] = v;
+				idx[o] = j;
+				o++;
+			}
+		}
+		b.set(i, new SparseRowVector(vals, idx), false);
+	}
+
+	private static void denseToSparseParallel(MatrixBlock r, int k, boolean allowCSR) {
+		final DenseBlock a = r.getDenseBlock();
+
+		final int m = r.rlen;
+		final int n = r.clen;
+		// remember number non zeros.
+		final long nnzTemp = r.getNonZeros();
+		// fallback to less-memory efficient MCSR format,
+		// which however allows much larger sparse matrices
+		if(!r.allocateSparseRowsBlock())
+			r.reset(); // reset if not allocated
+		final SparseBlockMCSR b = (SparseBlockMCSR) r.sparseBlock;
+		final int blockSize = Math.max(250, m / k);
+
+		ExecutorService pool = CommonThreadPool.get(k);
+		try {
+
+			List<Future<?>> tasks = new ArrayList<>();
+			for(int i = 0; i < m; i += blockSize) {
+				final int start = i;
+				final int end = Math.min(m, i + blockSize);
+				tasks.add(pool.submit(() -> toSparseMCSRRange(a, b, n, start, end)));
+			}
+
+			for(Future<?> t : tasks)
+				t.get();
+		}
+		catch(Exception e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			pool.shutdown();
+		}
+
+		r.nonZeros = nnzTemp;
+
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/transform/decode/Decoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/decode/Decoder.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
@@ -34,8 +36,8 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
  * interface for decoding matrices to frames.
  * 
  */
-public abstract class Decoder implements Externalizable
-{	
+public abstract class Decoder implements Externalizable{	
+	protected static final Log LOG = LogFactory.getLog(Decoder.class.getName());
 	private static final long serialVersionUID = -1732411001366177787L;
 	
 	protected ValueType[] _schema;
@@ -61,12 +63,33 @@ public abstract class Decoder implements Externalizable
 	/**
 	 * Block decode API converting a matrix block into a frame block.
 	 * 
-	 * @param in input matrix block
-	 * @param out output frame block
-	 * 
+	 * @param in  Input matrix block
+	 * @param out Output frame block
 	 * @return returns given output frame block for convenience
 	 */
 	public abstract FrameBlock decode(MatrixBlock in, FrameBlock out);
+
+	/**
+	 * Block decode API converting a matrix block into a frame block in parallel.
+	 * 
+	 * @param in  Input matrix block
+	 * @param out Output frame block
+	 * @param k   Parallelization degree
+	 * @return returns the given output frame block for convenience
+	 */
+	public FrameBlock decode(MatrixBlock in, FrameBlock out, int k) {
+		return decode(in, out);
+	}
+
+	/**
+	 * Block decode row block
+	 * 
+	 * @param in  input Matrix Block
+	 * @param out output FrameBlock
+	 * @param rl  row start to decode
+	 * @param ru  row end to decode (not inclusive)
+	 */
+	public abstract void decode(MatrixBlock in, FrameBlock out, int rl, int ru);
 	
 	/**
 	 * Returns a new Decoder that only handles a sub range of columns. The sub-range refers to the columns after

--- a/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderDummycode.java
@@ -53,7 +53,15 @@ public class DecoderDummycode extends Decoder
 	public FrameBlock decode(MatrixBlock in, FrameBlock out) {
 		//TODO perf (exploit sparse representation for better asymptotic behavior)
 		out.ensureAllocatedColumns(in.getNumRows());
-		for( int i=0; i<in.getNumRows(); i++ )
+		decode(in, out, 0, in.getNumRows());
+		return out;
+	}
+
+	@Override
+	public void decode(MatrixBlock in, FrameBlock out, int rl, int ru) {
+		//TODO perf (exploit sparse representation for better asymptotic behavior)
+		// out.ensureAllocatedColumns(in.getNumRows());
+		for( int i=rl; i<ru; i++ )
 			for( int j=0; j<_colList.length; j++ )
 				for( int k=_clPos[j]; k<_cuPos[j]; k++ )
 					if( in.quickGetValue(i, k-1) != 0 ) {
@@ -61,7 +69,6 @@ public class DecoderDummycode extends Decoder
 						out.set(i, col, UtilFunctions.doubleToObject(
 							out.getSchema()[col], k-_clPos[j]+1));
 					}
-		return out;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderPassThrough.java
@@ -54,8 +54,14 @@ public class DecoderPassThrough extends Decoder
 	@Override
 	public FrameBlock decode(MatrixBlock in, FrameBlock out) {
 		out.ensureAllocatedColumns(in.getNumRows());
+		decode(in, out, 0, in.getNumRows());
+		return out;
+	}
+	
+	@Override
+	public void decode(MatrixBlock in, FrameBlock out, int rl, int ru) {
 		int clen = Math.min(_colList.length, out.getNumColumns());
-		for( int i=0; i<in.getNumRows(); i++ ) {
+		for( int i=rl; i<ru; i++ ) {
 			for( int j=0; j<clen; j++ ) {
 				int srcColID = _srcCols[j];
 				int tgtColID = _colList[j];
@@ -64,9 +70,8 @@ public class DecoderPassThrough extends Decoder
 					UtilFunctions.doubleToObject(_schema[tgtColID-1], val));
 			}
 		}
-		return out;
 	}
-	
+
 	@Override
 	public Decoder subRangeDecoder(int colStart, int colEnd, int dummycodedOffset) {
 		List<Integer> colList = new ArrayList<>();

--- a/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderRecode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/decode/DecoderRecode.java
@@ -65,8 +65,14 @@ public class DecoderRecode extends Decoder
 
 	@Override
 	public FrameBlock decode(MatrixBlock in, FrameBlock out) {
+		decode(in, out, 0, in.getNumRows());
+		return out;
+	}
+
+	@Override
+	public void decode(MatrixBlock in, FrameBlock out, int rl, int ru) {
 		if( _onOut ) { //recode on output (after dummy)
-			for( int i=0; i<in.getNumRows(); i++ ) {
+			for( int i=rl; i<ru; i++ ) {
 				for( int j=0; j<_colList.length; j++ ) {
 					int colID = _colList[j];
 					double val = UtilFunctions.objectToDouble(
@@ -78,7 +84,7 @@ public class DecoderRecode extends Decoder
 		}
 		else { //recode on input (no dummy)
 			out.ensureAllocatedColumns(in.getNumRows());
-			for( int i=0; i<in.getNumRows(); i++ ) {
+			for( int i=rl; i<ru; i++ ) {
 				for( int j=0; j<_colList.length; j++ ) {
 					double val = in.quickGetValue(i, _colList[j]-1);
 					long key = UtilFunctions.toLong(val);
@@ -86,7 +92,6 @@ public class DecoderRecode extends Decoder
 				}
 			}
 		}
-		return out;
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -373,7 +373,6 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	public void buildPartial(FrameBlock in) {
 		if(!isApplicable())
 			return;
-		LOG.error("Building entire min-max col");
 		// derive bin boundaries from min/max per column
 		double[] pairMinMax = getMinMaxOfCol(in, _colID, 0, -1);
 		_colMins = pairMinMax[0];

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -36,6 +36,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.columns.Array;
+import org.apache.sysds.runtime.frame.data.columns.StringArray;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.utils.stats.TransformStatistics;
 
@@ -187,39 +188,34 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		final Array<?> c = in.getColumn(_colID - 1);
 		final double mi = _binMins[0];
 		final double mx = _binMaxs[_binMaxs.length-1];
-		if(!c.containsNull())
+		if(!(c instanceof StringArray) && !c.containsNull())
 			for(int i = startInd; i < endInd; i++)
-				codes[i - startInd] = getCodeIndex(c.getAsDouble(i), mi,mx);
+				codes[i - startInd] = getCodeIndex(c.getAsDouble(i), mi, mx);
 		else 
 			for(int i = startInd; i < endInd; i++)
-				codes[i - startInd] = getCodeIndex(c.getAsNaNDouble(i),mi,mx);
+				codes[i - startInd] = getCodeIndex(c.getAsNaNDouble(i),mi, mx);
 	}
 
 	protected final double getCodeIndex(double inVal){
-		return getCodeIndex(inVal, _binMins[0],_binMaxs[_binMaxs.length-1]);
+		return getCodeIndex(inVal, _binMins[0], _binMaxs[_binMaxs.length-1]);
 	}
 
-	protected final double getCodeIndex(double inVal, double mi, double mx){
-		final boolean nan = Double.isNaN(inVal); 
-		if(nan || (_binMethod != BinMethod.EQUI_HEIGHT_APPROX && (inVal < mi || inVal > mx)))
+	protected final double getCodeIndex(double inVal, double min, double max){
+		if(Double.isNaN(inVal))
 			return Double.NaN;
 		else if(_binMethod == BinMethod.EQUI_WIDTH)
-			return getEqWidth(inVal);
+			return getEqWidth(inVal, min, max);
 		else // if (_binMethod == BinMethod.EQUI_HEIGHT || _binMethod == BinMethod.EQUI_HEIGHT_APPROX)
 			return getCodeIndexEQHeight(inVal);
 	}
 
-	private final double getEqWidth(double inVal) {
-		final double max = _binMaxs[_binMaxs.length - 1];
-		final double min = _binMins[0];
-
+	private final double getEqWidth(double inVal, double min, double max) {
 		if(max == min)
 			return 1;
-		
-		// TODO: Skip computing bin boundaries for equi-width
-		double binWidth = (max - min) / _numBin;
-		double code = Math.ceil((inVal - min) / binWidth);
-		return (code == 0) ? code + 1 : code;
+		if(_numBin <= 0)
+			throw new RuntimeException("Invalid num bins");
+		final int code = (int)(Math.ceil((inVal - min) / (max - min) * _numBin) );
+		return code > _numBin ? _numBin : code < 1 ? 1 : code;
 	}
 
 	private final double getCodeIndexEQHeight(double inVal){
@@ -241,7 +237,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		if(ix < 0) // somewhere in between values
 			// +2 because negative values are found from binary search.
 			// plus 2 to correct for the absolute value of that.
-			return Math.abs(ix + 1) + 1;
+			return Math.min(Math.abs(ix + 1) + 1, _binMaxs.length);
 		else if(ix == 0) // If first bucket boundary add it there.
 			return 1;
 		else
@@ -377,6 +373,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	public void buildPartial(FrameBlock in) {
 		if(!isApplicable())
 			return;
+		LOG.error("Building entire min-max col");
 		// derive bin boundaries from min/max per column
 		double[] pairMinMax = getMinMaxOfCol(in, _colID, 0, -1);
 		_colMins = pairMinMax[0];

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -169,7 +169,7 @@ public class ColumnEncoderBin extends ColumnEncoder {
 		final double[] codes = tmp != null && tmp.length == endLength ? tmp : new double[endLength];
 		if (_binMins == null || _binMins.length == 0 || _binMaxs.length == 0) {
 			LOG.warn("ColumnEncoderBin: applyValue without bucket boundaries, assign 1");
-			Arrays.fill(codes, startInd, endInd, 1.0);
+			Arrays.fill(codes, 0, endLength, 1.0);
 			return codes;
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderComposite.java
@@ -216,8 +216,7 @@ public class ColumnEncoderComposite extends ColumnEncoder {
 			}
 		}
 		catch(Exception ex) {
-			LOG.error("Failed to transform-apply frame with \n" + this);
-			throw ex;
+			throw new DMLRuntimeException("Failed to transform-apply frame with \n" + this, ex);
 		}
 		return out;
 	}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -232,7 +232,10 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 
 			if(distinct != -1) {
 				_domainSize = Math.max(1, distinct);
-				LOG.error("DummyCoder for column: " + _colID + " has domain size: " + _domainSize);
+				if(LOG.isDebugEnabled()){
+
+					LOG.debug("DummyCoder for column: " + _colID + " has domain size: " + _domainSize);
+				}
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -41,7 +41,8 @@ import org.apache.sysds.utils.stats.TransformStatistics;
 public class ColumnEncoderDummycode extends ColumnEncoder {
 	private static final long serialVersionUID = 5832130477659116489L;
 
-	public int _domainSize = -1; // length = #of dummycoded columns
+	/** The number of columns outputted from this column group. */ 
+	public int _domainSize = -1; 
 
 	public ColumnEncoderDummycode() {
 		super(-1);
@@ -230,8 +231,8 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 			}
 
 			if(distinct != -1) {
-				_domainSize = distinct;
-				LOG.debug("DummyCoder for column: " + _colID + " has domain size: " + _domainSize);
+				_domainSize = Math.max(1, distinct);
+				LOG.error("DummyCoder for column: " + _colID + " has domain size: " + _domainSize);
 			}
 		}
 	}
@@ -249,7 +250,7 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 	@Override
 	public void initMetaData(FrameBlock meta) {
 		// initialize domain sizes and output num columns
-		_domainSize = (int) meta.getColumnMetadata()[_colID - 1].getNumDistinct();
+		_domainSize = Math.max(1, (int) meta.getColumnMetadata()[_colID - 1].getNumDistinct());
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderPassThrough.java
@@ -68,12 +68,17 @@ public class ColumnEncoderPassThrough extends ColumnEncoder {
 
 	@Override
 	protected double[] getCodeCol(CacheBlock<?> in, int startInd, int endInd, double[] tmp) {
-		final int endLength = endInd - startInd;
-		final double[] codes = tmp != null && tmp.length == endLength ? tmp : new double[endLength];
-		for (int i=startInd; i<endInd; i++) {
-			codes[i-startInd] = in.getDoubleNaN(i, _colID-1);
+		try{
+			final int endLength = endInd - startInd;
+			final double[] codes = tmp != null && tmp.length == endLength ? tmp : new double[endLength];
+			for (int i = startInd; i < endInd; i++) {
+				codes[i - startInd] = in.getDoubleNaN(i, _colID - 1);
+			}
+			return codes;
 		}
-		return codes;
+		catch(Exception e){
+			throw new RuntimeException("Failed to get code for col: " + _colID + " on range: " + startInd + "->" + endInd, e);
+		}
 	}
 
 	protected void applySparse(CacheBlock<?> in, MatrixBlock out, int outputCol, int rowStart, int blk){

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -111,7 +111,13 @@ public class MultiColumnEncoder implements Encoder {
 				DependencyThreadPool pool = new DependencyThreadPool(k);
 				LOG.debug("Encoding with full DAG on " + k + " Threads");
 				try {
-					pool.submitAllAndWait(getEncodeTasks(in, out, pool));
+					List<DependencyTask<?>> tasks = getEncodeTasks(in, out, pool);
+					LOG.error(tasks);
+					pool.submitAll(tasks);
+					for(Future<Future<?>> t : pool.submitAll(tasks)){
+						t.get().get();
+						LOG.error(tasks);
+					}
 				}
 				finally{
 					pool.shutdown();
@@ -295,10 +301,11 @@ public class MultiColumnEncoder implements Encoder {
 			pool.submitAllAndWait(getBuildTasks(in));
 		}
 		catch(ExecutionException | InterruptedException e) {
-			LOG.error("MT Column build failed");
-			e.printStackTrace();
+			throw new RuntimeException(e);
 		}
-		pool.shutdown();
+		finally{
+			pool.shutdown();
+		}
 	}
 
 	public void legacyBuild(FrameBlock in) {
@@ -411,10 +418,11 @@ public class MultiColumnEncoder implements Encoder {
 				pool.submitAllAndWait(getApplyTasks(in, out, outputCol));
 		}
 		catch(ExecutionException | InterruptedException e) {
-			LOG.error("MT Column apply failed");
-			e.printStackTrace();
+			throw new DMLRuntimeException(e);
 		}
-		pool.shutdown();
+		finally{
+			pool.shutdown();
+		}
 	}
 
 	private void deriveNumRowPartitions(CacheBlock<?> in, int k) {
@@ -689,18 +697,20 @@ public class MultiColumnEncoder implements Encoder {
 			meta = new FrameBlock(_columnEncoders.size(), ValueType.STRING);
 		this.allocateMetaData(meta);
 		if (k > 1) {
+			ExecutorService pool = CommonThreadPool.get(k);
 			try {
-				ExecutorService pool = CommonThreadPool.get(k);
 				ArrayList<ColumnMetaDataTask<? extends ColumnEncoder>> tasks = new ArrayList<>();
 				for(ColumnEncoder columnEncoder : _columnEncoders)
 					tasks.add(new ColumnMetaDataTask<>(columnEncoder, meta));
 				List<Future<Object>> taskret = pool.invokeAll(tasks);
-				pool.shutdown();
 				for (Future<Object> task : taskret)
-					task.get();
+				task.get();
 			}
 			catch(Exception ex) {
 				throw new DMLRuntimeException(ex);
+			}
+			finally{
+				pool.shutdown();
 			}
 		}
 		else {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -112,11 +112,11 @@ public class MultiColumnEncoder implements Encoder {
 				LOG.debug("Encoding with full DAG on " + k + " Threads");
 				try {
 					List<DependencyTask<?>> tasks = getEncodeTasks(in, out, pool);
-					LOG.error(tasks);
-					pool.submitAll(tasks);
+					// LOG.error(tasks);
+					// pool.submitAll(tasks);
 					for(Future<Future<?>> t : pool.submitAll(tasks)){
 						t.get().get();
-						LOG.error(tasks);
+						// LOG.error(tasks);
 					}
 				}
 				finally{
@@ -1175,8 +1175,8 @@ public class MultiColumnEncoder implements Encoder {
 		private final ColumnEncoder _encoder;
 		private final MatrixBlock _out;
 		private final CacheBlock<?> _in;
-		private int _offset = -1; // offset dude to dummycoding in
-									// previous columns needs to be updated by external task!
+		/** Offset because of dummmy coding such that the column id is correct. */
+		private int _offset = -1; 
 
 		private ApplyTasksWrapperTask(ColumnEncoder encoder, CacheBlock<?> in, 
 				MatrixBlock out, DependencyThreadPool pool) {
@@ -1197,7 +1197,7 @@ public class MultiColumnEncoder implements Encoder {
 			// and _outputCol has been updated!
 			if(_offset == -1)
 				throw new DMLRuntimeException(
-					"OutputCol for apply task wrapper has not been updated!, Most likely some " + "concurrency issues");
+					"OutputCol for apply task wrapper has not been updated!, Most likely some concurrency issues\n " + this);
 			return super.call();
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -112,12 +112,7 @@ public class MultiColumnEncoder implements Encoder {
 				LOG.debug("Encoding with full DAG on " + k + " Threads");
 				try {
 					List<DependencyTask<?>> tasks = getEncodeTasks(in, out, pool);
-					// LOG.error(tasks);
-					// pool.submitAll(tasks);
-					for(Future<Future<?>> t : pool.submitAll(tasks)){
-						t.get().get();
-						// LOG.error(tasks);
-					}
+					pool.submitAllAndWait(tasks);
 				}
 				finally{
 					pool.shutdown();

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/MultiColumnEncoder.java
@@ -102,7 +102,6 @@ public class MultiColumnEncoder implements Encoder {
 	}
 
 	public MatrixBlock encode(CacheBlock<?> in, int k, boolean compressedOut){
-	
 		deriveNumRowPartitions(in, k);
 		try {
 			if(isCompressedTransformEncode(in, compressedOut))
@@ -679,8 +678,7 @@ public class MultiColumnEncoder implements Encoder {
 
 	@Override
 	public FrameBlock getMetaData(FrameBlock meta) {
-		getMetaData(meta, 1);
-		return meta;
+		return getMetaData(meta, 1);
 	}
 
 	public FrameBlock getMetaData(FrameBlock meta, int k) {

--- a/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
@@ -514,13 +514,19 @@ public class UtilFunctions {
 			case BOOLEAN: return ((Boolean)in) ? 1 : 0;
 			case CHARACTER: return (Character)in;
 			case STRING:
+				String inStr = (String) in;
 				try {
-					return !((String) in).isEmpty() ? Double.parseDouble((String) in) : 0;
+					return !(inStr).isEmpty() ? Double.parseDouble(inStr) : 0;
 				}
 				catch(NumberFormatException e) {
-					if(in.equals("true"))
+					final int len = inStr.length();
+					if(len == 1 && inStr.equalsIgnoreCase("T"))
 						return 1.0;
-					else if(in.equals("false"))
+					else if (len == 1 && inStr.equalsIgnoreCase("F"))
+						return 0.0;
+					else if(inStr.equalsIgnoreCase("true"))
+						return 1.0;
+					else if(inStr.equalsIgnoreCase("false"))
 						return 0.0;
 					else
 						throw new DMLRuntimeException("failed parsing object to double",e);

--- a/src/test/java/org/apache/sysds/performance/micro/FrameCompressedTransform.java
+++ b/src/test/java/org/apache/sysds/performance/micro/FrameCompressedTransform.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.performance.micro;
+
+import org.apache.sysds.runtime.data.SparseBlock.Type;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.columns.Array;
+import org.apache.sysds.runtime.frame.data.columns.IntegerArray;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.transform.encode.EncoderFactory;
+import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
+
+public class FrameCompressedTransform {
+
+	static int specCols = 5;
+	static String spec = "{ids:true,dummycode:[1,2,3,4,5]}";
+
+	public static void main(String[] args) {
+
+		// scaleRows();
+		// scaleDistinct();
+		scaleCols();
+	}
+
+	public static void scaleRows() {
+
+		System.out.println("Rows,Comp,MCSR,CSR,COO,Dense");
+		for(int i = 1; i < 300; i += 1) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(i, 1000)));
+		}
+
+		for(int i = 300; i < 16000; i += 100) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(i, 1000)));
+		}
+
+		for(int i = 16000; i < 160000; i += 1000) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(i, 1000)));
+		}
+	}
+
+	public static void scaleDistinct() {
+
+		System.out.println("Distinct,Comp,MCSR,CSR,COO,Dense");
+		for(int i = 1; i < 10; i += 1) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i)));
+		}
+
+		for(int i = 10; i < 100; i += 10) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i)));
+		}
+
+		for(int i = 100; i < 100000; i += 100) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i)));
+		}
+
+	}
+
+	public static void scaleCols() {
+
+		System.out.println("Cols,Comp,MCSR,CSR,COO,Dense");
+		for(int i = 1; i < 10; i += 1) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i, 1000)));
+		}
+
+		for(int i = 10; i < 100; i += 10) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i, 1000)));
+		}
+
+		for(int i = 100; i < 1000; i += 100) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i, 1000)));
+		}
+
+		for(int i = 1000; i < 10000; i += 1000) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i, 1000)));
+		}
+
+		for(int i = 10000; i < 20000; i += 10000) {
+			System.out.print(i + ",");
+			System.out.println(getSize(genFrameBlock(100000, i, 1000)));
+		}
+
+	}
+
+	private static String getSize(FrameBlock e) {
+		if(specCols != e.getNumColumns())
+			createSpec(e.getNumColumns());
+		MultiColumnEncoder encoderCompressed = //
+			EncoderFactory.createEncoder(spec, e.getColumnNames(), e.getNumColumns(), null);
+		MatrixBlock outCompressed = encoderCompressed.encode(e, 16, true);
+
+		long compSize = outCompressed.getInMemorySize();
+
+		long denseSize = outCompressed.estimateSizeDenseInMemory();
+		long csr = outCompressed.estimateSizeSparseInMemory(Type.CSR);
+		long mcsr = outCompressed.estimateSizeSparseInMemory(Type.MCSR);
+		long coo = outCompressed.estimateSizeSparseInMemory(Type.COO);
+
+		// MatrixBlock uc = CompressedMatrixBlock.getUncompressed(outCompressed);
+		// uc.denseToSparse(true);
+
+		// SparseBlock sb = uc.getSparseBlock();
+		// if(sb == null) {
+		// System.out.println(uc);
+		// System.exit(-1);
+		// }
+
+		// long csr = new MatrixBlock(uc.getNumRows(), uc.getNumColumns(), uc.getNonZeros(), new SparseBlockCSR(sb))
+		// .getInMemorySize();
+		// long mcsr = new MatrixBlock(uc.getNumRows(), uc.getNumColumns(), uc.getNonZeros(), new SparseBlockMCSR(sb))
+		// .getInMemorySize();
+		// long coo = new MatrixBlock(uc.getNumRows(), uc.getNumColumns(), uc.getNonZeros(), new SparseBlockCOO(sb))
+		// .getInMemorySize();
+
+		// long denseSize = uc.estimateSizeDenseInMemory();
+
+		return compSize + "," + mcsr + "," + csr + "," + coo + "," + denseSize;
+	}
+
+	private static void createSpec(int nCol) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{ids:true,dummycode:[1");
+		for(int i = 1; i < nCol; i++) {
+			sb.append(",");
+			sb.append(i + 1);
+		}
+		sb.append("]}");
+		spec = sb.toString();
+		specCols = nCol;
+	}
+
+	private static FrameBlock genFrameBlock(int nRow, int nDistinct) {
+		IntegerArray a = new IntegerArray(new int[nRow]);
+		for(int i = 0; i < nRow; i++)
+			a.set(i, i % nDistinct);
+		return new FrameBlock(new Array<?>[] {a, a, a, a, a});
+	}
+
+	private static FrameBlock genFrameBlock(int nRow, int cols, int nDistinct) {
+		IntegerArray a = new IntegerArray(new int[nRow]);
+		for(int i = 0; i < nRow; i++)
+			a.set(i, i % nDistinct);
+		Array<?>[] r = new Array<?>[cols];
+		for(int i = 0; i < cols; i++)
+			r[i] = a;
+
+		return new FrameBlock(r);
+	}
+}

--- a/src/test/java/org/apache/sysds/performance/micro/InformationLoss.java
+++ b/src/test/java/org/apache/sysds/performance/micro/InformationLoss.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.performance.micro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.sysds.performance.generators.FrameFile;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.functionobjects.Builtin;
+import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
+import org.apache.sysds.runtime.functionobjects.Divide;
+import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
+import org.apache.sysds.runtime.io.MatrixWriter;
+import org.apache.sysds.runtime.io.WriterTextCSV;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.Pair;
+import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
+import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
+import org.apache.sysds.runtime.transform.decode.Decoder;
+import org.apache.sysds.runtime.transform.decode.DecoderFactory;
+import org.apache.sysds.runtime.transform.encode.EncoderFactory;
+import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
+import org.apache.sysds.runtime.util.CommonThreadPool;
+import org.apache.sysds.runtime.util.DataConverter;
+import org.apache.sysds.test.TestUtils;
+
+/**
+ * evaluate the different loss in accuracy on different number of distinct values on transform specifications.
+ */
+public class InformationLoss {
+
+	public static void main(String[] args) throws Exception {
+
+		String frame_path = args[0];
+		String binningTechnique = args[1];
+
+		writeRandomMatrix(frame_path);
+
+		final Pair<FrameBlock, MatrixBlock> p = readFrame(frame_path);
+		final FrameBlock f = p.getKey();
+		final MatrixBlock org = p.getValue();
+
+		System.gc(); // indicate to do garbage collection here.
+
+		for(int i = 1; i < 20; i++) {
+			String spec = generateSpec(i, f.getNumColumns(), binningTechnique);
+			System.out.print(i + ",");
+			calculateLoss(f, org, spec);
+		}
+
+		for(int i = 20; i < 200; i += 10) {
+			String spec = generateSpec(i, f.getNumColumns(), binningTechnique);
+			System.out.print(i + ",");
+			calculateLoss(f, org, spec);
+		}
+
+		for(int i = 200; i <= 2000; i += 100) {
+			String spec = generateSpec(i, f.getNumColumns(), binningTechnique);
+			System.out.print(i + ",");
+			calculateLoss(f, org, spec);
+		}
+
+	}
+
+	private static Pair<FrameBlock, MatrixBlock> readFrame(String path) throws Exception {
+		FrameBlock f = FrameFile.create(path).take();
+		f = f.applySchema(f.detectSchema(16), 16); // apply scheme
+
+		MatrixBlock org = DataConverter.convertToMatrixBlock(f);
+		f = null;
+		System.gc(); // cleanup original frame.
+
+		// normalize org.
+		org = org//
+			.replaceOperations(null, Double.NaN, 0)//
+			.replaceOperations(null, Double.POSITIVE_INFINITY, 0).replaceOperations(null, Double.NEGATIVE_INFINITY, 0);
+
+		Pair<MatrixBlock, MatrixBlock> mm = getMinMax(org);
+
+		// normalize org to 0-1 range
+		org = org //
+			.binaryOperations(new BinaryOperator(Minus.getMinusFnObject()), mm.getKey())
+			.binaryOperations(new BinaryOperator(Divide.getDivideFnObject()),
+				mm.getValue().binaryOperations(new BinaryOperator(Minus.getMinusFnObject()), mm.getKey()))
+			.replaceOperations(null, Double.NaN, 0);
+
+		f = DataConverter.convertToFrameBlock(org, 16);
+
+		return new Pair<>(f, org);
+	}
+
+	private static Pair<MatrixBlock, MatrixBlock> getMinMax(final MatrixBlock org) throws Exception {
+		ExecutorService pool = CommonThreadPool.get(16);
+
+		Future<MatrixBlock> minF = pool.submit(() -> (MatrixBlock) org.colMin(16));
+		Future<MatrixBlock> maxF = pool.submit(() -> (MatrixBlock) org.colMax(16));
+
+		MatrixBlock min = minF.get();
+		MatrixBlock max = maxF.get();
+
+		return new Pair<>(min, max);
+	}
+
+	private static void writeRandomMatrix(String path) throws IOException {
+		if(!new File(path).exists()) {
+			MatrixWriter w = new WriterTextCSV(new FileFormatPropertiesCSV(false, ",", false));
+			MatrixBlock mb = TestUtils.generateTestMatrixBlock(1000, 10, 0, 1, 0.5, 23);
+			w.writeMatrixToHDFS(mb, path, mb.getNumRows(), mb.getNumColumns(), 1000, mb.getNonZeros(), false);
+		}
+	}
+
+	private static FrameBlock encodeAndDecode(FrameBlock f, MatrixBlock org, String spec) {
+
+		MultiColumnEncoder encoder = //
+			EncoderFactory.createEncoder(spec, f.getColumnNames(), f.getNumColumns(), null);
+		MatrixBlock binned = encoder.encode(f, 16, true);
+		Decoder d = DecoderFactory.createDecoder(spec, f.getColumnNames(false), f.getSchema(), encoder.getMetaData(null),
+			binned.getNumColumns());
+		FrameBlock dr = new FrameBlock(f.getSchema());
+		d.decode(binned, dr, 16);
+		return dr;
+	}
+
+	private static MatrixBlock delta(FrameBlock f, MatrixBlock org, String spec) {
+		return DataConverter//
+			.convertToMatrixBlock(encodeAndDecode(f, org, spec))
+			.binaryOperations(new BinaryOperator(Minus.getMinusFnObject(), 16), org)
+			// .binaryOperations(new BinaryOperator(Divide.getDivideFnObject(), 16), org)
+			.unaryOperations(new UnaryOperator(Builtin.getBuiltinFnObject(BuiltinCode.ABS), 16), null)
+			.replaceOperations(null, Double.NaN, 0);
+
+	}
+
+	private static void calculateLoss(FrameBlock f, MatrixBlock org, String spec) throws Exception {
+
+		final MatrixBlock delta = delta(f, org, spec);
+		ExecutorService pool = CommonThreadPool.get(16);
+
+		Future<Double> minF = pool.submit(() -> delta.min(16));
+		Future<Double> maxF = pool.submit(() -> delta.max(16).quickGetValue(0, 0));
+		Future<Double> meanF = pool
+			.submit(() -> delta.sum(16).quickGetValue(0, 0) / (delta.getNumRows() * delta.getNumColumns()));
+
+		double min = minF.get();
+		double max = maxF.get();
+		double mean = meanF.get();
+
+		pool.shutdown();
+		System.out.println(String.format("%e, %e, %e", min, max, mean));
+	}
+
+	private static String generateSpec(int bins, int cols, String technique) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{\"ids\":true,\"bin\":[");
+		for(int i = 0; i < cols; i++) {
+			sb.append(String.format("{\"id\":%d,\"method\":\"%s\",\"numbins\":%d}", i + 1, technique, bins));
+			if(i + 1 < cols)
+				sb.append(',');
+		}
+		sb.append("]}");
+		return sb.toString();
+
+	}
+
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
@@ -353,7 +353,7 @@ public class ColGroupNegativeTests {
 		}
 
 		@Override
-		protected AColGroup appendNInternal(AColGroup[] groups) {
+		protected AColGroup appendNInternal(AColGroup[] groups, int blen, int rlen) {
 			// TODO Auto-generated method stub
 			return null;
 		}
@@ -591,7 +591,7 @@ public class ColGroupNegativeTests {
 		}
 
 		@Override
-		protected AColGroup appendNInternal(AColGroup[] groups) {
+		protected AColGroup appendNInternal(AColGroup[] groups, int blen, int rlen) {
 			// TODO Auto-generated method stub
 			return null;
 		}

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupTest.java
@@ -2282,8 +2282,7 @@ public class ColGroupTest extends ColGroupBase {
 		try {
 
 			AColGroup g2 = g.append(g);
-			AColGroup g2n = AColGroup.appendN(new AColGroup[] {g, g});
-
+			AColGroup g2n = AColGroup.appendN(new AColGroup[] {g, g}, nRow,  nRow*2);
 			if(g2 != null && g2n != null) {
 				double s2 = g2.getSum(nRow * 2);
 				double s = g.getSum(nRow) * 2;
@@ -2293,6 +2292,9 @@ public class ColGroupTest extends ColGroupBase {
 
 				UA_ROW(InstructionUtils.parseBasicAggregateUnaryOperator("uar+", 1), 0, nRow * 2, g2, g2n, nRow * 2);
 			}
+		}
+		catch(NotImplementedException e){
+			// okay
 		}
 		catch(Exception e) {
 			e.printStackTrace();

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/CustomColGroupTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/CustomColGroupTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.colgroup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupEmpty;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupSDCSingleZeros;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.PlaceHolderDict;
+import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
+import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.junit.Test;
+
+public class CustomColGroupTest {
+	protected static final Log LOG = LogFactory.getLog(CustomColGroupTest.class.getName());
+
+    @Test
+    public void appendEmptyToSDCZero() {
+        IColIndex i = ColIndexFactory.createI(3);
+        AColGroup e = new ColGroupEmpty(i);
+        AColGroup s = ColGroupSDCSingleZeros.create(i, 10, new PlaceHolderDict(1),
+            OffsetFactory.createOffset(new int[] {5, 10}), null);
+
+        AColGroup r = AColGroup.appendN(new AColGroup[] {e, s}, 20, 40);
+
+        assertTrue(r instanceof ColGroupSDCSingleZeros);
+        assertEquals(r.getColIndices(),i);
+        assertEquals(((ColGroupSDCSingleZeros)r).getNumRows(), 40);
+
+    }
+
+
+    @Test
+    public void appendEmptyToSDCZero2() {
+        IColIndex i = ColIndexFactory.createI(3);
+        AColGroup e = new ColGroupEmpty(i);
+        AColGroup s = ColGroupSDCSingleZeros.create(i, 10, new PlaceHolderDict(1),
+            OffsetFactory.createOffset(new int[] {5, 10}), null);
+
+        AColGroup r = AColGroup.appendN(new AColGroup[] {e, s, e, e, s, s, e}, 20, 7*20);
+        LOG.error(r);
+        assertTrue(r instanceof ColGroupSDCSingleZeros);
+        assertEquals(r.getColIndices(),i);
+        assertEquals(((ColGroupSDCSingleZeros)r).getNumRows(), 7 * 20);
+
+    }
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/indexes/IndexesTest.java
@@ -129,7 +129,11 @@ public class IndexesTest {
 			tests.add(createWithArray(144, 32));
 			tests.add(createWithArray(13, 23));
 			tests.add(createWithArray(145, 14));
+			tests.add(createWithArray(300, 14));
 			tests.add(createWithArray(23, 51515));
+			tests.add(createWithArray(128, 321));
+			tests.add(createWithArray(129, 1324));
+			tests.add(createWithArray(127, 1323));
 			tests.add(createWithArray(66, 132));
 			tests.add(createRangeWithArray(66, 132));
 			tests.add(createRangeWithArray(32, 132));
@@ -170,13 +174,16 @@ public class IndexesTest {
 			DataOutputStream fos = new DataOutputStream(bos);
 			actual.write(fos);
 
+			long actualSize = bos.size();
 			// Serialize in
 			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
 			DataInputStream fis = new DataInputStream(bis);
 
 			IColIndex n = ColIndexFactory.read(fis);
+			long expectedSize = actual.getExactSizeOnDisk();
 
 			compare(actual, n);
+			assertEquals(actual.toString(), expectedSize, actualSize);
 		}
 		catch(IOException e) {
 			throw new RuntimeException("Error in io " + actual, e);
@@ -198,7 +205,7 @@ public class IndexesTest {
 			long actualSize = bos.size();
 			long expectedSize = actual.getExactSizeOnDisk();
 
-			assertEquals(expectedSize, actualSize);
+			assertEquals(actual.toString(), expectedSize, actualSize);
 		}
 		catch(IOException e) {
 			throw new RuntimeException("Error in io", e);
@@ -606,7 +613,6 @@ public class IndexesTest {
 	}
 
 	private static void compare(int[] expected, IIterate actual) {
-		// LOG.error(expected);
 		for(int i = 0; i < expected.length; i++) {
 			assertTrue(actual.hasNext());
 			assertEquals(i, actual.i());

--- a/src/test/java/org/apache/sysds/test/component/compress/io/IOCompressionTestUtils.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/io/IOCompressionTestUtils.java
@@ -61,8 +61,8 @@ public class IOCompressionTestUtils {
 		// assertTrue("Disk size is not equivalent", a.getExactSizeOnDisk() > b.getExactSizeOnDisk());
 	}
 
-	public synchronized static MatrixBlock read(String path) throws Exception {
-		return ReaderCompressed.readCompressedMatrixFromHDFS(path);
+	public synchronized static MatrixBlock read(String path, long rlen, long clen, int blen) throws Exception {
+		return ReaderCompressed.readCompressedMatrixFromHDFS(path, rlen, clen, blen);
 	}
 
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/io/IOEmpty.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/io/IOEmpty.java
@@ -69,7 +69,7 @@ public class IOEmpty {
 	public void writeEmptyAndRead() throws Exception {
 		String n = getName();
 		write(n, 10, 10, 1000);
-		MatrixBlock mb = IOCompressionTestUtils.read(n);
+		MatrixBlock mb = IOCompressionTestUtils.read(n, 10, 10, 1000);
 		IOCompressionTestUtils.verifyEquivalence(mb, new MatrixBlock(10, 10, 0.0));
 	}
 
@@ -87,7 +87,7 @@ public class IOEmpty {
 		write(n, 1000, 10, 100);
 		File f = new File(n);
 		assertTrue(f.isDirectory() || f.isFile());
-		MatrixBlock mb = IOCompressionTestUtils.read(n);
+		MatrixBlock mb = IOCompressionTestUtils.read(n, 1000, 10, 100);
 		IOCompressionTestUtils.verifyEquivalence(mb, new MatrixBlock(1000, 10, 0.0));
 	}
 

--- a/src/test/java/org/apache/sysds/test/component/compress/io/IOSpark.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/io/IOSpark.java
@@ -138,75 +138,75 @@ public class IOSpark {
 	}
 
 	@Test
-	public void writeSparkReadCPMultiColBlock() {
+	public void writeSparkReadMultiColBlock() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 124, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 100);
+		testWriteSparkRead(mb, 100, 100);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiRowBlock() {
+	public void writeSparkReadMultiRowBlock() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(1322, 33, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 100);
+		testWriteSparkRead(mb, 100, 100);
 	}
 
 	@Test
-	public void writeSparkReadCPSingleBlock() {
+	public void writeSparkReadSingleBlock() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 99, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 100);
+		testWriteSparkRead(mb, 100, 100);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiBlock() {
+	public void writeSparkReadMultiBlock() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(580, 244, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 100);
+		testWriteSparkRead(mb, 100, 100);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiColBlockReblockUp() {
+	public void writeSparkReadMultiColBlockReblockUp() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 124, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 150);
+		testWriteSparkRead(mb, 100, 150);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiRowBlockReblockUp() {
+	public void writeSparkReadMultiRowBlockReblockUp() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(1322, 33, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 150);
+		testWriteSparkRead(mb, 100, 150);
 	}
 
 	@Test
-	public void writeSparkReadCPSingleBlockReblockUp() {
+	public void writeSparkReadSingleBlockReblockUp() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 99, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 150);
+		testWriteSparkRead(mb, 100, 150);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiBlockReblockUp() {
+	public void writeSparkReadMultiBlockReblockUp() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(580, 244, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 150);
+		testWriteSparkRead(mb, 100, 150);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiColBlockReblockDown() {
+	public void writeSparkReadMultiColBlockReblockDown() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 124, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 80);
+		testWriteSparkRead(mb, 100, 80);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiRowBlockReblockDown() {
+	public void writeSparkReadMultiRowBlockReblockDown() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(1322, 33, 1, 3, 1.0, 2514));
-		testWriteSparkReadCP(mb, 100, 80);
+		testWriteSparkRead(mb, 100, 80);
 	}
 
 	@Test
-	public void writeSparkReadCPSingleBlockReblockDown() {
+	public void writeSparkReadSingleBlockReblockDown() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(50, 99, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 80);
+		testWriteSparkRead(mb, 100, 80);
 	}
 
 	@Test
-	public void writeSparkReadCPMultiBlockReblockDown() {
+	public void writeSparkReadMultiBlockReblockDown() {
 		MatrixBlock mb = TestUtils.ceil(TestUtils.generateTestMatrixBlock(580, 244, 1, 3, 1.0, 33));
-		testWriteSparkReadCP(mb, 100, 80);
+		testWriteSparkRead(mb, 100, 80);
 	}
 
 	@Test
@@ -269,11 +269,11 @@ public class IOSpark {
 		testReblock(mb, 100, 25);
 	}
 
-	private void testWriteSparkReadCP(MatrixBlock mb, int blen1, int blen2) {
-		testWriteSparkReadCP(mb, blen1, blen2, 1);
+	private void testWriteSparkRead(MatrixBlock mb, int blen1, int blen2) {
+		testWriteSparkRead(mb, blen1, blen2, 1);
 	}
 
-	private void testWriteSparkReadCP(MatrixBlock mb, int blen1, int blen2, int rep) {
+	private void testWriteSparkRead(MatrixBlock mb, int blen1, int blen2, int rep) {
 
 		try {
 			CompressedMatrixBlock.debug = true;
@@ -300,7 +300,7 @@ public class IOSpark {
 			Thread.sleep(100);
 
 			// Read locally the spark block written.
-			MatrixBlock mbr = IOCompressionTestUtils.read(f2);
+			MatrixBlock mbr = IOCompressionTestUtils.read(f2, mb.getNumRows(), mb.getNumColumns(), blen2);
 			IOCompressionTestUtils.verifyEquivalence(mb, mbr);
 			LOG.warn("IOSpark Writer Read: " + t.stop());
 		}
@@ -310,7 +310,7 @@ public class IOSpark {
 
 				if(rep < 3) {
 					Thread.sleep(1000);
-					testWriteSparkReadCP(mb, blen1, blen2, rep + 1);
+					testWriteSparkRead(mb, blen1, blen2, rep + 1);
 					return;
 				}
 			}

--- a/src/test/java/org/apache/sysds/test/component/compress/io/IOTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/io/IOTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
 import org.apache.sysds.runtime.compress.io.WriterCompressed;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -139,7 +140,8 @@ public class IOTest {
 			WriterCompressed.writeCompressedMatrixToHDFS(mb, filename);
 			File f = new File(filename);
 			assertTrue(f.isFile() || f.isDirectory());
-			MatrixBlock mbr = IOCompressionTestUtils.read(filename);
+			MatrixBlock mbr = IOCompressionTestUtils.read(filename, mb.getNumRows(), mb.getNumColumns(),
+				OptimizerUtils.DEFAULT_BLOCKSIZE);
 			IOCompressionTestUtils.verifyEquivalence(mb, mbr);
 		}
 		catch(Exception e) {
@@ -180,7 +182,7 @@ public class IOTest {
 			WriterCompressed.writeCompressedMatrixToHDFS(mb, filename, blen);
 			File f = new File(filename);
 			assertTrue(f.isFile() || f.isDirectory());
-			MatrixBlock mbr = IOCompressionTestUtils.read(filename);
+			MatrixBlock mbr = IOCompressionTestUtils.read(filename, mb.getNumRows(), mb.getNumColumns(), blen);
 			IOCompressionTestUtils.verifyEquivalence(mb, mbr);
 		}
 		catch(Exception e) {

--- a/src/test/java/org/apache/sysds/test/component/compress/offset/CustomOffsetTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/offset/CustomOffsetTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,24 +17,23 @@
  * under the License.
  */
 
-package org.apache.sysds.runtime.compress.utils;
+package org.apache.sysds.test.component.compress.offset;
 
-import org.apache.spark.api.java.function.Function;
-import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
-import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import static org.junit.Assert.assertEquals;
 
-public class CompressRDDClean implements Function<MatrixBlock, MatrixBlock> {
+import org.apache.sysds.runtime.compress.colgroup.offset.AOffset;
+import org.apache.sysds.runtime.compress.colgroup.offset.AOffset.OffsetSliceInfo;
+import org.apache.sysds.runtime.compress.colgroup.offset.OffsetFactory;
+import org.junit.Test;
 
-	private static final long serialVersionUID = -704403012606821854L;
+public class CustomOffsetTest {
 
-	@Override
-	public MatrixBlock call(MatrixBlock mb) throws Exception {
+    @Test
+    public void sliceE() {
+        AOffset a = OffsetFactory.createOffset(new int[] {441, 1299, 14612, 16110, 18033, 18643, 18768, 25798, 32315});
 
-		if(mb instanceof CompressedMatrixBlock) {
-			CompressedMatrixBlock cmb = (CompressedMatrixBlock) mb;
-			cmb.clearSoftReferenceToDecompressed();
-			return cmb;
-		}
-		return mb;
-	}
+        OffsetSliceInfo i = a.slice(1000, 2000);
+        System.out.println(a);
+        assertEquals(OffsetFactory.createOffset(new int[] {299}), i.offsetSlice);
+    }
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/util/ArrCountMapTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/util/ArrCountMapTest.java
@@ -195,7 +195,7 @@ public class ArrCountMapTest {
 		assertEquals(19, m.getId(I(19.0)));
 	}
 
-	@Test()
+	@Test
 	public void sortBucketsSmall() {
 		for(int i = 0; i < 9; i++)
 			m.increment(I((double) i));

--- a/src/test/java/org/apache/sysds/test/component/compress/util/ArrayListTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/util/ArrayListTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+import org.junit.Test;
+
+public class ArrayListTest {
+
+	@Test
+	public void allocate() {
+		assertEquals(4, new IntArrayList(4).extractValues().length);
+	}
+
+	@Test
+	public void allocate2() {
+		assertEquals(16, new IntArrayList(16).extractValues().length);
+	}
+
+	@Test
+	public void sizeEmpty() {
+		assertEquals(0, new IntArrayList(16).size());
+	}
+
+	@Test
+	public void sizeEmpty2() {
+		assertEquals(0, new IntArrayList(32).size());
+	}
+
+	@Test
+	public void sizeEmpty3() {
+		assertEquals(0, new IntArrayList().size());
+	}
+
+	@Test(expected = DMLCompressionException.class)
+	public void directError() {
+		new IntArrayList(null);
+	}
+
+	@Test
+	public void directAllocation() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+
+		assertEquals(3, a.size());
+		assertEquals(1, a.get(0));
+		assertEquals(2, a.get(1));
+		assertEquals(3, a.get(2));
+	}
+
+	@Test
+	public void appendValue() {
+		IntArrayList a = new IntArrayList();
+
+		for(int i = 0; i < 10; i++) {
+			a.appendValue(i);
+		}
+
+		assertEquals(10, a.size());
+		assertEquals(6, a.get(6));
+	}
+
+	@Test
+	public void appendValue2() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+
+		for(int i = 0; i < 10; i++) {
+			a.appendValue(i);
+		}
+
+		assertEquals(13, a.size());
+		assertEquals(6, a.get(6 + 3));
+	}
+
+	@Test
+	public void appendValueArray() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+		IntArrayList b = new IntArrayList(new int[] {4, 5, 6});
+		a.appendValue(b);
+
+		assertEquals(6, a.size());
+		assertEquals(6, a.get(5));
+	}
+
+	@Test
+	public void appendValueArray2() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+		IntArrayList b = new IntArrayList(new int[] {4, 5, 6});
+		a.appendValue(b);
+		a.appendValue(b);
+		a.appendValue(b);
+
+		assertEquals(12, a.size());
+		assertEquals(6, a.get(5));
+	}
+
+	@Test
+	public void appendValueArray3() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+		IntArrayList b = new IntArrayList(new int[] {4, 5, 6});
+		a.appendValue(b);
+		a.appendValue(b);
+		a.appendValue(b);
+		int[] ex = a.extractValues();
+
+		assertTrue(ex.length >= a.size());
+		assertEquals(6, a.get(5));
+		assertEquals(6, ex[5]);
+	}
+
+
+	@Test
+	public void appendValueArray4() {
+		IntArrayList a = new IntArrayList(new int[] {1, 2, 3});
+		IntArrayList b = new IntArrayList(new int[] {4, 5, 6});
+		for(int i = 0; i < 10; i++){
+
+			a.appendValue(b);
+			a.appendValue(1);
+		}
+		int[] ex = a.extractValues();
+
+		assertTrue(ex.length >= a.size());
+		assertEquals(10*3+3 + 10,  a.size());
+		assertEquals(6, a.get(5));
+		assertEquals(6, ex[5]);
+	}
+
+	@Test
+	public void extract() {
+		IntArrayList a = new IntArrayList();
+		for(int i = 0; i < 2; i++)
+			a.appendValue(i);
+
+		int[] ex = a.extractValues();
+		assertTrue(ex.length > a.size());
+		int[] et = a.extractValues(true);
+		assertTrue(et.length == a.size());
+		assertEquals(1, a.get(1));
+		assertEquals(1, ex[1]);
+		assertEquals(1, et[1]);
+	}
+
+	@Test
+	public void toStringTest() {
+		IntArrayList a = new IntArrayList();
+		for(int i = 0; i < 2; i++)
+			a.appendValue(i);
+		String as = a.toString();
+		// int[] ex = a.extractValues();
+		// assertTrue(ex.length > a.size());
+		int[] et = a.extractValues(true);
+		String es = Arrays.toString(et);
+		assertEquals(es, as);
+	}
+
+	@Test
+	public void toStringEmpty() {
+		IntArrayList a = new IntArrayList();
+		// for(int i = 0; i < 2; i++)
+		// a.appendValue(i);
+		String as = a.toString();
+		// int[] ex = a.extractValues();
+		// assertTrue(ex.length > a.size());
+		int[] et = a.extractValues(true);
+		String es = Arrays.toString(et);
+		assertEquals(es, as);
+	}
+
+	@Test
+	public void extractExactEach() {
+		IntArrayList a = new IntArrayList();
+		for(int i = 0; i < 10; i++) {
+			assertEquals(i, a.extractValues(true).length);
+			assertTrue(i <= a.extractValues(false).length);
+			a.appendValue(i);
+		}
+		assertTrue(10 <= a.extractValues(false).length);
+		assertEquals(10, a.extractValues(true).length);
+	}
+
+	@Test
+	public void reset1(){
+		IntArrayList a = new IntArrayList();
+		a.appendValue(1);
+		a.appendValue(2);
+		assertEquals(2, a.size());
+		a.reset();
+		assertEquals(0, a.size());
+		
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/util/CountTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/util/CountTest.java
@@ -23,7 +23,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.sysds.runtime.compress.utils.ACount;
+import org.apache.sysds.runtime.compress.utils.ACount.DArrCounts;
 import org.apache.sysds.runtime.compress.utils.ACount.DCounts;
+import org.apache.sysds.runtime.compress.utils.DblArray;
 import org.junit.Test;
 
 public class CountTest {
@@ -84,5 +88,17 @@ public class CountTest {
 		assertEquals(3 + 3, h.get(2.0).count);
 		assertEquals(4 + 3, h.get(3.0).count);
 		assertEquals(1 + 3, h.get(1.0).count);
+	}
+
+	@Test(expected = NotImplementedException.class)
+	public void getDouble() {
+		ACount<DblArray> a = new DArrCounts(new DblArray(new double[] {1, 2}), 1);
+		a.get(0.0);
+	}
+
+	@Test(expected = NotImplementedException.class)
+	public void incDouble() {
+		ACount<DblArray> a = new DArrCounts(new DblArray(new double[] {1, 2}), 1);
+		a.inc(0.0, 0, 1);
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/util/ListHashMapTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/util/ListHashMapTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.runtime.compress.utils.DblArray;
+import org.apache.sysds.runtime.compress.utils.DblArrayIntListHashMap;
+import org.apache.sysds.runtime.compress.utils.IntArrayList;
+import org.junit.Test;
+
+public class ListHashMapTest {
+
+	@Test
+	public void add() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray a = new DblArray(new double[] {1, 2, 3});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(a, 0);
+		}
+		IntArrayList l = m.get(a);
+		assertEquals(rep, l.size());
+
+	}
+
+	@Test
+	public void add2() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray a = new DblArray(new double[] {1, 2, 3});
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(a, i);
+			m.appendValue(b, i);
+		}
+		IntArrayList l = m.get(a);
+		assertEquals(rep, l.size());
+
+	}
+
+	@Test
+	public void add3() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			m.appendValue(a, i);
+			m.appendValue(b, i);
+		}
+		IntArrayList l = m.get(b);
+		assertEquals(rep, l.size());
+
+	}
+
+	@Test
+	public void add4() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			m.appendValue(a, i);
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+		}
+		IntArrayList l = m.get(b);
+		assertEquals(rep, l.size());
+
+	}
+
+	@Test
+	public void extractAll() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			m.appendValue(a, i);
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+		}
+
+		assertEquals(rep + 1, m.extractValues().size());
+
+	}
+
+	@Test
+	public void toStringWorks() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			m.appendValue(a, i);
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+		}
+		m.toString();
+	}
+
+	@Test
+	public void size() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			m.appendValue(a, i);
+			assertEquals(i + 1, m.size());
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+			assertEquals(rep + 1, m.size());
+		}
+		m.toString();
+	}
+
+	@Test
+	public void get() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap();
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			assertTrue(m.get(a) == null);
+			m.appendValue(a, i);
+			assertEquals(i + 1, m.size());
+			assertTrue(m.get(a) != null);
+
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+			assertEquals(rep + 1, m.size());
+		}
+		m.toString();
+	}
+
+	@Test
+	public void getCustom() {
+		DblArrayIntListHashMap m = new DblArrayIntListHashMap(25);
+		DblArray b = new DblArray(new double[] {1, 2, 4});
+		final int rep = 100;
+		for(int i = 0; i < rep; i++) {
+			DblArray a = new DblArray(new double[] {1, i, i});
+			assertTrue(m.get(a) == null);
+			m.appendValue(a, i);
+			assertEquals(i + 1, m.size());
+			assertTrue(m.get(a) != null);
+
+		}
+		for(int i = 0; i < rep; i++) {
+			m.appendValue(b, i);
+			assertEquals(rep + 1, m.size());
+		}
+
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedTestUtils.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedTestUtils.java
@@ -99,7 +99,6 @@ public class FederatedTestUtils {
 			final FederatedRequest frq = new FederatedRequest(RequestType.PUT_VAR, null, id, mb);
 			final Future<FederatedResponse> fr = FederatedData.executeFederatedOperation(addr, frq);
 			final FederatedResponse r = fr.get(timeout, TimeUnit.MILLISECONDS);
-			LOG.error(r);
 			if(r.isSuccessful())
 				return id;
 			else

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestLogger.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestLogger.java
@@ -73,16 +73,28 @@ public class TransformCompressedTestLogger {
 			MultiColumnEncoder encoderCompressed = EncoderFactory.createEncoder(spec, data.getColumnNames(),
 				data.getNumColumns(), meta);
 			MatrixBlock outCompressed = encoderCompressed.encode(data, true);
-			FrameBlock outCompressedMD = encoderCompressed.getMetaData(null);
+			// FrameBlock outCompressedMD = encoderCompressed.getMetaData(null);
 			MultiColumnEncoder encoderNormal = EncoderFactory.createEncoder(spec, data.getColumnNames(),
 				data.getNumColumns(), meta);
 			MatrixBlock outNormal = encoderNormal.encode(data);
-			FrameBlock outNormalMD = encoderNormal.getMetaData(null);
+			// FrameBlock outNormalMD = encoderNormal.getMetaData(null);
 
 			final List<LoggingEvent> log = LoggingUtils.reinsert(appender);
 			assertTrue(log.get(3).getMessage().toString().contains("Compression ratio"));
 			TestUtils.compareMatrices(outNormal, outCompressed, 0, "Not Equal after apply");
-			TestUtils.compareFrames(outNormalMD, outCompressedMD, true);
+
+			MultiColumnEncoder ec = EncoderFactory.createEncoder(spec, data.getColumnNames(), data.getNumColumns(),
+				encoderCompressed.getMetaData(null));
+			
+			MatrixBlock outMeta1 = ec.apply(data, 1);
+
+			TestUtils.compareMatrices(outNormal, outMeta1, 0, "Not Equal after apply");
+
+			MultiColumnEncoder ec2 = EncoderFactory.createEncoder(spec, data.getColumnNames(), data.getNumColumns(),
+				encoderNormal.getMetaData(null));
+			
+			MatrixBlock outMeta12 = ec2.apply(data, 1);
+			TestUtils.compareMatrices(outNormal, outMeta12, 0, "Not Equal after apply2");
 		}
 		catch(Exception e) {
 			e.printStackTrace();

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
@@ -61,25 +61,25 @@ public class TransformCompressedTestMultiCol {
 			Arrays.fill(kPlusCols, ValueType.BOOLEAN);
 
 			FrameBlock[] blocks = new FrameBlock[] {//
-				TestUtils.generateRandomFrameBlock(100, //
+				TestUtils.generateRandomFrameBlock(16, //
 					new ValueType[] {ValueType.UINT4, ValueType.UINT8, ValueType.UINT4}, 231), //
-				TestUtils.generateRandomFrameBlock(100, //
+				TestUtils.generateRandomFrameBlock(10, //
 					new ValueType[] {ValueType.BOOLEAN, ValueType.UINT8, ValueType.UINT4}, 231), //
 				new FrameBlock(new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.INT32}, 100), //
-				TestUtils.generateRandomFrameBlock(100, //
+				TestUtils.generateRandomFrameBlock(11, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
 				TestUtils.generateRandomFrameBlock(432, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
-				TestUtils.generateRandomFrameBlock(100, //
+				TestUtils.generateRandomFrameBlock(12, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.9),
-				TestUtils.generateRandomFrameBlock(100, //
+				TestUtils.generateRandomFrameBlock(14, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.99),
 
 				TestUtils.generateRandomFrameBlock(5, kPlusCols, 322),
 				TestUtils.generateRandomFrameBlock(1020, kPlusCols, 322),
 
 			};
-			blocks[2].ensureAllocatedColumns(100);
+			blocks[2].ensureAllocatedColumns(20);
 
 			for(FrameBlock block : blocks) {
 				for(int k : threads) {
@@ -145,14 +145,24 @@ public class TransformCompressedTestMultiCol {
 				data.getNumColumns(), meta);
 
 			MatrixBlock outCompressed = encoderCompressed.encode(data, k, true);
-			FrameBlock outCompressedMD = encoderCompressed.getMetaData(null);
 			MultiColumnEncoder encoderNormal = EncoderFactory.createEncoder(spec, data.getColumnNames(),
 				data.getNumColumns(), meta);
 			MatrixBlock outNormal = encoderNormal.encode(data, k);
-			FrameBlock outNormalMD = encoderNormal.getMetaData(null);
 
 			TestUtils.compareMatrices(outNormal, outCompressed, 0, "Not Equal after apply");
-			TestUtils.compareFrames(outNormalMD, outCompressedMD, true);
+
+			MultiColumnEncoder ec2 = EncoderFactory.createEncoder(spec, data.getColumnNames(), data.getNumColumns(),
+				encoderNormal.getMetaData(null));
+			
+			MatrixBlock outMeta12 = ec2.apply(data, k);
+			TestUtils.compareMatrices(outNormal, outMeta12, 0, "Not Equal after apply2");
+
+			MultiColumnEncoder ec = EncoderFactory.createEncoder(spec, data.getColumnNames(), data.getNumColumns(),
+				encoderCompressed.getMetaData(null));
+			
+			MatrixBlock outMeta1 = ec.apply(data, k);
+			TestUtils.compareMatrices(outNormal, outMeta1, 0, "Not Equal after apply");
+
 		}
 		catch(Exception e) {
 			e.printStackTrace();

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
@@ -53,7 +53,7 @@ public class TransformCompressedTestMultiCol {
 	@Parameters
 	public static Collection<Object[]> data() {
 		final ArrayList<Object[]> tests = new ArrayList<>();
-		final int[] threads = new int[] {1, 100};
+		final int[] threads = new int[] {1, 4};
 		try {
 
 			ValueType[] kPlusCols = new ValueType[1002];
@@ -61,25 +61,25 @@ public class TransformCompressedTestMultiCol {
 			Arrays.fill(kPlusCols, ValueType.BOOLEAN);
 
 			FrameBlock[] blocks = new FrameBlock[] {//
-				// TestUtils.generateRandomFrameBlock(16, //
-				// 	new ValueType[] {ValueType.UINT4, ValueType.UINT8, ValueType.UINT4}, 231), //
-				// TestUtils.generateRandomFrameBlock(10, //
-				// 	new ValueType[] {ValueType.BOOLEAN, ValueType.UINT8, ValueType.UINT4}, 231), //
-				// new FrameBlock(new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.INT32}, 100), //
-				// TestUtils.generateRandomFrameBlock(11, //
-				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
-				// TestUtils.generateRandomFrameBlock(432, //
-				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
-				// TestUtils.generateRandomFrameBlock(12, //
-				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.9),
+				TestUtils.generateRandomFrameBlock(16, //
+					new ValueType[] {ValueType.UINT4, ValueType.UINT8, ValueType.UINT4}, 231), //
+				TestUtils.generateRandomFrameBlock(10, //
+					new ValueType[] {ValueType.BOOLEAN, ValueType.UINT8, ValueType.UINT4}, 231), //
+				new FrameBlock(new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.INT32}, 100), //
+				TestUtils.generateRandomFrameBlock(11, //
+					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
+				TestUtils.generateRandomFrameBlock(432, //
+					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
+				TestUtils.generateRandomFrameBlock(12, //
+					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.9),
 				TestUtils.generateRandomFrameBlock(14, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.99),
 
-				// TestUtils.generateRandomFrameBlock(5, kPlusCols, 322),
-				// TestUtils.generateRandomFrameBlock(1020, kPlusCols, 322),
+				TestUtils.generateRandomFrameBlock(5, kPlusCols, 322),
+				TestUtils.generateRandomFrameBlock(1020, kPlusCols, 322),
 
 			};
-			// blocks[2].ensureAllocatedColumns(20);
+			blocks[2].ensureAllocatedColumns(20);
 
 			for(FrameBlock block : blocks) {
 				for(int k : threads) {
@@ -102,7 +102,7 @@ public class TransformCompressedTestMultiCol {
 
 	@Test
 	public void testDummyCode() {
-		// test("{dummycode:[C1,C2,C3]}");
+		test("{dummycode:[C1,C2,C3]}");
 	}
 
 	@Test 

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
@@ -53,7 +53,7 @@ public class TransformCompressedTestMultiCol {
 	@Parameters
 	public static Collection<Object[]> data() {
 		final ArrayList<Object[]> tests = new ArrayList<>();
-		final int[] threads = new int[] {1, 4};
+		final int[] threads = new int[] {1, 100};
 		try {
 
 			ValueType[] kPlusCols = new ValueType[1002];
@@ -61,25 +61,25 @@ public class TransformCompressedTestMultiCol {
 			Arrays.fill(kPlusCols, ValueType.BOOLEAN);
 
 			FrameBlock[] blocks = new FrameBlock[] {//
-				TestUtils.generateRandomFrameBlock(16, //
-					new ValueType[] {ValueType.UINT4, ValueType.UINT8, ValueType.UINT4}, 231), //
-				TestUtils.generateRandomFrameBlock(10, //
-					new ValueType[] {ValueType.BOOLEAN, ValueType.UINT8, ValueType.UINT4}, 231), //
-				new FrameBlock(new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.INT32}, 100), //
-				TestUtils.generateRandomFrameBlock(11, //
-					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
-				TestUtils.generateRandomFrameBlock(432, //
-					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
-				TestUtils.generateRandomFrameBlock(12, //
-					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.9),
+				// TestUtils.generateRandomFrameBlock(16, //
+				// 	new ValueType[] {ValueType.UINT4, ValueType.UINT8, ValueType.UINT4}, 231), //
+				// TestUtils.generateRandomFrameBlock(10, //
+				// 	new ValueType[] {ValueType.BOOLEAN, ValueType.UINT8, ValueType.UINT4}, 231), //
+				// new FrameBlock(new ValueType[] {ValueType.BOOLEAN, ValueType.INT32, ValueType.INT32}, 100), //
+				// TestUtils.generateRandomFrameBlock(11, //
+				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
+				// TestUtils.generateRandomFrameBlock(432, //
+				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.2),
+				// TestUtils.generateRandomFrameBlock(12, //
+				// 	new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.9),
 				TestUtils.generateRandomFrameBlock(14, //
 					new ValueType[] {ValueType.UINT4, ValueType.BOOLEAN, ValueType.FP32}, 231, 0.99),
 
-				TestUtils.generateRandomFrameBlock(5, kPlusCols, 322),
-				TestUtils.generateRandomFrameBlock(1020, kPlusCols, 322),
+				// TestUtils.generateRandomFrameBlock(5, kPlusCols, 322),
+				// TestUtils.generateRandomFrameBlock(1020, kPlusCols, 322),
 
 			};
-			blocks[2].ensureAllocatedColumns(20);
+			// blocks[2].ensureAllocatedColumns(20);
 
 			for(FrameBlock block : blocks) {
 				for(int k : threads) {
@@ -102,7 +102,12 @@ public class TransformCompressedTestMultiCol {
 
 	@Test
 	public void testDummyCode() {
-		test("{dummycode:[C1,C2,C3]}");
+		// test("{dummycode:[C1,C2,C3]}");
+	}
+
+	@Test 
+	public void testDummyCodeV2(){
+		test("{ids:true, dummycode:[1,2,3]}");
 	}
 
 	@Test
@@ -139,7 +144,8 @@ public class TransformCompressedTestMultiCol {
 
 	public void test(String spec) {
 		try {
-
+			LOG.error(data);
+			LOG.error(k);
 			FrameBlock meta = null;
 			MultiColumnEncoder encoderCompressed = EncoderFactory.createEncoder(spec, data.getColumnNames(),
 				data.getNumColumns(), meta);

--- a/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/transform/TransformCompressedTestMultiCol.java
@@ -144,8 +144,6 @@ public class TransformCompressedTestMultiCol {
 
 	public void test(String spec) {
 		try {
-			LOG.error(data);
-			LOG.error(k);
 			FrameBlock meta = null;
 			MultiColumnEncoder encoderCompressed = EncoderFactory.createEncoder(spec, data.getColumnNames(),
 				data.getNumColumns(), meta);

--- a/src/test/java/org/apache/sysds/test/component/matrix/SparseCSRTest.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/SparseCSRTest.java
@@ -53,7 +53,6 @@ public class SparseCSRTest {
 		int[] colInd = new int[] {10, 20, 30, 40, 50, 60, 80, 90, 100};
 		double[] val = new double[] {1, 1, 1, 1, 1, 1, 1, 1, 1};
 		SparseBlockCSR b = new SparseBlockCSR(rs, colInd, val, val.length);
-		LOG.error(b);
 
 		assertEquals(0, b.posFIndexGTE(1, 0));
 		assertEquals(0, b.posFIndexGTE(1, 10));
@@ -71,7 +70,6 @@ public class SparseCSRTest {
 		int[] colInd = new int[] {100, 10, 20, 30, 40, 50, 60, 80, 90, 100};
 		double[] val = new double[] {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 		SparseBlockCSR b = new SparseBlockCSR(rs, colInd, val, val.length);
-		LOG.error(b);
 
 		assertEquals(0, b.posFIndexGTE(1, 0));
 		assertEquals(0, b.posFIndexGTE(1, 10));

--- a/src/test/java/org/apache/sysds/test/functions/io/compressed/WriteCompressedTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/io/compressed/WriteCompressedTest.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.test.functions.io.compressed;
 
 import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -84,7 +85,7 @@ public class WriteCompressedTest extends AutomatedTestBase {
 		runTest(null);
 
 		double sumDML = TestUtils.readDMLScalar(output("sum.scalar"));
-		MatrixBlock mbr = IOCompressionTestUtils.read(output("out.cla"));
+		MatrixBlock mbr = IOCompressionTestUtils.read(output("out.cla"), rows, cols, OptimizerUtils.DEFAULT_BLOCKSIZE);
 		
 		TestUtils.compareScalars(sumDML, mbr.sum(), eps);
 

--- a/src/test/java/org/apache/sysds/test/functions/transform/TransformApplyUnknownsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/transform/TransformApplyUnknownsTest.java
@@ -19,20 +19,22 @@
 
 package org.apache.sysds.test.functions.transform;
 
-import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.transform.encode.EncoderFactory;
+import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
 import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class TransformApplyUnknownsTest extends AutomatedTestBase 
-{
+public class TransformApplyUnknownsTest extends AutomatedTestBase {
+	protected static final Log LOG = LogFactory.getLog(TransformApplyUnknownsTest.class.getName());
 	private static final int rows = 70;
 	
 	@Override
@@ -91,8 +93,10 @@ public class TransformApplyUnknownsTest extends AutomatedTestBase
 			Assert.assertEquals(out.getNumRows(), data2.getNumRows());
 			Assert.assertEquals(out.getNumColumns(), data2.getNumColumns());
 			for(int i=-5; i<=rows+5; i++) {
-				if( i < 1 | i > rows )
-					Assert.assertTrue(Double.isNaN(out.quickGetValue(i+5, 0)));
+				if( i < 1 )
+					Assert.assertEquals(1, out.quickGetValue(i+5, 0), 0.0);
+				else if(i > rows)
+					Assert.assertEquals(out.quickGetValue(out.getNumRows()-1, 0), out.quickGetValue(i+5, 0), 0.0);
 				else
 					Assert.assertEquals(((i-1)/10+1), out.quickGetValue(i+5, 0), 1e-8);
 			}


### PR DESCRIPTION
I am surprised, but with moderate to large size files our parallel writers are better if we enable snappy on the write path. It improve the write speed a little. and significantly reduce the size of the files on disk.

Uncompressed:
```txt
StandardDisk,    6.345+-  0.907 ms,   1260913549 Byte/s,   1278545356 Byte/s
```

Snappy:
```txt
StandardDisk,    6.021+-  0.946 ms,   1328816357Byte/s,     291445747 Byte/s
```
