### PR TITLE
[SYSTEMDS-3623] Lossy compression with binning

### DIFF
--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -86,7 +86,7 @@ public enum Builtins {
 	COLSUM("colSums", false),
 	COLVAR("colVars", false),
 	COMPONENTS("components", true),
-	COMPRESS("compress", false),
+	COMPRESS("compress", false, ReturnType.MULTI_RETURN),
 	CONFUSIONMATRIX("confusionMatrix", true),
 	CONV2D("conv2d", false),
 	CONV2D_BACKWARD_FILTER("conv2d_backward_filter", false),

--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -400,7 +400,7 @@ public class Types
 	// Operations that require 2 operands
 	public enum OpOp2 {
 		AND(true), APPLY_SCHEMA(false), BITWAND(true), BITWOR(true), BITWSHIFTL(true), BITWSHIFTR(true),
-		BITWXOR(true), CBIND(false), CONCAT(false), COV(false), DIV(true),
+		BITWXOR(true), CBIND(false), COMPRESS(true), CONCAT(false), COV(false), DIV(true),
 		DROP_INVALID_TYPE(false), DROP_INVALID_LENGTH(false), EQUAL(true),
 		FRAME_ROW_REPLICATE(true), GREATER(true), GREATEREQUAL(true), INTDIV(true),
 		INTERQUANTILE(false), IQM(false), LESS(true),

--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -19,10 +19,15 @@
 
 package org.apache.sysds.hops;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.common.Types.OpOp1;
 import org.apache.sysds.common.Types.OpOp2;
@@ -38,7 +43,6 @@ import org.apache.sysds.hops.fedplanner.FTypes.FederatedPlanner;
 import org.apache.sysds.hops.rewrite.HopRewriteUtils;
 import org.apache.sysds.lops.Checkpoint;
 import org.apache.sysds.lops.Lop;
-import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.lops.compile.Dag;
 import org.apache.sysds.parser.ForStatementBlock;
 import org.apache.sysds.runtime.DMLRuntimeException;
@@ -60,10 +64,6 @@ import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 public class OptimizerUtils 
 {
@@ -269,7 +269,7 @@ public class OptimizerUtils
 	 * This variable allows for insertion of Compress and decompress in the dml script from the user.
 	 * This is added because we want to have a way to test, and verify the correct placement of compress and decompress commands.
 	 */
-	public static boolean ALLOW_SCRIPT_LEVEL_COMPRESS_COMMAND = false;
+	public static boolean ALLOW_SCRIPT_LEVEL_COMPRESS_COMMAND = true;
 
 
 	/**

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -412,7 +412,7 @@ public class BuiltinFunctionExpression extends DataIdentifier
 			if(OptimizerUtils.ALLOW_SCRIPT_LEVEL_COMPRESS_COMMAND){
 				Expression expressionTwo = getSecondExpr();
 				checkNumParameters(getSecondExpr() != null ? 2 : 1);
-				checkMatrixParam(getFirstExpr());
+				checkMatrixFrameParam(getFirstExpr());
 				if(expressionTwo != null)
 					checkMatrixParam(getSecondExpr());
 

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinCompress.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinCompress.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sysds.runtime.compress.lib;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
+import org.apache.sysds.runtime.compress.CompressionStatistics;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.transform.encode.ColumnEncoderBin;
+import org.apache.sysds.runtime.transform.encode.EncoderFactory;
+import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
+
+public class CLALibBinCompress {
+	public static ColumnEncoderBin.BinMethod binMethod = ColumnEncoderBin.BinMethod.EQUI_WIDTH;
+	public static Pair<MatrixBlock, FrameBlock> binCompress(MatrixBlock X, MatrixBlock d, int k){
+		// Create transform spec acc to binMethod
+		String spec = createSpec(d);
+
+		// Apply compressed transform encode using spec
+		MultiColumnEncoder encoder = //
+			EncoderFactory.createEncoder(spec, null, X.getNumColumns(), null);
+		MatrixBlock binned = encoder.encode(X, k, true);
+
+		// Get metadata from transformencode
+		FrameBlock meta = encoder.getMetaData(null);
+
+		// Optional: recompress
+		Pair<MatrixBlock, CompressionStatistics> recompressed = CompressedMatrixBlockFactory.compress(binned, k);
+		return new ImmutablePair<>(recompressed.getKey(), meta);
+	}
+
+	private static String createSpec(MatrixBlock d) {
+		d.sparseToDense();
+		double[] values = d.getDenseBlockValues();
+
+		String binning = binMethod.toString();
+
+		StringBuilder stringBuilder = new StringBuilder();
+		stringBuilder.append("{\"ids\":true,\"bin\":[");
+		for(int i = 0; i < values.length; i++) {
+			stringBuilder.append(String.format("{\"id\":%d,\"method\":\"%s\",\"numbins\":%d}", i + 1, binning, (int)values[i]));
+			if(i + 1 < values.length)
+				stringBuilder.append(',');
+		}
+		stringBuilder.append("]}");
+		return stringBuilder.toString();
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinCompress.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinCompress.java
@@ -46,9 +46,13 @@ public class CLALibBinCompress {
 		encoder.initMetaData(meta);
 		FrameBlock newMeta = encoder.getMetaData(meta, k);
 
-		// Optional: recompress
-		Pair<MatrixBlock, CompressionStatistics> recompressed = CompressedMatrixBlockFactory.compress(binned, k);
-		return new ImmutablePair<>(recompressed.getKey(), newMeta);
+		// FIXME Optional: recompress, else can be removed (lines 54-55) once fixed compression
+		if(X instanceof MatrixBlock) {
+			Pair<MatrixBlock, CompressionStatistics> recompressed = CompressedMatrixBlockFactory.compress(binned, k);
+			return new ImmutablePair<>(recompressed.getKey(), newMeta);
+		}
+		else
+			return new ImmutablePair<>(binned, newMeta);
 	}
 
 	private static String createSpec(MatrixBlock d) {

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderBin.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.runtime.transform.encode;
 
-import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -30,9 +28,11 @@ import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
+import static org.apache.sysds.runtime.util.UtilFunctions.getEndIndex;
 import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.lops.Lop;
+import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.columns.Array;
@@ -495,7 +495,17 @@ public class ColumnEncoderBin extends ColumnEncoder {
 	}
 
 	public enum BinMethod {
-		INVALID, EQUI_WIDTH, EQUI_HEIGHT, EQUI_HEIGHT_APPROX
+		INVALID, EQUI_WIDTH, EQUI_HEIGHT, EQUI_HEIGHT_APPROX;
+
+		@Override
+		public String toString(){
+			switch(this) {
+				case EQUI_WIDTH: return "EQUI-WIDTH";
+				case EQUI_HEIGHT: return "EQUI-HEIGHT";
+				case EQUI_HEIGHT_APPROX: return "EQUI_HEIGHT_APPROX";
+				default: throw new DMLRuntimeException("Invalid encoder type.");
+			}
+		}
 	}
 
 	private static class BinSparseApplyTask extends ColumnApplyTask<ColumnEncoderBin> {

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -19,12 +19,6 @@
 
 package org.apache.sysds.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.DataOutputStream;
@@ -50,6 +44,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.NotImplementedException;
@@ -2740,6 +2739,11 @@ public class TestUtils {
 		writer.writeFrameToHDFS(frame, file, data.length, schema.length);
 	}
 
+	public static void writeTestFrame(String file, FrameBlock data, ValueType[] schema, FileFormat fmt, boolean isR) throws IOException {
+		FrameWriter writer = FrameWriterFactory.createFrameWriter(fmt);
+		writer.writeFrameToHDFS(data, file, data.getNumRows(), schema.length);
+	}
+
 	/**
 	 * <p>
 	 * Writes a frame to a file using the text format.
@@ -2752,6 +2756,10 @@ public class TestUtils {
 	 * @throws IOException
 	 */
 	public static void writeTestFrame(String file, double[][] data, ValueType[] schema, FileFormat fmt) throws IOException {
+		writeTestFrame(file, data, schema, fmt, false);
+	}
+
+	public static void writeTestFrame(String file, FrameBlock data, ValueType[] schema, FileFormat fmt) throws IOException {
 		writeTestFrame(file, data, schema, fmt, false);
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/compress/matrixByBin/CompressByBinTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/matrixByBin/CompressByBinTest.java
@@ -20,13 +20,22 @@
 package org.apache.sysds.test.functions.compress.matrixByBin;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
 
 import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.columns.Array;
+import org.apache.sysds.runtime.frame.data.columns.ArrayFactory;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.transform.encode.ColumnEncoderBin;
+import org.apache.sysds.runtime.util.DataConverter;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.apache.sysds.test.functions.builtin.part1.BuiltinDistTest;
+import org.junit.Assert;
 import org.junit.Test;
 
 
@@ -41,6 +50,8 @@ public class CompressByBinTest extends AutomatedTestBase {
 
 	private final static int cols = 10;
 
+	private final static int nbins = 10;
+
 	private final static int[] dVector = new int[cols];
 
 	@Override
@@ -49,12 +60,18 @@ public class CompressByBinTest extends AutomatedTestBase {
 	}
 
 	@Test
-	public void testCompressBinsDefaultMatrixCP() { runCompress(Types.ExecType.CP); }
+	public void testCompressBinsMatrixWidthCP() { runCompress(Types.ExecType.CP, ColumnEncoderBin.BinMethod.EQUI_WIDTH); }
 
 	@Test
-	public void testCompressBinsDefaultFrameCP() { runCompressFrame(Types.ExecType.CP); }
+	public void testCompressBinsMatrixHeightCP() { runCompress(Types.ExecType.CP, ColumnEncoderBin.BinMethod.EQUI_HEIGHT); }
 
-	private void runCompress(Types.ExecType instType)
+	@Test
+	public void testCompressBinsFrameWidthCP() { runCompressFrame(Types.ExecType.CP, ColumnEncoderBin.BinMethod.EQUI_WIDTH); }
+
+	@Test
+	public void testCompressBinsFrameHeightCP() { runCompressFrame(Types.ExecType.CP, ColumnEncoderBin.BinMethod.EQUI_HEIGHT); }
+
+	private void runCompress(Types.ExecType instType, ColumnEncoderBin.BinMethod binMethod)
 	{
 		Types.ExecMode platformOld = setExecMode(instType);
 
@@ -64,41 +81,14 @@ public class CompressByBinTest extends AutomatedTestBase {
 
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-args", input("X")};
+			programArgs = new String[]{"-args", input("X"), Boolean.toString(binMethod == ColumnEncoderBin.BinMethod.EQUI_WIDTH),output("meta"), output("res")};
 
-			//generate actual dataset
-			double[][] X = getRandomMatrix(rows, cols, -100, 100, 1, 7);
+			double[][] X = generateMatrixData(binMethod);
 			writeInputMatrixWithMTD("X", X, true);
 
 			runTest(true, false, null, -1);
 
-		}
-		finally {
-			rtplatform = platformOld;
-		}
-	}
-
-	private void runCompressFrame(Types.ExecType instType)
-	{
-		Types.ExecMode platformOld = setExecMode(instType);
-
-		try
-		{
-			loadTestConfiguration(getTestConfiguration(TEST_NAME));
-
-			String HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain", "-args", input("X")};
-
-			//generate actual dataset
-			double[][] X = getRandomMatrix(rows, cols, -100, 100, 1, 7);
-			writeInputMatrixWithMTD("X", X, true);
-
-			Types.ValueType[] schema = new Types.ValueType[]{Types.ValueType.INT32};
-			FrameBlock Xf = TestUtils
-				.generateRandomFrameBlock(1000, schema, 7);
-			writeInputFrameWithMTD("X", Xf, false, schema, Types.FileFormat.CSV);
-			runTest(true, false, null, -1);
+			checkMetaFile(DataConverter.convertToMatrixBlock(X), binMethod);
 
 		}
 		catch(IOException e) {
@@ -108,4 +98,128 @@ public class CompressByBinTest extends AutomatedTestBase {
 			rtplatform = platformOld;
 		}
 	}
+
+	private void runCompressFrame(Types.ExecType instType, ColumnEncoderBin.BinMethod binMethod)
+	{
+		Types.ExecMode platformOld = setExecMode(instType);
+
+		try
+		{
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-explain", "-args", input("X"), Boolean.toString(binMethod == ColumnEncoderBin.BinMethod.EQUI_WIDTH) , output("meta"), output("res")};
+
+			Types.ValueType[] schema = new Types.ValueType[cols];
+			Arrays.fill(schema, Types.ValueType.FP32);
+			FrameBlock Xf = generateFrameData(binMethod, schema);
+			writeInputFrameWithMTD("X", Xf, false, schema, Types.FileFormat.CSV);
+
+			runTest(true, false, null, -1);
+
+			checkMetaFile(Xf, binMethod);
+
+		}
+		catch(IOException e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+
+	private double[][] generateMatrixData(ColumnEncoderBin.BinMethod binMethod) {
+		double[][] X;
+		if(binMethod == ColumnEncoderBin.BinMethod.EQUI_WIDTH) {
+			//generate actual dataset
+			X = getRandomMatrix(rows, cols, -100, 100, 1, 7);
+			// make sure that bins in [-100, 100]
+			for(int i = 0; i < cols; i++) {
+				X[0][i] = -100;
+				X[1][i] = 100;
+			}
+		} else if(binMethod == ColumnEncoderBin.BinMethod.EQUI_HEIGHT) {
+			X = new double[rows][cols];
+			for(int c = 0; c < cols; c++) {
+				double[] vals = new Random().doubles(nbins).toArray();
+				// Create one column
+				for(int i = 0, j = 0; i < rows; i++) {
+					X[i][c] = vals[j];
+					if(i == (int) ((j + 1) * (rows / nbins)))
+						j++;
+				}
+			}
+		} else
+			throw new RuntimeException("Invalid binning method.");
+
+		return X;
+	}
+
+	private FrameBlock generateFrameData(ColumnEncoderBin.BinMethod binMethod, Types.ValueType[] schema) {
+		FrameBlock Xf;
+		if(binMethod == ColumnEncoderBin.BinMethod.EQUI_WIDTH) {
+			Xf = TestUtils.generateRandomFrameBlock(1000, schema, 7);
+
+			for(int i = 0; i < cols; i++) {
+				Xf.set(0, i, -100);
+				Xf.set(rows-1, i, 100);
+			}
+		} else if(binMethod == ColumnEncoderBin.BinMethod.EQUI_HEIGHT) {
+			Xf = new FrameBlock();
+			for(int c = 0; c < schema.length; c++) {
+				double[] vals = new Random().doubles(nbins).toArray();
+				// Create one column
+				Array<Float> f = (Array<Float>) ArrayFactory.allocate(Types.ValueType.FP32, rows);
+				for(int i = 0, j = 0; i < rows; i++) {
+					f.set(i, vals[j]);
+					if(i == (int) ((j + 1) * (rows / nbins)))
+						j++;
+				}
+				Xf.appendColumn(f);
+			}
+
+		} else
+			throw new RuntimeException("Invalid binning method.");
+
+		return Xf;
+	}
+
+	private void checkMetaFile(CacheBlock<?> X, ColumnEncoderBin.BinMethod binningType) throws IOException{
+		FrameBlock outputMeta = readDMLFrameFromHDFS("meta", Types.FileFormat.CSV);
+		Assert.assertEquals(nbins, outputMeta.getNumRows());
+
+		double[] binStarts = new double[nbins];
+		double[] binEnds = new double[nbins];
+
+		for(int c = 0; c < cols; c++) {
+			if(binningType == ColumnEncoderBin.BinMethod.EQUI_WIDTH) {
+				for(int i = -100, j = 0; i < 100; i += 20) {
+					// check bin starts
+					double binStart = Double.parseDouble(((String) outputMeta.getColumn(c).get(j)).split("·")[0]);
+					Assert.assertEquals(i, binStart, 0.0);
+					j++;
+				}
+			} else {
+				binStarts[c] = Double.parseDouble(((String) outputMeta.getColumn(c).get(0)).split("·")[0]);
+				binEnds[c] = Double.parseDouble(((String) outputMeta.getColumn(c).get(nbins-1)).split("·")[1]);
+			}
+		}
+
+		if(binningType == ColumnEncoderBin.BinMethod.EQUI_HEIGHT) {
+			MatrixBlock mX = null;
+			if(X instanceof FrameBlock) {
+				mX = DataConverter.convertToMatrixBlock((FrameBlock) X);
+			}
+			else {
+				mX = (MatrixBlock) X;
+			}
+			double[] colMins = mX.colMin().getDenseBlockValues();
+			double[] colMaxs = mX.colMax().getDenseBlockValues();
+
+			Assert.assertArrayEquals(colMins, binStarts, 0.0000000001);
+			Assert.assertArrayEquals(colMaxs, binEnds, 0.0000000001);
+		}
+	}
+
 }

--- a/src/test/java/org/apache/sysds/test/functions/compress/matrixByBin/CompressByBinTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/matrixByBin/CompressByBinTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.compress.matrixByBin;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.functions.builtin.part1.BuiltinDistTest;
+import org.junit.Test;
+
+
+public class CompressByBinTest extends AutomatedTestBase {
+
+
+	private final static String TEST_NAME = "compressByBins";
+	private final static String TEST_DIR = "functions/compress/matrixByBin/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + BuiltinDistTest.class.getSimpleName() + "/";
+
+	private final static int rows = 1000;
+
+	private final static int cols = 10;
+
+	private final static int[] dVector = new int[cols];
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"X"}));
+	}
+
+	@Test
+	public void testCompressBinsDefaultCP() { runCompress(Types.ExecType.CP); }
+
+	private void runCompress(Types.ExecType instType)
+	{
+		Types.ExecMode platformOld = setExecMode(instType);
+
+		try
+		{
+			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[]{"-args", input("X")};
+			fullRScriptName = HOME + TEST_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
+
+			//generate actual dataset
+			double[][] X = getRandomMatrix(rows, cols, -100, 100, 1, 7);
+			writeInputMatrixWithMTD("X", X, true);
+
+			runTest(true, false, null, -1);
+
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}

--- a/src/test/scripts/functions/compress/matrixByBin/compressByBins.dml
+++ b/src/test/scripts/functions/compress/matrixByBin/compressByBins.dml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+X = read($1)
+
+# d = ceil(rand(rows = 1, cols = ncol(X), min = 1, max = 100))
+d = matrix(10, rows = 1, cols = ncol(X))
+
+[res, meta] = compress(X, d)
+print(toString(res))
+print(toString(meta))
+

--- a/src/test/scripts/functions/compress/matrixByBin/compressByBins.dml
+++ b/src/test/scripts/functions/compress/matrixByBin/compressByBins.dml
@@ -28,3 +28,6 @@ d = matrix(10, rows = 1, cols = ncol(X))
 print(toString(res))
 print(toString(meta))
 
+write(meta, $3, format="csv");
+
+


### PR DESCRIPTION
This PR overloads `[res, meta] = compress(X, d)` with X - nxd non-compressed matrix/frame and d-1xd vector specifying #bins in each column. It returns an actual compressed matrix and transform meta.
Now, the bins are calculated via per default equi-width, or optionally equi-height binning.