### PR TITLE
[MINOR] MatrixBlock Sparse Optimizations

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
@@ -384,7 +384,7 @@ public class LibCommonsMath
 			T.setValue(i, i, alpha.getValue(0, 0));
 		}
 
-		MatrixBlock[] e = multiReturnOperations(T, "eigen");
+		MatrixBlock[] e = computeEigen(T);
 		TV.setNonZeros((long) m*m);
 		e[1] = TV.aggregateBinaryOperations(TV, e[1], op_mul_agg);
 		return e;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixDenseToSparse.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixDenseToSparse.java
@@ -34,8 +34,8 @@ import org.apache.sysds.runtime.data.SparseRowVector;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
-public interface LibMatrixSparseToDense {
-	public static final Log LOG = LogFactory.getLog(LibMatrixSparseToDense.class.getName());
+public interface LibMatrixDenseToSparse {
+	public static final Log LOG = LogFactory.getLog(LibMatrixDenseToSparse.class.getName());
 
 	/**
 	 * Convert the given matrix block to a sparse allocation.

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixDenseToSparse.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixDenseToSparse.java
@@ -133,10 +133,9 @@ public interface LibMatrixDenseToSparse {
 		if(lnnz <= 0)
 			return;
 
+		// allocate sparse row and append non-zero values
 		final double[] vals = new double[lnnz];
 		final int[] idx = new int[lnnz];
-		// allocate sparse row and append non-zero values
-		// b.allocate(i, lnnz);
 
 		for(int j = 0, o = 0; j < n; j++) {
 			double v = avals[aix + j];

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
@@ -279,7 +279,7 @@ public class LibMatrixMult
 			// aggregate partial results (nnz, ret for vector/matrix)
 			// reset nonZero before execution.
 			// nonZero count cannot be trusted since it is not atomic
-			// and some of the matrix multiplication kernel call quick set value modifying the count.
+			// and some of the matrix multiplication kernels call quick set value modifying the count.
 			ret.nonZeros = 0; 
 			long nnzCount = 0;
 			for(Future<Object> task : pool.invokeAll(tasks)) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlockCSR;
@@ -33,6 +35,8 @@ import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
 public interface LibMatrixSparseToDense {
+	public static final Log LOG = LogFactory.getLog(LibMatrixSparseToDense.class.getName());
+
 	/**
 	 * Convert the given matrix block to a sparse allocation.
 	 * 
@@ -49,7 +53,7 @@ public interface LibMatrixSparseToDense {
 
 		final int k = InfrastructureAnalyzer.getLocalParallelism();
 
-		if(k > 1 && r.getNumRows() > 1000) 
+		if(k > 1 && r.getNumRows() > 1000)
 			denseToSparseParallel(r, k, allowCSR);
 		else if(allowCSR && r.nonZeros <= Integer.MAX_VALUE)
 			denseToSparseCSR(r);
@@ -156,9 +160,9 @@ public interface LibMatrixSparseToDense {
 		r.reset(r.getNumRows(), r.getNumColumns(), nnzTemp);
 		// fallback to less-memory efficient MCSR format, for efficient parallel conversion.
 		r.sparseBlock = new SparseBlockMCSR(r.getNumRows());
+		r.sparse = true;
 		final SparseBlockMCSR b = (SparseBlockMCSR) r.sparseBlock;
 		final int blockSize = Math.max(250, m / k);
-
 		ExecutorService pool = CommonThreadPool.get(k);
 		try {
 
@@ -180,6 +184,5 @@ public interface LibMatrixSparseToDense {
 		}
 
 		r.nonZeros = nnzTemp;
-
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixSparseToDense.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.matrix.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.sysds.runtime.controlprogram.parfor.stat.InfrastructureAnalyzer;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.data.SparseBlockCSR;
+import org.apache.sysds.runtime.data.SparseBlockMCSR;
+import org.apache.sysds.runtime.data.SparseRowVector;
+import org.apache.sysds.runtime.util.CommonThreadPool;
+import org.apache.sysds.runtime.util.UtilFunctions;
+
+public interface LibMatrixSparseToDense {
+	/**
+	 * Convert the given matrix block to a sparse allocation.
+	 * 
+	 * @param r        The matrix block to modify, and return the sparse block in.
+	 * @param allowCSR If CSR is allowed.
+	 */
+	public static void denseToSparse(MatrixBlock r, boolean allowCSR) {
+		final DenseBlock a = r.getDenseBlock();
+
+		// set target representation, early abort on empty blocks
+		r.sparse = true;
+		if(a == null)
+			return;
+
+		final int k = InfrastructureAnalyzer.getLocalParallelism();
+
+		if(k > 1 && r.getNumRows() > 1000) 
+			denseToSparseParallel(r, k, allowCSR);
+		else if(allowCSR && r.nonZeros <= Integer.MAX_VALUE)
+			denseToSparseCSR(r);
+		else
+			denseToSparseMCSR(r);
+
+		// cleanup dense block
+		r.denseBlock = null;
+	}
+
+	private static void denseToSparseCSR(MatrixBlock r) {
+		final DenseBlock a = r.getDenseBlock();
+		final int m = r.rlen;
+		final int n = r.clen;
+		try {
+			// allocate target in memory-efficient CSR format
+			int lnnz = (int) r.nonZeros;
+			int[] rptr = new int[m + 1];
+			int[] indexes = new int[lnnz];
+			double[] values = new double[lnnz];
+			for(int i = 0, pos = 0; i < m; i++) {
+				double[] avals = a.values(i);
+				int aix = a.pos(i);
+				for(int j = 0; j < n; j++) {
+					double aval = avals[aix + j];
+					if(aval != 0) {
+						indexes[pos] = j;
+						values[pos] = aval;
+						pos++;
+					}
+				}
+				rptr[i + 1] = pos;
+			}
+			r.sparseBlock = new SparseBlockCSR(rptr, indexes, values, lnnz);
+		}
+		catch(ArrayIndexOutOfBoundsException ioobe) {
+			r.sparse = false;
+			// this means something was wrong with the sparse count.
+			final long nnzBefore = r.nonZeros;
+			final long nnzNew = r.recomputeNonZeros();
+
+			// try again.
+			if(nnzBefore != nnzNew)
+				denseToSparse(r, true);
+			else
+				denseToSparse(r, false);
+
+		}
+	}
+
+	private static void denseToSparseMCSR(MatrixBlock r) {
+		final DenseBlock a = r.getDenseBlock();
+
+		final int m = r.rlen;
+		final int n = r.clen;
+		// remember number non zeros.
+		long nnzTemp = r.getNonZeros();
+		// fallback to less-memory efficient MCSR format,
+		// which however allows much larger sparse matrices
+		if(!r.allocateSparseRowsBlock())
+			r.reset(); // reset if not allocated
+		SparseBlockMCSR sblock = (SparseBlockMCSR) r.sparseBlock;
+		toSparseMCSRRange(a, sblock, n, 0, m);
+		r.nonZeros = nnzTemp;
+	}
+
+	private static void toSparseMCSRRange(DenseBlock a, SparseBlockMCSR b, int n, int rl, int ru) {
+		for(int i = rl; i < ru; i++)
+			toSparseMCSRRow(a, b, n, i);
+	}
+
+	private static void toSparseMCSRRow(DenseBlock a, SparseBlockMCSR b, int n, int i) {
+		final double[] avals = a.values(i);
+		final int aix = a.pos(i);
+		// compute nnz per row (not via recomputeNonZeros as sparse allocated)
+		final int lnnz = UtilFunctions.computeNnz(avals, aix, n);
+		if(lnnz <= 0)
+			return;
+
+		final double[] vals = new double[lnnz];
+		final int[] idx = new int[lnnz];
+		// allocate sparse row and append non-zero values
+		// b.allocate(i, lnnz);
+
+		for(int j = 0, o = 0; j < n; j++) {
+			double v = avals[aix + j];
+			if(v != 0.0) {
+				vals[o] = v;
+				idx[o] = j;
+				o++;
+			}
+		}
+		b.set(i, new SparseRowVector(vals, idx), false);
+	}
+
+	private static void denseToSparseParallel(MatrixBlock r, int k, boolean allowCSR) {
+		final DenseBlock a = r.getDenseBlock();
+		r.denseBlock = null;
+		r.sparseBlock = null;
+		final int m = r.rlen;
+		final int n = r.clen;
+		// remember number non zeros.
+		final long nnzTemp = r.getNonZeros();
+		r.reset(r.getNumRows(), r.getNumColumns(), nnzTemp);
+		// fallback to less-memory efficient MCSR format, for efficient parallel conversion.
+		r.sparseBlock = new SparseBlockMCSR(r.getNumRows());
+		final SparseBlockMCSR b = (SparseBlockMCSR) r.sparseBlock;
+		final int blockSize = Math.max(250, m / k);
+
+		ExecutorService pool = CommonThreadPool.get(k);
+		try {
+
+			List<Future<?>> tasks = new ArrayList<>();
+			for(int i = 0; i < m; i += blockSize) {
+				final int start = i;
+				final int end = Math.min(m, i + blockSize);
+				tasks.add(pool.submit(() -> toSparseMCSRRange(a, b, n, start, end)));
+			}
+
+			for(Future<?> t : tasks)
+				t.get();
+		}
+		catch(Exception e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			pool.shutdown();
+		}
+
+		r.nonZeros = nnzTemp;
+
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -1302,7 +1302,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 	}
 	
 	public void denseToSparse(boolean allowCSR){
-		LibMatrixSparseToDense.denseToSparse(this, allowCSR);
+		LibMatrixDenseToSparse.denseToSparse(this, allowCSR);
 	}
 	
 	public void sparseToDense() {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -40,6 +40,8 @@ import java.util.stream.IntStream;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.commons.math3.random.Well1024a;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.sysds.common.Types.BlockType;
@@ -122,7 +124,7 @@ import org.apache.sysds.utils.NativeHelper;
 
 
 public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>, Externalizable {
-	// private static final Log LOG = LogFactory.getLog(MatrixBlock.class.getName());
+	protected static final Log LOG = LogFactory.getLog(MatrixBlock.class.getName());
 
 	private static final long serialVersionUID = 7319972089143154056L;
 	

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -1343,7 +1343,7 @@ public class TestUtils {
 			double avgDistance = sumPercentDistance / (rows * cols);
 			if(countErrors != 0)
 				fail(message + "\n" + countErrors + " values are not in equal of total: " + (rows * cols));
-			if(avgDistance <= maxAveragePercentDistance)
+			if(avgDistance < maxAveragePercentDistance)
 				fail(message + "\nThe avg distance: " + avgDistance + " was lower than threshold "
 					+ maxAveragePercentDistance);
 		}

--- a/src/test/java/org/apache/sysds/test/component/matrix/MatrixMultiplyTest.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/MatrixMultiplyTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.test.component.matrix;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -154,11 +155,12 @@ public class MatrixMultiplyTest {
 
 			String totalMessage = "\n\n" + sizeErrMessage + "\n" + sparseErrMessage;
 
-			if(ret.getNumRows() * ret.getNumColumns() < 1000) {
+			if(ret.getNumRows() * ret.getNumColumns() < 1000 || ret.getNonZeros() < 100) {
 				totalMessage += "\n\nExp" + exp;
 				totalMessage += "\n\nAct" + ret;
 			}
 
+			assertEquals(totalMessage,exp.getNonZeros(), ret.getNonZeros());
 			TestUtils.compareMatricesPercentageDistance(exp, ret, 0.999, 0.99999, totalMessage, false);
 		}
 		catch(Exception e) {

--- a/src/test/java/org/apache/sysds/test/component/matrix/MatrixToSparseOrDense.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/MatrixToSparseOrDense.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.matrix;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(value = Parameterized.class)
+public class MatrixToSparseOrDense {
+	protected static final Log LOG = LogFactory.getLog(MatrixMultiplyTest.class.getName());
+
+	private final MatrixBlock a;
+
+	public MatrixToSparseOrDense(int rows, int cols, double sparsity) {
+
+		this.a = TestUtils.generateTestMatrixBlock(rows, cols, -10, 10, sparsity, 42151);
+	}
+
+	@Parameters
+	public static Collection<Object[]> data() {
+
+		List<Object[]> tests = new ArrayList<>();
+		try {
+			double[] sparsities = new double[] {0.0001, 0.1, 0.5};
+			int[] is = new int[] {1, 2, 10, 1302};
+			int[] js = new int[] {1, 2, 5, 1203};
+
+			for(int s = 0; s < sparsities.length; s++) {
+				for(int i = 0; i < is.length; i++) {
+					for(int j = 0; j < js.length; j++) {
+						tests.add(new Object[] {is[i], js[j], sparsities[s]});
+
+					}
+				}
+
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail("failed constructing tests");
+		}
+
+		return tests;
+	}
+
+	@Test
+	public void testA() {
+		MatrixBlock c = new MatrixBlock();
+		c.copy(a);
+		TestUtils.compareMatricesPercentageDistance(a, c, 1.0, 1.0, "");
+	}
+
+	@Test
+	public void testB_MCSR() {
+		MatrixBlock c = new MatrixBlock();
+		c.copy(a);
+		c.denseToSparse(false);
+		TestUtils.compareMatricesPercentageDistance(a, c, 1.0, 1.0, "");
+	}
+
+	@Test
+	public void testB_CSR() {
+		MatrixBlock c = new MatrixBlock();
+		c.copy(a);
+		c.denseToSparse(true);
+		TestUtils.compareMatricesPercentageDistance(a, c, 1.0, 1.0, "");
+	}
+
+	@Test
+	public void testCDense() {
+		MatrixBlock c = new MatrixBlock();
+		c.copy(a);
+		c.sparseToDense();
+		TestUtils.compareMatricesPercentageDistance(a, c, 1.0, 1.0, "");
+	}
+}


### PR DESCRIPTION
This commit adds a specialized kernel for Sparse %*% Ultra Sparse Matrix multiplication, that previously
accessed all cells in rows where there could be a multiplication in the left matrix no matter if it was sparse or not. 

The optimization Improve default calls to Decision trees on kaggle playground-series-s3e23 from 100 sec to 30.

Also included is sparse handling of  Binary cell operations and a small optimization to Commons math eigen to skip a indirect call.
