### PR TITLE
[SYSTEMDS-3632] Sparse Reuse of RowVectors

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/data/DenseBlockFP64.java
+++ b/src/main/java/org/apache/sysds/runtime/data/DenseBlockFP64.java
@@ -34,7 +34,7 @@ public class DenseBlockFP64 extends DenseBlockDRB
 
 	public DenseBlockFP64(int[] dims) {
 		super(dims);
-		reset(_rlen, _odims, 0);
+		resetNoFill(_rlen, _odims);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlockCSR.java
@@ -835,9 +835,18 @@ public class SparseBlockCSR extends SparseBlock
 	}
 
 	@Override
-	public int posFIndexGTE(int r, int c) {
-		int index = internPosFIndexGTE(r, c);
-		return (index>=0) ? index-pos(r) : index;
+	public final int posFIndexGTE(int r, int c) {
+		final int pos = pos(r);
+		final int len = size(r);
+		final int end = pos + len;
+
+		// search for existing col index
+		int index = Arrays.binarySearch(_indexes, pos, end, c);
+		if(index < 0)
+			// search gt col index (see binary search)
+			index = Math.abs(index + 1);
+
+		return (index < end) ? index - pos : -1;
 	}
 	
 	private int internPosFIndexGTE(int r, int c) {

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRow.java
@@ -131,6 +131,14 @@ public abstract class SparseRow implements Serializable
 	 * @param eps epsilon value
 	 */
 	public abstract void compact(double eps);
+
+	/**
+	 * Make a copy of this row.
+	 * 
+	 * @param deep if the copy should be deep
+	 * @return A copy
+	 */
+	public abstract SparseRow copy(boolean deep);
 	
 	@Override
 	public String toString() {

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRowScalar.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRowScalar.java
@@ -41,8 +41,8 @@ public final class SparseRowScalar extends SparseRow{
 	}
 	
 	@Override
-	public boolean isEmpty() {
-		return (index < 0);
+	public final boolean isEmpty() {
+		return index < 0;
 	}
 	
 	@Override
@@ -114,5 +114,10 @@ public final class SparseRowScalar extends SparseRow{
 
 	public double getValue(){
 		return value;
+	}
+
+	@Override
+	public SparseRow copy(boolean deep){
+		return new SparseRowScalar(index, value);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/data/SparseRowVector.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseRowVector.java
@@ -24,17 +24,30 @@ import java.util.Arrays;
 import org.apache.sysds.runtime.util.SortUtils;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
-public final class SparseRowVector extends SparseRow{
+/**
+ * A sparse row vector that is able to grow dynamically as values are appended to it.
+ */
+public final class SparseRowVector extends SparseRow {
 	private static final long serialVersionUID = 2971077474424464992L;
 
-	//initial capacity of any created sparse row
-	//WARNING: be aware that this affects the core memory estimates (incl. implicit assumptions)! 
+	/**
+	 * <p>Initial capacity of any created sparse row</p>
+	 * WARNING: be aware that this affects the core memory estimates (incl. implicit assumptions)! 
+	 */
 	public static final int initialCapacity = 4;
 	
+	/**
+	 * An estimate of the number of non zero values in this row.
+	 * The estimate is used to set a threshold on how much the array should grow at certain
+	 * lengths to not double the size at all times.
+	 */
 	private int estimatedNzs = initialCapacity;
-	private int size = 0;
-	private double[] values = null;
-	private int[] indexes = null;
+	/** The current size of the row vector */
+	private int size;
+	/** The values contained in the vector, can be allocated larger than needed */
+	private double[] values;
+	/** The column indexes of the values contained, can be allocated larger than needed */
+	private int[] indexes;
 	
 	public SparseRowVector() {
 		this(initialCapacity);
@@ -44,6 +57,7 @@ public final class SparseRowVector extends SparseRow{
 		estimatedNzs = capacity;
 		values = new double[capacity];
 		indexes = new int[capacity];
+		size = 0;
 	}
 	
 	public SparseRowVector(int nnz, double[] v, int vlen) {
@@ -88,10 +102,10 @@ public final class SparseRowVector extends SparseRow{
 	public SparseRowVector(int estnnz, int maxnnz) {
 		if( estnnz > initialCapacity )
 			estimatedNzs = estnnz;
-		// maxNzs = maxnnz;
 		int capacity = initialCapacity;
 		values = new double[capacity];
 		indexes = new int[capacity];
+		size = 0;
 	}
 	
 	public SparseRowVector(SparseRow that) {

--- a/src/test/java/org/apache/sysds/test/component/matrix/SparseCSRTest.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/SparseCSRTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.matrix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.data.SparseBlockCSR;
+import org.junit.Test;
+
+public class SparseCSRTest {
+	protected static final Log LOG = LogFactory.getLog(CompressedMatrixBlock.class.getName());
+
+	@Test
+	public void testGTE() {
+		int[] rs = new int[] {0, 9};
+		int[] colInd = new int[] {10, 20, 30, 40, 50, 60, 80, 90, 100};
+		double[] val = new double[] {1, 1, 1, 1, 1, 1, 1, 1, 1};
+		SparseBlockCSR b = new SparseBlockCSR(rs, colInd, val, val.length);
+
+		assertEquals(0, b.posFIndexGTE(0, 0));
+		assertEquals(0, b.posFIndexGTE(0, 10));
+		assertEquals(1, b.posFIndexGTE(0, 11));
+		assertEquals(7, b.posFIndexGTE(0, 90));
+		assertEquals(8, b.posFIndexGTE(0, 91));
+		assertEquals(-1, b.posFIndexGTE(0, 101));
+		assertEquals(-1, b.posFIndexGTE(0, 10100));
+
+	}
+
+	@Test
+	public void testGTE2Rows() {
+		int[] rs = new int[] {0, 0, 9};
+		int[] colInd = new int[] {10, 20, 30, 40, 50, 60, 80, 90, 100};
+		double[] val = new double[] {1, 1, 1, 1, 1, 1, 1, 1, 1};
+		SparseBlockCSR b = new SparseBlockCSR(rs, colInd, val, val.length);
+		LOG.error(b);
+
+		assertEquals(0, b.posFIndexGTE(1, 0));
+		assertEquals(0, b.posFIndexGTE(1, 10));
+		assertEquals(1, b.posFIndexGTE(1, 11));
+		assertEquals(7, b.posFIndexGTE(1, 90));
+		assertEquals(8, b.posFIndexGTE(1, 91));
+		assertEquals(-1, b.posFIndexGTE(1, 101));
+		assertEquals(-1, b.posFIndexGTE(1, 10100));
+
+	}
+
+	@Test
+	public void testGTE2RowsNN() {
+		int[] rs = new int[] {0, 1, 10};
+		int[] colInd = new int[] {100, 10, 20, 30, 40, 50, 60, 80, 90, 100};
+		double[] val = new double[] {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+		SparseBlockCSR b = new SparseBlockCSR(rs, colInd, val, val.length);
+		LOG.error(b);
+
+		assertEquals(0, b.posFIndexGTE(1, 0));
+		assertEquals(0, b.posFIndexGTE(1, 10));
+		assertEquals(1, b.posFIndexGTE(1, 11));
+		assertEquals(7, b.posFIndexGTE(1, 90));
+		assertEquals(8, b.posFIndexGTE(1, 91));
+		assertEquals(-1, b.posFIndexGTE(1, 101));
+		assertEquals(-1, b.posFIndexGTE(1, 10100));
+
+	}
+}


### PR DESCRIPTION
I had an issue when reusing sparseRowVectors, where the maximum number of non zeros in a Sparse Row is set to the number of columns for the parent SparseMCSR Block. But when reusing the rows in allocations of append with other sparse blocks some edge cases increased the number of non zero values above the number of columns in the original matrix.

to fix this i made a few changes inside the Sparse CSR blocks, and while at it made an mini optimization of the posFIndexGTE(int r, int c), method to reduce the number of if statements improving overall performance.