### PR TITLE
[MINOR] DML Hadoop Startup skip

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -41,10 +41,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.conf.CompilerConfig;
 import org.apache.sysds.conf.ConfigurationManager;
@@ -204,16 +202,15 @@ public class DMLScript
 	public static void main(String[] args)
 	{
 		try{
-			Configuration conf = new Configuration(ConfigurationManager.getCachedJobConf());
-			String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
-			DMLScript.executeScript(conf, otherArgs);
+			DMLScript.executeScript(args);
 		} catch(Exception e){
-			errorPrint(e);
 			for(String s: args){
 				if(s.trim().contains("-debug")){
 					e.printStackTrace();
+					return;
 				}
 			}
+			errorPrint(e);
 		}
 	}
 
@@ -226,7 +223,7 @@ public class DMLScript
 	 * @return true if success, false otherwise
 	 * @throws IOException If an internal IOException happens.
 	 */
-	public static boolean executeScript( Configuration conf, String[] args )
+	public static boolean executeScript( String[] args )
 		throws IOException, ParseException, DMLScriptException
 	{
 		//parse arguments and set execution properties

--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -218,7 +218,6 @@ public class DMLScript
 	 * Single entry point for all public invocation alternatives (e.g.,
 	 * main, executeScript, JaqlUdf etc)
 	 * 
-	 * @param conf Hadoop configuration
 	 * @param args arguments
 	 * @return true if success, false otherwise
 	 * @throws IOException If an internal IOException happens.

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -19,6 +19,11 @@
 
 package org.apache.sysds.test;
 
+import static java.lang.Math.ceil;
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -38,18 +43,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static java.lang.Math.ceil;
-import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.SparkSession.Builder;
 import org.apache.sysds.api.DMLScript;
@@ -59,7 +58,6 @@ import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.common.Types.ValueType;
-import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.fedplanner.FTypes.FType;

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -1568,9 +1568,7 @@ public abstract class AutomatedTestBase {
 	 * @throws IOException if an IOException occurs in the hadoop GenericOptionsParser
 	 */
 	public static void main(String[] args) throws IOException, ParseException, DMLScriptException {
-		Configuration conf = new Configuration(ConfigurationManager.getCachedJobConf());
-		String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
-		DMLScript.executeScript(conf, otherArgs);
+		DMLScript.executeScript(args);
 	}
 
 	private void addProgramIndependentArguments(ArrayList<String> args, String[] otherArgs) {


### PR DESCRIPTION
This PR contains a bit of a controversy.

At startup the first thing we do is to call Hadoop to parse the Hadoop specific arguments.
This takes ~ 200 ms at startup before we start our timing of SystemDS.

before:

```txt
1,6187 +- 0,0766 seconds time elapsed  ( +-  4,73% )
```

after:

```txt
  1,4366 +- 0,0496 seconds time elapsed  ( +-  3,46% )
```

The downside of this modification is that Hadoop arguments are not parsed to the Hadoop file system, that said, i am unaware if the arguments actually work at the moment because ---to the best of my knowledge---we have not tested if the system work when there are more than one HDFS system available.

The script used for the test is :

```R
print("Hello World!")
```

