### PR TITLE
[WIP] Add hadoop native binaries for IO

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -85,6 +85,11 @@ jobs:
         path: /var/cache/apt/archives
         key: ${{ runner.os }}-${{ hashFiles('.github/workflows/python.yml') }}
 
+    - name: Hadoop Native 
+      run: |
+        wget https://systemds.apache.org/assets/datasets/hadoop/native-3.3.4.zip
+        unzip native-3.3.4.zip
+
     - name: Maven clean & package
       run: mvn -ntp clean package -P distribution -B
 


### PR DESCRIPTION
This PR adds native binaries to the python test.

It is WIP, since i need to add the files somewhere for download,
therefore i thought i could add it to the webpage.
But the webpage, is, slightly out of date, and needs more time to fix, since there are many packages that are out of date and have "critical vulnerabilities."
