### PR TITLE
[SYSTEMDS-3640] Hash Column for Criteo

### DIFF
--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -77,17 +77,21 @@ public class Types
 	public enum ValueType {
 		UINT4, UINT8, // Used for parsing in UINT values from numpy.
 		FP32, FP64, INT32, INT64, BOOLEAN, STRING, UNKNOWN,
+		HASH64, // Indicate that the value is a hash of 64 bit.
 		CHARACTER;
 		
 		public boolean isNumeric() {
 			return this == UINT8 || this == INT32 || this == INT64 || this == FP32 || this == FP64 || this== UINT4;
 		}
+		
 		public boolean isUnknown() {
 			return this == UNKNOWN;
 		}
+
 		public boolean isPseudoNumeric() {
 			return isNumeric() || this == BOOLEAN || this == CHARACTER;
 		}
+
 		public String toExternalString() {
 			switch(this) {
 				case FP32:
@@ -100,10 +104,13 @@ public class Types
 				default:      return toString();
 			}
 		}
+
 		public static ValueType fromExternalString(String value) {
 			//for now we support both internal and external strings
 			//until we have completely changed the external types
-			String lValue = (value != null) ? value.toUpperCase() : null;
+			if(value == null)
+				throw new DMLRuntimeException("Unknown null value type");
+			final String lValue = value.toUpperCase();
 			switch(lValue) {
 				case "FP32":     return FP32;
 				case "FP64":
@@ -117,6 +124,7 @@ public class Types
 				case "STRING":   return STRING;
 				case "CHARACTER": return CHARACTER;
 				case "UNKNOWN":  return UNKNOWN;
+				case "HASH64": return HASH64;
 				default:
 					throw new DMLRuntimeException("Unknown value type: "+value);
 			}
@@ -143,6 +151,13 @@ public class Types
 			switch(a){
 				case CHARACTER:
 					return STRING;
+				case HASH64:
+					switch(b){
+						case STRING: 
+							return b;
+						default:
+							return a;
+					}
 				case STRING:
 					return a;
 				case FP64:

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
@@ -154,7 +154,7 @@ public abstract class APreAgg extends AColGroupValue {
 			final boolean left = shouldPreAggregateLeft(lg);
 			if(!loggedWarningForDirect && shouldDirectMultiply(lg, leftIdx.size(), rightIdx.size(), left)) {
 				loggedWarningForDirect = true;
-				LOG.warn("Not implemented direct tsmm colgroup");
+				LOG.warn("Not implemented direct tsmm colgroup: " + lg.getClass().getSimpleName()  + " %*% " + this.getClass().getSimpleName() );
 			}
 
 			if(left) {

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibScalar.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibScalar.java
@@ -58,7 +58,7 @@ public final class CLALibScalar {
 
 	public static MatrixBlock scalarOperations(ScalarOperator sop, CompressedMatrixBlock m1, MatrixValue result) {
 		if(isInvalidForCompressedOutput(m1, sop)) {
-			LOG.warn("scalar overlapping not supported for op: " + sop.fn);
+			LOG.warn("scalar overlapping not supported for op: " + sop.fn.getClass().getSimpleName());
 			MatrixBlock m1d = m1.decompress(sop.getNumThreads());
 			return m1d.scalarOperations(sop, result);
 		}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -422,8 +422,9 @@ public abstract class Array<T> implements Writable {
 				return new OptionalArray<>(changeTypeDouble(), nulls);
 			case UINT4:
 			case UINT8:
-			case HASH64:
 				throw new NotImplementedException();
+			case HASH64:
+				return new OptionalArray<>(changeTypeHash64(), nulls);
 			case INT32:
 				return new OptionalArray<>(changeTypeInteger(), nulls);
 			case INT64:

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -422,6 +422,7 @@ public abstract class Array<T> implements Writable {
 				return new OptionalArray<>(changeTypeDouble(), nulls);
 			case UINT4:
 			case UINT8:
+			case HASH64:
 				throw new NotImplementedException();
 			case INT32:
 				return new OptionalArray<>(changeTypeInteger(), nulls);
@@ -456,7 +457,8 @@ public abstract class Array<T> implements Writable {
 				return changeTypeDouble();
 			case UINT4:
 			case UINT8:
-				throw new NotImplementedException();
+			case HASH64:
+				return changeTypeHash64();
 			case INT32:
 				return changeTypeInteger();
 			case INT64:
@@ -512,6 +514,13 @@ public abstract class Array<T> implements Writable {
 	 * @return Long type of array
 	 */
 	protected abstract Array<Long> changeTypeLong();
+
+	/**
+	 * Change type to a Hash46 array type
+	 * 
+	 * @return A Hash64 array 
+	 */
+	protected abstract Array<String> changeTypeHash64();
 
 	/**
 	 * Change type to a String array type

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -520,7 +520,7 @@ public abstract class Array<T> implements Writable {
 	 * 
 	 * @return A Hash64 array 
 	 */
-	protected abstract Array<String> changeTypeHash64();
+	protected abstract Array<Object> changeTypeHash64();
 
 	/**
 	 * Change type to a String array type

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/Array.java
@@ -457,6 +457,7 @@ public abstract class Array<T> implements Writable {
 				return changeTypeDouble();
 			case UINT4:
 			case UINT8:
+				throw new NotImplementedException();
 			case HASH64:
 				return changeTypeHash64();
 			case INT32:

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
@@ -23,6 +23,7 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.util.BitSet;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
@@ -35,7 +36,9 @@ public interface ArrayFactory {
 	public final static int bitSetSwitchPoint = 64;
 
 	public enum FrameArrayType {
-		STRING, BOOLEAN, BITSET, INT32, INT64, FP32, FP64, CHARACTER, RAGGED, OPTIONAL, DDC;
+		STRING, BOOLEAN, BITSET, INT32, INT64, FP32, FP64, 
+		CHARACTER, RAGGED, OPTIONAL, DDC,
+		HASH64;
 	}
 
 	public static StringArray create(String[] col) {
@@ -81,6 +84,8 @@ public interface ArrayFactory {
 	public static long getInMemorySize(ValueType type, int _numRows, boolean containsNull) {
 		if(containsNull) {
 			switch(type) {
+				case HASH64:
+					type = ValueType.INT64;
 				case BOOLEAN:
 				case INT64:
 				case FP64:
@@ -123,6 +128,8 @@ public interface ArrayFactory {
 					return Array.baseMemoryCost() + MemoryEstimates.stringCost(12) * _numRows;
 				case CHARACTER:
 					return Array.baseMemoryCost() + (long) MemoryEstimates.charArrayCost(_numRows);
+				case HASH64:
+					throw new NotImplementedException();
 				default: // not applicable
 					throw new DMLRuntimeException("Invalid type to estimate size of :" + type);
 			}
@@ -154,6 +161,8 @@ public interface ArrayFactory {
 				return new OptionalArray<>(new DoubleArray(new double[nRow]), true);
 			case CHARACTER:
 				return new OptionalArray<>(new CharArray(new char[nRow]), true);
+			case HASH64:
+				throw new NotImplementedException();
 			case UNKNOWN:
 			case STRING:
 			default:
@@ -184,6 +193,8 @@ public interface ArrayFactory {
 				return new DoubleArray(new double[nRow]);
 			case CHARACTER:
 				return new CharArray(new char[nRow]);
+			case HASH64:
+				throw new NotImplementedException();
 			case UNKNOWN:
 			case STRING:
 			default:
@@ -222,9 +233,11 @@ public interface ArrayFactory {
 				return OptionalArray.readOpt(in, nRow);
 			case DDC:
 				return DDCArray.read(in);
-			default: // String
+			case STRING:
 				arr = new StringArray(new String[nRow]);
 				break;
+			default: 
+				throw new NotImplementedException(v + "");
 		}
 		arr.readFields(in);
 		return arr;
@@ -325,6 +338,8 @@ public interface ArrayFactory {
 				return IntegerArray.parseInt(s);
 			case INT64:
 				return LongArray.parseLong(s);
+			case HASH64: 
+				throw new NotImplementedException();
 			case STRING:
 			case UNKNOWN:
 			default:

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
@@ -45,6 +45,18 @@ public interface ArrayFactory {
 		return new StringArray(col);
 	}
 
+	public static HashLongArray createHash64(String[] col){
+		return new HashLongArray(col);
+	} 
+
+	public static OptionalArray<Object> createHash64Opt(String[] col){
+		return new OptionalArray<Object>(col, ValueType.HASH64);
+	} 
+
+	public static HashLongArray createHash64(long[] col){
+		return new HashLongArray(col);
+	} 
+
 	public static BooleanArray create(boolean[] col) {
 		return new BooleanArray(col);
 	}
@@ -113,6 +125,7 @@ public interface ArrayFactory {
 					else
 						return BooleanArray.estimateInMemorySize(_numRows);
 				case INT64:
+				case HASH64:
 					return Array.baseMemoryCost() + (long) MemoryEstimates.longArrayCost(_numRows);
 				case FP64:
 					return Array.baseMemoryCost() + (long) MemoryEstimates.doubleArrayCost(_numRows);
@@ -128,8 +141,6 @@ public interface ArrayFactory {
 					return Array.baseMemoryCost() + MemoryEstimates.stringCost(12) * _numRows;
 				case CHARACTER:
 					return Array.baseMemoryCost() + (long) MemoryEstimates.charArrayCost(_numRows);
-				case HASH64:
-					throw new NotImplementedException();
 				default: // not applicable
 					throw new DMLRuntimeException("Invalid type to estimate size of :" + type);
 			}
@@ -162,7 +173,7 @@ public interface ArrayFactory {
 			case CHARACTER:
 				return new OptionalArray<>(new CharArray(new char[nRow]), true);
 			case HASH64:
-				throw new NotImplementedException();
+				return new OptionalArray<>(new HashLongArray(new long[nRow]), true);
 			case UNKNOWN:
 			case STRING:
 			default:
@@ -235,6 +246,9 @@ public interface ArrayFactory {
 				return DDCArray.read(in);
 			case STRING:
 				arr = new StringArray(new String[nRow]);
+				break;
+			case HASH64:
+				arr = new HashLongArray(new long[nRow]);
 				break;
 			default: 
 				throw new NotImplementedException(v + "");
@@ -338,8 +352,8 @@ public interface ArrayFactory {
 				return IntegerArray.parseInt(s);
 			case INT64:
 				return LongArray.parseLong(s);
-			case HASH64: 
-				throw new NotImplementedException();
+			case HASH64:
+				return HashLongArray.parseHashLong(s);
 			case STRING:
 			case UNKNOWN:
 			default:

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayFactory.java
@@ -194,7 +194,7 @@ public interface ArrayFactory {
 			case CHARACTER:
 				return new CharArray(new char[nRow]);
 			case HASH64:
-				throw new NotImplementedException();
+				return new HashLongArray(new long[nRow]);
 			case UNKNOWN:
 			case STRING:
 			default:

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
@@ -466,7 +466,7 @@ public class BitSetArray extends ABooleanArray {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64(){
+	protected Array<Object> changeTypeHash64(){
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++)
 			ret[i] = get(i) ? 1L : 0L;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BitSetArray.java
@@ -466,6 +466,14 @@ public class BitSetArray extends ABooleanArray {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64(){
+		long[] ret = new long[size()];
+		for(int i = 0; i < size(); i++)
+			ret[i] = get(i) ? 1L : 0L;
+		return new HashLongArray(ret);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		String[] ret = new String[size()];
 		for(int i = 0; i < size(); i++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -266,7 +266,7 @@ public class BooleanArray extends ABooleanArray {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64(){
+	protected Array<Object> changeTypeHash64(){
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++)
 			ret[i] = _data[i]  ? 1L : 0L;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/BooleanArray.java
@@ -266,6 +266,14 @@ public class BooleanArray extends ABooleanArray {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64(){
+		long[] ret = new long[size()];
+		for(int i = 0; i < size(); i++)
+			ret[i] = _data[i]  ? 1L : 0L;
+		return new HashLongArray(ret);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		String[] ret = new String[size()];
 		for(int i = 0; i < size(); i++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
@@ -254,6 +254,14 @@ public class CharArray extends Array<Character> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64(){
+		long[] ret = new long[size()];
+		for(int i = 0; i < size(); i++)
+			ret[i] = _data[i];
+		return new HashLongArray(ret);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		String[] ret = new String[size()];
 		for(int i = 0; i < size(); i++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/CharArray.java
@@ -254,7 +254,7 @@ public class CharArray extends Array<Character> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64(){
+	protected Array<Object> changeTypeHash64(){
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++)
 			ret[i] = _data[i];

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DDCArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DDCArray.java
@@ -232,7 +232,7 @@ public class DDCArray<T> extends ACompressedArray<T> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64(){
+	protected Array<Object> changeTypeHash64(){
 		return new DDCArray<>(dict.changeTypeHash64(), map);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DDCArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DDCArray.java
@@ -232,6 +232,11 @@ public class DDCArray<T> extends ACompressedArray<T> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64(){
+		return new DDCArray<>(dict.changeTypeHash64(), map);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		return new DDCArray<>(dict.changeTypeString(), map);
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
@@ -313,6 +313,17 @@ public class DoubleArray extends Array<Double> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64() {
+		long[] ret = new long[size()];
+		for(int i = 0; i < size(); i++) {
+			if(_data[i] != (long) _data[i])
+				throw new DMLRuntimeException("Unable to change to Long from Double array because of value:" + _data[i]);
+			ret[i] = (long) _data[i];
+		}
+		return new HashLongArray(ret);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		String[] ret = new String[size()];
 		for(int i = 0; i < size(); i++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/DoubleArray.java
@@ -313,7 +313,7 @@ public class DoubleArray extends Array<Double> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++) {
 			if(_data[i] != (long) _data[i])

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -254,7 +254,7 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++)
 			ret[i] = (int) _data[i];

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/FloatArray.java
@@ -254,6 +254,14 @@ public class FloatArray extends Array<Float> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64() {
+		long[] ret = new long[size()];
+		for(int i = 0; i < size(); i++)
+			ret[i] = (int) _data[i];
+		return new HashLongArray(ret);
+	}
+
+	@Override
 	protected Array<Float> changeTypeFloat() {
 		return this;
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/HashLongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/HashLongArray.java
@@ -33,7 +33,7 @@ import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import org.apache.sysds.utils.MemoryEstimates;
 
-public class HashLongArray extends Array<String> {
+public class HashLongArray extends Array<Object> {
 	private long[] _data;
 
 	public HashLongArray(long[] data) {
@@ -46,7 +46,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public String get(int index) {
+	public Object get(int index) {
 		return Long.toHexString(_data[index]);
 	}
 
@@ -55,8 +55,19 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
+	public void set(int index, Object value) {
+		if(value instanceof String)
+			_data[index] = parseLong((String)value);
+		else if(value instanceof Long)
+			_data[index] = (Long)value;
+		else 
+			throw new NotImplementedException("not supported : " + value);
+	}
+
+
+	@Override
 	public void set(int index, String value) {
-		_data[index] = (value != null) ? Long.parseLong(value, 16) : 0L;
+		_data[index] = parseLong((String)value);
 	}
 
 	@Override
@@ -65,7 +76,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public void set(int rl, int ru, Array<String> value) {
+	public void set(int rl, int ru, Array<Object> value) {
 		set(rl, ru, value, 0);
 	}
 
@@ -77,13 +88,10 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public void setNz(int rl, int ru, Array<String> value) {
-		if(value instanceof StringArray){
-			throw new NotImplementedException();
-		}
-		else{
-			throw new NotImplementedException();
-		}
+	public void setNz(int rl, int ru, Array<Object> value) {
+	
+		throw new NotImplementedException();
+		
 		// long[] data2 = ((LongArray) value)._data;
 		// for(int i = rl; i <= ru; i++)
 		// 	if(data2[i] != 0)
@@ -96,8 +104,14 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
+	public void append(Object value) {
+		append(parseLong(value));
+	}
+
+
+	@Override
 	public void append(String value) {
-		append(Long.parseLong(value, 16));
+		append(parseLong(value));
 	}
 
 	public void append(long value) {
@@ -107,7 +121,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public Array<String> append(Array<String> other) {
+	public Array<Object> append(Array<Object> other) {
 		throw new NotImplementedException();
 		// final int endSize = this._size + other.size();
 		// final long[] ret = new long[endSize];
@@ -134,12 +148,12 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public Array<String> clone() {
+	public Array<Object> clone() {
 		return new HashLongArray(Arrays.copyOf(_data, _size));
 	}
 
 	@Override
-	public Array<String> slice(int rl, int ru) {
+	public Array<Object> slice(int rl, int ru) {
 		return new HashLongArray(Arrays.copyOfRange(_data, rl, ru));
 	}
 
@@ -247,7 +261,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		return this;
 	}
 
@@ -264,6 +278,11 @@ public class HashLongArray extends Array<String> {
 		fill(parseLong(value));
 	}
 
+	@Override
+	public void fill(Object value) {
+		fill(parseLong(value));
+	}
+
 	public void fill(Long value) {
 		value = value != null ? value : 0L;
 		Arrays.fill(_data, value);
@@ -274,10 +293,20 @@ public class HashLongArray extends Array<String> {
 		return _data[i];
 	}
 
+	public static long parseLong(Object s) {
+		if(s instanceof String)
+			return parseLong((String) s);
+		else if (s instanceof Long)
+			return (Long)s;
+		else 
+			throw new NotImplementedException("not supported" + s); 
+	}
+
+
 	public static long parseLong(String s) {
 		if(s == null || s.isEmpty())
 			return 0L;
-		return Long.parseLong(s, 16);
+		return Long.parseUnsignedLong(s, 16);
 	}
 
 	@Override
@@ -302,7 +331,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public Array<String> select(int[] indices) {
+	public Array<Object> select(int[] indices) {
 		final long[] ret = new long[indices.length];
 		for(int i = 0; i < indices.length; i++)
 			ret[i] = _data[indices[i]];
@@ -310,7 +339,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public Array<String> select(boolean[] select, int nTrue) {
+	public Array<Object> select(boolean[] select, int nTrue) {
 		final long[] ret = new long[nTrue];
 		int k = 0;
 		for(int i = 0; i < select.length; i++)
@@ -330,7 +359,7 @@ public class HashLongArray extends Array<String> {
 	}
 
 	@Override
-	public boolean equals(Array<String> other) {
+	public boolean equals(Array<Object> other) {
 		if(other instanceof HashLongArray)
 			return Arrays.equals(_data, ((HashLongArray) other)._data);
 		else

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/IntegerArray.java
@@ -256,7 +256,7 @@ public class IntegerArray extends Array<Integer> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		long[] ret = new long[size()];
 		for(int i = 0; i < size(); i++)
 			ret[i] = _data[i];

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -259,7 +259,7 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		return new HashLongArray(_data);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/LongArray.java
@@ -259,6 +259,11 @@ public class LongArray extends Array<Long> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64() {
+		return new HashLongArray(_data);
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		String[] ret = new String[size()];
 		for(int i = 0; i < size(); i++)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
@@ -343,6 +343,12 @@ public class OptionalArray<T> extends Array<T> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64() {
+		Array<String> a = _a.changeTypeHash64();
+		return new OptionalArray<>(a, _n);
+	}
+
+	@Override
 	protected Array<Character> changeTypeCharacter() {
 		Array<Character> a = _a.changeTypeCharacter();
 		return new OptionalArray<>(a, _n);

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
@@ -343,8 +343,8 @@ public class OptionalArray<T> extends Array<T> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
-		Array<String> a = _a.changeTypeHash64();
+	protected Array<Object> changeTypeHash64() {
+		Array<Object> a = _a.changeTypeHash64();
 		return new OptionalArray<>(a, _n);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/OptionalArray.java
@@ -63,6 +63,17 @@ public class OptionalArray<T> extends Array<T> {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
+	public OptionalArray(T[] a, ValueType vt){
+		super(a.length);
+		_a = (Array<T>) ArrayFactory.allocate(vt, a.length);
+		_n = ArrayFactory.allocateBoolean(a.length);
+		for(int i = 0; i < a.length; i++) {
+			_a.set(i, a[i]);
+			_n.set(i, a[i] != null);
+		}
+	}
+
 	public OptionalArray(Array<T> a, boolean empty) {
 		super(a.size());
 		if(a instanceof OptionalArray)

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/RaggedArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/RaggedArray.java
@@ -289,7 +289,7 @@ public class RaggedArray<T> extends Array<T> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		return _a.changeTypeHash64();
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/RaggedArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/RaggedArray.java
@@ -289,6 +289,11 @@ public class RaggedArray<T> extends Array<T> {
 	}
 
 	@Override
+	protected Array<String> changeTypeHash64() {
+		return _a.changeTypeHash64();
+	}
+
+	@Override
 	protected Array<String> changeTypeString() {
 		return _a.changeTypeString();
 	}

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/StringArray.java
@@ -568,7 +568,7 @@ public class StringArray extends Array<String> {
 	}
 
 	@Override
-	protected Array<String> changeTypeHash64() {
+	protected Array<Object> changeTypeHash64() {
 		try {
 			long[] ret = new long[size()];
 			for(int i = 0; i < size(); i++) {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.frame.data.lib;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -107,6 +108,7 @@ public class FrameLibApplySchema {
 	}
 
 	private FrameBlock apply() {
+		LOG.error(Arrays.toString(schema));
 		if(k <= 1 || nCol == 1)
 			applySingleThread();
 		else

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameLibApplySchema.java
@@ -108,7 +108,6 @@ public class FrameLibApplySchema {
 	}
 
 	private FrameBlock apply() {
-		LOG.error(Arrays.toString(schema));
 		if(k <= 1 || nCol == 1)
 			applySingleThread();
 		else

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
@@ -122,6 +122,18 @@ public interface FrameUtil {
 		return null;
 	}
 
+	public static ValueType isHash(final String val, final int len){
+		if(len == 8){
+			for(int i = 0; i < 8; i++){
+				char v = val.charAt(i);
+				if( v< '0' ||  v > 'f')
+					return null;
+			}
+			return ValueType.HASH64;
+		}
+		return null;
+	}
+
 	public static ValueType isFloatType(final String val, final int len) {
 		if(len <= 30 && (simpleFloatMatch(val, len) || floatPattern.matcher(val).matches())) {
 			if(len <= 7 || (len == 8 && val.charAt(0) == '-'))
@@ -226,6 +238,10 @@ public interface FrameUtil {
 			case CHARACTER:
 				if(len == 1)
 					return ValueType.CHARACTER;
+			case HASH64:
+				r = isHash(val, len);
+				if(r != null)
+					return r;
 			case STRING:
 			default:
 				return ValueType.STRING;

--- a/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/lib/FrameUtil.java
@@ -122,11 +122,11 @@ public interface FrameUtil {
 		return null;
 	}
 
-	public static ValueType isHash(final String val, final int len){
-		if(len == 8){
-			for(int i = 0; i < 8; i++){
+	public static ValueType isHash(final String val, final int len) {
+		if(len == 8) {
+			for(int i = 0; i < 8; i++) {
 				char v = val.charAt(i);
-				if( v< '0' ||  v > 'f')
+				if(v < '0' || v > 'f')
 					return null;
 			}
 			return ValueType.HASH64;
@@ -181,7 +181,7 @@ public interface FrameUtil {
 			final char c = val.charAt(i);
 			if(c >= '0' && c <= '9')
 				continue;
-			else if(c == '.' || c == ','){
+			else if(c == '.' || c == ',') {
 				if(encounteredDot == true)
 					return false;
 				else
@@ -221,7 +221,7 @@ public interface FrameUtil {
 		switch(minType) {
 			case UNKNOWN:
 			case BOOLEAN:
-			// case CHARACTER:
+				// case CHARACTER:
 				if(isBooleanType(val, len) != null)
 					return ValueType.BOOLEAN;
 			case UINT8:

--- a/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
@@ -46,6 +46,7 @@ import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.data.TensorIndexes;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.columns.CharArray;
+import org.apache.sysds.runtime.frame.data.columns.HashLongArray;
 import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.data.Pair;
@@ -492,6 +493,7 @@ public class UtilFunctions {
 			case FP64:    return Double.parseDouble(in);
 			case FP32:    return Float.parseFloat(in);
 			case CHARACTER: return CharArray.parseChar(in);
+			case HASH64:  return HashLongArray.parseLong(in);
 			default: throw new RuntimeException("Unsupported value type: "+vt);
 		}
 	}
@@ -674,7 +676,7 @@ public class UtilFunctions {
 	public static Object objectToObject(ValueType vt, Object in) {
 		if( in instanceof Double && vt == ValueType.FP64
 			|| in instanceof Float && vt == ValueType.FP32
-			|| in instanceof Long && vt == ValueType.INT64
+			|| in instanceof Long && (vt == ValueType.INT64 || vt == ValueType.HASH64)
 			|| in instanceof Integer && vt == ValueType.INT32
 			|| in instanceof Boolean && vt == ValueType.BOOLEAN
 			|| in instanceof String && vt == ValueType.STRING )

--- a/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/util/UtilFunctions.java
@@ -484,16 +484,16 @@ public class UtilFunctions {
 	public static Object stringToObject(ValueType vt, String in) {
 		if( in == null || in.isEmpty() )  return null;
 		switch( vt ) {
-			case STRING:  return in;
-			case BOOLEAN: return Boolean.parseBoolean(in);
+			case STRING:    return in;
+			case BOOLEAN:   return Boolean.parseBoolean(in);
 			case UINT4:
 			case UINT8:
-			case INT32:   return Integer.parseInt(in);
-			case INT64:   return Long.parseLong(in);
-			case FP64:    return Double.parseDouble(in);
-			case FP32:    return Float.parseFloat(in);
+			case INT32:     return Integer.parseInt(in);
+			case INT64:     return Long.parseLong(in);
+			case FP64:      return Double.parseDouble(in);
+			case FP32:      return Float.parseFloat(in);
 			case CHARACTER: return CharArray.parseChar(in);
-			case HASH64:  return HashLongArray.parseLong(in);
+			case HASH64:    return HashLongArray.parseHashLong(in);
 			default: throw new RuntimeException("Unsupported value type: "+vt);
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -2549,6 +2549,7 @@ public class TestUtils {
 			case INT32:   return random.nextInt();
 			case INT64:   return random.nextLong();
 			case BOOLEAN: return random.nextBoolean();
+			case HASH64:  return Long.toHexString(random.nextLong());
 			case STRING:
 				return random.ints('a', 'z' + 1)
 						.limit(10)

--- a/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
@@ -1366,54 +1366,49 @@ public class CustomArrayTests {
 
 	@Test
 	public void parseHash() {
-		assertEquals(10, HashLongArray.parseLong("a"));
-	}
-
-	@Test
-	public void parseHash2() {
-		assertEquals(-255, HashLongArray.parseLong("-ff"));
+		assertEquals(10, HashLongArray.parseHashLong("a"));
 	}
 
 	@Test
 	public void parseHash_ff() {
-		assertEquals(255, HashLongArray.parseLong("ff"));
+		assertEquals(255, HashLongArray.parseHashLong("ff"));
 	}
 
 	@Test
 	public void parseHash_fff() {
-		assertEquals(4095, HashLongArray.parseLong("fff"));
+		assertEquals(4095, HashLongArray.parseHashLong("fff"));
 	}
 
 	@Test
 	public void parseHash_ffff() {
-		assertEquals(65535, HashLongArray.parseLong("ffff"));
+		assertEquals(65535, HashLongArray.parseHashLong("ffff"));
 	}
 
 
 	@Test
 	public void parseHash_fffff() {
-		assertEquals(1048575, HashLongArray.parseLong("fffff"));
+		assertEquals(1048575, HashLongArray.parseHashLong("fffff"));
 	}
 
 	@Test
 	public void parseHash_ffffff() {
-		assertEquals(16777215, HashLongArray.parseLong("ffffff"));
+		assertEquals(16777215, HashLongArray.parseHashLong("ffffff"));
 	}
 
 	@Test
 	public void parseHash_fffffff() {
-		assertEquals(268435455L, HashLongArray.parseLong("fffffff"));
+		assertEquals(268435455L, HashLongArray.parseHashLong("fffffff"));
 	}
 
 
 	@Test
 	public void parseHash_ffffffff() {
-		assertEquals(4294967295L, HashLongArray.parseLong("ffffffff"));
+		assertEquals(4294967295L, HashLongArray.parseHashLong("ffffffff"));
 	}
 
 	@Test
 	public void parseHash_ffffffff_ffffffff() {
-		assertEquals(Long.MAX_VALUE, HashLongArray.parseLong("fffffffffffffff"));
+		assertEquals(-1, HashLongArray.parseHashLong("ffffffffffffffff"));
 	}
 
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/CustomArrayTests.java
@@ -45,6 +45,7 @@ import org.apache.sysds.runtime.frame.data.columns.CharArray;
 import org.apache.sysds.runtime.frame.data.columns.DDCArray;
 import org.apache.sysds.runtime.frame.data.columns.DoubleArray;
 import org.apache.sysds.runtime.frame.data.columns.FloatArray;
+import org.apache.sysds.runtime.frame.data.columns.HashLongArray;
 import org.apache.sysds.runtime.frame.data.columns.IntegerArray;
 import org.apache.sysds.runtime.frame.data.columns.LongArray;
 import org.apache.sysds.runtime.frame.data.columns.OptionalArray;
@@ -857,7 +858,7 @@ public class CustomArrayTests {
 		try {
 			Array<Long> a = null;
 			Array<Long> b = new DDCArray<Long>(new LongArray(new long[] {1, 2, 3, 4}), //
-				MapToFactory.create(10, new int[] {0, 0, 0, 0, 1, 1, 1, 2, 2, 3,3}, 4));
+				MapToFactory.create(10, new int[] {0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3}, 4));
 			Array<Long> c = ArrayFactory.set(a, b, 10, 19, 20);
 			assertEquals((long) c.get(0), 0L);
 			assertEquals((long) c.get(10), 1L);
@@ -873,7 +874,7 @@ public class CustomArrayTests {
 		try {
 			Array<Long> a = null;
 			Array<Long> b = new DDCArray<Long>(new OptionalArray<Long>(new Long[] {1L, 2L, 3L, 4L}), //
-				MapToFactory.create(10, new int[] {0, 0, 0, 0, 1, 1, 1, 2, 2, 3,3}, 4));
+				MapToFactory.create(10, new int[] {0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3}, 4));
 			Array<Long> c = ArrayFactory.set(a, b, 10, 19, 20);
 			assertEquals(c.get(0), null);
 			assertEquals((long) c.get(10), 1L);
@@ -883,8 +884,6 @@ public class CustomArrayTests {
 			fail(e.getMessage());
 		}
 	}
-
-	
 
 	@Test
 	public void testSetOptionalB() {
@@ -1364,4 +1363,57 @@ public class CustomArrayTests {
 			assertEquals(a.hashDouble(i), Double.NaN, 0.0);
 		}
 	}
+
+	@Test
+	public void parseHash() {
+		assertEquals(10, HashLongArray.parseLong("a"));
+	}
+
+	@Test
+	public void parseHash2() {
+		assertEquals(-255, HashLongArray.parseLong("-ff"));
+	}
+
+	@Test
+	public void parseHash_ff() {
+		assertEquals(255, HashLongArray.parseLong("ff"));
+	}
+
+	@Test
+	public void parseHash_fff() {
+		assertEquals(4095, HashLongArray.parseLong("fff"));
+	}
+
+	@Test
+	public void parseHash_ffff() {
+		assertEquals(65535, HashLongArray.parseLong("ffff"));
+	}
+
+
+	@Test
+	public void parseHash_fffff() {
+		assertEquals(1048575, HashLongArray.parseLong("fffff"));
+	}
+
+	@Test
+	public void parseHash_ffffff() {
+		assertEquals(16777215, HashLongArray.parseLong("ffffff"));
+	}
+
+	@Test
+	public void parseHash_fffffff() {
+		assertEquals(268435455L, HashLongArray.parseLong("fffffff"));
+	}
+
+
+	@Test
+	public void parseHash_ffffffff() {
+		assertEquals(4294967295L, HashLongArray.parseLong("ffffffff"));
+	}
+
+	@Test
+	public void parseHash_ffffffff_ffffffff() {
+		assertEquals(Long.MAX_VALUE, HashLongArray.parseLong("fffffffffffffff"));
+	}
+
 }

--- a/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayConstantTests.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/array/FrameArrayConstantTests.java
@@ -102,6 +102,8 @@ public class FrameArrayConstantTests {
 	@Test
 	public void testConstruction_1() {
 		try {
+			if(t == ValueType.HASH64)
+				return;
 			Array<?> a = ArrayFactory.allocate(t, nRow, "1.0");
 			for(int i = 0; i < nRow; i++)
 				assertEquals(a.getAsDouble(i), 1.0, 0.0000000001);

--- a/src/test/java/org/apache/sysds/test/component/frame/iterators/IteratorTest.java
+++ b/src/test/java/org/apache/sysds/test/component/frame/iterators/IteratorTest.java
@@ -22,6 +22,7 @@ package org.apache.sysds.test.component.frame.iterators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
@@ -36,8 +37,20 @@ import org.junit.Test;
 
 public class IteratorTest {
 
-	private final FrameBlock fb1 = TestUtils.generateRandomFrameBlock(10, 10, 23);
-	private final FrameBlock fb2 = TestUtils.generateRandomFrameBlock(40, 30, 22);
+	private final FrameBlock fb1;
+	private final FrameBlock fb2;
+
+	public IteratorTest() {
+		try {
+			fb1 = TestUtils.generateRandomFrameBlock(10, 10, 23);
+			fb2 = TestUtils.generateRandomFrameBlock(40, 30, 22);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
 
 	@Test
 	public void StringObjectStringFB1() {
@@ -236,28 +249,26 @@ public class IteratorTest {
 		compareIterators(a, b);
 	}
 
-
-	@Test(expected= DMLRuntimeException.class)
-	public void invalidRange1(){
+	@Test(expected = DMLRuntimeException.class)
+	public void invalidRange1() {
 		IteratorFactory.getStringRowIterator(fb2, -1, 1);
 	}
 
-	@Test(expected= DMLRuntimeException.class)
-	public void invalidRange2(){
+	@Test(expected = DMLRuntimeException.class)
+	public void invalidRange2() {
 		IteratorFactory.getStringRowIterator(fb2, 132415, 132416);
 	}
 
-	@Test(expected= DMLRuntimeException.class)
-	public void invalidRange3(){
+	@Test(expected = DMLRuntimeException.class)
+	public void invalidRange3() {
 		IteratorFactory.getStringRowIterator(fb2, 13, 4);
 	}
 
-	@Test(expected= DMLRuntimeException.class)
-	public void remove(){
-		RowIterator<?> a =IteratorFactory.getStringRowIterator(fb2, 0, 4);
+	@Test(expected = DMLRuntimeException.class)
+	public void remove() {
+		RowIterator<?> a = IteratorFactory.getStringRowIterator(fb2, 0, 4);
 		a.remove();
 	}
-
 
 	private static void compareIterators(RowIterator<?> a, RowIterator<?> b) {
 		while(a.hasNext()) {


### PR DESCRIPTION
This PR contains a new value type for frames called HASH64, this column type can contains hashes of 8 characters in hex format. It behaves internally as if it is a string column, but allocate a single long value per cell. 
This reduce the allocation of columns with hash values from 40+ byte per value to 8 byte.