### PR TITLE
[SYSTEMDS-3637] Manifest for SystemDS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,14 @@
 				<directory>src/assembly/bin</directory>
 				<targetPath>META-INF/</targetPath>
 			</resource>
+			<resource>
+				<!-- add the Log4j properties file into the jar to have default logging settings -->
+				<directory>conf</directory>
+				<includes>
+					<include>log4j.properties</include>
+				</includes>
+				<targetPath>./</targetPath>
+			</resource>
 		</resources>
 		<testResources>
 			<testResource>
@@ -211,9 +219,6 @@
 						</goals>
 						<configuration>
 							<forceCreation>true</forceCreation>
-							<includes>
-								<include>org/apache/sysds/**</include>
-							</includes>
 							<archive>
 								<manifest>
 									<addClasspath>true</addClasspath>

--- a/pom.xml
+++ b/pom.xml
@@ -211,10 +211,18 @@
 						</goals>
 						<configuration>
 							<forceCreation>true</forceCreation>
+							<includes>
+								<include>org/apache/sysds/**</include>
+							</includes>
 							<archive>
 								<manifest>
+									<addClasspath>true</addClasspath>
+									<classpathPrefix>lib/</classpathPrefix>
 									<mainClass>org.apache.sysds.api.DMLScript</mainClass>
 								</manifest>
+								<manifestEntries>
+									<Class-Path>SystemDS.jar ${project.artifactId}-${project.version}.jar</Class-Path>
+								</manifestEntries>
 							</archive>
 						</configuration>
 					</execution>
@@ -227,7 +235,6 @@
 							<classifier>perf</classifier>
 							<includes>
 								<include>org/apache/sysds/performance/**</include>
-								<include>log4j.properties</include>
 							</includes>
 							<archive>
 								<manifest>
@@ -236,7 +243,7 @@
 									<mainClass>org.apache.sysds.performance.Main</mainClass>
 								</manifest>
 								<manifestEntries>
-									<Class-Path>SystemDS.jar ${project.build.directory}/${project.artifactId}-${project.version}-tests.jar</Class-Path>
+									<Class-Path>SystemDS.jar ${project.artifactId}-${project.version}-tests.jar</Class-Path>
 								</manifestEntries>
 							</archive>
 						</configuration>
@@ -1427,7 +1434,7 @@
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
 			<version>4.1.68.Final</version>
-			<scope>provided</scope>
+			<!-- <scope>provided</scope> -->
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
To improve the startup time further we can specify a manifest that is included in the SystemDS jar file.

this improves performance to 1,1932 from 1.2804.

It also change the way we can execute our scripts from java from:

`java -cp target/SystemDS.jar:./lib/*:./target/lib/*  org.apache.sysds.api.DMLScript   -f tmp/test.dml`

to: 

`java -jar target/SystemDS.jar -f tmp/test.dml`


 