### PR TITLE
 [SYSTEMDS-3643] Fused Scaling Compressed Multiplication 

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/APreAgg.java
@@ -85,9 +85,12 @@ public abstract class APreAgg extends AColGroupValue {
 	 * @return A aggregate dictionary
 	 */
 	public final IDictionary preAggregateThatIndexStructure(APreAgg that) {
-		long outputLength = (long)that._colIndexes.size() * this.getNumValues();
+		final long outputLength = (long)that._colIndexes.size() * this.getNumValues();
 		if(outputLength > Integer.MAX_VALUE)
 			throw new NotImplementedException("Not supported pre aggregate of above integer length");
+		if(outputLength <= 0) // if the pre aggregate output is empty or nothing, return null
+			return null;
+		
 		// create empty Dictionary that we slowly fill, hence the dictionary is empty and no check
 		final Dictionary ret = Dictionary.createNoCheck(new double[(int)outputLength]);
 

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictLibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictLibMatrixMult.java
@@ -65,11 +65,12 @@ public class DictLibMatrixMult {
 	 */
 	public static void MMDictsWithScaling(IDictionary left, IDictionary right, IColIndex leftRows,
 		IColIndex rightColumns, MatrixBlock result, int[] counts) {
-		LOG.warn("Inefficient double allocation of dictionary");
-		final boolean modifyRight = right.getInMemorySize() > left.getInMemorySize();
-		final IDictionary rightM = modifyRight ? right.scaleTuples(counts, rightColumns.size()) : right;
-		final IDictionary leftM = modifyRight ? left : left.scaleTuples(counts, leftRows.size());
-		MMDicts(leftM, rightM, leftRows, rightColumns, result);
+		// LOG.warn("Inefficient double allocation of dictionary");
+		// final boolean modifyRight = right.getInMemorySize() > left.getInMemorySize();
+		// final IDictionary rightM = modifyRight ? right.scaleTuples(counts, rightColumns.size()) : right;
+		// final IDictionary leftM = modifyRight ? left : left.scaleTuples(counts, leftRows.size());
+		// MMDictsScaling(left, right, leftRows, rightColumns, result, counts);
+		left.MMDictScaling(right, leftRows, rightColumns, result, counts);
 	}
 
 	/**
@@ -99,6 +100,23 @@ public class DictLibMatrixMult {
 	public static void MMDicts(IDictionary left, IDictionary right, IColIndex rowsLeft, IColIndex colsRight,
 		MatrixBlock result) {
 		left.MMDict(right, rowsLeft, colsRight, result);
+	}
+
+	/**
+	 * Matrix multiply the two dictionaries, note that the left side is considered transposed but not allocated
+	 * transposed making the multiplication a: t(left) %*% right. Furthermore, this multiplication contains a scaling
+	 * factor. changing the operation to: t(left) %*% (right * scaling) where scaling is a
+	 * 
+	 * @param left      The left side dictionary
+	 * @param right     The right side dictionary
+	 * @param rowsLeft  The row indexes on the left hand side
+	 * @param colsRight The column indexes on the right hand side
+	 * @param result    The result matrix to put the results into.
+	 * @param scaling   The scaling factor vector.
+	 */
+	public static void MMDictsScaling(IDictionary left, IDictionary right, IColIndex rowsLeft, IColIndex colsRight,
+		MatrixBlock result, int[] scaling) {
+		left.MMDictScaling(right, rowsLeft, colsRight, result, scaling);
 	}
 
 	/**
@@ -198,17 +216,43 @@ public class DictLibMatrixMult {
 
 	protected static void MMDictsDenseDense(double[] left, double[] right, IColIndex rowsLeft, IColIndex colsRight,
 		MatrixBlock result) {
-		final int commonDim = Math.min(left.length / rowsLeft.size(), right.length / colsRight.size());
+		final int leftSide = rowsLeft.size();
+		final int rightSide = colsRight.size();
+		final int commonDim = Math.min(left.length / leftSide, right.length / rightSide);
 		final int resCols = result.getNumColumns();
 		final double[] resV = result.getDenseBlockValues();
+
 		for(int k = 0; k < commonDim; k++) {
-			final int offL = k * rowsLeft.size();
-			final int offR = k * colsRight.size();
-			for(int i = 0; i < rowsLeft.size(); i++) {
+			final int offL = k * leftSide;
+			final int offR = k * rightSide;
+			for(int i = 0; i < leftSide; i++) {
 				final int offOut = rowsLeft.get(i) * resCols;
 				final double vl = left[offL + i];
 				if(vl != 0) {
-					for(int j = 0; j < colsRight.size(); j++)
+					for(int j = 0; j < rightSide; j++)
+						resV[offOut + colsRight.get(j)] += vl * right[offR + j];
+				}
+			}
+		}
+	}
+
+	protected static void MMDictsScalingDenseDense(double[] left, double[] right, IColIndex rowsLeft,
+		IColIndex colsRight, MatrixBlock result, int[] scaling) {
+		final int leftSide = rowsLeft.size();
+		final int rightSide = colsRight.size();
+		final int commonDim = Math.min(left.length / leftSide, right.length / rightSide);
+		final int resCols = result.getNumColumns();
+		final double[] resV = result.getDenseBlockValues();
+
+		for(int k = 0; k < commonDim; k++) {
+			final int offL = k * leftSide;
+			final int offR = k * rightSide;
+			final int s = scaling[k];
+			for(int i = 0; i < leftSide; i++) {
+				final int offOut = rowsLeft.get(i) * resCols;
+				final double vl = left[offL + i] * s;
+				if(vl != 0) {
+					for(int j = 0; j < rightSide; j++)
 						resV[offOut + colsRight.get(j)] += vl * right[offR + j];
 				}
 			}
@@ -236,10 +280,34 @@ public class DictLibMatrixMult {
 		}
 	}
 
+	protected static void MMDictsScalingSparseDense(SparseBlock left, double[] right, IColIndex rowsLeft,
+		IColIndex colsRight, MatrixBlock result, int[] scaling) {
+		final double[] resV = result.getDenseBlockValues();
+		final int commonDim = Math.min(left.numRows(), right.length / colsRight.size());
+		for(int i = 0; i < commonDim; i++) {
+			if(left.isEmpty(i))
+				continue;
+			final int apos = left.pos(i);
+			final int alen = left.size(i) + apos;
+			final int[] aix = left.indexes(i);
+			final double[] leftVals = left.values(i);
+			final int offRight = i * colsRight.size();
+			final int s = scaling[i];
+			for(int k = apos; k < alen; k++) {
+				final int offOut = rowsLeft.get(aix[k]) * result.getNumColumns();
+				final double v = leftVals[k] * s;
+				for(int j = 0; j < colsRight.size(); j++)
+					resV[offOut + colsRight.get(j)] += v * right[offRight + j];
+			}
+		}
+	}
+
 	protected static void MMDictsDenseSparse(double[] left, SparseBlock right, IColIndex rowsLeft, IColIndex colsRight,
 		MatrixBlock result) {
 		final double[] resV = result.getDenseBlockValues();
-		final int commonDim = Math.min(left.length / rowsLeft.size(), right.numRows());
+		final int leftSize = rowsLeft.size();
+		final int commonDim = Math.min(left.length / leftSize, right.numRows());
+
 		for(int i = 0; i < commonDim; i++) {
 			if(right.isEmpty(i))
 				continue;
@@ -247,10 +315,36 @@ public class DictLibMatrixMult {
 			final int alen = right.size(i) + apos;
 			final int[] aix = right.indexes(i);
 			final double[] rightVals = right.values(i);
-			final int offLeft = i * rowsLeft.size();
-			for(int j = 0; j < rowsLeft.size(); j++) {
+			final int offLeft = i * leftSize;
+			for(int j = 0; j < leftSize; j++) {
 				final int offOut = rowsLeft.get(j) * result.getNumColumns();
 				final double v = left[offLeft + j];
+				if(v != 0) {
+					for(int k = apos; k < alen; k++)
+						resV[offOut + colsRight.get(aix[k])] += v * rightVals[k];
+				}
+			}
+		}
+	}
+
+		protected static void MMDictsScalingDenseSparse(double[] left, SparseBlock right, IColIndex rowsLeft, IColIndex colsRight,
+		MatrixBlock result, int[] scaling) {
+		final double[] resV = result.getDenseBlockValues();
+		final int leftSize = rowsLeft.size();
+		final int commonDim = Math.min(left.length / leftSize, right.numRows());
+
+		for(int i = 0; i < commonDim; i++) {
+			if(right.isEmpty(i))
+				continue;
+			final int apos = right.pos(i);
+			final int alen = right.size(i) + apos;
+			final int[] aix = right.indexes(i);
+			final double[] rightVals = right.values(i);
+			final int offLeft = i * leftSize;
+			final int s = scaling[i];
+			for(int j = 0; j < leftSize; j++) {
+				final int offOut = rowsLeft.get(j) * result.getNumColumns();
+				final double v = left[offLeft + j] * s;
 				if(v != 0) {
 					for(int k = apos; k < alen; k++)
 						resV[offOut + colsRight.get(aix[k])] += v * rightVals[k];
@@ -280,6 +374,35 @@ public class DictLibMatrixMult {
 			for(int k = leftAPos; k < leftAlen; k++) {
 				final int offOut = rowsLeft.get(leftAix[k]) * resCols;
 				final double v = leftVals[k];
+				for(int j = rightAPos; j < rightAlen; j++)
+					resV[offOut + colsRight.get(rightAix[j])] += v * rightVals[j];
+			}
+		}
+	}
+
+	protected static void MMDictsScalingSparseSparse(SparseBlock left, SparseBlock right, IColIndex rowsLeft,
+		IColIndex colsRight, MatrixBlock result, int[] scaling) {
+		final int commonDim = Math.min(left.numRows(), right.numRows());
+		final double[] resV = result.getDenseBlockValues();
+		final int resCols = result.getNumColumns();
+		// remember that the left side is transposed...
+		for(int i = 0; i < commonDim; i++) {
+			if(left.isEmpty(i) || right.isEmpty(i))
+				continue;
+			final int leftAPos = left.pos(i);
+			final int leftAlen = left.size(i) + leftAPos;
+			final int[] leftAix = left.indexes(i);
+			final double[] leftVals = left.values(i);
+			final int rightAPos = right.pos(i);
+			final int rightAlen = right.size(i) + rightAPos;
+			final int[] rightAix = right.indexes(i);
+			final double[] rightVals = right.values(i);
+
+			final int s = scaling[i];
+
+			for(int k = leftAPos; k < leftAlen; k++) {
+				final int offOut = rowsLeft.get(leftAix[k]) * resCols;
+				final double v = leftVals[k] * s;
 				for(int j = rightAPos; j < rightAlen; j++)
 					resV[offOut + colsRight.get(rightAix[j])] += v * rightVals[j];
 			}

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictLibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DictLibMatrixMult.java
@@ -65,11 +65,6 @@ public class DictLibMatrixMult {
 	 */
 	public static void MMDictsWithScaling(IDictionary left, IDictionary right, IColIndex leftRows,
 		IColIndex rightColumns, MatrixBlock result, int[] counts) {
-		// LOG.warn("Inefficient double allocation of dictionary");
-		// final boolean modifyRight = right.getInMemorySize() > left.getInMemorySize();
-		// final IDictionary rightM = modifyRight ? right.scaleTuples(counts, rightColumns.size()) : right;
-		// final IDictionary leftM = modifyRight ? left : left.scaleTuples(counts, leftRows.size());
-		// MMDictsScaling(left, right, leftRows, rightColumns, result, counts);
 		left.MMDictScaling(right, leftRows, rightColumns, result, counts);
 	}
 
@@ -100,23 +95,6 @@ public class DictLibMatrixMult {
 	public static void MMDicts(IDictionary left, IDictionary right, IColIndex rowsLeft, IColIndex colsRight,
 		MatrixBlock result) {
 		left.MMDict(right, rowsLeft, colsRight, result);
-	}
-
-	/**
-	 * Matrix multiply the two dictionaries, note that the left side is considered transposed but not allocated
-	 * transposed making the multiplication a: t(left) %*% right. Furthermore, this multiplication contains a scaling
-	 * factor. changing the operation to: t(left) %*% (right * scaling) where scaling is a
-	 * 
-	 * @param left      The left side dictionary
-	 * @param right     The right side dictionary
-	 * @param rowsLeft  The row indexes on the left hand side
-	 * @param colsRight The column indexes on the right hand side
-	 * @param result    The result matrix to put the results into.
-	 * @param scaling   The scaling factor vector.
-	 */
-	public static void MMDictsScaling(IDictionary left, IDictionary right, IColIndex rowsLeft, IColIndex colsRight,
-		MatrixBlock result, int[] scaling) {
-		left.MMDictScaling(right, rowsLeft, colsRight, result, scaling);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
@@ -22,13 +22,16 @@ package org.apache.sysds.runtime.compress.colgroup.dictionary;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.lang.ref.SoftReference;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Arrays;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
+import org.apache.sysds.runtime.compress.utils.Util;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Plus;
@@ -51,6 +54,8 @@ public class Dictionary extends ADictionary {
 	private static final long serialVersionUID = -6517136537249507753L;
 
 	protected final double[] _values;
+	/** A Cache to contain a MatrixBlock version of the dictionary. */
+	protected volatile SoftReference<MatrixBlockDictionary> cache = null;
 
 	protected Dictionary(double[] values) {
 		_values = values;
@@ -799,7 +804,14 @@ public class Dictionary extends ADictionary {
 
 	@Override
 	public MatrixBlockDictionary getMBDict(int nCol) {
-		return MatrixBlockDictionary.createDictionary(_values, nCol, true);
+		if(cache != null) {
+			MatrixBlockDictionary r = cache.get();
+			if(r != null)
+				return r;
+		}
+		MatrixBlockDictionary ret = MatrixBlockDictionary.createDictionary(_values, nCol, true);
+		cache = new SoftReference<>(ret);
+		return ret;
 	}
 
 	@Override
@@ -843,13 +855,15 @@ public class Dictionary extends ADictionary {
 	@Override
 	public Dictionary preaggValuesFromDense(int numVals, IColIndex colIndexes, IColIndex aggregateColumns, double[] b,
 		int cut) {
-		double[] ret = new double[numVals * aggregateColumns.size()];
-		for(int k = 0, off = 0; k < numVals * colIndexes.size(); k += colIndexes.size(), off += aggregateColumns.size()) {
-			for(int h = 0; h < colIndexes.size(); h++) {
-				int idb = colIndexes.get(h) * cut;
+		final int cz = colIndexes.size();
+		final int az = aggregateColumns.size();
+		final double[] ret = new double[numVals * az];
+		for(int k = 0, off = 0; k < numVals * cz; k += cz, off += az) {
+			for(int h = 0; h < cz; h++) {
+				final int idb = colIndexes.get(h) * cut;
 				double v = _values[k + h];
 				if(v != 0)
-					for(int i = 0; i < aggregateColumns.size(); i++)
+					for(int i = 0; i < az; i++)
 						ret[off + i] += v * b[idb + aggregateColumns.get(i)];
 			}
 		}
@@ -861,13 +875,15 @@ public class Dictionary extends ADictionary {
 		double[] retV = new double[_values.length];
 		for(int i = 0; i < _values.length; i++) {
 			final double v = _values[i];
-			retV[i] = v == pattern ? replace : v;
+			retV[i] = Util.eq(v, pattern) ? replace : v;
 		}
 		return create(retV);
 	}
 
 	@Override
 	public IDictionary replaceWithReference(double pattern, double replace, double[] reference) {
+		if(Util.eq(pattern, Double.NaN))
+			throw new NotImplementedException();
 		final double[] retV = new double[_values.length];
 		final int nCol = reference.length;
 		final int nRow = _values.length / nCol;
@@ -1041,13 +1057,31 @@ public class Dictionary extends ADictionary {
 	}
 
 	@Override
+	public void MMDictScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		right.MMDictScalingDense(_values, rowsLeft, colsRight, result, scaling);
+	}
+
+	@Override
 	public void MMDictDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
 		DictLibMatrixMult.MMDictsDenseDense(left, _values, rowsLeft, colsRight, result);
 	}
 
 	@Override
+	public void MMDictScalingDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		DictLibMatrixMult.MMDictsScalingDenseDense(left, _values, rowsLeft, colsRight, result, scaling);
+	}
+
+	@Override
 	public void MMDictSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result) {
 		DictLibMatrixMult.MMDictsSparseDense(left, _values, rowsLeft, colsRight, result);
+	}
+
+	@Override
+	public void MMDictScalingSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		DictLibMatrixMult.MMDictsScalingSparseDense(left, _values, rowsLeft, colsRight, result, scaling);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
@@ -524,46 +524,46 @@ public interface IDictionary {
 	public long getNumberNonZerosWithReference(int[] counts, double[] reference, int nRows);
 
 	/**
-	 * Copies and adds the dictionary entry from this dictionary to the d dictionary
+	 * Adds the dictionary entry from this dictionary to the d dictionary
 	 * 
-	 * @param v    the target dictionary (dense double array)
-	 * @param fr   the from index
-	 * @param to   the to index
-	 * @param nCol the number of columns
+	 * @param v    The target dictionary (dense double array)
+	 * @param fr   The from index is the tuple index to copy from.
+	 * @param to   The to index is the row index to copy into.
+	 * @param nCol The number of columns in both cases
 	 */
 	public void addToEntry(double[] v, int fr, int to, int nCol);
 
 	/**
-	 * copies and adds the dictonary entry from this dictionary yo the d dictionary rep times.
+	 * Adds the dictionary entry from this dictionary to the v dictionary rep times.
 	 * 
-	 * @param v    the target dictionary (dense double array)
-	 * @param fr   the from index
-	 * @param to   the to index
-	 * @param nCol the number of columns
-	 * @param rep  the number of repetitions to apply (simply multiply do not loop)
+	 * @param v    The target dictionary (dense double array)
+	 * @param fr   The from index is the tuple index to copy from.
+	 * @param to   The to index is the row index to copy into.
+	 * @param nCol The number of columns in both cases
+	 * @param rep  The number of repetitions to apply (simply multiply do not loop)
 	 */
 	public void addToEntry(double[] v, int fr, int to, int nCol, int rep);
 
 	/**
 	 * Vectorized add to entry, this call helps with a bit of locality for the cache.
 	 * 
-	 * @param v    THe target dictionary (dense double array)
-	 * @param f1   from index 1
-	 * @param f2   from index 2
-	 * @param f3   from index 3
-	 * @param f4   from index 4
-	 * @param f5   from index 5
-	 * @param f6   from index 6
-	 * @param f7   from index 7
-	 * @param f8   from index 8
-	 * @param t1   to index 1
-	 * @param t2   to index 2
-	 * @param t3   to index 3
-	 * @param t4   to index 4
-	 * @param t5   to index 5
-	 * @param t6   to index 6
-	 * @param t7   to index 7
-	 * @param t8   to index 8
+	 * @param v    The target dictionary (dense double array)
+	 * @param f1   From index 1
+	 * @param f2   From index 2
+	 * @param f3   From index 3
+	 * @param f4   From index 4
+	 * @param f5   From index 5
+	 * @param f6   From index 6
+	 * @param f7   From index 7
+	 * @param f8   From index 8
+	 * @param t1   To index 1
+	 * @param t2   To index 2
+	 * @param t3   To index 3
+	 * @param t4   To index 4
+	 * @param t5   To index 5
+	 * @param t6   To index 6
+	 * @param t7   To index 7
+	 * @param t8   To index 8
 	 * @param nCol Number of columns in the dictionary
 	 */
 	public void addToEntryVectorized(double[] v, int f1, int f2, int f3, int f4, int f5, int f6, int f7, int f8, int t1,
@@ -821,6 +821,20 @@ public interface IDictionary {
 	public void MMDict(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result);
 
 	/**
+	 * Matrix multiplication of dictionaries
+	 * 
+	 * Note the left is this, and it is transposed
+	 * 
+	 * @param right     Right hand side of multiplication
+	 * @param rowsLeft  Offset rows on the left
+	 * @param colsRight Offset cols on the right
+	 * @param result    The output matrix block
+	 * @param scaling   The scaling
+	 */
+	public void MMDictScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling);
+
+	/**
 	 * Matrix multiplication of dictionaries left side dense and transposed right side is this.
 	 * 
 	 * @param left      Dense left side
@@ -831,6 +845,18 @@ public interface IDictionary {
 	public void MMDictDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result);
 
 	/**
+	 * Matrix multiplication of dictionaries left side dense and transposed right side is this.
+	 * 
+	 * @param left      Dense left side
+	 * @param rowsLeft  Offset rows on the left
+	 * @param colsRight Offset cols on the right
+	 * @param result    The output matrix block
+	 * @param scaling   The scaling
+	 */
+	public void MMDictScalingDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling);
+
+	/**
 	 * Matrix multiplication of dictionaries left side sparse and transposed right side is this.
 	 * 
 	 * @param left      Sparse left side
@@ -839,6 +865,18 @@ public interface IDictionary {
 	 * @param result    The output matrix block
 	 */
 	public void MMDictSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result);
+	
+/**
+	 * Matrix multiplication of dictionaries left side sparse and transposed right side is this.
+	 * 
+	 * @param left      Sparse left side
+	 * @param rowsLeft  Offset rows on the left
+	 * @param colsRight Offset cols on the right
+	 * @param result    The output matrix block
+	 * @param scaling   The scaling
+	 */
+	public void MMDictScalingSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling);
 
 	/**
 	 * Matrix multiplication but allocate output in upper triangle and twice if on diagonal, note this is left

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IdentityDictionarySlice.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IdentityDictionarySlice.java
@@ -69,13 +69,13 @@ public class IdentityDictionarySlice extends IdentityDictionary {
 	@Override
 	public double getValue(int i) {
 		throw new NotImplementedException();
-
 	}
 
 	@Override
 	public final double getValue(int r, int c, int nCol) {
-		throw new NotImplementedException();
-
+		if(r < l || r > u)
+			return 0;
+		return super.getValue(r - l, c, nCol);
 	}
 
 	@Override
@@ -276,6 +276,23 @@ public class IdentityDictionarySlice extends IdentityDictionary {
 	@Override
 	public double getSparsity() {
 		return 1d / nRowCol;
+	}
+
+	@Override
+	public IDictionary preaggValuesFromDense(final int numVals, final IColIndex colIndexes,
+		final IColIndex aggregateColumns, final double[] b, final int cut) {
+		return getMBDict().preaggValuesFromDense(numVals, colIndexes, aggregateColumns, b, cut);
+	}
+
+	@Override
+	public void addToEntryVectorized(double[] v, int f1, int f2, int f3, int f4, int f5, int f6, int f7, int f8, int t1,
+		int t2, int t3, int t4, int t5, int t6, int t7, int t8, int nCol) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void addToEntry(final double[] v, final int fr, final int to, final int nCol, int rep) {
+		throw new NotImplementedException();
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
@@ -507,4 +507,22 @@ public class PlaceHolderDict implements IDictionary, Serializable {
 		return new PlaceHolderDict(nVal);
 	}
 
+	@Override
+	public void MMDictScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void MMDictScalingDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new RuntimeException(errMessage);
+	}
+
+	@Override
+	public void MMDictScalingSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new RuntimeException(errMessage);
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
@@ -613,4 +613,22 @@ public class QDictionary extends ADictionary {
 	public IDictionary reorder(int[] reorder) {
 		throw new NotImplementedException();
 	}
+
+	@Override
+	public void MMDictScaling(IDictionary right, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void MMDictScalingDense(double[] left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void MMDictScalingSparse(SparseBlock left, IColIndex rowsLeft, IColIndex colsRight, MatrixBlock result,
+		int[] scaling) {
+		throw new NotImplementedException();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/data/SparseBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/data/SparseBlockFactory.java
@@ -153,10 +153,9 @@ public abstract class SparseBlockFactory{
 			rowPtr[rowPtr.length -1] = off;
 
 			return new SparseBlockCSR(rowPtr, colIdx, valsSparse, nnz);
-
 		}
 		else {
-			throw new NotImplementedException();
+			return new SparseBlockMCSR(nRow); // empty MCSR block
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -2044,6 +2044,17 @@ public class TestUtils {
 		return matrix;
 	}
 
+	public static double[] generateTestVector(int cols, double min, double max, double sparsity, long seed) {
+		double[] vector = new double[cols];
+		Random random = (seed == -1) ? TestUtils.random : new Random(seed);
+		for(int j = 0; j < cols; j++) {
+			if(random.nextDouble() > sparsity)
+				continue;
+			vector[j] = (random.nextDouble() * (max - min) + min);
+		}
+		return vector;
+	}
+
 	/**
 	 *
 	 * Generates a test matrix with the specified parameters as a MatrixBlock.

--- a/src/test/java/org/apache/sysds/test/component/compress/dictionary/DictionaryTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/dictionary/DictionaryTests.java
@@ -21,21 +21,29 @@ package org.apache.sysds.test.component.compress.dictionary;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
-import org.apache.sysds.runtime.compress.colgroup.dictionary.IDictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.Dictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.IDictionary;
+import org.apache.sysds.runtime.compress.colgroup.dictionary.IdentityDictionary;
 import org.apache.sysds.runtime.compress.colgroup.dictionary.MatrixBlockDictionary;
+import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
+import org.apache.sysds.runtime.compress.colgroup.indexes.IColIndex;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Builtin.BuiltinCode;
+import org.apache.sysds.runtime.functionobjects.Divide;
+import org.apache.sysds.runtime.functionobjects.Minus;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +79,30 @@ public class DictionaryTests {
 			addAll(tests, new double[] {1, 2, 3, 4, 5}, 1);
 			addAll(tests, new double[] {1, 2, 3, 4, 5, 6}, 2);
 			addAll(tests, new double[] {1, 2.2, 3.3, 4.4, 5.5, 6.6}, 3);
+
+			tests.add(new Object[] {new IdentityDictionary(2), Dictionary.create(new double[] {1, 0, 0, 1}), 2, 2});
+			tests.add(new Object[] {new IdentityDictionary(2, true), //
+				Dictionary.create(new double[] {1, 0, 0, 1, 0, 0}), 3, 2});
+			tests.add(new Object[] {new IdentityDictionary(3), //
+				Dictionary.create(new double[] {1, 0, 0, 0, 1, 0, 0, 0, 1}), 3, 3});
+			tests.add(new Object[] {new IdentityDictionary(3, true), //
+				Dictionary.create(new double[] {1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0}), 4, 3});
+
+			tests.add(new Object[] {new IdentityDictionary(4), //
+				Dictionary.create(new double[] {//
+					1, 0, 0, 0, //
+					0, 1, 0, 0, //
+					0, 0, 1, 0, //
+					0, 0, 0, 1,//
+				}), 4, 4});
+			tests.add(new Object[] {new IdentityDictionary(4, true), //
+				Dictionary.create(new double[] {//
+					1, 0, 0, 0, //
+					0, 1, 0, 0, //
+					0, 0, 1, 0, //
+					0, 0, 0, 1, //
+					0, 0, 0, 0}),
+				5, 4});
 
 			create(tests, 30, 300, 0.2);
 		}
@@ -405,6 +437,170 @@ public class DictionaryTests {
 		containsValueWithReference(1.0, getReference(nCol, 3241, -1.0, -1.0));
 	}
 
+	@Test
+	public void equalsEl() {
+		assertEquals(a, b);
+	}
+
+	@Test
+	public void opRightMinus() {
+		BinaryOperator op = new BinaryOperator(Minus.getMinusFnObject());
+		double[] vals = TestUtils.generateTestVector(nCol, -1, 1, 1.0, 132L);
+		opRight(op, vals, ColIndexFactory.create(0, nCol));
+	}
+
+	@Test
+	public void opRightMinusNoCol() {
+		BinaryOperator op = new BinaryOperator(Minus.getMinusFnObject());
+		double[] vals = TestUtils.generateTestVector(nCol, -1, 1, 1.0, 132L);
+		opRight(op, vals);
+	}
+
+	@Test
+	public void opRightMinusZero() {
+		BinaryOperator op = new BinaryOperator(Minus.getMinusFnObject());
+		double[] vals = new double[nCol];
+		opRight(op, vals, ColIndexFactory.create(0, nCol));
+	}
+
+	@Test
+	public void opRightDivOne() {
+		BinaryOperator op = new BinaryOperator(Divide.getDivideFnObject());
+		double[] vals = new double[nCol];
+		Arrays.fill(vals, 1);
+		opRight(op, vals, ColIndexFactory.create(0, nCol));
+	}
+
+	@Test
+	public void opRightDiv() {
+		BinaryOperator op = new BinaryOperator(Divide.getDivideFnObject());
+		double[] vals = TestUtils.generateTestVector(nCol, -1, 1, 1.0, 232L);
+		opRight(op, vals, ColIndexFactory.create(0, nCol));
+	}
+
+	private void opRight(BinaryOperator op, double[] vals, IColIndex cols) {
+		IDictionary aa = a.binOpRight(op, vals, cols);
+		IDictionary bb = b.binOpRight(op, vals, cols);
+		compare(aa, bb, nRow, nCol);
+	}
+
+	private void opRight(BinaryOperator op, double[] vals) {
+		IDictionary aa = a.binOpRight(op, vals);
+		IDictionary bb = b.binOpRight(op, vals);
+		compare(aa, bb, nRow, nCol);
+	}
+
+	@Test
+	public void testAddToEntry1() {
+		double[] ret1 = new double[nCol];
+		a.addToEntry(ret1, 0, 0, nCol);
+		double[] ret2 = new double[nCol];
+		b.addToEntry(ret2, 0, 0, nCol);
+		assertTrue(Arrays.equals(ret1, ret2));
+	}
+
+	@Test
+	public void testAddToEntry2() {
+		double[] ret1 = new double[nCol * 2];
+		a.addToEntry(ret1, 0, 1, nCol);
+		double[] ret2 = new double[nCol * 2];
+		b.addToEntry(ret2, 0, 1, nCol);
+		assertTrue(Arrays.equals(ret1, ret2));
+	}
+
+	@Test
+	public void testAddToEntry3() {
+		double[] ret1 = new double[nCol * 3];
+		a.addToEntry(ret1, 0, 2, nCol);
+		double[] ret2 = new double[nCol * 3];
+		b.addToEntry(ret2, 0, 2, nCol);
+		assertTrue(Arrays.equals(ret1, ret2));
+	}
+
+	@Test
+	public void testAddToEntry4() {
+		if(a.getNumberOfValues(nCol) > 2) {
+
+			double[] ret1 = new double[nCol * 3];
+			a.addToEntry(ret1, 2, 2, nCol);
+			double[] ret2 = new double[nCol * 3];
+			b.addToEntry(ret2, 2, 2, nCol);
+			assertTrue(Arrays.equals(ret1, ret2));
+		}
+	}
+
+	@Test
+	public void testAddToEntryVectorized1() {
+		try {
+			double[] ret1 = new double[nCol * 3];
+			a.addToEntryVectorized(ret1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+			double[] ret2 = new double[nCol * 3];
+			b.addToEntryVectorized(ret2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+			assertTrue(Arrays.equals(ret1, ret2));
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testAddToEntryVectorized2() {
+		try {
+
+			if(a.getNumberOfValues(nCol) > 1) {
+				double[] ret1 = new double[nCol * 3];
+				a.addToEntryVectorized(ret1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+				double[] ret2 = new double[nCol * 3];
+				b.addToEntryVectorized(ret2, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+				assertTrue("Error: " + a.getClass().getSimpleName() + " " + b.getClass().getSimpleName(),
+					Arrays.equals(ret1, ret2));
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testAddToEntryVectorized3() {
+		try {
+
+			if(a.getNumberOfValues(nCol) > 2) {
+				double[] ret1 = new double[nCol * 3];
+				a.addToEntryVectorized(ret1, 1, 2, 1, 2, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+				double[] ret2 = new double[nCol * 3];
+				b.addToEntryVectorized(ret2, 1, 2, 1, 2, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0, 1, nCol);
+				assertTrue("Error: " + a.getClass().getSimpleName() + " " + b.getClass().getSimpleName(),
+					Arrays.equals(ret1, ret2));
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testAddToEntryVectorized4() {
+		try {
+
+			if(a.getNumberOfValues(nCol) > 3) {
+				double[] ret1 = new double[nCol * 57];
+				a.addToEntryVectorized(ret1, 3, 3, 0, 3, 0, 2, 0, 3, 20, 1, 12, 2, 10, 3, 6, 56, nCol);
+				double[] ret2 = new double[nCol * 57];
+				b.addToEntryVectorized(ret2, 3, 3, 0, 3, 0, 2, 0, 3, 20, 1, 12, 2, 10, 3, 6, 56, nCol);
+				assertTrue("Error: " + a.getClass().getSimpleName() + " " + b.getClass().getSimpleName(),
+					Arrays.equals(ret1, ret2));
+			}
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
 	public void containsValueWithReference(double value, double[] reference) {
 		assertEquals(//
 			a.containsValueWithReference(value, reference), //
@@ -412,9 +608,37 @@ public class DictionaryTests {
 	}
 
 	private static void compare(IDictionary a, IDictionary b, int nRow, int nCol) {
-		for(int i = 0; i < nRow; i++)
-			for(int j = 0; j < nCol; j++)
-				assertEquals(a.getValue(i, j, nCol), b.getValue(i, j, nCol), 0.0001);
+		try {
+
+			String errorM = a.getClass().getSimpleName() + " " + b.getClass().getSimpleName();
+			for(int i = 0; i < nRow; i++)
+				for(int j = 0; j < nCol; j++)
+					assertEquals(errorM, a.getValue(i, j, nCol), b.getValue(i, j, nCol), 0.0001);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void preaggValuesFromDense() {
+		try {
+
+			final int nv = a.getNumberOfValues(nCol);
+			IColIndex idc = ColIndexFactory.create(0, nCol);
+
+			double[] bv = TestUtils.generateTestVector(nCol * nCol, -1, 1, 1.0, 321521L);
+
+			IDictionary aa = a.preaggValuesFromDense(nv, idc, idc, bv, nCol);
+			IDictionary bb = b.preaggValuesFromDense(nv, idc, idc, bv, nCol);
+
+			compare(aa, bb, aa.getNumberOfValues(nCol), nCol);
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	public void productWithDefault(double retV, double[] def) {

--- a/src/test/java/org/apache/sysds/test/component/matrix/SparseFactory.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/SparseFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.matrix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.data.SparseBlockFactory;
+import org.junit.Test;
+
+public class SparseFactory {
+	protected static final Log LOG = LogFactory.getLog(SparseFactory.class.getName());
+
+	@Test
+	public void testCreateFromArray() {
+		double[] dense = new double[] {0, 0, 0, 1, 1, 1, 0, 0, 0};
+		SparseBlock sb = SparseBlockFactory.createFromArray(dense, 3, 3);
+		
+		assertEquals(0, sb.get(0, 0), 0.0);
+		assertEquals(0, sb.get(1, 1), 1.0);
+		assertEquals(0, sb.get(2, 2), 0.0);
+	}
+}


### PR DESCRIPTION
This PR contains the code to fuse the scaling part into the Matrix Multiplication kernels of CLA. 
This is used to not allocate new Dictionaries, when the two column group sides have identical index structures.

The change improve instructions such as MMChain and TSMM