### PR TITLE
[SYSTEMDS-3646] Extend max_parallelize OP ordering to support GPU OPs

### DIFF
--- a/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
+++ b/src/main/java/org/apache/sysds/lops/compile/linearization/ILinearize.java
@@ -183,9 +183,15 @@ public class ILinearize {
 	// followed by asynchronously triggering operators and CP chains.
 	private static List<Lop> doMaxParallelizeSort(List<Lop> v)
 	{
-		List<Lop> final_v = null;
+		List<Lop> v2 = v;
+		boolean hasSpark = v.stream().anyMatch(ILinearize::isDistributedOp);
+		boolean hasGPU = v.stream().anyMatch(ILinearize::isGPUOp);
+
 		// Fallback to default depth-first if all operators are CP
-		if (v.stream().anyMatch(ILinearize::isDistributedOp)) {
+		if (!hasSpark && !hasGPU)
+			return depthFirst(v);
+
+		if (hasSpark) {
 			// Step 1: Collect the Spark roots and #Spark instructions in each subDAG
 			Map<Long, Integer> sparkOpCount = new HashMap<>();
 			List<Lop> roots = v.stream().filter(OperatorOrderingUtils::isLopRoot).collect(Collectors.toList());
@@ -204,13 +210,29 @@ public class ILinearize {
 			roots.forEach(r -> depthFirst(r, operatorList, sparkOpCount, false));
 			roots.forEach(Lop::resetVisitStatus);
 
-			final_v = operatorList;
+			v2 = operatorList;
 		}
-		else
-			final_v = depthFirst(v);
 
-		return final_v;
-		//TODO: Support GPU operator chains
+		if (hasGPU) {
+			// Step 1: Collect the GPU roots and #GPU instructions in each subDAG
+			Map<Long, Integer> gpuOpCount = new HashMap<>();
+			List<Lop> roots = v2.stream().filter(OperatorOrderingUtils::isLopRoot).collect(Collectors.toList());
+			HashSet<Lop> gpuRoots = new HashSet<>();
+			roots.forEach(r -> OperatorOrderingUtils.collectGPURoots(r, gpuOpCount, gpuRoots));
+			gpuRoots.forEach(sr -> sr.setAsynchronous(true));
+
+			// Step 2: Depth-first linearization of GPU roots.
+			// Maintain the default order (by ID) to trigger independent GPU OP chains first
+			ArrayList<Lop> operatorList = new ArrayList<>();
+			gpuRoots.forEach(r -> depthFirst(r, operatorList, gpuOpCount, false));
+
+			// Step 3: Place the rest of the operators (CP).
+			roots.forEach(r -> depthFirst(r, operatorList, gpuOpCount, false));
+			roots.forEach(Lop::resetVisitStatus);
+
+			v2 = operatorList;
+		}
+		return v2;
 	}
 
 	// Place the operators in a depth-first manner, but order
@@ -240,6 +262,13 @@ public class ILinearize {
 
 	private static boolean isDistributedOp(Lop lop) {
 		return lop.isExecSpark()
+			|| (lop instanceof UnaryCP
+			&& (((UnaryCP) lop).getOpCode().equalsIgnoreCase("prefetch")
+			|| ((UnaryCP) lop).getOpCode().equalsIgnoreCase("broadcast")));
+	}
+
+	private static boolean isGPUOp(Lop lop) {
+		return lop.isExecGPU()
 			|| (lop instanceof UnaryCP
 			&& (((UnaryCP) lop).getOpCode().equalsIgnoreCase("prefetch")
 			|| ((UnaryCP) lop).getOpCode().equalsIgnoreCase("broadcast")));

--- a/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddPrefetchLop.java
+++ b/src/main/java/org/apache/sysds/lops/rewrite/RewriteAddPrefetchLop.java
@@ -113,12 +113,12 @@ public class RewriteAddPrefetchLop extends LopRewriteRule
 		boolean anyOutputList = lop.getOutputs().stream()
 			.anyMatch(out -> out.getDataType() == Types.DataType.LIST);
 
-		//FIXME: Rewire _inputParams when needed (e.g. GroupedAggregate)
+		// FIXME: Rewire _inputParams when needed (e.g. GroupedAggregate)
 		boolean hasParameterizedOut = lop.getOutputs().stream()
 			.anyMatch(out -> ((out instanceof ParameterizedBuiltin)
 				|| (out instanceof GroupedAggregate)
 				|| (out instanceof GroupedAggregateM)));
-		//TODO: support non-matrix outputs
+		// TODO: support non-matrix outputs
 		return transformOP && !hasParameterizedOut && !anyOutputList
 			&& (lop.isAllOutputsCP() || OperatorOrderingUtils.isCollectForBroadcast(lop))
 			&& lop.getDataType() == Types.DataType.MATRIX;
@@ -133,7 +133,7 @@ public class RewriteAddPrefetchLop extends LopRewriteRule
 		boolean anyOutputList = lop.getOutputs().stream()
 			.anyMatch(out -> out.getDataType() == Types.DataType.LIST);
 
-		//FIXME: Rewire _inputParams when needed (e.g. Replace)
+		// FIXME: Rewire _inputParams when needed (e.g. Replace)
 		boolean hasParameterizedOut = lop.getOutputs().stream()
 			.anyMatch(out -> ((out instanceof ParameterizedBuiltin)
 				|| (out instanceof GroupedAggregate)

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/DnnCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/DnnCPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.sysds.runtime.instructions.cp;
 
 import java.util.ArrayList;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
@@ -28,6 +29,8 @@ import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.DnnParameters;
 import org.apache.sysds.runtime.matrix.data.LibMatrixDNN;
 import org.apache.sysds.runtime.matrix.data.LibMatrixDNN.PoolingType;
@@ -598,5 +601,24 @@ public class DnnCPInstruction extends UnaryCPInstruction {
 				warnedUnderUtilitization = true;
 			}
 		}
+	}
+
+	@Override
+	public Pair<String, LineageItem> getLineageItem(ExecutionContext ec) {
+		ArrayList<CPOperand> inputs = new ArrayList<>();
+		inputs.add(input1);
+		inputs.add(_in2);
+		inputs.add(_in3);
+		inputs.add(_in4);
+		inputs.add(_in5);
+		inputs.add(_in6);
+		inputs.add(_in7);
+		inputs.add(_in8);
+		inputs.addAll(_input_shape);
+		inputs.addAll(_filter_shape);
+		inputs.addAll(_stride);
+		inputs.addAll(_padding);
+		return Pair.of(output.getName(),
+			new LineageItem(getOpcode(), LineageItemUtils.getLineage(ec, inputs.toArray(new CPOperand[0]))));
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/gpu/context/GPUMemoryManager.java
@@ -345,6 +345,7 @@ public class GPUMemoryManager {
 					// Else, deallocate another free pointer. We are calling pollFistFreeNotExact with
 					// the same size (not with freedSize-size) to reduce potentials for creating holes
 				}
+				// FIXME: performance improvement. Slow due to looping and holes.
 			}
 			if (DMLScript.STATISTICS)
 				LineageCacheStatistics.incrementEvictTimeGpu(System.nanoTime() - t0);

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageCache.java
@@ -769,14 +769,16 @@ public class LineageCache
 				LineageCacheStatistics.incrementDelHitsGpu();
 			switch(centry.getCacheStatus()) {
 				case EMPTY:  //first hit
-					// Set the GPUOject in the cache. Will be garbage collected
-					if (!LineageCacheEviction._removelist.containsKey(centry._key)) {
-						// Cache right away if removed before
+					// Cache right away if removed before or a heavy hitter
+					if (LineageCacheConfig.isDelayedCachingGPU()  //if delayed caching enabled
+						&& !LineageCacheEviction._removelist.containsKey(centry._key)
+						&& !LineageCacheConfig.isComputeGPUOps(centry._key.getOpcode())) {
+						// Delayed Caching: Set the GPUOject in the cache. Will be garbage collected
 						centry.setGPUValue(gpuObj.getDensePointer(), gpuObj.getAllocatedSize(),
 							gpuObj.getMatrixObject().getMetaData(), computetime);
 						centry.setCacheStatus(LineageCacheStatus.TOCACHEGPU);
 						break;
-					}
+					} //else, falls through and cache
 				case TOCACHEGPU:  //second hit
 					// Set the GPUOject in the cache and update the status
 					centry.setGPUValue(gpuObj.getDensePointer(), gpuObj.getAllocatedSize(),

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageGPUCacheEviction.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageGPUCacheEviction.java
@@ -20,6 +20,7 @@
 package org.apache.sysds.runtime.lineage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -104,8 +105,8 @@ public class LineageGPUCacheEviction
 			return;
 		// Reset the timestamp to maintain the LRU component of the scoring function
 		entry.updateTimestamp();
-		// Scale score of the sought entry after every cache hit
-		entry.updateScore(true);
+		// TODO: Scale score after every cache hit if not LRU
+		//entry.updateScore(true);
 	}
 
 	protected static void removeSingleEntry(Map<LineageItem, LineageCacheEntry> cache, LineageCacheEntry e) {
@@ -161,6 +162,7 @@ public class LineageGPUCacheEviction
 	public static LineageCacheEntry pollFistFreeNotExact(long size) {
 		// Assuming no exact match
 		List<Long> sortedSizes = new ArrayList<>(freeQueues.keySet());
+		Collections.sort(sortedSizes);
 		// If the asked size is bigger than all, return a pointer of the highest size available
 		long maxSize = sortedSizes.get(sortedSizes.size()-1);
 		if (size > maxSize)

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -658,6 +658,8 @@ public class Statistics
 
 			if( OptimizerUtils.isSparkExecutionMode() )
 				sb.append(SparkStatistics.displayStatistics());
+			if (SparkStatistics.anyAsyncOp())
+				sb.append(SparkStatistics.displayAsyncStats());
 
 			sb.append(ParamServStatistics.displayStatistics());
 

--- a/src/main/java/org/apache/sysds/utils/stats/SparkStatistics.java
+++ b/src/main/java/org/apache/sysds/utils/stats/SparkStatistics.java
@@ -118,6 +118,9 @@ public class SparkStatistics {
 		asyncTriggerCheckpointCount.reset();
 	}
 
+	public static boolean anyAsyncOp() {
+		return (getAsyncPrefetchCount() > 0) || (getAsyncBroadcastCount() > 0) || (getAsyncSparkOpCount() > 0);
+	}
 	public static String displayStatistics() {
 		StringBuilder sb = new StringBuilder();
 		String lazy = SparkExecutionContext.isLazySparkContextCreation() ? "(lazy)" : "(eager)";
@@ -131,8 +134,13 @@ public class SparkStatistics {
 						parallelizeTime.longValue()*1e-9,
 						broadcastTime.longValue()*1e-9,
 						collectTime.longValue()*1e-9));
+		return sb.toString();
+	}
+
+	public static String displayAsyncStats() {
+		StringBuilder sb = new StringBuilder();
 		sb.append("Async. OP count (pf,bc,op): \t" +
-				String.format("%d/%d/%d.\n", getAsyncPrefetchCount(), getAsyncBroadcastCount(), getAsyncSparkOpCount()));
+			String.format("%d/%d/%d.\n", getAsyncPrefetchCount(), getAsyncBroadcastCount(), getAsyncSparkOpCount()));
 		return sb.toString();
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/GPULineageCacheEvictionTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.lineage.Lineage;
-import org.apache.sysds.runtime.lineage.LineageCacheConfig;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
@@ -40,7 +39,7 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 	
 	protected static final String TEST_DIR = "functions/lineage/";
 	protected static final String TEST_NAME = "GPUCacheEviction";
-	protected static final int TEST_VARIANTS = 3;
+	protected static final int TEST_VARIANTS = 5;
 	protected String TEST_CLASS_DIR = TEST_DIR + GPULineageCacheEvictionTest.class.getSimpleName() + "/";
 	
 	@BeforeClass
@@ -71,6 +70,16 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		testLineageTraceExec(TEST_NAME+"3");
 	}
 
+	@Test
+	public void TransferLearningAlexnet() {  //transfer learning and reuse
+		testLineageTraceExec(TEST_NAME+"4");
+	}
+
+	@Test
+	public void TransferLearningVGG() {  //transfer learning and reuse
+		testLineageTraceExec(TEST_NAME+"5");
+	}
+
 
 	private void testLineageTraceExec(String testname) {
 		System.out.println("------------ BEGIN " + testname + "------------");
@@ -86,8 +95,6 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		
 		// reset clears the lineage cache held memory from the last run
 		Lineage.resetInternalState();
-		boolean gpu2Mem = LineageCacheConfig.GPU2HOSTEVICTION;
-		//LineageCacheConfig.GPU2HOSTEVICTION = true;
 		OptimizerUtils.ASYNC_PREFETCH = true;
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
@@ -105,7 +112,6 @@ public class GPULineageCacheEvictionTest extends AutomatedTestBase{
 		//run the test
 		runTest(true, EXCEPTION_NOT_EXPECTED, null, -1);
 		AutomatedTestBase.TEST_GPU = false;
-		LineageCacheConfig.GPU2HOSTEVICTION = gpu2Mem;
 		OptimizerUtils.ASYNC_PREFETCH = false;
 		HashMap<MatrixValue.CellIndex, Double> R_reused = readDMLMatrixFromOutputDir("R");
 

--- a/src/test/scripts/functions/lineage/GPUCacheEviction4.dml
+++ b/src/test/scripts/functions/lineage/GPUCacheEviction4.dml
@@ -1,0 +1,282 @@
+conv2d_forward = function(matrix[double] X, matrix[double] W, matrix[double] b,
+  int C, int Hin, int Win, int Hf, int Wf, int strideh, int stridew,
+  int padh, int padw) return (matrix[double] out, int Hout, int Wout)
+{
+  N = nrow(X)
+  F = nrow(W)
+  Hout = as.integer(floor((Hin + 2*padh - Hf)/strideh + 1))
+  Wout = as.integer(floor((Win + 2*padw - Wf)/stridew + 1))
+  # Convolution - built-in implementation
+  out = conv2d(X, W, input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf],
+               stride=[strideh,stridew], padding=[padh,padw])
+  # Add bias term to each output filter
+  out = bias_add(out, b)
+}
+
+conv2d_backward = function(matrix[double] dout, int Hout, int Wout, matrix[double] X,
+  matrix[double] W, matrix[double] b, int C, int Hin, int Win, int Hf, int Wf,
+  int strideh, int stridew, int padh, int padw)
+  return (matrix[double] dX, matrix[double] dW, matrix[double] db)
+{
+  N = nrow(X)
+  F = nrow(W)
+  # Partial derivatives for convolution - built-in implementation
+  dW = conv2d_backward_filter(X, dout, stride=[strideh,stridew], padding=[padh,padw],
+                              input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf])
+  dX = conv2d_backward_data(W, dout, stride=[strideh,stridew], padding=[padh,padw],
+                            input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf])
+  # Partial derivatives for bias vector
+  # Here we sum each column, reshape to (F, Hout*Wout), and sum each row
+  # to result in the summation for each channel.
+  db = rowSums(matrix(colSums(dout), rows=F, cols=Hout*Wout))  # shape (F, 1)
+}
+
+conv2d_init = function(int F, int C, int Hf, int Wf, int seed = -1)
+  return (matrix[double] W, matrix[double] b) {
+  W = rand(rows=F, cols=C*Hf*Wf, pdf="normal", seed=seed) * sqrt(2.0/(C*Hf*Wf))
+  b = matrix(0, rows=F, cols=1)
+}
+
+affine_forward = function(matrix[double] X, matrix[double] W, matrix[double] b) return (matrix[double] out) {
+  out = X %*% W + b;
+}
+
+affine_init = function(int D, int M, int seed = -1 ) return (matrix[double] W, matrix[double] b) {
+  W = rand(rows=D, cols=M, pdf="normal", seed=seed) * sqrt(2.0/D);
+  b = matrix(0, rows=1, cols=M);
+}
+
+relu_forward = function(matrix[double] X) return (matrix[double] out) {
+  out = max(0, X);
+}
+
+max_pool2d_forward = function(matrix[double] X, int C, int Hin, int Win, int Hf, int Wf,
+  int strideh, int stridew, int padh, int padw) return(matrix[double] out, int Hout, int Wout)
+{
+  N = nrow(X)
+  Hout = as.integer(floor((Hin + 2*padh - Hf)/strideh + 1))
+  Wout = as.integer(floor((Win + 2*padw - Wf)/stridew + 1))
+  out = max_pool(X, input_shape=[N,C,Hin,Win], pool_size=[Hf,Wf],
+    stride=[strideh,stridew], padding=[padh,padw])
+}
+
+softmax_forward = function(matrix[double] scores) return (matrix[double] probs) {
+  scores = scores - rowMaxs(scores);  # numerical stability
+  unnorm_probs = exp(scores);  # unnormalized probabilities
+  probs = unnorm_probs / rowSums(unnorm_probs);  # normalized probabilities
+}
+
+getWeights = function(int fel, int lid,
+    matrix[double] W_pt, matrix[double] b_pt, 
+    matrix[double] W_init, matrix[double] b_init)
+  return (matrix[double] Wl, matrix[double] bl) 
+{
+  if (lid < fel) { #extract pretrained features
+    Wl = W_pt;
+    bl = b_pt;
+    print("Extract feature of layer "+lid);
+  }
+  else {  #use initialized weights
+    Wl = W_init;
+    bl = b_init;
+    print("Initialize weights for layer "+lid);
+  }
+}
+
+rwRowIndexMax = function(matrix[double] X, matrix[double] oneVec, matrix[double] idxSeq) 
+    return (matrix[double] index) {
+  rm = rowMaxs(X) %*% oneVec;
+  I = X == rm;
+  index = rowMaxs(I * idxSeq);
+}
+
+predict = function(matrix[double] X, int C, int Hin, int Win, int K,
+    matrix[double] W1, matrix[double] b1, matrix[double] W2, matrix[double] b2,
+    matrix[double] W3, matrix[double] b3, matrix[double] W4, matrix[double] b4,
+    matrix[double] W5, matrix[double] b5, matrix[double] W6, matrix[double] b6,
+    matrix[double] W7, matrix[double] b7, matrix[double] W8, matrix[double] b8)
+  return (matrix[double] Y_pred)
+{
+  N = nrow(X);
+  Hf = 5;  #filter height
+  Wf = 5;  #filter width
+  # Define filters
+  F1 = 96;
+  F2 = 256;
+  F3 = 384;
+  F4 = 384;
+  F5 = 256;
+  N3 = 4096;
+  # Define strides
+  s4 = 4;
+  s2 = 2;
+  s1 = 1;
+  # Define pads
+  pad2 = 2;
+  pad1 = 1;
+  pad0 = 0;
+
+  # Initialize the weights for the non-transferred layers
+  [W1_init, b1_init] = conv2d_init(F1, C, Hf=11, Wf=11, 43);
+  [W2_init, b2_init] = conv2d_init(F2, F1, Hf=5, Wf=5, 43);
+  [W3_init, b3_init] = conv2d_init(F3, F2, Hf=3, Wf=3, 43);
+  [W4_init, b4_init] = conv2d_init(F4, F3, Hf=3, Wf=3, 43);
+  [W5_init, b5_init] = conv2d_init(F5, F4, Hf=3, Wf=3, 43);
+  [W6_init, b6_init] = affine_init(9216, 4096, 43);
+  [W7_init, b7_init] = affine_init(N3, N3, 43);
+  [W8_init, b8_init] = affine_init(N3, K, 43);
+  W8_init = W8_init/sqrt(2);
+
+  # Compute prediction over mini-batches
+  verbose = FALSE;
+  probs = matrix(0, rows=N, cols=K);
+  Y_pred = matrix(0, rows=N, cols=4);
+  batch_size = 64;
+  oneVec = matrix(1, rows=1, cols=K);
+  idxSeq = matrix(1, rows=batch_size, cols=1) %*% t(seq(1, K));
+  iters = ceil (N / batch_size);
+  for (i in 1:iters) {
+    # Get next batch
+    beg = ((i-1) * batch_size) %% N + 1;
+    end = min(N, beg+batch_size-1);
+    X_batch = X[beg:end,];
+
+    j = 1;
+    fel = 8;
+    while (j < 5) {
+      # Compute forward pass
+      # layer 1: conv1 -> relu1 -> pool1
+      lid = 1;
+      [Wl1, bl1] = getWeights(fel, lid, W1, b1, W1_init, b1_init);
+      [outc1, Houtc1, Woutc1] = conv2d_forward(X_batch, Wl1, bl1, C, Hin, Win, Hf=11, Wf=11,
+          s4, s4, pad0, pad0);
+      if(verbose) print("sum(conv1) = "+sum(outc1));
+      if(verbose) print(nrow(outc1)+", "+ncol(outc1));
+      outr1 = relu_forward(outc1);
+      [outp1, Houtp1, Woutp1] = max_pool2d_forward(outr1, F1, Houtc1, Woutc1, Hf=3, Wf=3,
+          strideh=s2, stridew=s2, padh=0, padw=0)
+      if(verbose) print("sum(pool1) = "+sum(outp1));
+      if(verbose) print(nrow(outp1)+", "+ncol(outp1));
+
+      # layer 2: conv2 -> relu2 -> pool2
+      lid = 2;
+      [Wl2, bl2] = getWeights(fel, lid, W2, b2, W2_init, b2_init);
+      [outc2, Houtc2, Woutc2] = conv2d_forward(outp1, Wl2, bl2, F1, Houtp1, Woutp1, Hf=5,
+          Wf=5, s1, s1, pad2, pad2);
+      if(verbose) print("sum(conv2) = "+sum(outc2));
+      if(verbose) print(nrow(outc2)+", "+ncol(outc2));
+      outr2 = relu_forward(outc2);
+      [outp2, Houtp2, Woutp2] = max_pool2d_forward(outr2, F2, Houtc2, Woutc2, Hf=3, Wf=3,
+          strideh=s2, stridew=s2, padh=0, padw=0)
+      if(verbose) print("sum(pool2) = "+sum(outp2));
+      if(verbose) print(nrow(outp2)+", "+ncol(outp2));
+
+      # layer 3: conv3 -> relu3
+      lid = 3
+      [Wl3, bl3] = getWeights(fel, lid, W3, b3, W3_init, b3_init);
+      [outc3, Houtc3, Woutc3] = conv2d_forward(outp2, Wl3, bl3, F2, Houtp2, Woutp2, Hf=3,
+          Wf=3, s1, s1, pad1, pad1);
+      if(verbose) print("sum(conv3) = "+sum(outc3));
+      if(verbose) print(nrow(outc3)+", "+ncol(outc3));
+      outr3 = relu_forward(outc3);
+
+      # layer 4: conv4 -> relu4
+      lid = 4;
+      [Wl4, bl4] = getWeights(fel, lid, W4, b4, W4_init, b4_init);
+      [outc4, Houtc4, Woutc4] = conv2d_forward(outr3, Wl4, bl4, F3, Houtc3, Woutc3, Hf=3,
+          Wf=3, s1, s1, pad1, pad1);
+      if(verbose) print("sum(conv4) = "+sum(outc4));
+      if(verbose) print(nrow(outc4)+", "+ncol(outc4));
+      outr4 = relu_forward(outc4);
+
+      # layer 5: conv5 -> relu5 -> pool3
+      lid = 5;
+      [Wl5, bl5] = getWeights(fel, lid, W5, b5, W5_init, b5_init);
+      [outc5, Houtc5, Woutc5] = conv2d_forward(outr4, Wl5, bl5, F4, Houtc4, Woutc4, Hf=3,
+          Wf=3, s1, s1, pad1, pad1);
+      if(verbose) print("sum(conv5) = "+sum(outc5));
+      if(verbose) print(nrow(outc5)+", "+ncol(outc5));
+      outr5 = relu_forward(outc5);
+      [outp5, Houtp5, Woutp5] = max_pool2d_forward(outr5, F5, Houtc5, Woutc5, Hf=3, Wf=3,
+          strideh=s2, stridew=s2, padh=0, padw=0)
+      if(verbose) print("sum(pool3) = "+sum(outp5));
+      if(verbose) print(nrow(outp5)+", "+ncol(outp5));
+
+      # layer 6: affine1 -> relu6
+      lid = 6;
+      [Wl6, bl6] = getWeights(fel, lid, W6, b6, W6_init, b6_init);
+      outa6 = affine_forward(outp5, Wl6, bl6);
+      if(verbose) print(nrow(outa6)+", "+ncol(outa6));
+      outr6 = relu_forward(outa6);
+
+      # layer 7: affine2 -> relu7
+      lid = 7;
+      [Wl7, bl7] = getWeights(fel, lid, W7, b7, W7_init, b7_init);
+      outa7 = affine_forward(outr6, Wl7, bl7);
+      if(verbose) print(nrow(outa7)+", "+ncol(outa7));
+      outr7 = relu_forward(outa7);
+
+      # layer 8: affine3 -> softmax
+      lid = 8;
+      [Wl8, bl8] = getWeights(fel, lid, W8, b8, W8_init, b8_init);
+      outa8 = affine_forward(outr7, Wl8, bl8);
+      if(verbose) print(nrow(outa8)+", "+ncol(outa8));
+      probs_batch = softmax_forward(outa8);
+
+      # Store the predictions
+      Y_pred[beg:end,j] = rwRowIndexMax(probs_batch, oneVec, idxSeq);
+      j = j + 1;
+      fel = fel - 1;
+    }
+  }
+}
+
+generate_dummy_data = function(int N, int C, int Hin, int Win, int K)
+  return (matrix[double] X, matrix[double] Y) {
+  X = rand(rows=N, cols=C*Hin*Win, pdf="normal", seed=45) #linearized images
+  classes = round(rand(rows=N, cols=1, min=1, max=K, pdf="uniform", seed=46))
+  Y = table(seq(1, N), classes, N, K)  #one-hot encoding
+}
+
+# Read training data and settings
+N = 64;    #num of training images
+Nval = 512;  #num of validation images
+Ntest = 64; #num of test images
+C = 3;       #num of color channels
+Hin = 227; #227   #input image height
+Win = 227; #227   #input image width
+K = 10;      #num of classes
+epochs = 1;
+
+# Generate dummy data
+[X, Y] = generate_dummy_data(N, C, Hin, Win, K);
+[X_val, Y_val] = generate_dummy_data(Nval, C, Hin, Win, K);
+[X_test, Y_test] = generate_dummy_data(Ntest, C, Hin, Win, K);
+
+# Train
+#[W1, b1, W2, b2] = train(X, Y, X_val, Y_val, C, Hin, Win, epochs);
+
+# Predict
+Hf = 5;
+Wf = 5;
+# Initialize random weights. FIXME: use pretrained weights
+[W1, b1] = conv2d_init(96, C, Hf=11, Wf=11, 42);
+[W2, b2] = conv2d_init(256, 96, Hf=5, Wf=5, 42);
+[W3, b3] = conv2d_init(384, 256, Hf=3, Wf=3, 42);
+[W4, b4] = conv2d_init(384, 384, Hf=3, Wf=3, 42);
+[W5, b5] = conv2d_init(256, 384, Hf=3, Wf=3, 42);
+[W6, b6] = affine_init(9216, 4096, 42);
+[W7, b7] = affine_init(4096, 4096, 42);
+[W8, b8] = affine_init(4096, K, 42);
+W8 = W8/sqrt(2);
+
+# Load the CuDNN libraries by calling a conv2d
+print("Eagerly loading cuDNN library");
+[outc1, Houtc1, Woutc1] = conv2d_forward(X[1:8,], W1, b1, C, Hin, Win, 11, 11, 1, 1, 2, 2);
+print(sum(outc1));
+
+print("Starting exploratory feature transfers");
+Y_pred = predict(X_test, C, Hin, Win, K, W1, b1, W2, b2, W3, b3, W4, b4,
+   W5, b5, W6, b6, W7, b7, W8, b8);
+write(Y_pred, $1, format="text");
+

--- a/src/test/scripts/functions/lineage/GPUCacheEviction5.dml
+++ b/src/test/scripts/functions/lineage/GPUCacheEviction5.dml
@@ -1,0 +1,264 @@
+conv2d_forward = function(matrix[double] X, matrix[double] W, matrix[double] b,
+  int C, int Hin, int Win, int Hf, int Wf, int strideh, int stridew,
+  int padh, int padw) return (matrix[double] out, int Hout, int Wout)
+{
+  N = nrow(X)
+  F = nrow(W)
+  Hout = as.integer(floor((Hin + 2*padh - Hf)/strideh + 1))
+  Wout = as.integer(floor((Win + 2*padw - Wf)/stridew + 1))
+  # Convolution - built-in implementation
+  out = conv2d(X, W, input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf],
+               stride=[strideh,stridew], padding=[padh,padw])
+  # Add bias term to each output filter
+  out = bias_add(out, b)
+}
+
+conv2d_backward = function(matrix[double] dout, int Hout, int Wout, matrix[double] X,
+  matrix[double] W, matrix[double] b, int C, int Hin, int Win, int Hf, int Wf,
+  int strideh, int stridew, int padh, int padw)
+  return (matrix[double] dX, matrix[double] dW, matrix[double] db)
+{
+  N = nrow(X)
+  F = nrow(W)
+  # Partial derivatives for convolution - built-in implementation
+  dW = conv2d_backward_filter(X, dout, stride=[strideh,stridew], padding=[padh,padw],
+                              input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf])
+  dX = conv2d_backward_data(W, dout, stride=[strideh,stridew], padding=[padh,padw],
+                            input_shape=[N,C,Hin,Win], filter_shape=[F,C,Hf,Wf])
+  # Partial derivatives for bias vector
+  # Here we sum each column, reshape to (F, Hout*Wout), and sum each row
+  # to result in the summation for each channel.
+  db = rowSums(matrix(colSums(dout), rows=F, cols=Hout*Wout))  # shape (F, 1)
+}
+
+conv2d_init = function(int F, int C, int Hf, int Wf, int seed = -1)
+  return (matrix[double] W, matrix[double] b) {
+  W = rand(rows=F, cols=C*Hf*Wf, pdf="normal", seed=seed) * sqrt(2.0/(C*Hf*Wf))
+  b = matrix(0, rows=F, cols=1)
+}
+
+affine_forward = function(matrix[double] X, matrix[double] W, matrix[double] b) return (matrix[double] out) {
+  out = X %*% W + b;
+}
+
+affine_init = function(int D, int M, int seed = -1 ) return (matrix[double] W, matrix[double] b) {
+  W = rand(rows=D, cols=M, pdf="normal", seed=seed) * sqrt(2.0/D);
+  b = matrix(0, rows=1, cols=M);
+}
+
+relu_forward = function(matrix[double] X) return (matrix[double] out) {
+  out = max(0, X);
+}
+
+max_pool2d_forward = function(matrix[double] X, int C, int Hin, int Win, int Hf, int Wf,
+  int strideh, int stridew, int padh, int padw) return(matrix[double] out, int Hout, int Wout)
+{
+  N = nrow(X)
+  Hout = as.integer(floor((Hin + 2*padh - Hf)/strideh + 1))
+  Wout = as.integer(floor((Win + 2*padw - Wf)/stridew + 1))
+  out = max_pool(X, input_shape=[N,C,Hin,Win], pool_size=[Hf,Wf],
+    stride=[strideh,stridew], padding=[padh,padw])
+}
+
+softmax_forward = function(matrix[double] scores) return (matrix[double] probs) {
+  scores = scores - rowMaxs(scores);  # numerical stability
+  unnorm_probs = exp(scores);  # unnormalized probabilities
+  probs = unnorm_probs / rowSums(unnorm_probs);  # normalized probabilities
+}
+
+getWeights = function(int fel, int lid,
+    matrix[double] W_pt, matrix[double] b_pt, 
+    matrix[double] W_init, matrix[double] b_init)
+  return (matrix[double] Wl, matrix[double] bl) 
+{
+  if (lid < fel) { #extract pretrained features
+    Wl = W_pt;
+    bl = b_pt;
+  }
+  else {  #use initialized weights
+    Wl = W_init;
+    bl = b_init;
+  }
+}
+
+rwRowIndexMax = function(matrix[double] X, matrix[double] oneVec, matrix[double] idxSeq) 
+    return (matrix[double] index) {
+  rm = rowMaxs(X) %*% oneVec;
+  I = X == rm;
+  index = rowMaxs(I * idxSeq);
+}
+
+
+predict = function(matrix[double] X, int C, int Hin, int Win, int K)
+  return (matrix[double] Y_pred)
+{
+  # Get the transferred layers. FIXME: use pretrained weights
+  [W1_pt, b1_pt] = conv2d_init(64, C, Hf=3, Wf=3, 42);
+  [W2_pt, b2_pt] = conv2d_init(64, 64, Hf=3, Wf=3, 42);
+  [W3_pt, b3_pt] = conv2d_init(128, 64, Hf=3, Wf=3, 42);
+  [W4_pt, b4_pt] = conv2d_init(128, 128, Hf=3, Wf=3, 42);
+  [W5_pt, b5_pt] = conv2d_init(256, 128, Hf=3, Wf=3, 42);
+  [W6_pt, b6_pt] = conv2d_init(256, 256, Hf=3, Wf=3, 42);
+  [W7_pt, b7_pt] = conv2d_init(256, 256, Hf=3, Wf=3, 42);
+  [W8_pt, b8_pt] = conv2d_init(512, 256, Hf=3, Wf=3, 42);
+  [W9_pt, b9_pt] = conv2d_init(512, 512, Hf=3, Wf=3, 42);
+  [W10_pt, b10_pt] = conv2d_init(512, 512, Hf=3, Wf=3, 42);
+  [W11_pt, b11_pt] = conv2d_init(512, 512, Hf=3, Wf=3, 42);
+  [W12_pt, b12_pt] = conv2d_init(512, 512, Hf=3, Wf=3, 42);
+  [W13_pt, b13_pt] = conv2d_init(512, 512, Hf=3, Wf=3, 42);
+  [W14_pt, b14_pt] = affine_init(25088, 4096, 42);
+  [W15_pt, b15_pt] = affine_init(4096, 4096, 42);
+  [W16_pt, b16_pt] = affine_init(4096, K, 42);
+  W16_pt = W16_pt/sqrt(2);
+
+  # Initialize the weights for the non-transferred layers
+  [W1_init, b1_init] = conv2d_init(64, C, Hf=3, Wf=3, 43);
+  [W2_init, b2_init] = conv2d_init(64, 64, Hf=3, Wf=3, 43);
+  [W3_init, b3_init] = conv2d_init(128, 64, Hf=3, Wf=3, 43);
+  [W4_init, b4_init] = conv2d_init(128, 128, Hf=3, Wf=3, 43);
+  [W5_init, b5_init] = conv2d_init(256, 128, Hf=3, Wf=3, 43);
+  [W6_init, b6_init] = conv2d_init(256, 256, Hf=3, Wf=3, 43);
+  [W7_init, b7_init] = conv2d_init(256, 256, Hf=3, Wf=3, 43);
+  [W8_init, b8_init] = conv2d_init(512, 256, Hf=3, Wf=3, 43);
+  [W9_init, b9_init] = conv2d_init(512, 512, Hf=3, Wf=3, 43);
+  [W10_init, b10_init] = conv2d_init(512, 512, Hf=3, Wf=3, 43);
+  [W11_init, b11_init] = conv2d_init(512, 512, Hf=3, Wf=3, 43);
+  [W12_init, b12_init] = conv2d_init(512, 512, Hf=3, Wf=3, 43);
+  [W13_init, b13_init] = conv2d_init(512, 512, Hf=3, Wf=3, 43);
+  [W14_init, b14_init] = affine_init(25088, 4096, 43);
+  [W15_init, b15_init] = affine_init(4096, 4096, 43);
+  [W16_init, b16_init] = affine_init(4096, K, 43);
+  W16_init = W16_init/sqrt(2);
+
+  # Compute prediction over mini-batches
+  N = nrow(X);
+  Y_pred = matrix(0, rows=N, cols=4);
+  batch_size = 8;
+  oneVec = matrix(1, rows=1, cols=K);
+  idxSeq = matrix(1, rows=batch_size, cols=1) %*% t(seq(1, K));
+  iters = ceil (N / batch_size);
+
+  for (i in 1:iters) {
+    # Get next batch
+    beg = ((i-1) * batch_size) %% N + 1;
+    end = min(N, beg+batch_size-1);
+    X_batch = X[beg:end,];
+
+    # Extract 3 layers 
+    j = 1;
+    fel = 8; #extract layer 7, 6, 5 
+    while (j < 4) {
+      # Compute forward pass
+      # layer 1: Two conv2d layers (w/ activation relu) + 1 max-pooling layer
+      lid = 1;
+      [Wl1, bl1] = getWeights(fel, lid, W1_pt, b1_pt, W1_init, b1_init);
+      [outc1, Houtc1, Woutc1] = conv2d_forward(X_batch,Wl1,bl1,C,Hin,Win,3,3,1,1,1,1);
+      outr1 = relu_forward(outc1);
+      [Wl2, bl2] = getWeights(fel, lid, W2_pt, b2_pt, W2_init, b2_init);
+      [outc2, Houtc2, Woutc2] = conv2d_forward(outr1,Wl2,bl2,64,Houtc1,Woutc1,3,3,1,1,1,1);
+      outr2 = relu_forward(outc2);
+      [outp1, Houtp1, Woutp1] = max_pool2d_forward(outr2,64,Houtc2, Woutc2,2,2,2,2,0,0);
+
+      # layer 2: Two conv2d layers (w/ activation relu) + 1 max-pooling layer
+      lid = 2;
+      [Wl3, bl3] = getWeights(fel, lid, W3_pt, b3_pt, W3_init, b3_init);
+      [outc3, Houtc3, Woutc3] = conv2d_forward(outp1,Wl3,bl3,64,Houtp1,Woutp1,3,3,1,1,1,1);
+      outr3 = relu_forward(outc3);
+      [Wl4, bl4] = getWeights(fel, lid, W4_pt, b4_pt, W4_init, b4_init);
+      [outc4, Houtc4, Woutc4] = conv2d_forward(outr3,Wl4,bl4,128,Houtc3,Woutc3,3,3,1,1,1,1);
+      outr4 = relu_forward(outc4);
+      [outp2, Houtp2, Woutp2] = max_pool2d_forward(outr4,128,Houtc4, Woutc4,2,2,2,2,0,0);
+
+      # layer 3: Three conv2d layers (w/ activation relu) + 1 max-pooling layer
+      lid = 3;
+      [Wl5, bl5] = getWeights(fel, lid, W5_pt, b5_pt, W5_init, b5_init);
+      [outc5, Houtc5, Woutc5] = conv2d_forward(outp2,Wl5,bl5,128,Houtp2,Woutp2,3,3,1,1,1,1);
+      outr5 = relu_forward(outc5);
+      [Wl6, bl6] = getWeights(fel, lid, W6_pt, b6_pt, W6_init, b6_init);
+      [outc6, Houtc6, Woutc6] = conv2d_forward(outr5,Wl6,bl6,256,Houtc5,Woutc5,3,3,1,1,1,1);
+      outr6 = relu_forward(outc6);
+      [Wl7, bl7] = getWeights(fel, lid, W7_pt, b7_pt, W7_init, b7_init);
+      [outc7, Houtc7, Woutc7] = conv2d_forward(outr6,Wl7,bl7,256,Houtc6,Woutc6,3,3,1,1,1,1);
+      outr7 = relu_forward(outc7);
+      [outp3, Houtp3, Woutp3] = max_pool2d_forward(outr7,256,Houtc7, Woutc7,2,2,2,2,0,0);
+
+      # layer 4: Three conv2d layers (w/ activation relu) + 1 max-pooling layer
+      lid = 4;
+      [Wl8, bl8] = getWeights(fel, lid, W8_pt, b8_pt, W8_init, b8_init);
+      [outc8, Houtc8, Woutc8] = conv2d_forward(outp3,Wl8,bl8,256,Houtp3,Woutp3,3,3,1,1,1,1);
+      outr8 = relu_forward(outc8);
+      [Wl9, bl9] = getWeights(fel, lid, W9_pt, b9_pt, W9_init, b9_init);
+      [outc9, Houtc9, Woutc9] = conv2d_forward(outr8,Wl9,bl9,512,Houtc8,Woutc8,3,3,1,1,1,1);
+      outr9 = relu_forward(outc9);
+      [Wl10, bl10] = getWeights(fel, lid, W10_pt, b10_pt, W10_init, b10_init);
+      [outc10, Houtc10, Woutc10] = conv2d_forward(outr9,Wl10,bl10,512,Houtc9,Woutc9,3,3,1,1,1,1);
+      outr10 = relu_forward(outc10);
+      [outp4, Houtp4, Woutp4] = max_pool2d_forward(outr10,512,Houtc10, Woutc10,2,2,2,2,0,0);
+
+      # layer 5: Three conv2d layers (w/ activation relu) + 1 max-pooling layer
+      lid = 5;
+      [Wl11, bl11] = getWeights(fel, lid, W11_pt, b11_pt, W11_init, b11_init);
+      [outc11, Houtc11, Woutc11] = conv2d_forward(outp4,Wl11,bl11,512,Houtp4,Woutp4,3,3,1,1,1,1);
+      outr11 = relu_forward(outc11);
+      [Wl12, bl12] = getWeights(fel, lid, W12_pt, b12_pt, W12_init, b12_init);
+      [outc12, Houtc12, Woutc12] = conv2d_forward(outr11,Wl12,bl12,512,Houtc11,Woutc11,3,3,1,1,1,1);
+      outr12 = relu_forward(outc12);
+      [Wl13, bl13] = getWeights(fel, lid, W13_pt, b13_pt, W13_init, b13_init);
+      [outc13, Houtc13, Woutc13] = conv2d_forward(outr12,Wl13,bl13,512,Houtc12,Woutc12,3,3,1,1,1,1);
+      outr13 = relu_forward(outc13);
+      [outp5, Houtp5, Woutp5] = max_pool2d_forward(outr13,512,Houtc13, Woutc13,2,2,2,2,0,0);
+
+      # layer 6: Fully connected layer (w/ activation relu)
+      lid = 6;
+      [Wl14, bl14] = getWeights(fel, lid, W14_pt, b14_pt, W14_init, b14_init);
+      outa6 = affine_forward(outp5, Wl14, bl14);
+      outr6 = relu_forward(outa6);
+
+      # layer 7: Fully connected layer (w/ activation relu)
+      lid = 7;
+      [Wl15, bl15] = getWeights(fel, lid, W15_pt, b15_pt, W15_init, b15_init);
+      outa7 = affine_forward(outr6, Wl15, bl15);
+      outr7 = relu_forward(outa7);
+
+      # layer 8: Fully connected layer (w/ activation softmax)
+      lid = 8;
+      [Wl16, bl16] = getWeights(fel, lid, W16_pt, b16_pt, W16_init, b16_init);
+      outa8 = affine_forward(outr7, Wl16, bl16);
+      probs_batch = softmax_forward(outa8);
+
+      # Store the predictions
+      Y_pred[beg:end,j] = rwRowIndexMax(probs_batch, oneVec, idxSeq);
+      j = j + 1;
+      fel = fel - 1;
+    }
+  }
+}
+
+generate_dummy_data = function(int N, int C, int Hin, int Win, int K)
+  return (matrix[double] X, matrix[double] Y) {
+  X = rand(rows=N, cols=C*Hin*Win, pdf="normal", seed=45) #linearized images
+  classes = round(rand(rows=N, cols=1, min=1, max=K, pdf="uniform", seed=46))
+  Y = table(seq(1, N), classes, N, K)  #one-hot encoding
+}
+
+# Read training data and settings
+N = 32;      #num of images in the target dataset
+C = 3;       #num of color channels
+Hin = 224;   #input image height
+Win = 224;   #input image width
+K = 10;      #num of classes
+
+# Generate dummy data
+[X, Y] = generate_dummy_data(N, C, Hin, Win, K);
+
+# Load the CuDNN libraries by calling a conv2d
+print("Eagerly loading cuDNN library");
+[W1, b1] = conv2d_init(96, C, Hf=11, Wf=11, 42);
+[outc1, Houtc1, Woutc1] = conv2d_forward(X[1:8,], W1, b1, C, Hin, Win, 11, 11, 1, 1, 2, 2);
+print(sum(outc1));
+
+print("Starting exploratory feature transfers");
+t1 = time();
+Y_pred = predict(X, C, Hin, Win, K);
+write(Y_pred, $1, format="text");
+


### PR DESCRIPTION
This patch extends the max_parallelize operator linearization strategy to support GPU operators, however parallelizing GPU operator chains do not improve performance if the threads use the default GPU stream. This patch also fixes bugs in the GPU cache eviction, adds a flag for disabling delayed caching and adds tests for feature extraction from pre-trained Alexnet and VGG16 models.