### PR TITLE
[SYSTEMDS-3153] Missing value imputation using KNN

### DIFF
--- a/scripts/perftest/KnnMissingValueImputation.sh
+++ b/scripts/perftest/KnnMissingValueImputation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+CMD=$1
+MAXMEM=$2
+
+echo "KNN MISSING VALUE IMPUTATION" >>results/times.txt
+
+mkdir -p logs
+LogName='logs/KnnMissingValueImputation.log'
+rm -f $LogName     # full log file
+rm -f $LogName.log # Reduced log file
+
+is=("1000 10000 100000 1000000 10000000")
+
+for i in $is; do
+  for method in "dist" "dist_missing" "dist_sample"; do
+    if [ $(((i*i*8)/10**6)) -gt $MAXMEM ] && [ $method == "dist" ]; then
+      continue;
+    elif [ $(((i*9*i*8/100)/10**6)) -gt $MAXMEM ] && [ $method == "dist_missing" ]; then
+      continue;
+    fi
+
+    tstart=$(date +%s.%N)
+    ${CMD} -f ./scripts/ImputeByKNN.dml \
+    --config conf/SystemDS-config.xml \
+    --stats \
+    --nvargs num_rows=$i method=$method max_mem=$MAXMEM \
+    >>$LogName 2>&1
+    ttrain=$(echo "$(date +%s.%N) - $tstart - .4" | bc)
+    echo "KNN Missing Value Imputation $i rows, $method method:" $ttrain >>results/times.txt
+  done
+done
+
+echo -e "\n\n" >>results/times.txt

--- a/scripts/perftest/runAll.sh
+++ b/scripts/perftest/runAll.sh
@@ -126,6 +126,7 @@ echo -e "\n\n" >> results/times.txt
 ./runAllClustering.sh ${CMD} ${TEMPFOLDER} ${MAXMEM}
 ./runAllDimensionReduction.sh ${CMD} ${TEMPFOLDER} ${MAXMEM}
 ./runAllALS.sh ${CMD} ${TEMPFOLDER} ${MAXMEM}
+./KnnMissingValueImputation.sh ${CMD} ${MAXMEM}
 
 ### IO Benchmarks:
 ./runAllIO.sh ${CMD} ${TEMPFOLDER} ${MAXMEM}

--- a/scripts/perftest/scripts/ImputeByKNN.dml
+++ b/scripts/perftest/scripts/ImputeByKNN.dml
@@ -1,0 +1,52 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+max_mem = $max_mem
+num_rows = $num_rows
+method = $method
+num_nan = num_rows * 0.1
+
+print("Testing method " + method + " with " + num_rows + " rows and " + num_nan + " rows containing missing values.")
+
+# Prepare the data
+X = Rand (rows = num_rows, cols = 10, min = 0.0, max = 1.0, pdf = "uniform");
+
+sample_fraction = 100
+exp = 2
+while ((sample_fraction / 10^exp * num_rows * 0.9 * num_rows * 0.1 * 8 / 10^6) > max_mem) {
+  sample_fraction = (sample_fraction - 1)
+
+  if (sample_fraction == 0) {
+    sample_fraction = 100
+    exp = exp + 1
+  }
+}
+
+
+sample_fraction = sample_fraction / 10^exp
+
+
+for (i in 1:num_nan) {
+  X[i, 1] = 'NaN';
+}
+
+#Perform the KNN imputation
+result = imputeByKNN(X = X, method = method, seed = 42, sample_frac = sample_fraction)


### PR DESCRIPTION
This patch adds a performance test for missing value imputation using KNN. I tested the individual methods (`dist`, `dist_missing`, `dist_sample`) with different dataset sizes where 10% of the rows contain missing values. We want to ensure that at least the `dist_sample` method can handle arbitrarily large datasets by reducing the sample size.