### PR TITLE
Bug fix in cache management for nested lists

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ParForProgramBlock.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.Queue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -652,7 +653,7 @@ public class ParForProgramBlock extends ForProgramBlock {
 		
 		//preserve shared input/result variables of cleanup
 		ArrayList<String> varList = ec.getVarList();
-		boolean[] varState = ec.pinVariables(varList);
+		Queue<Boolean> varState = ec.pinVariables(varList);
 		
 		try 
 		{
@@ -677,7 +678,7 @@ public class ParForProgramBlock extends ForProgramBlock {
 		catch(Exception ex) {
 			throw new DMLRuntimeException("PARFOR: Failed to execute loop in parallel.",ex);
 		}
-		
+
 		//reset state of shared input/result variables 
 		ec.unpinVariables(varList, varState);
 		
@@ -1198,7 +1199,7 @@ public class ParForProgramBlock extends ForProgramBlock {
 		}
 	}
 
-	private void cleanupSharedVariables( ExecutionContext ec, boolean[] varState ) {
+	private void cleanupSharedVariables( ExecutionContext ec, Queue<Boolean> varState ) {
 		//TODO needs as precondition a systematic treatment of persistent read information.
 	}
 	

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/FunctionCallCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/FunctionCallCPInstruction.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Queue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -182,7 +183,7 @@ public class FunctionCallCPInstruction extends CPInstruction {
 		
 		// Pin the input variables so that they do not get deleted 
 		// from pb's symbol table at the end of execution of function
-		boolean[] pinStatus = ec.pinVariables(_boundInputNames);
+		Queue<Boolean> pinStatus = ec.pinVariables(_boundInputNames);
 		
 		// Create a symbol table under a new execution context for the function invocation,
 		// and copy the function arguments into the created table. 

--- a/src/test/java/org/apache/sysds/test/functions/caching/PinVariablesTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/caching/PinVariablesTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.caching;
+
+import org.apache.oro.util.Cache;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.controlprogram.LocalVariableMap;
+import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysds.runtime.instructions.cp.ListObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.instructions.cp.Data;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.List;
+
+public class PinVariablesTest extends AutomatedTestBase {
+    private final static String TEST_NAME = "PinVariables";
+    private final static String TEST_DIR = "functions/caching/";
+    private final static String TEST_CLASS_DIR = TEST_DIR + PinVariablesTest.class.getSimpleName() + "/";
+
+    @Override
+    public void setUp() {
+        addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME));
+    }
+
+    @Test
+    public void testPinNoLists() {
+        createMockDataAndCall(true, false, false);
+    }
+
+    @Test
+    public void testPinShallowLists() {
+        createMockDataAndCall(true, true, false);
+    }
+
+    @Test
+    public void testPinNestedLists() {
+        createMockDataAndCall(true, true, true);
+    }
+
+    private void createMockDataAndCall(boolean matrices, boolean list, boolean nestedList) {
+        LocalVariableMap vars = new LocalVariableMap();
+        List<String> varList = new LinkedList<>();
+        Queue<Boolean> varStates = new LinkedList<>();
+
+        if (matrices) {
+            MatrixObject mat1 = new MatrixObject(Types.ValueType.FP64, "SomeFile1");
+            mat1.enableCleanup(true);
+            MatrixObject mat2 = new MatrixObject(Types.ValueType.FP64, "SomeFile2");
+            mat2.enableCleanup(true);
+            MatrixObject mat3 = new MatrixObject(Types.ValueType.FP64, "SomeFile3");
+            mat3.enableCleanup(false);
+            vars.put("mat1", mat1);
+            vars.put("mat2", mat2);
+            vars.put("mat3", mat3);
+
+            varList.add("mat2");
+            varList.add("mat3");
+
+            varStates.add(true);
+            varStates.add(false);
+        }
+        if (list) {
+            MatrixObject mat4 = new MatrixObject(Types.ValueType.FP64, "SomeFile4");
+            mat4.enableCleanup(true);
+            MatrixObject mat5 = new MatrixObject(Types.ValueType.FP64, "SomeFile5");
+            mat5.enableCleanup(false);
+            List<Data> l1_data = new LinkedList<>();
+            l1_data.add(mat4);
+            l1_data.add(mat5);
+
+            if (nestedList) {
+                MatrixObject mat6 = new MatrixObject(Types.ValueType.FP64, "SomeFile6");
+                mat4.enableCleanup(true);
+                List<Data> l2_data = new LinkedList<>();
+                l2_data.add(mat6);
+                ListObject l2 = new ListObject(l2_data);
+                l1_data.add(l2);
+            }
+
+            ListObject l1 = new ListObject(l1_data);
+            vars.put("l1", l1);
+
+            varList.add("l1");
+
+            // cleanup flag of inner matrix (m4)
+            varStates.add(true);
+            varStates.add(false);
+            if (nestedList)
+                varStates.add(true);
+        }
+
+        ExecutionContext ec = new ExecutionContext(vars);
+
+        commonPinVariablesTest(ec, varList, varStates);
+    }
+
+    private void commonPinVariablesTest(ExecutionContext ec, List<String> varList, Queue<Boolean> varStatesExp) {
+        Queue<Boolean> varStates = ec.pinVariables(varList);
+
+        // check returned cleanupEnabled flags
+        Assert.assertEquals(varStatesExp, varStates);
+
+        // assert updated cleanupEnabled flag to false
+        for (String varName : varList) {
+            Data dat = ec.getVariable(varName);
+
+            if (dat instanceof CacheableData<?>)
+                Assert.assertFalse(((CacheableData<?>)dat).isCleanupEnabled());
+            else if (dat instanceof ListObject) {
+                assertListFlagsDisabled((ListObject)dat);
+            }
+        }
+
+        ec.unpinVariables(varList, varStates);
+
+        // check returned flags after unpinVariables()
+        Queue<Boolean> varStates2 = ec.pinVariables(varList);
+        Assert.assertEquals(varStatesExp, varStates2);
+    }
+
+    private void assertListFlagsDisabled(ListObject l) {
+        for (Data dat : l.getData()) {
+            if (dat instanceof CacheableData<?>)
+                Assert.assertFalse(((CacheableData<?>)dat).isCleanupEnabled());
+            else if (dat instanceof ListObject)
+                assertListFlagsDisabled((ListObject)dat);
+        }
+    }
+}


### PR DESCRIPTION
SystemDS was previously not supporting nested lists correctly since the data of CacheableData objects within nested loops were always deleted after a function call. 
Normally, there are rmvar statements after function calls to remove alll variables used within the function. To protect CacheableData objects (e.g. matrices) from having their data removed by the rmvar statements we use a cleanup-enabled flag. This flag was not correctly set for variables that were within a nested list. These commits fix this problem by flagging all elements, also within nested lists.

Automated tests have been added to test the changes.

@phaniarnab   