### PR TITLE
[MINOR] Performance improvement of the builtin dist function

### DIFF
--- a/scripts/builtin/dist.dml
+++ b/scripts/builtin/dist.dml
@@ -33,7 +33,7 @@
 
 m_dist = function(Matrix[Double] X) return (Matrix[Double] Y) {
   n = nrow(X)
-  s = rowSums(X * X)
-  Y = - 2*X %*% t(X) + s + t(s)
+  s = rowSums(X^2)
+  Y = sqrt(-2 * X %*% t(X) + s + t(s))
   Y = replace(target = Y, pattern=NaN, replacement = 0);
 }

--- a/scripts/builtin/dist.dml
+++ b/scripts/builtin/dist.dml
@@ -32,7 +32,8 @@
 # -----------------------------------------------------------------------------------------------
 
 m_dist = function(Matrix[Double] X) return (Matrix[Double] Y) {
-  G = X %*% t(X);
-  Y = sqrt(-2 * G + outer(diag(G), t(diag(G)), "+"));
+  n = nrow(X)
+  s = rowSums(X * X)
+  Y = - 2*X %*% t(X) + s + t(s)
   Y = replace(target = Y, pattern=NaN, replacement = 0);
 }


### PR DESCRIPTION
This patch improves the builtin dist function by removing the outer product operator. For 100 function calls on an arbitrary matrix with 4000 rows and 800 cols, the new dist function shortens the runtime from 66.541s to 60.268s.

The following experiment was run with varying rows and cols size:
```
X = rand(rows=4000, cols=800, min=-1, max=1, seed=42)

for (i in 1:100){
    Y = new_distance_matrix(X)
}

print( sum(Y) )


new_distance_matrix = function(matrix[double] X)
  return (matrix[double] out)
{
  n = nrow(X)
  s = rowSums(X * X)
  out = - 2*X %*% t(X) + s + t(s)
  out = replace(target = out, pattern=NaN, replacement = 0);
}
```

Terminal outputs from the experiments using the _time_ prefix and _-stats_ argument of the systemds CLI can be seen [here](https://glossy-flame-9af.notion.site/Distance-function-improvement-751d04bfe5c9458e9cf51a6d99c5d4c6).
