### PR TITLE
[SYSTEMDS-???] Frame text and csv write without meta

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/FrameBlock.java
@@ -106,6 +106,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	/** Locks on the columns not tied to the columns objects. */
 	private SoftReference<Object[]> _columnLocks = null;
 
+	/** Materialized number of rows in this FrameBlock */
 	private int _nRow = 0;
 
 	/** Cached size in memory to avoid repeated scans of string columns */
@@ -756,7 +757,8 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	public void write(DataOutput out) throws IOException {
 		final boolean isDefaultMeta = isColNamesDefault() && isColumnMetadataDefault();
 		// write header (rows, cols, default)
-		out.writeInt(getNumRows());
+		final int nRow = getNumRows();
+		out.writeInt(nRow);
 		out.writeInt(getNumColumns());
 		out.writeBoolean(isDefaultMeta);
 		// write columns (value type, data)
@@ -767,7 +769,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 				out.writeUTF(getColumnName(j));
 				_colmeta[j].write(out);
 			}
-			if(type >= 0) // if allocated write column data
+			if(type >= 0 && nRow > 0) // if allocated write column data
 				_coldata[j].write(out);
 		}
 	}
@@ -796,6 +798,8 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 			isDefaultMeta ? null : new String[numCols]; // if meta is default allocate on demand
 		_colmeta = (_colmeta != null && _colmeta.length == numCols) ? _colmeta : new ColumnMetadata[numCols];
 		_coldata = (_coldata != null && _coldata.length == numCols) ? _coldata : new Array[numCols];
+		if(_nRow == 0)
+			_coldata = null;
 		// read columns (value type, meta, data)
 		for(int j = 0; j < numCols; j++) {
 			byte type = in.readByte();
@@ -807,7 +811,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 			else
 				_colmeta[j] = new ColumnMetadata(); // must be allocated.
 
-			if(type >= 0) // if in allocated column data then read it
+			if(type >= 0 && _nRow > 0) // if in allocated column data then read it
 				_coldata[j] = ArrayFactory.read(in, _nRow);
 		}
 		_msize = -1;
@@ -815,30 +819,12 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 
 	@Override
 	public void writeExternal(ObjectOutput out) throws IOException {
-		
-		// if((out instanceof ObjectOutputStream)){
-		// 	ObjectOutputStream oos = (ObjectOutputStream)out;
-		// 	FastBufferedDataOutputStream fos = new FastBufferedDataOutputStream(oos);
-		// 	write(fos); //note: cannot close fos as this would close oos
-		// 	fos.flush();
-		// }
-		// else{
-			write(out);
-		// }
+		write(out);
 	}
 
 	@Override
 	public void readExternal(ObjectInput in) throws IOException {
-		// if(in instanceof ObjectInputStream) {
-		// 	// fast deserialize of dense/sparse blocks
-		// 	ObjectInputStream ois = (ObjectInputStream) in;
-		// 	FastBufferedDataInputStream fis = new FastBufferedDataInputStream(ois);
-		// 	readFields(fis); // note: cannot close fos as this would close oos
-		// }
-		// else {
-			// redirect deserialization to writable impl
-			readFields(in);
-		// }
+		readFields(in);
 	}
 
 	@Override
@@ -893,6 +879,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 				}
 				catch(InterruptedException | ExecutionException e) {
 					LOG.error(e);
+					size = 0;
 					for(Array<?> aa : _coldata)
 						size += aa.getInMemorySize();
 				}
@@ -937,10 +924,10 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	public boolean isShallowSerialize(boolean inclConvert) {
 		// shallow serialize if non-string schema because a frame block
 		// is always dense but strings have large array overhead per cell
-		boolean ret = true;
-		for(int j = 0; j < _schema.length && ret; j++)
-			ret &= _coldata[j].isShallowSerialize();
-		return ret;
+		for(int j = 0; j < _schema.length; j++)
+			if(!_coldata[j].isShallowSerialize())
+				return false;
+		return true;
 	}
 
 	@Override
@@ -1217,6 +1204,22 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 		_msize = -1;
 	}
 
+	public FrameBlock copyShallow(){
+		FrameBlock ret = new FrameBlock();
+		ret._nRow = _nRow;
+		ret._msize = _msize; 
+		final int nCol = getNumColumns();
+		if(_coldata != null)
+			ret._coldata = Arrays.copyOf(_coldata, nCol);
+		if(_colnames != null)
+			ret._colnames = Arrays.copyOf(_colnames, nCol);
+		if(_colmeta != null)
+			ret._colmeta = Arrays.copyOf(_colmeta, nCol);
+		if(_schema != null)
+			ret._schema = Arrays.copyOf(_schema, nCol);
+		return ret;
+	}
+
 	/**
 	 * Copy src matrix into the index range of the existing current matrix.
 	 *
@@ -1358,7 +1361,7 @@ public class FrameBlock implements CacheBlock<FrameBlock>, Externalizable {
 	}
 
 	public final FrameBlock detectSchema(int k) {
-		return FrameLibDetectSchema.detectSchema(this, k);
+		return FrameLibDetectSchema.detectSchema(this, 0.01, k);
 	}
 
 	public final FrameBlock detectSchema(double sampleFraction, int k) {

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayWrapper.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/ArrayWrapper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,29 +17,32 @@
  * under the License.
  */
 
-package org.apache.sysds.runtime.io;
+package org.apache.sysds.runtime.frame.data.columns;
 
-import java.util.List;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 
-import org.apache.sysds.hops.OptimizerUtils;
-import org.apache.sysds.runtime.frame.data.FrameBlock;
-import org.apache.sysds.runtime.frame.data.columns.Array;
-import org.apache.sysds.runtime.frame.data.lib.FrameLibCompress;
-import org.apache.sysds.runtime.matrix.data.Pair;
+import org.apache.hadoop.io.Writable;
 
-public class FrameWriterCompressed extends FrameWriterBinaryBlockParallel {
+public class ArrayWrapper implements Writable {
 
-	private final boolean parallel;
+	public Array<?> _a; 
 
-	public FrameWriterCompressed(boolean parallel) {
-		this.parallel = parallel;
+	public ArrayWrapper(Array<?> a){
+		_a = a;
 	}
 
 	@Override
-	protected Pair<List<Pair<Integer, Array<?>>>, FrameBlock> extractDictionaries(FrameBlock src) {
-		int k = parallel ? OptimizerUtils.getParallelBinaryWriteParallelism() : 1;
-		FrameBlock compressed = FrameLibCompress.compress(src, k);
-		return super.extractDictionaries(compressed);
+	public void write(DataOutput out) throws IOException {
+		out.writeInt(_a.size());
+		_a.write(out);
 	}
 
+	@Override
+	public void readFields(DataInput in) throws IOException {
+		int s = in.readInt();
+		_a = ArrayFactory.read(in, s);
+	}
+	
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/utils/FrameRDDConverterUtils.java
@@ -90,10 +90,7 @@ public class FrameRDDConverterUtils
  			JavaRDD<String> tmp = input.values()
 					.map(new TextToStringFunction());
 			String tmpStr = tmp.first();
-			boolean metaHeader = tmpStr.startsWith(TfUtils.TXMTD_MVPREFIX) 
-					|| tmpStr.startsWith(TfUtils.TXMTD_NDPREFIX);
-			tmpStr = (metaHeader) ? tmpStr.substring(tmpStr.indexOf(delim)+1) : tmpStr;
-			long rlen = tmp.count() - (hasHeader ? 1 : 0) - (metaHeader ? 2 : 0);
+			long rlen = tmp.count() ;
 			long clen = IOUtilFunctions.splitCSV(tmpStr, delim).length;
 			mc.set(rlen, clen, mc.getBlocksize(), -1);
 		}
@@ -582,14 +579,14 @@ public class FrameRDDConverterUtils
 					_colnames = row.split(_delim);
 					continue;
 				}
-				if( row.startsWith(TfUtils.TXMTD_MVPREFIX) ) {
-					_mvMeta = Arrays.asList(Arrays.copyOfRange(IOUtilFunctions.splitCSV(row, _delim), 1, (int)_clen+1));
-					continue;
-				}
-				else if( row.startsWith(TfUtils.TXMTD_NDPREFIX) ) {
-					_ndMeta = Arrays.asList(Arrays.copyOfRange(IOUtilFunctions.splitCSV(row, _delim), 1, (int)_clen+1));
-					continue;
-				}
+				// if( row.startsWith(TfUtils.TXMTD_MVPREFIX) ) {
+				// 	_mvMeta = Arrays.asList(Arrays.copyOfRange(IOUtilFunctions.splitCSV(row, _delim), 1, (int)_clen+1));
+				// 	continue;
+				// }
+				// else if( row.startsWith(TfUtils.TXMTD_NDPREFIX) ) {
+				// 	_ndMeta = Arrays.asList(Arrays.copyOfRange(IOUtilFunctions.splitCSV(row, _delim), 1, (int)_clen+1));
+				// 	continue;
+				// }
 				
 				//adjust row index for header and meta data
 				rowix += (_hasHeader ? 0 : 1) - ((_mvMeta == null) ? 0 : 2);
@@ -670,18 +667,18 @@ public class FrameRDDConverterUtils
 					ret.add(sb.toString());
 					sb.setLength(0); //reset
 				}
-				if( !blk.isColumnMetadataDefault() ) {
-					sb.append(TfUtils.TXMTD_MVPREFIX + _props.getDelim());
-					for( int j=0; j<blk.getNumColumns(); j++ )
-						sb.append(blk.getColumnMetadata(j).getMvValue() + ((j<blk.getNumColumns()-1)?_props.getDelim():""));
-					ret.add(sb.toString());
-					sb.setLength(0); //reset
-					sb.append(TfUtils.TXMTD_NDPREFIX + _props.getDelim());
-					for( int j=0; j<blk.getNumColumns(); j++ )
-						sb.append(blk.getColumnMetadata(j).getNumDistinct() + ((j<blk.getNumColumns()-1)?_props.getDelim():""));
-					ret.add(sb.toString());
-					sb.setLength(0); //reset		
-				}
+				// if( !blk.isColumnMetadataDefault() ) {
+				// 	sb.append(TfUtils.TXMTD_MVPREFIX + _props.getDelim());
+				// 	for( int j=0; j<blk.getNumColumns(); j++ )
+				// 		sb.append(blk.getColumnMetadata(j).getMvValue() + ((j<blk.getNumColumns()-1)?_props.getDelim():""));
+				// 	ret.add(sb.toString());
+				// 	sb.setLength(0); //reset
+				// 	sb.append(TfUtils.TXMTD_NDPREFIX + _props.getDelim());
+				// 	for( int j=0; j<blk.getNumColumns(); j++ )
+				// 		sb.append(blk.getColumnMetadata(j).getNumDistinct() + ((j<blk.getNumColumns()-1)?_props.getDelim():""));
+				// 	ret.add(sb.toString());
+				// 	sb.setLength(0); //reset		
+				// }
 			}
 		
 			//handle Frame block data

--- a/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCSVParallel.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameReaderTextCSVParallel.java
@@ -144,7 +144,6 @@ public class FrameReaderTextCSVParallel extends FrameReaderTextCSV
 		@Override
 		public Integer call() throws Exception {
 			return countLinesInReader(_split, _informat, _job, _nCol, _hasHeader);
-
 		}
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/io/FrameWriterTextCSV.java
+++ b/src/main/java/org/apache/sysds/runtime/io/FrameWriterTextCSV.java
@@ -31,7 +31,6 @@ import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.frame.data.iterators.IteratorFactory;
-import org.apache.sysds.runtime.transform.TfUtils;
 import org.apache.sysds.runtime.util.HDFSTool;
 
 /**
@@ -107,17 +106,7 @@ public class FrameWriterTextCSV extends FrameWriter
 					}
 					sb.append('\n');
 				}
-				//append meta data
-				if( !src.isColumnMetadataDefault() ) {
-					sb.append(TfUtils.TXMTD_MVPREFIX + delim);
-					for( int j=0; j<cols; j++ )
-						sb.append(src.getColumnMetadata(j).getMvValue() + ((j<cols-1)?delim:""));
-					sb.append("\n");
-					sb.append(TfUtils.TXMTD_NDPREFIX + delim);
-					for( int j=0; j<cols; j++ )
-						sb.append(src.getColumnMetadata(j).getNumDistinct() + ((j<cols-1)?delim:""));
-					sb.append("\n");
-				}
+
 				br.write( sb.toString() );
 	            sb.setLength(0);
 			}

--- a/src/main/java/org/apache/sysds/runtime/io/IOUtilFunctions.java
+++ b/src/main/java/org/apache/sysds/runtime/io/IOUtilFunctions.java
@@ -72,6 +72,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.data.TensorBlock;
 import org.apache.sysds.runtime.data.TensorIndexes;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
+import org.apache.sysds.runtime.frame.data.columns.ArrayWrapper;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixCell;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
@@ -648,10 +649,10 @@ public class IOUtilFunctions {
 			try {
 				if( reader.next(key, value) ) {
 					boolean hasValue = true;
-					if( value.toString().startsWith(TfUtils.TXMTD_MVPREFIX) )
-						hasValue = reader.next(key, value);
-					if( value.toString().startsWith(TfUtils.TXMTD_NDPREFIX) )
-						hasValue = reader.next(key, value);
+					// if( value.toString().startsWith(TfUtils.TXMTD_MVPREFIX) )
+					// 	hasValue = reader.next(key, value);
+					// if( value.toString().startsWith(TfUtils.TXMTD_NDPREFIX) )
+					// 	hasValue = reader.next(key, value);
 					String row = value.toString().trim();
 					if( hasValue && !row.isEmpty() ) {
 						ncol = IOUtilFunctions.countTokensCSV(row, delim);
@@ -888,6 +889,13 @@ public class IOUtilFunctions {
 	public static Writer getSeqWriterFrame(Path path, Configuration job, int replication) throws IOException {
 		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
 			Writer.keyClass(LongWritable.class), Writer.valueClass(FrameBlock.class),
+			Writer.compression(getCompressionEncodingType(), getCompressionCodec()),
+			Writer.replication((short) (replication > 0 ? replication : 1)));
+	}
+
+	public static Writer getSeqWriterArray(Path path, Configuration job, int replication) throws IOException {
+		return SequenceFile.createWriter(job, Writer.file(path), Writer.bufferSize(4096),
+			Writer.keyClass(LongWritable.class), Writer.valueClass(ArrayWrapper.class),
 			Writer.compression(getCompressionEncodingType(), getCompressionCodec()),
 			Writer.replication((short) (replication > 0 ? replication : 1)));
 	}

--- a/src/main/java/org/apache/sysds/runtime/util/DataConverter.java
+++ b/src/main/java/org/apache/sysds/runtime/util/DataConverter.java
@@ -1120,27 +1120,27 @@ public class DataConverter {
 			colLength = colsToPrint < clen ? colsToPrint : clen;
 
 		//print frame header
-		sb.append("# FRAME: ");
-		sb.append("nrow = " + fb.getNumRows() + ", ");
-		sb.append("ncol = " + fb.getNumColumns() + lineseparator);
+		// sb.append("# FRAME: ");
+		// sb.append("nrow = " + fb.getNumRows() + ", ");
+		// sb.append("ncol = " + fb.getNumColumns() + lineseparator);
 
 		//print column names
-		sb.append("#"); sb.append(separator);
-		for( int j=0; j<colLength; j++ ) {
-			sb.append(fb.getColumnNames()[j]);
-			if( j != colLength-1 )
-				sb.append(separator);
-		}
-		sb.append(lineseparator);
+		// sb.append("#"); sb.append(separator);
+		// for( int j=0; j<colLength; j++ ) {
+		// 	sb.append(fb.getColumnNames()[j]);
+		// 	if( j != colLength-1 )
+		// 		sb.append(separator);
+		// }
+		// sb.append(lineseparator);
 
-		//print schema
-		sb.append("#"); sb.append(separator);
-		for( int j=0; j<colLength; j++ ) {
-			sb.append(fb.getSchema()[j]);
-			if( j != colLength-1 )
-				sb.append(separator);
-		}
-		sb.append(lineseparator);
+		// //print schema
+		// sb.append("#"); sb.append(separator);
+		// for( int j=0; j<colLength; j++ ) {
+		// 	sb.append(fb.getSchema()[j]);
+		// 	if( j != colLength-1 )
+		// 		sb.append(separator);
+		// }
+		// sb.append(lineseparator);
 
 		//print data
 		DecimalFormat df = new DecimalFormat();


### PR DESCRIPTION
This commit removes the #meta part of the writing and reading csv files for frames. This change removes the branching of reading every line of csv files that improve the I/O time. It was not an issue before, because the IO was significantly slower, but now with the disk speed on high Raid 0 or fast nvme ssds it matters.