### PR TITLE
[MINOR] copy shaded jar instead of moving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
 						<configuration>
 							<target name="copy and rename JAR files">
 								<!-- https://ant.apache.org/manual/Tasks -->
-								<move
+								<copy
 									file="${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar" 
 									tofile="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
 							</target>


### PR DESCRIPTION

```bash
mvn --settings ../tmp-settings-nexus.xml -Pdistribution deploy \
    -DaltDeploymentRepository=local-temp::default::file:///$PWD/${tmp_repo} \
    -Daether.checksums.algorithms='SHA-512,SHA-1,MD5'
```

logs

```
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar (61 kB at 1.1 MB/s)
gpg: can't open '/workspaces/j143-systemds/target/systemds-3.2.0-shaded.jar': No such file or directory
gpg: signing failed: No such file or directory
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```