### PR TITLE
[SYSTEMDS-3673] log4j and slf4j update to latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
 		<enableGPU>false</enableGPU>
 		<jcuda.scope>provided</jcuda.scope>
 		<jcuda.version>10.2.0</jcuda.version>
-		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.2</log4j.version>
+		<slf4j.version>2.0.11</slf4j.version>
+		<log4j.version>2.22.1</log4j.version>
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
 		<maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
 		<maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
@@ -1107,6 +1107,10 @@
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
 					<artifactId>log4j-core</artifactId>
 				</exclusion>
 				<exclusion>
@@ -1148,10 +1152,6 @@
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
 					<artifactId>log4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-core</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1154,6 +1154,10 @@
 					<artifactId>log4j-api</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>


### PR DESCRIPTION
fix SLF4J: Failed to load class org.slf4j.impl.StaticLoggerBinder

Here are the artifacts built with these changes:

maven: https://repository.apache.org/content/repositories/orgapachesystemds-1095/org/apache/systemds/systemds/3.2.0/

svn: https://dist.apache.org/repos/dist/dev/systemds/3.2.0-rc2-temp-HKHk/

**Concerns**

- [ ] scripts shall work with & without `SYSTEMDS_ROOT` variable set
- [ ] for the logging config files? or is it backwards compatible?

---

Fixes SYSTEMDS-3673 / Fixes https://github.com/j143/systemds/issues/306 