### PR TITLE
[MINOR] Fix run script

### DIFF
--- a/bin/systemds
+++ b/bin/systemds
@@ -431,7 +431,8 @@ if [ $WORKER == 1 ]; then
   print_out "#  starting Federated worker on port $PORT"
   print_out "###############################################################################"
   CMD=" \
-  java $LOG4JPROPFULL \
+  java $SYSTEMDS_STANDALONE_OPTS \
+  $LOG4JPROPFULL \
   -jar $SYSTEMDS_JAR_FILE \
   -w $PORT \
   $CONFIG_FILE \
@@ -444,7 +445,8 @@ elif [ "$FEDMONITORING" == 1 ]; then
   print_out "#  starting Federated backend monitoring on port $PORT"
   print_out "###############################################################################"
   CMD=" \
-  java $LOG4JPROPFULL \
+  java $SYSTEMDS_STANDALONE_OPTS \
+  $LOG4JPROPFULL \
   -jar $SYSTEMDS_JAR_FILE \
   -fedMonitoring $PORT \
   $CONFIG_FILE \
@@ -457,7 +459,8 @@ elif [ $SYSDS_DISTRIBUTED == 0 ]; then
   print_out "#  Running script $SCRIPT_FILE locally with opts: $*"
   print_out "###############################################################################"
   CMD=" \
-  java $LOG4JPROPFULL \
+  java $SYSTEMDS_STANDALONE_OPTS \
+  $LOG4JPROPFULL \
   -jar $SYSTEMDS_JAR_FILE \
   -f $SCRIPT_FILE \
   -exec $SYSDS_EXEC_MODE \


### PR DESCRIPTION
This commit fixes a bug i introduced a couple of weeks ago, where i erroneously forgot to include the java arguments from  SYSTEMDS_STANDALONE_OPTS in the bin/systemds file when i was changing the launching from using -cp to -jar for performance gains in startup time of SystemDS.

