### PR TITLE
[SYSTEMDS-3687] Python API startup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ buildNumber.properties
 _site/
 
 # Tutorial data mnist
-src/main/python/systemds/examples/tutorials/*/
 scripts/nn/examples/data/*
 
 # User configuration files

--- a/src/main/python/conf/log4j.properties
+++ b/src/main/python/conf/log4j.properties
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,35 +19,15 @@
 #
 #-------------------------------------------------------------
 
-# Git ignore for python files.
-systemds/lib/
-systemds.egg-info/
-systemds/conf/
-build/
-LICENSE
-NOTICE
-generator.log
-dist
-docs/build
-docs/source/_build
-tests/onnx_systemds/output_test
-tests/onnx_systemds/dml_output
-tests/onnx_systemds/test_models/*.onnx
+log4j.rootLogger=ERROR,console
 
-# git ignore tmp test files
-tests/federated/output
-tests/federated/worker
-tests/federated/tmp
-tests/list/tmp
-tests/algorithms/readwrite/
-tests/examples/tutorials/model
-tests/lineage/temp
+log4j.logger.org.apache.sysds=ERROR
+log4j.logger.org.apache.sysds.utils.SettingsChecker=WARN
+log4j.logger.org.apache.spark=ERROR
+log4j.logger.org.apache.hadoop=OFF
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=INFO
 
-python_venv/
-venv
-
-# Main Jar location for API communiation.
-systemds/SystemDS.jar
-
-# tutorial
-systemds/examples/tutorials/*
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n

--- a/src/main/python/pre_setup.py
+++ b/src/main/python/pre_setup.py
@@ -80,6 +80,16 @@ if not os.path.exists(CONF_DIR):
 shutil.copy(os.path.join(SYSTEMDS_ROOT,'conf', 'log4j.properties'), os.path.join(this_path, PYTHON_DIR, 'conf', 'log4j.properties'))
 shutil.copy(os.path.join(SYSTEMDS_ROOT,'conf', 'SystemDS-config-defaults.xml'), os.path.join(this_path, PYTHON_DIR, 'conf', 'SystemDS-config-defaults.xml'))
 
+
+# Take SystemDS file.
+shutil.copy(os.path.join(SYSTEMDS_ROOT, 'target', 'SystemDS.jar'), os.path.join(PYTHON_DIR, 'SystemDS.jar'))
+
+# remove redundant SystemDS file inside lib.
+for file in os.listdir(os.path.join(PYTHON_DIR, 'lib')):
+    if "systemds" in file:
+        if "extra" not in file: 
+           os.remove(os.path.join(PYTHON_DIR, 'lib', file))
+
 SYSTEMDS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
 shutil.copyfile(os.path.join(SYSTEMDS_ROOT, 'LICENSE'), 'LICENSE')
 shutil.copyfile(os.path.join(SYSTEMDS_ROOT, 'NOTICE'), 'NOTICE')


### PR DESCRIPTION
This PR change the startup of the python interface to properly use the jar files, and fixes a release issue where if the SYSTEMDS_ROOT is not set the python API did not properly hook into the released jar artifacts.
