### PR TITLE
[Not for merge] python logging issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ buildNumber.properties
 _site/
 
 # Tutorial data mnist
-src/main/python/systemds/examples/tutorials/*/
 scripts/nn/examples/data/*
 
 # User configuration files

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -39,5 +39,5 @@ exclude:
   - updateAPI.sh
 
 # These allow the documentation to be updated with newer releases
-SYSTEMDS_VERSION: 3.2.0-SNAPSHOT
+SYSTEMDS_VERSION: 3.2.0
 

--- a/src/main/python/conf/log4j.properties
+++ b/src/main/python/conf/log4j.properties
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,35 +19,15 @@
 #
 #-------------------------------------------------------------
 
-# Git ignore for python files.
-systemds/lib/
-systemds.egg-info/
-systemds/conf/
-build/
-LICENSE
-NOTICE
-generator.log
-dist
-docs/build
-docs/source/_build
-tests/onnx_systemds/output_test
-tests/onnx_systemds/dml_output
-tests/onnx_systemds/test_models/*.onnx
+log4j.rootLogger=ERROR,console
 
-# git ignore tmp test files
-tests/federated/output
-tests/federated/worker
-tests/federated/tmp
-tests/list/tmp
-tests/algorithms/readwrite/
-tests/examples/tutorials/model
-tests/lineage/temp
+log4j.logger.org.apache.sysds=ERROR
+log4j.logger.org.apache.sysds.utils.SettingsChecker=WARN
+log4j.logger.org.apache.spark=ERROR
+log4j.logger.org.apache.hadoop=OFF
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=INFO
 
-python_venv/
-venv
-
-# Main Jar location for API communiation.
-systemds/SystemDS.jar
-
-# tutorial
-systemds/examples/tutorials/*
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n

--- a/src/main/python/docs/source/conf.py
+++ b/src/main/python/docs/source/conf.py
@@ -34,11 +34,11 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'SystemDS'
-copyright = '2023, Apache SystemDS'
+copyright = '2024, Apache SystemDS'
 author = 'Apache SystemDS'
 
 # The full version, including alpha/beta/rc tags
-release = '3.2.0-dev'
+release = '3.2.0'
 
 # -- General configuration ---------------------------------------------------
 # Add any Sphinx extension module names here, as strings.

--- a/src/main/python/pre_setup.py
+++ b/src/main/python/pre_setup.py
@@ -80,6 +80,16 @@ if not os.path.exists(CONF_DIR):
 shutil.copy(os.path.join(SYSTEMDS_ROOT,'conf', 'log4j.properties'), os.path.join(this_path, PYTHON_DIR, 'conf', 'log4j.properties'))
 shutil.copy(os.path.join(SYSTEMDS_ROOT,'conf', 'SystemDS-config-defaults.xml'), os.path.join(this_path, PYTHON_DIR, 'conf', 'SystemDS-config-defaults.xml'))
 
+
+# Take SystemDS file.
+shutil.copy(os.path.join(SYSTEMDS_ROOT, 'target', 'SystemDS.jar'), os.path.join(PYTHON_DIR, 'SystemDS.jar'))
+
+# remove redundant SystemDS file inside lib.
+for file in os.listdir(os.path.join(PYTHON_DIR, 'lib')):
+    if "systemds" in file:
+        if "extra" not in file: 
+           os.remove(os.path.join(PYTHON_DIR, 'lib', file))
+
 SYSTEMDS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd())))
 shutil.copyfile(os.path.join(SYSTEMDS_ROOT, 'LICENSE'), 'LICENSE')
 shutil.copyfile(os.path.join(SYSTEMDS_ROOT, 'NOTICE'), 'NOTICE')

--- a/src/main/python/systemds/project_info.py
+++ b/src/main/python/systemds/project_info.py
@@ -23,4 +23,4 @@
 # via string substitutions using the maven-resources-plugin
 __project_group_id__ = 'org.apache.systemds'
 __project_artifact_id__ = 'systemds'
-__project_version__ = '3.2.0-dev'
+__project_version__ = '3.2.0'


### PR DESCRIPTION

This is not fixing the log4j issue -- https://github.com/apache/systemds/commit/387b6c1c8e472dde65a36e8f3fd22091054ed347

```py

import logging

from systemds.context import SystemDSContext
from systemds.operator.algorithm import l2svm

with SystemDSContext() as sds:
    # Generate 10 by 10 matrix with values in range 0 to 100.
    features = sds.rand(10, 10, 0, 100)
    # Add value to all cells in features
    features += 1.1
    # Generate labels of all ones and zeros
    labels = sds.rand(10, 1, 1, 1, sparsity=0.5)

    model = l2svm(features, labels, verbose=False).compute()
    logging.info(model)
```


$ python ~/test.py 
24/04/08 03:26:16 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
$
