### PR TITLE
[MINOR] Fix logic for sprase-dense matrix multiply

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
@@ -1354,14 +1354,15 @@ public class LibMatrixMult
 				if( a.isEmpty(i) ) continue; 
 				int apos = a.pos(i);
 				int alen = a.size(i);
-				// int[] aix = a.indexes(i);
+				int[] aix = a.indexes(i);
 				double[] avals = a.values(i);
 				double[] cvals = c.values(i);
 				int cix = c.pos(i);
 				for(int k = apos; k < apos+alen; k++) {
 					double val = avals[k];
-					double[] bvals = b.values(k);
-					int bix = b.pos(k);
+					int colIndex = aix[k];
+					double[] bvals = b.values(colIndex);
+					int bix = b.pos(colIndex);
 					for(int j = 0; j < n; j++)
 						cvals[cix+j] += val * bvals[bix+j];
 				}


### PR DESCRIPTION
I noticed that the fallback implementation for sparse-dense matrix multiply produces wrong results or sometimes throws an index out of bounds exception. This patch fixes this issue. Further, this part of the code is only reached when LOW_LEVEL_OPTIMIZATION is set to false (by default it is true). Hence, this is bug should generally not occur.

**Example:**
A %*% B = C , where A is in sparse format, B and C are dense.

A = {{1, 0, 2, 0},                        
	{0, 1, 0, 0},
	{0, 0, 3, 0},
	{0, 5, 0, 0}}

B = {{1, 2, 3, 4},
	{5, 6, 7, 8},
	{9, 10, 11, 12},
	{13, 14, 15, 16}}

For A utilizing CSR, it throws and out of bound exception and when using MCSR it produced a wrong result. I will check if this or similar errors occur in other matrix multiply operators (specifically those called when LOW_LEVEL_OPTIMIZATION is true). 