### PR TITLE
[SYSTEMDS-3695] Fix frame builtin nary append for Spark backend

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/BuiltinNarySPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/BuiltinNarySPInstruction.java
@@ -20,12 +20,19 @@
 package org.apache.sysds.runtime.instructions.spark;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.api.java.function.PairFunction;
+import org.apache.sysds.hops.BinaryOp;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.context.SparkExecutionContext;
+import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Plus;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
@@ -34,6 +41,7 @@ import org.apache.sysds.runtime.instructions.cp.ScalarObject;
 import org.apache.sysds.runtime.instructions.spark.AppendGSPInstruction.ShiftMatrix;
 import org.apache.sysds.runtime.instructions.spark.functions.MapInputSignature;
 import org.apache.sysds.runtime.instructions.spark.functions.MapJoinSignature;
+import org.apache.sysds.runtime.instructions.spark.utils.FrameRDDAggregateUtils;
 import org.apache.sysds.runtime.instructions.spark.utils.RDDAggregateUtils;
 import org.apache.sysds.runtime.instructions.spark.utils.SparkUtils;
 import org.apache.sysds.runtime.lineage.LineageItem;
@@ -47,7 +55,15 @@ import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.UtilFunctions;
 import scala.Tuple2;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+
+import static org.apache.sysds.hops.BinaryOp.AppendMethod.MR_MAPPEND;
+import static org.apache.sysds.hops.BinaryOp.AppendMethod.MR_RAPPEND;
+import static org.apache.sysds.hops.OptimizerUtils.DEFAULT_FRAME_BLOCKSIZE;
+import static org.apache.sysds.runtime.instructions.spark.FrameAppendMSPInstruction.appendFrameMSP;
+import static org.apache.sysds.runtime.instructions.spark.FrameAppendRSPInstruction.appendFrameRSP;
 
 public class BuiltinNarySPInstruction extends SPInstruction implements LineageTraceable
 {
@@ -75,32 +91,78 @@ public class BuiltinNarySPInstruction extends SPInstruction implements LineageTr
 	public void processInstruction(ExecutionContext ec) {
 		SparkExecutionContext sec = (SparkExecutionContext)ec;
 		JavaPairRDD<MatrixIndexes,MatrixBlock> out = null;
-		DataCharacteristics mcOut = null;
+		DataCharacteristics dcout = null;
+		boolean inputIsMatrix = inputs[0].isMatrix();
+
 		
 		if( getOpcode().equals("cbind") || getOpcode().equals("rbind") ) {
 			//compute output characteristics
 			boolean cbind = getOpcode().equals("cbind");
-			mcOut = computeAppendOutputDataCharacteristics(sec, inputs, cbind);
-			
-			//get consolidated input via union over shifted and padded inputs
-			DataCharacteristics off = new MatrixCharacteristics(0, 0, mcOut.getBlocksize(), 0);
-			for( CPOperand input : inputs ) {
-				DataCharacteristics mcIn = sec.getDataCharacteristics(input.getName());
-				JavaPairRDD<MatrixIndexes,MatrixBlock> in = sec
-					.getBinaryMatrixBlockRDDHandleForVariable( input.getName() )
-					.flatMapToPair(new ShiftMatrix(off, mcIn, cbind))
-					.mapToPair(new PadBlocksFunction(mcOut)); //just padding
-				out = (out != null) ? out.union(in) : in;
-				updateAppendDataCharacteristics(mcIn, off, cbind);
+			dcout = computeAppendOutputDataCharacteristics(sec, inputs, cbind);
+			if(inputIsMatrix){
+				//get consolidated input via union over shifted and padded inputs
+				DataCharacteristics off = new MatrixCharacteristics(0, 0, dcout.getBlocksize(), 0);
+				for( CPOperand input : inputs ) {
+					DataCharacteristics mcIn = sec.getDataCharacteristics(input.getName());
+					JavaPairRDD<MatrixIndexes, MatrixBlock> in = sec
+							.getBinaryMatrixBlockRDDHandleForVariable(input.getName())
+							.flatMapToPair(new ShiftMatrix(off, mcIn, cbind))
+							.mapToPair(new PadBlocksFunction(dcout)); //just padding
+					out = (out != null) ? out.union(in) : in;
+					updateAppendDataCharacteristics(mcIn, off, cbind);
+				}
+				//aggregate partially overlapping blocks w/ single shuffle
+				int numPartOut = SparkUtils.getNumPreferredPartitions(dcout);
+				out = RDDAggregateUtils.mergeByKey(out, numPartOut, false);
 			}
-			
-			//aggregate partially overlapping blocks w/ single shuffle
-			int numPartOut = SparkUtils.getNumPreferredPartitions(mcOut);
-			out = RDDAggregateUtils.mergeByKey(out, numPartOut, false);
+			//FRAME
+			else {
+				JavaPairRDD<Long,FrameBlock> outFrame =  sec.getFrameBinaryBlockRDDHandleForVariable( inputs[0].getName() );;
+				dcout = new MatrixCharacteristics(sec.getDataCharacteristics(inputs[0].getName()));
+				FrameObject fo = new FrameObject(sec.getFrameObject(inputs[0].getName()));
+				boolean[] broadcasted = new boolean[inputs.length];
+				broadcasted[0] = false;
+
+				for(int i = 1; i < inputs.length; i++){
+					DataCharacteristics dcIn = sec.getDataCharacteristics(inputs[i].getName());
+					final int blk_size = dcout.getBlocksize() <= 0 ? DEFAULT_FRAME_BLOCKSIZE : dcout.getBlocksize();
+
+					broadcasted[i] = BinaryOp.FORCED_APPEND_METHOD == MR_MAPPEND ||
+							BinaryOp.FORCED_APPEND_METHOD == null && cbind && dcIn.getCols() <= blk_size &&
+							OptimizerUtils.checkSparkBroadcastMemoryBudget(dcout.getCols(), dcIn.getCols(), blk_size, dcIn.getNonZeros());
+
+					//easy case: broadcast & map
+					if(broadcasted[i]){
+						outFrame = appendFrameMSP(outFrame, sec.getBroadcastForFrameVariable(inputs[i].getName()));
+					}
+					//general case for frames:
+					else{
+						if(BinaryOp.FORCED_APPEND_METHOD != null && BinaryOp.FORCED_APPEND_METHOD != MR_RAPPEND)
+							throw new DMLRuntimeException("Forced append type ["+BinaryOp.FORCED_APPEND_METHOD+"] is not supported for frames");
+
+						JavaPairRDD<Long,FrameBlock> in2 = sec.getFrameBinaryBlockRDDHandleForVariable( inputs[i].getName() );
+						outFrame = appendFrameRSP(outFrame, in2, dcout.getRows(), cbind);
+					}
+					updateAppendDataCharacteristics(dcIn, dcout, cbind);
+					if(cbind)
+						fo.setSchema(fo.mergeSchemas(sec.getFrameObject(inputs[i].getName())));
+				}
+
+				//set output RDD and add lineage
+				sec.getDataCharacteristics(output.getName()).set(dcout);
+				sec.setRDDHandleForVariable(output.getName(), outFrame);
+				sec.getFrameObject(output.getName()).setSchema(fo.getSchema());
+				for( int i = 0; i < inputs.length; i++)
+					if(broadcasted[i])
+						sec.addLineageBroadcast(output.getName(), inputs[i].getName());
+					else
+						sec.addLineageRDD(output.getName(), inputs[i].getName());
+				return;
+			}
 		}
 		else if( ArrayUtils.contains(new String[]{"nmin","nmax","n+"}, getOpcode()) ) {
 			//compute output characteristics
-			mcOut = computeMinMaxOutputDataCharacteristics(sec, inputs);
+			dcout = computeMinMaxOutputDataCharacteristics(sec, inputs);
 			
 			//get scalars and consolidated input via join
 			List<ScalarObject> scalars = sec.getScalarInputs(inputs);
@@ -118,13 +180,41 @@ public class BuiltinNarySPInstruction extends SPInstruction implements LineageTr
 		}
 		
 		//set output RDD and add lineage
-		sec.getDataCharacteristics(output.getName()).set(mcOut);
+		sec.getDataCharacteristics(output.getName()).set(dcout);
 		sec.setRDDHandleForVariable(output.getName(), out);
 		for( CPOperand input : inputs )
 			if( !input.isScalar() )
 				sec.addLineageRDD(output.getName(), input.getName());
 	}
-	
+
+	private static class AlignBlkTask implements PairFlatMapFunction<Tuple2<Long, FrameBlock>, Long, FrameBlock> {
+		long max_rows;
+
+		public AlignBlkTask(long rows) {
+			max_rows = rows;
+		}
+
+		@Override
+		public Iterator<Tuple2<Long, FrameBlock>> call(Tuple2<Long, FrameBlock> longFrameBlockTuple2) throws Exception {
+			Long index = longFrameBlockTuple2._1;
+			FrameBlock fb = longFrameBlockTuple2._2;
+			ArrayList<Tuple2<Long, FrameBlock>> list = new ArrayList<Tuple2<Long, FrameBlock>>();
+			//single output block
+			if(max_rows <= DEFAULT_FRAME_BLOCKSIZE){
+				FrameBlock fbout = new FrameBlock(fb.getSchema());
+				fbout.ensureAllocatedColumns((int) max_rows);
+				fbout = fbout.leftIndexingOperations(fb,index.intValue() - 1, index.intValue() + fb.getNumRows() - 2,0, fb.getNumColumns()-1, null );
+				list.add(new Tuple2<>(1L, fbout));
+			} else {
+				throw new NotImplementedException("Other Alignment strategies need to be implemented");
+				//long aligned_index = (index / DEFAULT_FRAME_BLOCKSIZE)*OptimizerUtils.DEFAULT_FRAME_BLOCKSIZE+1;
+				//list.add(new Tuple2<>(index / DEFAULT_FRAME_BLOCKSIZE + 1, fb));
+			}
+
+			return list.iterator();
+		}
+	}
+
 	private static DataCharacteristics computeAppendOutputDataCharacteristics(SparkExecutionContext sec, CPOperand[] inputs, boolean cbind) {
 		DataCharacteristics mcIn1 = sec.getDataCharacteristics(inputs[0].getName());
 		DataCharacteristics mcOut = new MatrixCharacteristics(0, 0, mcIn1.getBlocksize(), 0);

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinWerTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinWerTest.java
@@ -46,10 +46,10 @@ public class BuiltinWerTest extends AutomatedTestBase {
 		runWerTest(ExecType.CP);
 	}
 
-//	@Test
-//	public void testSpark() {
-//		runWerTest(ExecType.SPARK);
-//	}
+	@Test
+	public void testSpark() {
+		runWerTest(ExecType.SPARK);
+	}
 
 	private void runWerTest(ExecType instType) {
 		ExecMode platformOld = setExecMode(instType);

--- a/src/test/java/org/apache/sysds/test/functions/frame/FrameAppendDistTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/frame/FrameAppendDistTest.java
@@ -22,6 +22,7 @@ package org.apache.sysds.test.functions.frame;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
@@ -40,6 +41,8 @@ import org.junit.Test;
 public class FrameAppendDistTest extends AutomatedTestBase
 {
 	private final static String TEST_NAME = "FrameAppend";
+	private final static String TEST_NAME2 = "FrameNAryAppend";
+	private final static String TEST_NAME3 = "FrameNAryAppendMisalign";
 	private final static String TEST_DIR = "functions/frame/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FrameAppendDistTest.class.getSimpleName() + "/";
 
@@ -65,61 +68,83 @@ public class FrameAppendDistTest extends AutomatedTestBase
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, 
-				new String[] {"C"}));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"C"}));
+		addTestConfiguration(TEST_NAME2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2,new String[] {"C"}));
+		addTestConfiguration(TEST_NAME3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3,new String[] {"C"}));
 	}
 
 	@Test
 	public void testAppendInBlock1DenseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols2a, false, AppendMethod.MR_RAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols2a, false, AppendMethod.MR_RAPPEND, false, TEST_NAME);
 	}   
 	
 	@Test
 	public void testAppendInBlock1SparseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols2a, true, AppendMethod.MR_RAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols2a, true, AppendMethod.MR_RAPPEND, false, TEST_NAME);
 	}   
 	
 	@Test
 	public void testAppendInBlock1DenseRBindSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows2, cols1a, cols1a, false, AppendMethod.MR_RAPPEND, true);
+		commonAppendTest(ExecMode.SPARK, rows1, rows2, cols1a, cols1a, false, AppendMethod.MR_RAPPEND, true, TEST_NAME);
 	}
 	
 	@Test
 	public void testAppendInBlock1SparseRBindSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols1a, true, AppendMethod.MR_RAPPEND, true);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1a, cols1a, true, AppendMethod.MR_RAPPEND, true, TEST_NAME);
 	}
 	
 	//NOTE: mappend only applied for m2_cols<=blocksize
 	@Test
 	public void testMapAppendInBlock2DenseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1b, cols2a, false, AppendMethod.MR_MAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1b, cols2a, false, AppendMethod.MR_MAPPEND, false, TEST_NAME);
 	}
 	
 	@Test
 	public void testMapAppendInBlock2SparseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1b, cols2a, true, AppendMethod.MR_MAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1b, cols2a, true, AppendMethod.MR_MAPPEND, false, TEST_NAME);
 	}
 	
 	@Test
 	public void testMapAppendOutBlock2DenseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1d, cols3d, false, AppendMethod.MR_MAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1d, cols3d, false, AppendMethod.MR_MAPPEND, false, TEST_NAME);
 	}
 	
 	@Test
 	public void testMapAppendOutBlock2SparseSP() {
-		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1d, cols3d, true, AppendMethod.MR_MAPPEND, false);
+		commonAppendTest(ExecMode.SPARK, rows1, rows1, cols1d, cols3d, true, AppendMethod.MR_MAPPEND, false, TEST_NAME);
 	}
+
+	@Test
+	public void testNAryCAppendMSP(){
+		commonAppendTest(ExecMode.SPARK ,100, 100, 5, 10, false, null, false, TEST_NAME2);;
+	}
+
+	@Test
+	public void testNAryCAppendRSP(){
+		commonAppendTest(ExecMode.SPARK ,30, 30, 5, 1001, false, null, false, TEST_NAME2);;
+	}
+
+	@Test
+	public void testNAryRAppendSP(){
+		commonAppendTest(ExecMode.SPARK ,100, 100, 5, 5, false, null, true, TEST_NAME2);;
+	}
+
+	@Test
+	public void testNAryAppendWithMisalignmentMSP(){
+		commonAppendTest(ExecMode.SPARK ,5, 10, 5, 5, false, null, false, TEST_NAME3);;
+	}
+
 	
 	public void commonAppendTest(ExecMode platform, int rows1, int rows2, int cols1, int cols2, boolean sparse,
-		AppendMethod forcedAppendMethod, boolean rbind)
+		AppendMethod forcedAppendMethod, boolean rbind, String test_name)
 	{
-		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME);
+		TestConfiguration config = getAndLoadTestConfiguration(test_name);
 		
 		ExecMode prevPlfm=rtplatform;
 		
 		double sparsity = (sparse) ? sparsity2 : sparsity1; 
 		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
-		setOutputBuffering(true);
+		//setOutputBuffering(true);
 		try
 		{
 			if(forcedAppendMethod != null) {
@@ -134,12 +159,12 @@ public class FrameAppendDistTest extends AutomatedTestBase
 			
 			/* This is for running the junit test the new way, i.e., construct the arguments directly */
 			String RI_HOME = SCRIPT_DIR + TEST_DIR;
-			fullDMLScriptName = RI_HOME + TEST_NAME + ".dml";
-			programArgs = new String[]{"-explain","-args",  input("A"), 
+			fullDMLScriptName = RI_HOME + test_name + ".dml";
+			programArgs = new String[]{"-explain","-args",  input("A"),
 				Long.toString(rows1), Long.toString(cols1), input("B"),
 				Long.toString(rows2), Long.toString(cols2), output("C"),
 				(rbind? "rbind": "cbind")};
-			fullRScriptName = RI_HOME + TEST_NAME + ".R";
+			fullRScriptName = RI_HOME + test_name + ".R";
 			rCmd = "Rscript" + " " + fullRScriptName + " " + 
 				inputDir() + " " + expectedDir() + " " + (rbind? "rbind": "cbind");
 	
@@ -157,14 +182,15 @@ public class FrameAppendDistTest extends AutomatedTestBase
 			runTest(true, exceptionExpected, null, expectedNumberOfJobs);
 			runRScript(true);
 
-			ValueType[] lschemaAB = rbind ? lschemaA : UtilFunctions.copyOf(lschemaA, lschemaB);
-			
+			ValueType[] lschemaOut = rbind ? lschemaA : UtilFunctions.copyOf(lschemaA, lschemaB);
+			if(!Objects.equals(test_name, TEST_NAME) && !rbind)
+				lschemaOut =  UtilFunctions.copyOf(lschemaOut, lschemaB);
 			for(String file: config.getOutputFiles())
 			{
 				FrameBlock frameBlock = readDMLFrameFromHDFS(file, FileFormat.BINARY);
 				FrameBlock frameRBlock = readRFrameFromHDFS(file + ".csv", FileFormat.CSV, frameBlock.getNumRows(),
 					frameBlock.getNumColumns());
-				verifyFrameData(frameBlock, frameRBlock, lschemaAB);
+				verifyFrameData(frameBlock, frameRBlock, lschemaOut);
 			}
 		}
 		catch(Exception ex) {

--- a/src/test/scripts/functions/frame/FrameNAryAppend.R
+++ b/src/test/scripts/functions/frame/FrameNAryAppend.R
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args <- commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+A=read.csv(paste(args[1], "A.csv", sep=""), header = FALSE, stringsAsFactors=FALSE)
+B=read.csv(paste(args[1], "B.csv", sep=""), header = FALSE, stringsAsFactors=FALSE)
+if(args[3] == "rbind") {
+	C=rbind(A, B, B)
+} else {
+	C=cbind(A, B, B)
+}
+write.csv(C, paste(args[2], "C.csv", sep=""), row.names = FALSE, quote = FALSE)

--- a/src/test/scripts/functions/frame/FrameNAryAppend.dml
+++ b/src/test/scripts/functions/frame/FrameNAryAppend.dml
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A=read($1, data_type="frame", rows=$2, cols=$3, format="binary")
+B=read($4, data_type="frame", rows=$5, cols=$6, format="binary")
+
+if ($8 == "rbind") {
+	C=rbind(A, B, B)
+} else {
+	C=cbind(A, B, B)
+}
+write(C, $7, format="binary")

--- a/src/test/scripts/functions/frame/FrameNAryAppendMisalign.R
+++ b/src/test/scripts/functions/frame/FrameNAryAppendMisalign.R
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args <- commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+A=read.csv(paste(args[1], "A.csv", sep=""), header = FALSE, stringsAsFactors=FALSE)
+B=read.csv(paste(args[1], "B.csv", sep=""), header = FALSE, stringsAsFactors=FALSE)
+t1=rbind(A, B, B)
+C=cbind(t1, t1, t1)
+write.csv(C, paste(args[2], "C.csv", sep=""), row.names = FALSE, quote = FALSE)

--- a/src/test/scripts/functions/frame/FrameNAryAppendMisalign.dml
+++ b/src/test/scripts/functions/frame/FrameNAryAppendMisalign.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A=read($1, data_type="frame", rows=$2, cols=$3, format="binary")
+B=read($4, data_type="frame", rows=$5, cols=$6, format="binary")
+t=rbind(A, B, B)
+C=cbind(t, t, t)
+#C=cbind(C, t)
+write(C, $7, format="binary")


### PR DESCRIPTION
This patch implements the nary append operation for frames (cbind and rbind). For the cbind, there are two physical implementation:
- map-size cbind (w/ broadcast)
- reduce-size cbind
I added test cases to check the functionality of the n-ary operators and I also enabled the Word-Error-Rate test case.

Additionally, this patch fixes the map-size cbind operation to handle misaligned frameblocks.
As discussed, I will make another PR for the misalignment fix of the other physical operator 