### PR TITLE
 [SYSTEMDS-3529] codecov badge + PyPI downloads badge 

### DIFF
--- a/.github/workflows/javaTests.yml
+++ b/.github/workflows/javaTests.yml
@@ -146,6 +146,14 @@ jobs:
     - name: Generate Code Coverage Report
       run: mvn jacoco:report
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        fail_ci_if_error: false
+        files: target/site/jacoco/jacoco.xml
+
     - name: Upload Jacoco Report Artifact PR
       if: (github.repository_owner == 'apache') && (github.ref_name != 'main')
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -44,4 +44,7 @@ To build from source visit [SystemDS Install from source](https://apache.github.
 [![Documentation](https://github.com/apache/systemds/actions/workflows/documentation.yml/badge.svg?branch=main)](https://github.com/apache/systemds/actions/workflows/documentation.yml)
 [![LicenseCheck](https://github.com/apache/systemds/actions/workflows/license.yml/badge.svg?branch=main)](https://github.com/apache/systemds/actions/workflows/license.yml)
 [![Java Tests](https://github.com/apache/systemds/actions/workflows/javaTests.yml/badge.svg?branch=main)](https://github.com/apache/systemds/actions/workflows/javaTests.yml)
+[![codecov](https://codecov.io/gh/evelina-gudauskayte/systemds/graph/badge.svg?token=DK8Z2AP5FV)](https://codecov.io/gh/evelina-gudauskayte/systemds)
 [![Python Test](https://github.com/apache/systemds/actions/workflows/python.yml/badge.svg?branch=main)](https://github.com/apache/systemds/actions/workflows/python.yml)
+[![Total PyPI downloads](https://static.pepy.tech/personalized-badge/systemds?units=abbreviation&period=total&left_color=grey&right_color=blue&left_text=Total%20PyPI%20Downloads)](https://pepy.tech/project/systemds)
+[![Monthly PyPI downloads](https://static.pepy.tech/personalized-badge/systemds?units=abbreviation&left_color=grey&right_color=blue&left_text=Monthly%20PyPI%20Downloads)](https://pepy.tech/project/systemds)


### PR DESCRIPTION
# [SYSTEMDS-3529](https://issues.apache.org/jira/browse/SYSTEMDS-3529)
The task was to add to the repository two badges:
1. PyPI downloads badge to show actual usage of the python API of systems and motivate people to contribute to the project.
2. Code coverage badge for test coverage transparency

# PyPI badge
I decided to include two separate badges to indicate download activity:

* **Downloads in the last month:** This badge highlights the project's current usage by showing recent downloads.
* **Total downloads:** This badge showcases the project's overall popularity with a potentially impressive number.

Another consideration was clarifying that the badges specifically refer to PyPI downloads, since systemd can be installed through various methods. To avoid misleading users, the badge text explicitly mentions 'PyPI downloads'.

I evaluated several methods for adding the PyPI download badges to the repository and chose the one that fits the best.

### [shields.io pypi badge](https://shields.io/badges/py-pi-downloads)
![PyPI - Downloads](https://img.shields.io/pypi/dm/systemds?label=PyPI%20downloads)
✅ Simple REST API to access the badge
✅ Reach customization options
✅ Static badge, no need for ci/cd pipeline to update it
✅ Direct REST API to get the badge
✅ [Open source project](https://github.com/badges/shields)
✅ Does let you to change the text on the left side of the badge
❌ **Can show downloads for last month/week/day, cannot show total downloads**

Shields.io uses another API to actually get the value of downloads → it serves as a wrapper. 

I still needed the total number of badges, so I decided to take a look at the API that is used inside of shields.io badge in case it has more functionality than shields.io shows

### [PyPi stats API](https://pypistats.org/packages/systemds)

✅ Simple REST API to access the data
✅ Reach customization options
✅ [Open source project](https://github.com/crflynn/pypistats.org)
❌ No API to retrieve the badge, only shields.io is available 
❌ **Can show downloads for last month/week/day, cannot show total downloads**

PyPi stats API does not allow getting total downloads, therefore I did not want to use it.  

### [Pepy.tech](https://www.pepy.tech/projects/systemds)

[![Total PyPI downloads](https://static.pepy.tech/personalized-badge/systemds?units=abbreviation&period=total&left_color=grey&right_color=blue&left_text=Total%20PyPI%20Downloads)](https://pepy.tech/project/systemds) [![Monthly PyPI downloads](https://static.pepy.tech/personalized-badge/systemds?units=abbreviation&left_color=grey&right_color=blue&left_text=Monthly%20PyPI%20Downloads)](https://pepy.tech/project/systemds)

✅ Simple REST API to access the data
✅ Reach customization options
✅ Static badge, no need for ci/cd pipeline to update it
✅ [Open source project](https://github.com/psincraian/pepy/tree/master)
✅ Does let you change the text on the left side of the badge
✅ Direct REST API to get the badge
✅ Can show total and monthly PyPI downloads

This solution showed itself the best, as the API allows me to create two badges that I was looking for. The only downside is that `personalized-badge` API is not well documented, and I had to read some of the source code to understand which customization options I actually had.  

I decided to stay with the default gray and blue badge, as I think it nicely contrasts with other badges and hints that this data is about python.

[This comment](https://github.com/badges/shields/issues/4319#issuecomment-1682919057) helped me find different solutions and understand different ways to count the downloads. 


# Codecov badge

For test coverage badge, I looked at how apache spark created their [badge](https://github.com/apache/spark/blob/master/README.md?plain=1#L13) and decided to try replicating the approach. 

### How to codecov?
1. You need to log in to [codecov webside ](https://app.codecov.io/login) using the github account that has access to systemds repository
2. Find systemds in the list of repositories on the website and click `Configure`
3. You should be met with a page like that: 
![image](https://github.com/apache/systemds/assets/33724450/70608ec3-2375-473a-b9e4-c1fe96b06032)
4. Set given token in projects `Settings` → `Secrets and Variables` → `Actions`
5. Trigger the [CI/CD pipeline](https://github.com/apache/systemds/actions/workflows/javaTests.yml) that runs the Java tests for systemds. 
6. After successful pipeline runs, Codecov will collect and display your code coverage data on a page like this: https://app.codecov.io/gh/*_your_username_*/systemds
7. Go to the settings page for the systemds repository on Codecov (link provided in previous step). Find and copy the badge link (image provided might be helpful).
![image](https://github.com/apache/systemds/assets/33724450/9aaf07c7-fef5-4042-bd75-3802b3c73f72)
8. Change the link in README.md 
9. 🎉🎉🎉 Done! You've successfully configured the Codecov badge for your systemds repository!

### Warnings! Read before merging ⚠️ ⚠️ ⚠️ 

Currently, the badge might show unknown instead of percent of test coverage as it looks into the main branch of my forked repository. 
[![codecov](https://codecov.io/github/evelina-gudauskayte/systemds/branch/main/graph/badge.svg?token=DK8Z2AP5FV)](https://codecov.io/github/evelina-gudauskayte/systemds)
This is how it should look like, but this badge is configured to my draft feature branch in fork, instead of original main repo as I do not have such access.
[![codecov](https://codecov.io/github/evelina-gudauskayte/systemds/branch/SYSTEMDS-3529_Code-coverage_PyPI_downloads_draft/graph/badge.svg?token=DK8Z2AP5FV)](https://codecov.io/github/evelina-gudauskayte/systemds)

**You have to reconfigure the badge before the merge! Current state is not intended to be in the main branch of systemds.** 
