### PR TITLE
[SYSTEMDS-3704] Add new tests to ILinearizeTest

### DIFF
--- a/src/test/java/org/apache/sysds/test/functions/linearization/ILinearizeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/linearization/ILinearizeTest.java
@@ -1,32 +1,35 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.sysds.test.functions.linearization;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Arrays;
 
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
@@ -46,32 +49,48 @@ import org.apache.sysds.lops.Data;
 
 public class ILinearizeTest extends AutomatedTestBase {
 
-	private final String testDir = "functions/linearization/";
-	private final String configFile = "SystemDS-config-pipeline-depth-first.xml";
+	private final static String TEST_DIR = "functions/linearization/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + ILinearizeTest.class.getSimpleName() + "/";
+	private final static String TEST_NAME = "LinearizationTest";
+	private static String CONF_FILE = "";
 
-	private String getConfPath() {
-		return SCRIPT_DIR + "/" + testDir + configFile;
+	enum Config {
+		BREADTH_FIRST("SystemDS-config-breadth-first.xml"),
+		DEPTH_FIRST("SystemDS-config-depth-first.xml"),
+		MIN_INTERMEDIATE("SystemDS-config-min-intermediate.xml"),
+		MAX_PARALLELIZE("SystemDS-config-max-parallelize.xml"),
+		PIPELINE_DEPTH_FIRST("SystemDS-config-pipeline-depth-first.xml");
+
+		public final String filePath;
+
+		Config(String filePath) {
+			this.filePath = filePath;
+		}
+	}
+
+	private String getConfPath(Config config) {
+		return SCRIPT_DIR + TEST_DIR + config.filePath;
 	}
 
 	@Override
 	public void setUp() {
 		setOutputBuffering(true);
-		disableConfigFile = true;
 		TestUtils.clearAssertionInformation();
-		addTestConfiguration("test", new TestConfiguration(testDir, "test"));
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
 	}
 
 	@Test
 	public void testLinearize_Pipeline() {
 
 		try {
-			DMLConfig dmlconf = DMLConfig.readConfigurationFile(getConfPath());
+			DMLConfig dmlconf = DMLConfig.readConfigurationFile(getConfPath(Config.PIPELINE_DEPTH_FIRST));
 			ConfigurationManager.setGlobalConfig(dmlconf);
 			System.out.print(ConfigurationManager.getLinearizationOrder());
-		} catch (Exception e) {
+		}
+		catch(Exception e) {
 			e.printStackTrace();
 		}
-		
+
 		// Set up Test example
 		// For testing we don't build a runnable programm
 		// We only want to know, whether the assignement of pipeline ids work as intended
@@ -95,7 +114,7 @@ public class ILinearizeTest extends AutomatedTestBase {
 		//		y3  |
 		//		 \ /
 		//		 y6
-		
+
 		List<Lop> lops = new ArrayList<>();
 		// Dummy inputs for filling the inputs of the lops
 		// Needed for the constructors
@@ -114,7 +133,7 @@ public class ILinearizeTest extends AutomatedTestBase {
 		lops.add(n3);
 		lops.add(n4);
 		lops.add(n5);
-		
+
 		// First pipeline (after step 1)
 		Lop o1 = new BinaryScalar(d1, d2, OpOp2.PLUS, DataType.SCALAR, ValueType.INT32);
 		Lop o2 = new BinaryScalar(o1, d2, OpOp2.PLUS, DataType.SCALAR, ValueType.INT32);
@@ -146,12 +165,15 @@ public class ILinearizeTest extends AutomatedTestBase {
 		lops.add(y5);
 
 		// Remove dummy inputs
-		lops.forEach(l -> {l.getInputs().remove(d1); l.getInputs().remove(d2);});
+		lops.forEach(l -> {
+			l.getInputs().remove(d1);
+			l.getInputs().remove(d2);
+		});
 
 		// RUN LINEARIZATION
 		IDagLinearizer dl = IDagLinearizerFactory.createDagLinearizer();
 		dl.linearize(lops); //TODO results
-		
+
 		// Set up expected pipelines
 		Map<Integer, List<Lop>> pipelineMap = new HashMap<>();
 		pipelineMap.put(4, Arrays.asList(n1, n2, n3, n4, n5, o1, o2));
@@ -159,8 +181,64 @@ public class ILinearizeTest extends AutomatedTestBase {
 		pipelineMap.put(5, Arrays.asList(y1, y2, y3, y4, y5));
 
 		// Check if all lops are in the correct pipeline
-		pipelineMap.get(4).forEach(l -> {if (l.getPipelineID() != 4) fail("Pipeline ID not set correctly");});
-		pipelineMap.get(3).forEach(l -> {if (l.getPipelineID() != 3) fail("Pipeline ID not set correctly");});
-		pipelineMap.get(5).forEach(l -> {if (l.getPipelineID() != 5) fail("Pipeline ID not set correctly");});
+		pipelineMap.get(4).forEach(l -> {
+			if(l.getPipelineID() != 4)
+				fail("Pipeline ID not set correctly");
+		});
+		pipelineMap.get(3).forEach(l -> {
+			if(l.getPipelineID() != 3)
+				fail("Pipeline ID not set correctly");
+		});
+		pipelineMap.get(5).forEach(l -> {
+			if(l.getPipelineID() != 5)
+				fail("Pipeline ID not set correctly");
+		});
+	}
+
+	@Test
+	public void testBreadthFirstLinearization() {
+		runLinearizationTest(Config.BREADTH_FIRST);
+	}
+
+	@Test
+	public void testDepthFirstLinearization() {
+		runLinearizationTest(Config.DEPTH_FIRST);
+	}
+
+	@Test
+	public void testMinIntermediateLinearization() {
+		runLinearizationTest(Config.MIN_INTERMEDIATE);
+	}
+
+	private void runLinearizationTest(Config config) {
+		//load config
+		CONF_FILE = getConfPath(config);
+
+		TestConfiguration testConfiguration = getTestConfiguration(TEST_NAME);
+		loadTestConfiguration(testConfiguration);
+
+		//generate paths and commands
+		String HOME = SCRIPT_DIR + TEST_DIR;
+		fullDMLScriptName = HOME + TEST_NAME + ".dml";
+		programArgs = new String[] {"-args", output("R")};
+		fullRScriptName = HOME + TEST_NAME + ".R";
+		rCmd = "Rscript" + " " + fullRScriptName + " " + expectedDir();
+
+		//run test
+		runTest(true, false, null, -1);
+		runRScript(true);
+
+		//check that the correct linearization order is used
+		assertEquals(config.toString(), ConfigurationManager.getLinearizationOrder().toString());
+
+		//compare matrices
+		HashMap<MatrixValue.CellIndex, Double> dmlFile = readDMLMatrixFromOutputDir("R");
+		HashMap<MatrixValue.CellIndex, Double> rFile = readRMatrixFromExpectedDir("R");
+		TestUtils.compareMatrices(dmlFile, rFile, 0, "Stat-DML", "Stat-R");
+	}
+
+	@Override
+	protected File getConfigTemplateFile() {
+		return new File(CONF_FILE);
 	}
 }

--- a/src/test/scripts/functions/linearization/LinearizationTest.R
+++ b/src/test/scripts/functions/linearization/LinearizationTest.R
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+args <- commandArgs(TRUE)
+options(digits=22)
+library("Matrix")
+
+A = matrix(1, nrow=10, ncol=2);
+B = matrix(2, nrow=2, ncol=1);
+C = matrix(3, nrow=10, ncol=10);
+D = matrix(4, nrow=10, ncol=10);
+E = matrix(5, nrow=10, ncol=20);
+F = matrix(6, nrow=20, ncol=1);
+
+RESULT = t(A %*% B) %*% C %*% D %*% (E %*% F);
+
+writeMM(as(RESULT, "CsparseMatrix"), paste(args[1], "R", sep=""));

--- a/src/test/scripts/functions/linearization/LinearizationTest.dml
+++ b/src/test/scripts/functions/linearization/LinearizationTest.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+A = matrix(1, rows=10, cols=2);
+B = matrix(2, rows=2, cols=1);
+C = matrix(3, rows=10, cols=10);
+D = matrix(4, rows=10, cols=10);
+E = matrix(5, rows=10, cols=20);
+F = matrix(6, rows=20, cols=1);
+
+RESULT = t(A %*% B) %*% C %*% D %*% (E %*% F);
+
+write(RESULT, $1);


### PR DESCRIPTION
This pull request adds new tests to ILinearizeTest.
Each new test loads a different config file with a linearization order. The tests check that the linearization order is set correctly in the configuration of SystemDS. They also run a .dml file and compare the output with the output of an equivalent RScript file.


cc @mboehm7 