### PR TITLE
[SYSTEMDS-2951] Multi-GPU Support for End-to-End ML Pipelines

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -22,8 +22,8 @@ package org.apache.sysds.runtime.controlprogram.caching;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -214,7 +214,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 	//for lazily evaluated RDDs, and (2) as abstraction for environments that do not necessarily have spark libraries available
 	private RDDObject _rddHandle = null; //RDD handle
 	private BroadcastObject<T> _bcHandle = null; //Broadcast handle
-	protected HashMap<GPUContext, GPUObject> _gpuObjects = null; //Per GPUContext object allocated on GPU
+	protected ConcurrentHashMap<GPUContext, GPUObject> _gpuObjects = null; //Per GPUContext object allocated on GPU
 
 	private LineageItem _lineage = null;
 	
@@ -229,7 +229,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 		_uniqueID = _seq.getNextID();
 		_cacheStatus = CacheStatus.EMPTY;
 		_numReadThreads = 0;
-		_gpuObjects = DMLScript.USE_ACCELERATOR ? new HashMap<>() : null;
+		_gpuObjects = DMLScript.USE_ACCELERATOR ? new ConcurrentHashMap<>() : null;
 	}
 	
 	/**
@@ -472,7 +472,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 
 	public synchronized void setGPUObject(GPUContext gCtx, GPUObject gObj) {
 		if( _gpuObjects == null )
-			_gpuObjects = new HashMap<>();
+			_gpuObjects = new ConcurrentHashMap<>();
 		GPUObject old = _gpuObjects.put(gCtx, gObj);
 		if (old != null)
 				throw new DMLRuntimeException("GPU : Inconsistent internal state - this CacheableData already has a GPUObject assigned to the current GPUContext (" + gCtx + ")");


### PR DESCRIPTION
## Main Updated:

1. Fixed a bug that while using multi-GPU with CUDA caused a "CurrentModificationException" error in `ParForProgramBlock`, where the GPU memory is modified during the process of freeing. Multi-GPU can now be used to accerate the `parfor` function and other functions using multiple workers and threads.
2. The mismatch between `_numThreads` and the actual number of threads is resolved when using multiple GPUs device but only allowing a single GPU (`sysds.gpu.availableGPUs=1`) to run `parfor` functions with multiple workers and multiple threads.

## Other bugs in Multi-GPU process:

1. In a multi-GPU environment, when initializing the first instance of `GPUContext` for `cudnnHandle`, `cublasHandle`, and `cusparseHandle` in Jcuda version `10.2.0`, the Native code freezes when executing into Jcuda code. The program cannot continue. This error can easily happen in the test environment of "4070+1080" dual graphics card environment, but sometimes it works fine. This bug is not present in Jcuda version `11.8.0`. This is presumed to be a Jcuda issue and cannot be fixed by SystemDS. 

## Other bugs outside Multi-GPU process we found:

1. Example script `scripts/nn/examples/AttentionExample.dml` can not be runned with even one GPU. Error message is `RuntimeException -- Unsupported operator:MAP`. We found that a function (with a high probability that it is the `map` function) passes an operator `_map` to `TernaryOp` class where it is not categorized by a GPU operation.

## TODO List:

1. We'll write a test class to detect whether multi-gpu in `parfor` is actually being implemented.
2. We'll try to fix or work around the multi-GPU run Handle initialization freeze issue.