### PR TITLE
Add hash2 as fourth method for raJoin

### DIFF
--- a/scripts/builtin/raJoin.dml
+++ b/scripts/builtin/raJoin.dml
@@ -28,7 +28,7 @@
 # colA      Integer indicating the column index of matrix A to execute inner join command
 # B         Matrix of right left data [shape: N x M]
 # colA      Integer indicating the column index of matrix B to execute inner join command
-# method    Join implementation method (nested-loop, sort-merge, hash)
+# method    Join implementation method (nested-loop, sort-merge, hash, hash2)
 # ------------------------------------------------------------------------------
 #
 # OUTPUT:
@@ -142,6 +142,79 @@ m_raJoin = function (Matrix[Double] A, Integer colA, Matrix[Double] B,
 
     # Select left rows and concatenate right rows
     Y = cbind(P1 %*% A, B);
+  }
+  else if ( method == "hash2" ) {
+    # Get join key columns
+    left = A[,colA]
+    right = B [,colB]
+
+    # Compute indexes and hash values
+    leftIdx = seq(1, nrow(A))
+    rightIdx = seq(1, nrow(B))
+    m = max(max(left),max(right)) + 1; # Assuming a large hash table size
+    leftHash = left %% m
+    rightHash = right %% m
+
+    # Build histogram of hash values for left join keys
+    hashBincount = table( leftHash, 1, max(leftHash), 1 )
+
+    #Initialize output indexes
+    leftOutIdx = matrix(0,0,1)
+    rightOutIdx = matrix(0,0,1)
+
+    # Check for one-to-many
+    if( max(hashBincount) > 1 )
+      stop("Hash join implementation only supports one-to-many joins: "+toString(hashBincount))
+
+    # Build and probe hash table
+    # Initialize hash table
+    hashTable=matrix(0,m,1)
+
+    # Create a select or matrix and use matrix multiplication to place values
+    hashTable = t(table(seq(1,nrow(leftIdx)), leftHash, nrow(leftIdx), nrow(hashTable))) %*% leftIdx
+
+    # Update lefHash to skip scattered values for future iterations by setting their hashes to m
+    leftIdxSct = removeEmpty(target=seq(1,nrow(hashTable)), margin="rows", select=(hashTable>=1))
+    selectedMatrix = table(seq(1, nrow(leftIdxSct)), leftIdxSct, nrow(leftIdxSct), nrow(hashTable))
+    leftHash = t(selectedMatrix) %*% matrix(m, rows=nrow(leftIdxSct), cols=1, byrow=TRUE)
+
+    #Probe hash table and get the left and right indexes
+    validLeftIdx = matrix(0,0,1)
+    validRightIdx = matrix(0,0,1)
+
+    lefCandIdx = table(seq(1, nrow(rightHash)), rightHash, nrow(rightHash), nrow(hashTable)) %*% hashTable
+    validKeyMask = (lefCandIdx>0)
+
+    # Check if non matching
+    if( as.scalar(colSums(validKeyMask)) > 0 ){
+      validLeftIdx = removeEmpty(target=lefCandIdx, margin="rows", select=validKeyMask)
+      validRightIdx = removeEmpty(target=rightIdx, margin="rows", select=validKeyMask)
+
+      # Find matching join keys
+      selectedValidLeftIdx = table(seq(1,nrow(validLeftIdx)), validLeftIdx, nrow(validLeftIdx), nrow(left)) %*% left
+      selectedValidRightIdx = table(seq(1,nrow(validRightIdx)), validRightIdx, nrow(validRightIdx), cols=nrow(right)) %*% right
+
+      matchMask = ( selectedValidLeftIdx == selectedValidRightIdx )
+      if ( as.scalar(colSums(matchMask[,1])) > 0) {
+        leftMatchIdx = removeEmpty(target=validLeftIdx, margin="rows", select=matchMask)
+        rightMatchIdx = removeEmpty(target=validRightIdx, margin="rows", select=matchMask)
+
+        #Append indexes to global results
+        leftOutIdx = rbind(leftOutIdx, removeEmpty(target=leftMatchIdx, margin="rows"))
+        rightOutIdx = rbind(rightOutIdx, removeEmpty(target=rightMatchIdx, margin="rows"))
+      }
+    }
+
+    # Create output
+    if ( nrow(leftOutIdx) == 0 | nrow(rightOutIdx) == 0 ) {
+      Y = matrix(0, rows=0, cols=1)
+    }
+    else {
+      Y = matrix(0, rows=nrow(leftOutIdx), cols=ncol(A)+ncol(B))
+      for( j in 1:nrow(leftOutIdx) ) {
+        Y[j, ] = cbind( A[as.scalar(leftOutIdx[j]), ], B[as.scalar(rightOutIdx[j]), ] )
+      }
+    }
   }
 }
 

--- a/scripts/builtin/raJoin.dml
+++ b/scripts/builtin/raJoin.dml
@@ -59,6 +59,7 @@ m_raJoin = function (Matrix[Double] A, Integer colA, Matrix[Double] B,
       }
     }
   }
+  # The sort-merge method is from original paper: Qery Processing on Tensor Computation Runtime, section 5-2
   else if (method == "sort-merge") {
     # get join key columns
     left = A[, colA]
@@ -143,6 +144,7 @@ m_raJoin = function (Matrix[Double] A, Integer colA, Matrix[Double] B,
     # Select left rows and concatenate right rows
     Y = cbind(P1 %*% A, B);
   }
+  # The hash2 method is from the original paper: Qery Processing on Tensor Computation Runtime, section 5-3
   else if ( method == "hash2" ) {
     # Get join key columns
     left = A[,colA]
@@ -152,6 +154,7 @@ m_raJoin = function (Matrix[Double] A, Integer colA, Matrix[Double] B,
     leftIdx = seq(1, nrow(A))
     rightIdx = seq(1, nrow(B))
     m = max(max(left),max(right)) + 1; # Assuming a large hash table size
+    #m = 100
     leftHash = left %% m
     rightHash = right %% m
 

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinRaJoinTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinRaJoinTest.java
@@ -60,6 +60,10 @@ public class BuiltinRaJoinTest extends AutomatedTestBase
 	public void testRaJoinTestwithDifferentColumn2() {
 		testRaJoinTestwithDifferentColumn("sort-merge");
 	}
+	@Test
+	public void testRaJoinTestwithDifferentColumn3() {
+		testRaJoinTestwithDifferentColumn("hash2");
+	}
 	
 	@Test
 	public void testRaJoinTestwithDifferentColumn21() {
@@ -70,6 +74,10 @@ public class BuiltinRaJoinTest extends AutomatedTestBase
 	public void testRaJoinTestwithDifferentColumn22() {
 		testRaJoinTestwithDifferentColumn2("sort-merge");
 	}
+	@Test
+	public void testRaJoinTestwithDifferentColumn23() {
+		testRaJoinTestwithDifferentColumn2("hash2");
+	}
 	
 	@Test
 	public void testRaJoinTestwithNoMatchingRows1() {
@@ -79,6 +87,11 @@ public class BuiltinRaJoinTest extends AutomatedTestBase
 	@Test
 	public void testRaJoinTestwithNoMatchingRows2() {
 		testRaJoinTestwithNoMatchingRows("sort-merge");
+	}
+
+	@Test
+	public void testRaJoinTestwithNoMatchingRows3() {
+		testRaJoinTestwithNoMatchingRows("hash2");
 	}
 	
 	@Test
@@ -95,6 +108,11 @@ public class BuiltinRaJoinTest extends AutomatedTestBase
 	public void testRaJoinTestwithAllMatchingRows3() {
 		testRaJoinTestwithAllMatchingRows("hash");
 	}
+
+	@Test
+	public void testRaJoinTestwithAllMatchingRows4() {
+		testRaJoinTestwithAllMatchingRows("hash2");
+	}
 	
 	@Test
 	public void testRaJoinTestwithOneToMany1() {
@@ -109,6 +127,11 @@ public class BuiltinRaJoinTest extends AutomatedTestBase
 	@Test
 	public void testRaJoinTestwithOneToMany3() {
 		testRaJoinTestwithOneToMany("hash");
+	}
+
+	@Test
+	public void testRaJoinTestwithOneToMany4() {
+		testRaJoinTestwithOneToMany("hash2");
 	}
 	
 	


### PR DESCRIPTION
In this pull request, I implemented hash2 as the fourth method for raJoin according to the original paper's function, which performs the join without sort or loop-based concatenation but currently only supports one-to-many, one-to-one, non matching joins. (The primary key of the left table needs to be unique)
Unfortunately, because I haven't resolved the issue that occurred in the hash collision at this time, so I made the hash table size larger than the largest number between two tables temporarily to avoid any hash collision.
m = max(max(left),max(right)) + 1;