### PR TITLE
N-Gram statistics using lineage

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLOptions.java
+++ b/src/main/java/org/apache/sysds/api/DMLOptions.java
@@ -57,6 +57,7 @@ public class DMLOptions {
 	public int                  statsCount    = 10;               // Default statistics count
 	public int[]                statsNGramSizes = { 3 };          // Default n-gram tuple sizes
 	public int                  statsTopKNGrams = 10;             // How many of the most heavy hitting n-grams are displayed
+	public boolean              statsNGramsUseLineage = true;     // If N-Grams use lineage for data-dependent tracking
 	public boolean              fedStats      = false;            // Whether to record and print the federated statistics
 	public int                  fedStatsCount = 10;               // Default federated statistics count
 	public boolean              memStats      = false;            // max memory statistics
@@ -219,7 +220,7 @@ public class DMLOptions {
 		dmlOptions.statsNGrams = line.hasOption("ngrams");
 		if (dmlOptions.statsNGrams){
 			String[] nGramArgs = line.getOptionValues("ngrams");
-			if (nGramArgs.length == 2) {
+			if (nGramArgs.length >= 2) {
 				try {
 					String[] nGramSizeSplit = nGramArgs[0].split(",");
 					dmlOptions.statsNGramSizes = new int[nGramSizeSplit.length];
@@ -229,9 +230,17 @@ public class DMLOptions {
 					}
 
 					dmlOptions.statsTopKNGrams = Integer.parseInt(nGramArgs[1]);
+
+					if (nGramArgs.length == 3) {
+						dmlOptions.statsNGramsUseLineage = Boolean.parseBoolean(nGramArgs[2]);
+					}
 				} catch (NumberFormatException e) {
 					throw new org.apache.commons.cli.ParseException("Invalid argument specified for -ngrams option, must be a valid integer");
 				}
+			}
+
+			if (dmlOptions.statsNGramsUseLineage) {
+				dmlOptions.lineage = true;
 			}
 		}
 

--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -104,6 +104,8 @@ public class DMLScript
 	public static int[]         STATISTICS_NGRAM_SIZES   = DMLOptions.defaultOptions.statsNGramSizes;
 	// Set top k displayed n-grams limit
 	public static int         STATISTICS_TOP_K_NGRAMS    = DMLOptions.defaultOptions.statsTopKNGrams;
+	// Set if N-Grams use lineage for data-dependent tracking
+	public static boolean     STATISTICS_NGRAMS_USE_LINEAGE = DMLOptions.defaultOptions.statsNGramsUseLineage;
 	// Set statistics maximum wrap length
 	public static int         STATISTICS_MAX_WRAP_LEN    = 30;
 	// Enable/disable to print federated statistics

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
@@ -267,18 +267,21 @@ public abstract class ProgramBlock implements ParseInfo {
 				}
 
 				if (DMLScript.STATISTICS_NGRAMS) {
+					final long nanoTime = System.nanoTime() - t0;
 					if (DMLScript.STATISTICS_NGRAMS_USE_LINEAGE) {
 						Statistics.getCurrentLineageItem().ifPresent(li -> {
 							Data data = ec.getVariable(li.getKey());
+							Statistics.LineageNGramExtension ext = new Statistics.LineageNGramExtension();
 							if (data != null) {
-								li.getValue().setDataType(data.getDataType().toString());
-								li.getValue().setValueType(data.getValueType().toString());
+								ext.setDataType(data.getDataType().toString());
+								ext.setValueType(data.getValueType().toString());
 							}
-							li.getValue().setExecNanos(System.nanoTime() - t0);
+							ext.setExecNanos(nanoTime);
+							Statistics.extendLineageItem(li.getValue(), ext);
 							Statistics.maintainNGramsFromLineage(li.getValue());
 						});
 					} else
-						Statistics.maintainNGrams(tmp.getExtendedOpcode(), System.nanoTime() - t0);
+						Statistics.maintainNGrams(tmp.getExtendedOpcode(), nanoTime);
 				}
 			}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
@@ -275,6 +275,12 @@ public abstract class ProgramBlock implements ParseInfo {
 							if (data != null) {
 								ext.setDataType(data.getDataType().toString());
 								ext.setValueType(data.getValueType().toString());
+								if (data instanceof MatrixObject) {
+									MatrixObject m = (MatrixObject)data;
+									ext.setMeta("NumRows", (double)m.getNumRows());
+									ext.setMeta("NumCols", (double)m.getNumColumns());
+									ext.setMeta("NNZ", (double)m.getNnz());
+								}
 							}
 							ext.setExecNanos(nanoTime);
 							Statistics.extendLineageItem(li.getValue(), ext);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
@@ -280,7 +280,7 @@ public abstract class ProgramBlock implements ParseInfo {
 								ext.setValueType(data.getValueType().toString());
 								if (data instanceof CacheableData) {
 									DataCharacteristics dc = ((CacheableData)data).getDataCharacteristics();
-									ext.setMeta("NDims:", (double)dc.getNumDims());
+									ext.setMeta("NDims", (double)dc.getNumDims());
 									ext.setMeta("NumRows", (double)dc.getRows());
 									ext.setMeta("NumCols", (double)dc.getCols());
 									ext.setMeta("NonZeros", (double)dc.getNonZeros());

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/ProgramBlock.java
@@ -19,6 +19,7 @@
 package org.apache.sysds.runtime.controlprogram;
 
 import java.util.ArrayList;
+import java.util.stream.LongStream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -37,6 +38,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.DMLScriptException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysds.runtime.controlprogram.caching.FrameObject;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -53,6 +55,7 @@ import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MetaData;
 import org.apache.sysds.runtime.meta.MetaDataFormat;
 import org.apache.sysds.utils.stats.RecompileStatistics;
@@ -275,11 +278,12 @@ public abstract class ProgramBlock implements ParseInfo {
 							if (data != null) {
 								ext.setDataType(data.getDataType().toString());
 								ext.setValueType(data.getValueType().toString());
-								if (data instanceof MatrixObject) {
-									MatrixObject m = (MatrixObject)data;
-									ext.setMeta("NumRows", (double)m.getNumRows());
-									ext.setMeta("NumCols", (double)m.getNumColumns());
-									ext.setMeta("NNZ", (double)m.getNnz());
+								if (data instanceof CacheableData) {
+									DataCharacteristics dc = ((CacheableData)data).getDataCharacteristics();
+									ext.setMeta("NDims:", (double)dc.getNumDims());
+									ext.setMeta("NumRows", (double)dc.getRows());
+									ext.setMeta("NumCols", (double)dc.getCols());
+									ext.setMeta("NonZeros", (double)dc.getNonZeros());
 								}
 							}
 							ext.setExecNanos(nanoTime);

--- a/src/main/java/org/apache/sysds/runtime/instructions/Instruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/Instruction.java
@@ -26,6 +26,7 @@ import org.apache.sysds.lops.Lop;
 import org.apache.sysds.parser.DataIdentifier;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.matrix.operators.Operator;
+import org.apache.sysds.utils.Statistics;
 
 public abstract class Instruction 
 {
@@ -214,6 +215,8 @@ public abstract class Instruction
 	 * @return instruction
 	 */
 	public Instruction preprocessInstruction(ExecutionContext ec) {
+		if (DMLScript.STATISTICS_NGRAMS && DMLScript.STATISTICS_NGRAMS_USE_LINEAGE)
+			Statistics.prepareNGramInst(null); // Reset the current LineageItem for this thread
 		// Lineage tracing
 		if (DMLScript.LINEAGE)
 			ec.traceLineage(this);

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
@@ -36,6 +36,9 @@ public class LineageItem {
 	private final long _id;
 	private final String _opcode;
 	private final String _data;
+	private String _datatype;
+	private String _valuetype;
+	private long _execNanos;
 	private LineageItem[] _inputs;
 	private long _height = 0; //distance leaf to node
 	private int _hash = 0;
@@ -202,6 +205,30 @@ public class LineageItem {
 			return LineageItemType.Instruction;
 		else
 			throw new DMLRuntimeException("An inner node could not be a literal!");
+	}
+
+	public void setDataType(String dataType) {
+		_datatype = dataType;
+	}
+
+	public String getDataType() {
+		return _datatype == null ? "" : _datatype;
+	}
+
+	public void setValueType(String valueType) {
+		_valuetype = valueType;
+	}
+
+	public String getValueType() {
+		return _valuetype == null ? "" : _valuetype;
+	}
+
+	public void setExecNanos(long nanos) {
+		_execNanos = nanos;
+	}
+
+	public long getExecNanos() {
+		return _execNanos;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItem.java
@@ -36,9 +36,6 @@ public class LineageItem {
 	private final long _id;
 	private final String _opcode;
 	private final String _data;
-	private String _datatype;
-	private String _valuetype;
-	private long _execNanos;
 	private LineageItem[] _inputs;
 	private long _height = 0; //distance leaf to node
 	private int _hash = 0;
@@ -205,30 +202,6 @@ public class LineageItem {
 			return LineageItemType.Instruction;
 		else
 			throw new DMLRuntimeException("An inner node could not be a literal!");
-	}
-
-	public void setDataType(String dataType) {
-		_datatype = dataType;
-	}
-
-	public String getDataType() {
-		return _datatype == null ? "" : _datatype;
-	}
-
-	public void setValueType(String valueType) {
-		_valuetype = valueType;
-	}
-
-	public String getValueType() {
-		return _valuetype == null ? "" : _valuetype;
-	}
-
-	public void setExecNanos(long nanos) {
-		_execNanos = nanos;
-	}
-
-	public long getExecNanos() {
-		return _execNanos;
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
@@ -124,6 +124,44 @@ public class LineageItemUtils {
 	public static boolean isFunctionDebugging () {
 		return FUNCTION_DEBUGGING;
 	}
+
+	public static String explainLineageType(LineageItem li) {
+		if (li.getType() == LineageItemType.Literal) {
+			String[] splt = li.getData().split("·");
+			if (splt.length >= 3)
+				return splt[1] + "·" + splt[2];
+			return "·";
+		}
+		return li.getDataType() + "·" + li.getValueType();
+	}
+
+	public static String explainLineageWithTypes(LineageItem li) {
+		if (li.getType() == LineageItemType.Literal) {
+			String[] splt = li.getData().split("·");
+			if (splt.length >= 3)
+				return "L·" + splt[1] + "·" + splt[2];
+			return "L··";
+		}
+		return li.getOpcode() + "·" + li.getDataType() + "·" + li.getValueType();
+	}
+
+	public static String explainLineageAsInstruction(LineageItem li) {
+		StringBuilder sb = new StringBuilder(explainLineageWithTypes(li));
+		sb.append("(");
+		if (li.getInputs() != null) {
+			int ctr = 0;
+			for (LineageItem liIn : li.getInputs()) {
+				if (ctr++ != 0)
+					sb.append(" ° ");
+				if (liIn.getType() == LineageItemType.Literal)
+					sb.append("L_" + explainLineageType(liIn));
+				else
+					sb.append(explainLineageType(liIn));
+			}
+		}
+		sb.append(")");
+		return sb.toString();
+	}
 	
 	public static String explainSingleLineageItem(LineageItem li) {
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
@@ -133,7 +133,7 @@ public class LineageItemUtils {
 				return splt[1] + "·" + splt[2];
 			return "·";
 		}
-		return ext.getDataType() + "·" + ext.getValueType();
+		return ext != null ? ext.getDataType() + "·" + ext.getValueType() : "··";
 	}
 
 	public static String explainLineageWithTypes(LineageItem li, Statistics.LineageNGramExtension ext) {
@@ -143,7 +143,7 @@ public class LineageItemUtils {
 				return "L·" + splt[1] + "·" + splt[2];
 			return "L··";
 		}
-		return li.getOpcode() + "·" + ext.getDataType() + "·" + ext.getValueType();
+		return li.getOpcode() + "·" + (ext != null ? ext.getDataType() + "·" + ext.getValueType() : "·");
 	}
 
 	public static String explainLineageAsInstruction(LineageItem li, Statistics.LineageNGramExtension ext) {

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageItemUtils.java
@@ -63,6 +63,7 @@ import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.instructions.fed.ReorgFEDInstruction.DiagMatrix;
 import org.apache.sysds.runtime.instructions.fed.ReorgFEDInstruction.Rdiag;
 import org.apache.sysds.runtime.util.HDFSTool;
+import org.apache.sysds.utils.Statistics;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -125,28 +126,28 @@ public class LineageItemUtils {
 		return FUNCTION_DEBUGGING;
 	}
 
-	public static String explainLineageType(LineageItem li) {
+	public static String explainLineageType(LineageItem li, Statistics.LineageNGramExtension ext) {
 		if (li.getType() == LineageItemType.Literal) {
 			String[] splt = li.getData().split("·");
 			if (splt.length >= 3)
 				return splt[1] + "·" + splt[2];
 			return "·";
 		}
-		return li.getDataType() + "·" + li.getValueType();
+		return ext.getDataType() + "·" + ext.getValueType();
 	}
 
-	public static String explainLineageWithTypes(LineageItem li) {
+	public static String explainLineageWithTypes(LineageItem li, Statistics.LineageNGramExtension ext) {
 		if (li.getType() == LineageItemType.Literal) {
 			String[] splt = li.getData().split("·");
 			if (splt.length >= 3)
 				return "L·" + splt[1] + "·" + splt[2];
 			return "L··";
 		}
-		return li.getOpcode() + "·" + li.getDataType() + "·" + li.getValueType();
+		return li.getOpcode() + "·" + ext.getDataType() + "·" + ext.getValueType();
 	}
 
-	public static String explainLineageAsInstruction(LineageItem li) {
-		StringBuilder sb = new StringBuilder(explainLineageWithTypes(li));
+	public static String explainLineageAsInstruction(LineageItem li, Statistics.LineageNGramExtension ext) {
+		StringBuilder sb = new StringBuilder(explainLineageWithTypes(li, ext));
 		sb.append("(");
 		if (li.getInputs() != null) {
 			int ctr = 0;
@@ -154,9 +155,9 @@ public class LineageItemUtils {
 				if (ctr++ != 0)
 					sb.append(" ° ");
 				if (liIn.getType() == LineageItemType.Literal)
-					sb.append("L_" + explainLineageType(liIn));
+					sb.append("L_" + explainLineageType(liIn, Statistics.getExtendedLineage(li)));
 				else
-					sb.append(explainLineageType(liIn));
+					sb.append(explainLineageType(liIn, Statistics.getExtendedLineage(li)));
 			}
 		}
 		sb.append(")");

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageMap.java
@@ -32,7 +32,10 @@ import org.apache.sysds.runtime.instructions.cp.VariableCPInstruction;
 import org.apache.sysds.runtime.instructions.spark.WriteSPInstruction;
 import org.apache.sysds.runtime.lineage.LineageItem.LineageItemType;
 import org.apache.sysds.utils.Explain;
+import org.apache.sysds.utils.Statistics;
+import scala.Tuple2;
 
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -146,6 +149,9 @@ public class LineageMap {
 	}
 	
 	private void trace(Instruction inst, ExecutionContext ec, Pair<String, LineageItem> li) {
+		if (li != null && li.getValue() != null && DMLScript.STATISTICS_NGRAMS && DMLScript.STATISTICS_NGRAMS_USE_LINEAGE)
+			Statistics.prepareNGramInst(li);
+
 		if (inst instanceof VariableCPInstruction) {
 			VariableCPInstruction vcp_inst = ((VariableCPInstruction) inst);
 			

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -526,10 +526,10 @@ public class Statistics
 			clearNGramRecording();
 			// We then record a new n-gram with all the LineageItems of the current lineage path
 			Entry<LineageItem, LineageNGramExtension> currentEntry = currentPath.get(currentPath.size()-1);
-			matchingBuilder.append(LineageItemUtils.explainLineageAsInstruction(currentEntry.getKey(), currentEntry.getValue()) + (indexes.size() > 0 ? ("[" + indexes.get(currentPath.size()-2) + "]") : ""), new NGramStats(1, currentEntry.getValue().getExecNanos(), 0));
+			matchingBuilder.append(LineageItemUtils.explainLineageAsInstruction(currentEntry.getKey(), currentEntry.getValue()) + (indexes.size() > 0 ? ("[" + indexes.get(currentPath.size()-2) + "]") : ""), new NGramStats(1, currentEntry.getValue() != null ? currentEntry.getValue().getExecNanos() : 0, 0));
 			for (int i = currentPath.size()-2; i >= 0; i--) {
 				currentEntry = currentPath.get(i);
-				matchingBuilder.append(LineageItemUtils.explainLineageAsInstruction(currentEntry.getKey(), currentEntry.getValue()) + (i > 0 ? ("[" + indexes.get(i-1) + "]") : ""), new NGramStats(1, currentEntry.getValue().getExecNanos(), 0));
+				matchingBuilder.append(LineageItemUtils.explainLineageAsInstruction(currentEntry.getKey(), currentEntry.getValue()) + (i > 0 ? ("[" + indexes.get(i-1) + "]") : ""), new NGramStats(1, currentEntry.getValue() != null ? currentEntry.getValue().getExecNanos() : 0, 0));
 			}
 		}
 

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -654,16 +654,22 @@ public class Statistics
 			} else {
 				builder.append(stdDevs);
 			}
-			builder.append(",");
-			if (e.getCumStats().getMeta() != null) {
-				boolean first = true;
-				for (Entry<String, Double> metaData : e.getCumStats().getMeta().entrySet()) {
-					if (first)
-						first = false;
-					else
-						builder.append("&");
-					if (metaData.getValue() != null)
-						builder.append(metaData.getKey()).append(":").append(metaData.getValue());
+			//builder.append(",");
+			boolean first = true;
+			NGramStats[] stats = e.getStats();
+			for (int i = 0; i < stats.length; i++) {
+				if (i != 0)
+					builder.append(",");
+				NGramStats stat = stats[i];
+				if (stat.getMeta() != null) {
+					for (Entry<String, Double> metaData : stat.getMeta().entrySet()) {
+						if (first)
+							first = false;
+						else
+							builder.append("&");
+						if (metaData.getValue() != null)
+							builder.append(metaData.getKey()).append(":").append(metaData.getValue());
+					}
 				}
 			}
 			return builder.toString();

--- a/src/main/java/org/apache/sysds/utils/Statistics.java
+++ b/src/main/java/org/apache/sysds/utils/Statistics.java
@@ -658,8 +658,7 @@ public class Statistics
 			boolean first = true;
 			NGramStats[] stats = e.getStats();
 			for (int i = 0; i < stats.length; i++) {
-				if (i != 0)
-					builder.append(",");
+				builder.append(",");
 				NGramStats stat = stats[i];
 				if (stat.getMeta() != null) {
 					for (Entry<String, Double> metaData : stat.getMeta().entrySet()) {

--- a/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
+++ b/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
@@ -211,6 +211,11 @@ public class NGramBuilder<T, U> {
 				.collect(Collectors.toList());
 	}
 
+	public synchronized void clearCurrentRecording() {
+		currentIndex = 0;
+		currentSize = 0;
+	}
+
 	private synchronized void registerElement(String id, U stat) {
 		nGrams.compute(id, (key, entry) ->  {
 			if (entry == null) {

--- a/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
+++ b/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.utils.stats;
 
+import org.apache.commons.lang3.function.TriFunction;
+
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
+++ b/src/main/java/org/apache/sysds/utils/stats/NGramBuilder.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,6 +54,30 @@ public class NGramBuilder<T, U> {
 		}
 
 		return builder.toString();
+	}
+
+	public static <T, U> void toCSVStream(String[] columnNames, List<NGramEntry<T, U>> entries, Function<NGramEntry<T, U>, String> statsMapper, Consumer<String> lineConsumer) {
+		StringBuilder builder = new StringBuilder(String.join(",", columnNames));
+		builder.append("\n");
+		lineConsumer.accept(builder.toString());
+		builder.setLength(0);
+
+		for (NGramEntry<T, U> entry : entries) {
+			builder.append(entry.getIdentifier().replace(",", ";"));
+			builder.append(",");
+			builder.append(entry.getCumStats());
+			builder.append(",");
+
+			if (statsMapper != null) {
+				builder.append(statsMapper.apply(entry));
+				builder.append(",");
+			}
+
+			builder.append(entry.getOccurrences());
+			builder.append("\n");
+			lineConsumer.accept(builder.toString());
+			builder.setLength(0);
+		}
 	}
 
 	public static class NGramEntry<T, U> {

--- a/src/test/java/org/apache/sysds/test/applications/ApplyTransformTest.java
+++ b/src/test/java/org/apache/sysds/test/applications/ApplyTransformTest.java
@@ -181,17 +181,5 @@ public class ApplyTransformTest extends AutomatedTestBase{
 			if(!XDML.containsKey(cell4)) success = false;
 			else success = success && (dummy_coding_maps != " ") ? (XDML.get(cell4).doubleValue() == 1) : (XDML.get(cell4).doubleValue() == 2);
 		 }
-
-		NGramBuilder<String, Statistics.NGramStats>[] builders = Statistics.mergeNGrams();
-		for (int i = 0; i < builders.length; i++) {
-			try (FileWriter writer = new FileWriter("/Users/janniklindemann/Dev/MScThesis/NGramAnalysis/" + TEST_NAME + testCtr + "_" + DMLScript.STATISTICS_NGRAM_SIZES[i] + "-grams.csv")) {
-				writer.write(NGramBuilder.toCSV(new String[] { "N-Gram", "Time[s]", "StdDev(Time[s])/Mean(Time[s])", "Count" }, builders[i].getTopK(100000, Statistics.NGramStats.getComparator(), true), e -> Statistics.getNGramStdDevs(e.getStats(), 5).replace("-", "").replace(",", ";")));
-			} catch (IOException e) {
-
-			}
-		}
-		testCtr++;
 	 }
-
-	public static int testCtr = 1;
 }

--- a/src/test/java/org/apache/sysds/test/applications/ApplyTransformTest.java
+++ b/src/test/java/org/apache/sysds/test/applications/ApplyTransformTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.test.applications;
 
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,6 +29,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.utils.Statistics;
+import org.apache.sysds.utils.stats.NGramBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -176,5 +181,17 @@ public class ApplyTransformTest extends AutomatedTestBase{
 			if(!XDML.containsKey(cell4)) success = false;
 			else success = success && (dummy_coding_maps != " ") ? (XDML.get(cell4).doubleValue() == 1) : (XDML.get(cell4).doubleValue() == 2);
 		 }
+
+		NGramBuilder<String, Statistics.NGramStats>[] builders = Statistics.mergeNGrams();
+		for (int i = 0; i < builders.length; i++) {
+			try (FileWriter writer = new FileWriter("/Users/janniklindemann/Dev/MScThesis/NGramAnalysis/" + TEST_NAME + testCtr + "_" + DMLScript.STATISTICS_NGRAM_SIZES[i] + "-grams.csv")) {
+				writer.write(NGramBuilder.toCSV(new String[] { "N-Gram", "Time[s]", "StdDev(Time[s])/Mean(Time[s])", "Count" }, builders[i].getTopK(100000, Statistics.NGramStats.getComparator(), true), e -> Statistics.getNGramStdDevs(e.getStats(), 5).replace("-", "").replace(",", ";")));
+			} catch (IOException e) {
+
+			}
+		}
+		testCtr++;
 	 }
+
+	public static int testCtr = 1;
 }

--- a/src/test/java/org/apache/sysds/test/applications/L2SVMTest.java
+++ b/src/test/java/org/apache/sysds/test/applications/L2SVMTest.java
@@ -67,7 +67,16 @@ public class L2SVMTest extends AutomatedTestBase
 	}
 	
 	@Test
-	public void testL2SVM()
+	public void testL2SVM1() {
+		testL2SVM(true);
+	}
+
+	@Test
+	public void testL2SVM2() {
+		testL2SVM(false);
+	}
+
+	private void testL2SVM(boolean ngrams)
 	{
 		System.out.println("------------ BEGIN " + TEST_NAME 
 			+ " TEST WITH {" + numRecords + ", " + numFeatures
@@ -83,9 +92,11 @@ public class L2SVMTest extends AutomatedTestBase
 
 		List<String> proArgs = new ArrayList<>();
 		proArgs.add("-stats");
-		proArgs.add("-ngrams");
-		proArgs.add("3,2");
-		proArgs.add("10");
+		if (ngrams) {
+			proArgs.add("-ngrams");
+			proArgs.add("3,2");
+			proArgs.add("10");
+		}
 		proArgs.add("-nvargs");
 		proArgs.add("X=" + input("X"));
 		proArgs.add("Y=" + input("Y"));


### PR DESCRIPTION
This PR is an extension to PR #2045 and implements support for data-dependent n-grams using and extending the existing lineage functionality. As we are dealing with DAGs which are not linear sequences of instructions, I implemented the extension in such a way that it tracks every instruction path of the length `n`. If we had for example the DAG `(a*b + c/d)` and wanted to record bigrams, the two operation sequences `[(*, +), (/, +)]` would be added to the bigram store. I also keep track of the individual data-types of each instruction which is why I extended the existing lineage functionality as the `_data` string is sometimes empty and contains inconsistent information.

The n-gram table now looks like this, where the arguments within brackets show the input parameters of an instruction (separated by `°`) and the suffix `[i]` represents the parameter index for the following instruction (e.g. for the first entry the result of `rblk` is used as the second paremeter for `ba+*`):
```
Most common 2-grams (sorted by absolute time):
  #  N-Gram                          Time(s)  StdDev(t)/Mean(t)  Count
  1  (rblk·MATRIX·FP64(MATRIX·FP64)    1,144         (, 1.067)      4
     [1], ba+*·MATRIX·FP64(MATRIX·F                                  
     P64 ° MATRIX·FP64))                                             
  2  (rblk·MATRIX·FP64(MATRIX·FP64)    0,853         (, 0.469)      3
     [0], ba+*·MATRIX·FP64(MATRIX·F                                  
     P64 ° MATRIX·FP64))                                             
  3  (createvar·MATRIX·FP64()[0], r    0,343    (0.627, 0.929)      2
     blk·MATRIX·FP64(MATRIX·FP64))                                   
  4  (rblk·MATRIX·FP64(MATRIX·FP64)    0,285                 -      1
     [0], cpvar·MATRIX·FP64(MATRIX·                                  
     FP64))                                                          
  5  (+*·MATRIX·FP64(MATRIX·FP64 °     0,153                 -      1
     SCALAR·FP64 ° MATRIX·FP64)[0],                                  
      write·MATRIX·FP64(MATRIX·FP64                                  
      ° L_SCALAR·STRING ° L_SCALAR·                                  
     STRING ° L_SCALAR·INT64))                                       
```
@mboehm7 