### PR TITLE
[SYSTEMDS-3701] Create Data Representation Search (DRSearch) Primitive

### DIFF
--- a/src/main/python/systemds/scuro/aligner/dr_search.py
+++ b/src/main/python/systemds/scuro/aligner/dr_search.py
@@ -1,0 +1,124 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+import itertools
+from typing import List
+
+from aligner.task import Task
+from modality.aligned_modality import AlignedModality
+from modality.modality import Modality
+from representations.representation import Representation
+
+
+def get_modalities_by_name(modalities, name):
+    for modality in modalities:
+        if modality.name == name:
+            return modality
+    
+    raise 'Modality ' + name + 'not in modalities'
+
+
+class DRSearch:
+    def __init__(self, modalities: List[Modality], task: Task, representations: List[Representation]):
+        """
+        The DRSearch primitive finds the best uni- or multimodal data representation for the given modalities for
+        a specific task
+        :param modalities: List of uni-modal modalities
+        :param task: custom task
+        :param representations: List of representations to be evaluated
+        """
+        self.modalities = modalities
+        self.task = task
+        self.representations = representations
+        self.scores = {}
+        self.best_modalities = None
+        self.best_representation = None
+        self.best_score = -1
+        
+    def set_best_params(self, modality_name: str, representation: Representation,
+                        score: float, modality_names: List[str]):
+        """
+        Updates the best parameters for given modalities, representation, and score
+        :param modality_name: The name of the aligned modality
+        :param representation: The representation used to retrieve the current score
+        :param score: achieved score for the set of modalities and representation
+        :param modality_names: List of modality names used in this setting
+        :return:
+        """
+        
+        # check if modality name is already in dictionary
+        if modality_name not in self.scores.keys():
+            # if not add it to dictionary
+            self.scores[modality_name] = {}
+        
+        # set score for representation
+        self.scores[modality_name][representation] = score
+        
+        # compare current score with best score
+        if score > self.best_score:
+            self.best_score = score
+            self.best_representation = representation
+            self.best_modalities = modality_names
+    
+    def fit(self):
+        """
+        This method finds the best representation out of a given List of uni-modal modalities and
+        representations
+        :return: The best parameters found in the search procedure
+        """
+        
+        for M in range(1, len(self.modalities) + 1):
+            for combination in itertools.combinations(self.modalities, M):
+                if len(combination) == 1:
+                    modality = combination[0]
+                    score = self.task.run(modality.representation.scale_data(modality.data, self.task.train_indices))
+                    self.set_best_params(modality.name, modality.representation.name, score, [modality.name])
+                    self.scores[modality] = score
+                else:
+                    for representation in self.representations:
+                        modality = AlignedModality(representation, list(combination)) # noqa
+                        modality.combine(self.task.train_indices)
+                            
+                        score = self.task.run(modality.data)
+                        self.set_best_params(modality.name, representation, score, modality.get_modality_names())
+                            
+        return self.best_representation, self.best_score, self.best_modalities
+
+    def transform(self, modalities: List[Modality]):
+        """
+        The transform method takes a list of uni-modal modalities and creates an aligned representation
+        by using the best parameters found during the fitting step
+        :param modalities: List of uni-modal modalities
+        :return: aligned data
+        """
+        
+        if self.best_score == -1:
+            raise 'Please fit representations first!'
+        
+        used_modalities = []
+        
+        for modality_name in self.best_modalities:
+            used_modalities.append(get_modalities_by_name(modalities, modality_name))
+        
+        modality = AlignedModality(self.best_representation, used_modalities)  # noqa
+        modality.combine(self.task.train_indices)
+        
+        return modality.data
+    

--- a/src/main/python/systemds/scuro/aligner/task.py
+++ b/src/main/python/systemds/scuro/aligner/task.py
@@ -1,0 +1,58 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+from typing import List
+
+from models.model import Model
+
+
+class Task:
+    def __init__(self, name: str, model: Model, labels, train_indices: List, val_indices: List):
+        """
+        Parent class for the prediction task that is performed on top of the aligned representation
+        :param name: Name of the task
+        :param model: ML-Model to run
+        :param labels: Labels used for prediction
+        :param train_indices: Indices to extract training data
+        :param val_indices: Indices to extract validation data
+        """
+        self.name = name
+        self.model = model
+        self.labels = labels
+        self.train_indices = train_indices
+        self.val_indices = val_indices
+
+    def get_train_test_split(self, data):
+        X_train = [data[i] for i in self.train_indices]
+        y_train = [self.labels[i] for i in self.train_indices]
+        X_test = [data[i] for i in self.val_indices]
+        y_test = [self.labels[i] for i in self.val_indices]
+        
+        return X_train, y_train, X_test, y_test
+    
+    def run(self, data):
+        """
+        The run method need to be implemented by every task class
+        It handles the training and validation procedures for the specific task
+        :param data: The aligned data used in the prediction process
+        :return: the validation accuracy
+        """
+        pass
+    

--- a/src/main/python/systemds/scuro/modality/video_modality.py
+++ b/src/main/python/systemds/scuro/modality/video_modality.py
@@ -49,5 +49,5 @@ class VideoModality(Modality):
     def read_chunk(self):
         pass
     
-    def read_all(self, indices):
+    def read_all(self, indices=None):
         self.data = self.representation.parse_all(self.file_path, indices=indices) # noqa


### PR DESCRIPTION
This PR introduces the new Data Representation Search (DRSearch) primitive for the Scuro library. 
The primitive includes a `.fit()` method that creates joint representations for all modality combinations using the provided representations and evaluates these representations against a given task. The included `.transform()` method takes the best parameters that were defined in the fit method to create the final data representation.