### PR TITLE
[SYSTEMDS-3715] NullPointer Exception on misspelled function data/value types

### DIFF
--- a/src/main/java/org/apache/sysds/parser/dml/DmlSyntacticValidator.java
+++ b/src/main/java/org/apache/sysds/parser/dml/DmlSyntacticValidator.java
@@ -622,6 +622,10 @@ public class DmlSyntacticValidator implements DmlListener {
 			//load and add builtin DML-bodied functions
 			String filePath = Builtins.getFilePath(functionName);
 			DMLProgram tmpProg = parseAndAddImportedFunctions(namespace, filePath, ctx);
+			if(tmpProg == null){
+				//a parse error occured, which was logged in the error listener and will be shown in the error message
+				return;
+			}
 			FunctionDictionary<FunctionStatementBlock> prog = tmpProg.getBuiltinFunctionDictionary();
 			if( prog != null ) { //robustness for existing functions
 				//add builtin functions

--- a/src/test/scripts/functions/tensor/BILSTMBackwardTest.dml
+++ b/src/test/scripts/functions/tensor/BILSTMBackwardTest.dml
@@ -29,12 +29,11 @@ debug = as.logical(as.integer($5))
 seq = as.logical(as.integer($6))
 
 factor = 0.01
-input_range = matrix("0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199", rows=1,cols=200)
-input = input_range*factor
-lstmIn = matrix(input[,1:batch_size*seq_length*num_features], rows=batch_size,cols=(seq_length*num_features))
+lstmIn = matrix(seq(0,batch_size*seq_length*num_features - 1)*factor, rows=batch_size,cols=(seq_length*num_features))
 
-input = input - (num_features + hidden_size)*hidden_size*factor
-W = matrix(input[,1:(num_features + hidden_size)*hidden_size*4],rows=num_features + hidden_size, cols=hidden_size*4)
+W = seq(0, (num_features + hidden_size)*hidden_size*4 - 1)*factor
+W = W - (num_features + hidden_size)*hidden_size*factor
+W = matrix(W,rows=num_features + hidden_size, cols=hidden_size*4)
 b = matrix(1,rows=1, cols=4*hidden_size)*factor
 out0 = matrix(1,rows=batch_size, cols=hidden_size)*factor
 c0 = matrix(0,rows=batch_size, cols=hidden_size)*factor
@@ -46,10 +45,10 @@ c0 = rbind(c0, c0)
 
 dc = matrix(0,rows=batch_size*2,cols=hidden_size)
 if(batch_size == 5){
-  dout = matrix(input_range[,1:batch_size*hidden_size*seq_length*2], rows=batch_size, cols=hidden_size*seq_length*2)
+  dout = matrix(seq(0, batch_size*hidden_size*seq_length*2 - 1), rows=batch_size, cols=hidden_size*seq_length*2)
 } else if(batch_size == 4) {
   dout = matrix(0, rows=batch_size, cols=hidden_size*2)
-  dc = matrix(input_range[,1:batch_size*hidden_size*2], rows=batch_size*2, cols=hidden_size)
+  dc = matrix(seq(0, batch_size*hidden_size*2 - 1), rows=batch_size*2, cols=hidden_size)
 } else if(batch_size == 3) {
 
 } else {

--- a/src/test/scripts/functions/tensor/BILSTMForwardTest.dml
+++ b/src/test/scripts/functions/tensor/BILSTMForwardTest.dml
@@ -29,16 +29,15 @@ debug = as.logical(as.integer($5))
 seq = as.logical(as.integer($6))
 
 factor = 0.01
-input_range = matrix("0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199", rows=1,cols=200)
-input = input_range*factor
-lstmIn = matrix(input[,1:batch_size*seq_length*num_features], rows=batch_size,cols=(seq_length*num_features))
+lstmIn = matrix(seq(0,batch_size*seq_length*num_features - 1)*factor, rows=batch_size,cols=(seq_length*num_features))
 
-input = input - (num_features + hidden_size)*hidden_size*factor
-W = matrix(input[,1:(num_features + hidden_size)*hidden_size*4],rows=num_features + hidden_size, cols=hidden_size*4)
+W = seq(0, (num_features + hidden_size)*hidden_size*4 - 1)*factor
+W = W - (num_features + hidden_size)*hidden_size*factor
+W = matrix(W,rows=num_features + hidden_size, cols=hidden_size*4)
 if(batch_size == 2){
-  b = (matrix(input_range[,1:4*hidden_size], rows=1, cols=4*hidden_size) - 2*hidden_size)*factor
-  c0 = (matrix(input_range[,1:2*batch_size*hidden_size], rows=batch_size*2, cols=hidden_size) - 2*hidden_size)*factor
-  out0 = (matrix(input_range[,1:2*batch_size*hidden_size], rows=batch_size*2, cols=hidden_size) + 2*hidden_size)*factor
+  b = (matrix(seq(0,4*hidden_size- 1), rows=1, cols=4*hidden_size) - 2*hidden_size)*factor
+  c0 = (matrix(seq(0,2*batch_size*hidden_size - 1), rows=batch_size*2, cols=hidden_size) - 2*hidden_size)*factor
+  out0 = (matrix(seq(0,2*batch_size*hidden_size - 1), rows=batch_size*2, cols=hidden_size) + 2*hidden_size)*factor
 } else {
   b = matrix(1,rows=1, cols=4*hidden_size)*factor
   out0 = matrix(1,rows=batch_size, cols=hidden_size)*factor


### PR DESCRIPTION
This minor patch fixes the null pointer which could a appear when parsing a dml-bodied built-in function.

The fixed error message looks like this now:
![image](https://github.com/user-attachments/assets/d82f8f64-9ec1-4603-ae05-4afeaa0082f3)


I also removed a manual defined sequence and replaced it by a sequence statement in in the BILSTM test dml script.