### PR TITLE
[SYSTEMDS-3754] Python API missing builtin trace

### DIFF
--- a/src/main/python/systemds/operator/nodes/matrix.py
+++ b/src/main/python/systemds/operator/nodes/matrix.py
@@ -259,6 +259,13 @@ class Matrix(OperationNode):
         raise ValueError(
             f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}")
 
+    def trace(self) -> 'Scalar':
+        """Calculate trace.
+
+        :return: `Matrix` representing operation
+        """
+        return Scalar(self.sds_context, 'trace', [self])
+
     def abs(self) -> 'Matrix':
         """Calculate absolute.
 

--- a/src/main/python/tests/matrix/test_aggregations.py
+++ b/src/main/python/tests/matrix/test_aggregations.py
@@ -112,5 +112,14 @@ class TestMatrixAggFn(unittest.TestCase):
         self.assertTrue(np.allclose(
             self.sds.from_numpy(m1).max(axis=1).compute(), m1.max(axis=1).reshape(dim, 1)))
 
+    def test_trace1(self):
+        self.assertTrue(np.allclose(
+            self.sds.from_numpy(m1).trace().compute(), m1.trace()))
+
+    def test_trace2(self):
+        self.assertTrue(np.allclose(
+            self.sds.from_numpy(m2).trace().compute(), m2.trace()))
+
+
 if __name__ == "__main__":
     unittest.main(exit=False)


### PR DESCRIPTION
[SYSTEMDS-3754] Python API missing builtin trace

This patch adds the built in operator for trace to the python api.