### PR TITLE
[SYSTEMDS-3749] Python API missing builtin sd

### DIFF
--- a/src/main/python/systemds/operator/nodes/matrix.py
+++ b/src/main/python/systemds/operator/nodes/matrix.py
@@ -259,6 +259,13 @@ class Matrix(OperationNode):
         raise ValueError(
             f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}")
 
+    def sd(self) -> 'Scalar':
+        """Calculate standard deviation of matrix.
+
+        :return: `Matrix` representing operation
+        """
+        return Scalar(self.sds_context, 'sd', [self])
+
     def abs(self) -> 'Matrix':
         """Calculate absolute.
 

--- a/src/main/python/tests/matrix/test_aggregations.py
+++ b/src/main/python/tests/matrix/test_aggregations.py
@@ -112,5 +112,14 @@ class TestMatrixAggFn(unittest.TestCase):
         self.assertTrue(np.allclose(
             self.sds.from_numpy(m1).max(axis=1).compute(), m1.max(axis=1).reshape(dim, 1)))
 
+    def test_sd1(self):
+        self.assertTrue(np.allclose(
+            self.sds.from_numpy(m1).sd().compute(), np.std(m1,ddof=1), 1e-9))
+
+    def test_sd2(self):
+        self.assertTrue(np.allclose(
+            self.sds.from_numpy(m2).sd().compute(), np.std(m2, ddof=1), 1e-9))
+
+
 if __name__ == "__main__":
     unittest.main(exit=False)


### PR DESCRIPTION
[SYSTEMDS-3749] Python API missing builtin sd

This patch adds the built in operator for sd to the python api.