### PR TITLE
[SystemDS-3750] Python API Builtin prod

### DIFF
--- a/src/main/python/systemds/operator/nodes/matrix.py
+++ b/src/main/python/systemds/operator/nodes/matrix.py
@@ -238,6 +238,22 @@ class Matrix(OperationNode):
             f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}"
         )
 
+    def prod(self, axis: int = None) -> "OperationNode":
+        """Calculate product of cells in matrix.
+
+        :param axis: can be 0 or 1 to do either row or column sums
+        :return: `Matrix` representing operation
+        """
+        if axis == 0:
+            return Matrix(self.sds_context, "colProds", [self])
+        elif axis == 1:
+            return Matrix(self.sds_context, "rowProds", [self])
+        elif axis is None:
+            return Scalar(self.sds_context, "prod", [self])
+        raise ValueError(
+            f"Axis has to be either 0, 1 or None, for column, row or complete {self.operation}"
+        )
+
     def mean(self, axis: int = None) -> "OperationNode":
         """Calculate mean of matrix.
 

--- a/src/main/python/tests/matrix/test_aggregations.py
+++ b/src/main/python/tests/matrix/test_aggregations.py
@@ -61,6 +61,32 @@ class TestMatrixAggFn(unittest.TestCase):
             )
         )
 
+    def test_sum4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).sum(2)
+
+    def test_prod1(self):
+        self.assertTrue(
+            np.allclose(self.sds.from_numpy(m1).prod().compute(), np.prod(m1))
+        )
+
+    def test_prod2(self):
+        self.assertTrue(
+            np.allclose(self.sds.from_numpy(m1).prod(0).compute(), np.prod(m1, 0))
+        )
+
+    def test_prod3(self):
+        self.assertTrue(
+            np.allclose(
+                self.sds.from_numpy(m1).prod(axis=1).compute(),
+                np.prod(m1, 1).reshape(dim, 1),
+            )
+        )
+
+    def test_prod4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).prod(2)
+
     def test_mean1(self):
         self.assertTrue(
             np.allclose(self.sds.from_numpy(m1).mean().compute(), m1.mean())
@@ -78,6 +104,10 @@ class TestMatrixAggFn(unittest.TestCase):
                 m1.mean(axis=1).reshape(dim, 1),
             )
         )
+
+    def test_mean4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).mean(2)
 
     def test_full(self):
         self.assertTrue(
@@ -109,6 +139,10 @@ class TestMatrixAggFn(unittest.TestCase):
             )
         )
 
+    def test_var4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).var(2)
+
     def test_min1(self):
         self.assertTrue(np.allclose(self.sds.from_numpy(m1).min().compute(), m1.min()))
 
@@ -125,6 +159,10 @@ class TestMatrixAggFn(unittest.TestCase):
             )
         )
 
+    def test_min4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).min(2)
+
     def test_max1(self):
         self.assertTrue(np.allclose(self.sds.from_numpy(m1).max().compute(), m1.max()))
 
@@ -140,6 +178,10 @@ class TestMatrixAggFn(unittest.TestCase):
                 m1.max(axis=1).reshape(dim, 1),
             )
         )
+
+    def test_max4(self):
+        with self.assertRaises(ValueError):
+            self.sds.from_numpy(m1).max(2)
 
     def test_trace1(self):
         self.assertTrue(


### PR DESCRIPTION
[SystemDS-3750] Python API Builtin prod

This patch adds the builtin operator for prod to the python api.
Additionally I added test cases, which checks for errors when selecting a invalid axis for sum, mean, var, min, max