### PR TITLE
Systemds 3696/selector-for-pruning-strategies

### DIFF
--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -77,10 +77,10 @@ m_incSliceLine = function(
     Matrix[Double] indicesRemoved = matrix(0,0,0),
     Boolean verbose = FALSE, list[unknown] params = list(),
     Matrix[Double] prevFoffb = matrix(0,0,0), Matrix[Double] prevFoffe = matrix(0,0,0),
-    Boolean disableIncSizePruning = FALSE, Boolean disableIncScorePruning = FALSE,
-    list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(),
-    list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0),
-    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE
+    list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(), 
+    list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0), 
+    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE,
+    Int pruningStrat = 0
     )
   return(
     Matrix[Double] TK, Matrix[Double] TKC, Matrix[Double] D,
@@ -99,6 +99,17 @@ m_incSliceLine = function(
   } else {
 
   t1 = time();
+
+  if(pruningStrat == 1){
+    disableIncScorePruning = TRUE;
+  }
+  if(pruningStrat == 2){
+    disableIncSizePruning = TRUE;
+  }
+  if(pruningStrat == 3){
+    disableIncScorePruning = TRUE;
+    disableIncSizePruning = TRUE;
+  }
 
   # store params for next run
   [params, k, maxL, minSup, alpha, tpEval, tpBlksz, selFeat, encodeLat] = storeParams(k, maxL, minSup, alpha, tpEval, tpBlksz, selFeat, encodeLat, params);

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -98,7 +98,8 @@ m_incSliceLine = function(
     [TK, TKC, D, L, Stats, Xout, eOut, foffb, foffe, metaLattice, params] = throwNoParamsError();
   } else {
 
-  t1 = time();
+  disableIncScorePruning = FALSE;
+  disableIncSizePruning = FALSE;
 
   if(pruningStrat == 1){
     disableIncScorePruning = TRUE;
@@ -110,6 +111,8 @@ m_incSliceLine = function(
     disableIncScorePruning = TRUE;
     disableIncSizePruning = TRUE;
   }
+
+  t1 = time();
 
   # store params for next run
   [params, k, maxL, minSup, alpha, tpEval, tpBlksz, selFeat, encodeLat] = storeParams(k, maxL, minSup, alpha, tpEval, tpBlksz, selFeat, encodeLat, params);

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -79,7 +79,8 @@ m_incSliceLine = function(
     Matrix[Double] prevFoffb = matrix(0,0,0), Matrix[Double] prevFoffe = matrix(0,0,0),
     list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(),
     list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0),
-    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE)
+    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE, 
+    Boolean disableIncSizePruning = FALSE, Boolean disableIncScorePruning = FALSE)
   return(
     Matrix[Double] TK, Matrix[Double] TKC, Matrix[Double] D,
     list[unknown] L, list[unknown] metaLattice,
@@ -176,12 +177,12 @@ m_incSliceLine = function(
 
   # compute score for lowest scoring prevTK slice to set high min score early on to prune slices based on scores
   minsc = -Inf;
-  if( nrow(prevTK2) > 0 ) {
+  if( nrow(prevTK2) > 0 & !disableIncScorePruning) {
     [minsc] = computeLowestPrevTK (prevTK2, X2, totalE, eAvg, alpha, minsc)
   }
 
   # create and score basic slices (conjunctions of 1 feature)
-  [S, R, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, verbose);
+  [S, R, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, verbose, disableIncScorePruning);
 
   # initialize lattice and statistics for incremental updates
   Stats = list();
@@ -233,11 +234,15 @@ m_incSliceLine = function(
     L = append(L, Lrep);
 
     # load one hot encoded previous lattice for the current level
-    prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
-      prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
+    prevLattice2 = matrix(0,0,0);
+    if(!disableIncSizePruning){
+      prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
+        prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
+    }
+
 
     if(selFeat){
-      if(length(prevLattice2)>0) {
+      if(length(prevLattice2)>0 & !disableIncSizePruning){ 
         prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
       }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
@@ -248,7 +253,7 @@ m_incSliceLine = function(
     }
 
     # prune unchanged slices with slice size < minSup
-    if(level <= length(prevStats)){
+    if(level <= length(prevStats) & !disableIncSizePruning){
       [S, S2] = pruneUnchangedSlices(S, S2,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
     }
 
@@ -309,7 +314,7 @@ m_incSliceLine = function(
 
 createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] changedX2,
     Matrix[Double] prevTK2,  Matrix[Double] e,
-    Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha, Double minsc, Boolean verbose)
+    Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha, Double minsc, Boolean verbose, Boolean disableIncScorePruning)
   return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
@@ -361,7 +366,7 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] changedX2
   R = cbind(sc, se, sm, ss);
 
   # score pruning of basic slices based on smallest score of all slices in prevTK
-  if(minsc > -Inf) {
+  if(minsc > -Inf & !disableIncScorePruning) {
     # compute upper bound scores for all basic slices
     ubSc = scoreUB(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
     fScores = (ubSc >= minsc);

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -221,6 +221,7 @@ m_incSliceLine = function(
   # reduce dataset to relevant attributes (minSup, err>0), S reduced on-the-fly
   if( selFeat ){
     X2 = removeEmpty(target=X2, margin="cols", select=t(selCols));
+    changedX2 = removeEmpty(target=changedX2, margin="cols", select=t(selCols));
   }
 
   # lattice enumeration w/ size/error pruning, one iteration per level
@@ -230,16 +231,9 @@ m_incSliceLine = function(
   while( nrow(S) > 0 & sum(S) > 0 & level < n & level < maxL ) {
     level = level + 1;
 
-    # load one hot encoded previous lattice for the current level
-    prevLattice2 = matrix(0,0,0);
-    if(!disableIncSizePruning){
-      prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb, 
-        prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
-    }
-
     # enumerate candidate join pairs, incl size/error pruning
     nrS = nrow(S);
-    [S, minsc] = getPairedCandidates(S, minsc, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe, prevLattice2, prevStats, changedX2, verbose, disableIncSizePruning)
+    [S, minsc] = getPairedCandidates(S, minsc, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
     S2 = S;
 
     # prepare and store output lattice for next run
@@ -251,13 +245,28 @@ m_incSliceLine = function(
     }
     L = append(L, Lrep);
 
+    # load one hot encoded previous lattice for the current level
+    prevLattice2 = matrix(0,0,0);
+    if(!disableIncSizePruning){
+      prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb, 
+        prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
+    }
+
 
     if(selFeat){
+      if(length(prevLattice2)>0 & !disableIncSizePruning){ 
+        prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
+      }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
     }
 
     if(verbose) {
         print("\nincSliceLine: level "+level+":")
+    }
+    
+    # prune unchanged slices with slice size < minSup
+    if(level <= length(prevStats) & !disableIncSizePruning){
+      [S, S2] = pruneUnchangedSlices(S, S2,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
     }
 
     if(verbose) {
@@ -441,7 +450,7 @@ analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
 getPairedCandidates = function(Matrix[Double] S, Double minsc,
     Matrix[Double] R, Matrix[Double] TKC, Integer level,
     Double eAvg, Integer minSup, Double alpha, Integer n2,
-    Matrix[Double] foffb, Matrix[Double] foffe, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Boolean verbose, Boolean disableIncSizePruning)
+    Matrix[Double] foffb, Matrix[Double] foffe)
   return(Matrix[Double] P, Double minsc)
 {
   # prune invalid slices (possible without affecting overall
@@ -471,21 +480,6 @@ getPairedCandidates = function(Matrix[Double] S, Double minsc,
     se = min(P1 %*% R[,2], P2 %*% R[,2])
     sm = min(P1 %*% R[,3], P2 %*% R[,3])
     ss = min(P1 %*% R[,4], P2 %*% R[,4])
-
-    # prune unchanged slices with slice size < minSup
-    if(level <= length(prevStats) & !disableIncSizePruning){
-      I = pruneUnchangedSlices(P,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
-      if(sum(I) > 0){
-        P = removeEmpty(target=P, margin="rows", select=I == 0);
-        P12 = removeEmpty(target=P12, margin="rows", select=I == 0);
-        ss = removeEmpty(target=ss, margin="rows", select=I == 0);
-        se = removeEmpty(target=se, margin="rows", select=I == 0);
-        sm = removeEmpty(target=sm, margin="rows", select=I == 0);
-        if(verbose) {
-          print(" -- Pruning " + sum(I) +" slices that are unchanged and below min sup.");
-        }
-      }
-    }
 
     # prune invalid self joins (>1 bit per feature)
     I = matrix(1, nrow(P), 1);
@@ -664,8 +658,8 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   minsc = min(sc);
 }
 
-pruneUnchangedSlices = function(Matrix[Double] S2, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
-  return(Matrix[Double] unchangedAndBelowMinSupI)
+pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
+  return(Matrix[Double] S, Matrix[Double] S2)
 {
   unchangedS = matrix(0,0,ncol(prevLattice2));
   unchangedR = matrix(0,0,4);
@@ -687,7 +681,13 @@ pruneUnchangedSlices = function(Matrix[Double] S2, Matrix[Double] prevLattice2, 
       unchangedAndBelowMinSup = rowSums(unchangedSizes < minSup & unchangedSizes > 0) != 0;
     }
 
-
+    if(sum(unchangedAndBelowMinSupI) > 0){
+      S2 = removeEmpty(target=S2, margin="rows", select=unchangedAndBelowMinSupI == 0);
+      S = removeEmpty(target=S, margin="rows", select=unchangedAndBelowMinSupI == 0);
+      if(verbose) {
+        print(" -- Pruning " + sum(unchangedAndBelowMinSupI) +" slices that are unchanged and below min sup.");
+      }
+    }
   }
 }
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -77,10 +77,11 @@ m_incSliceLine = function(
     Matrix[Double] indicesRemoved = matrix(0,0,0),
     Boolean verbose = FALSE, list[unknown] params = list(),
     Matrix[Double] prevFoffb = matrix(0,0,0), Matrix[Double] prevFoffe = matrix(0,0,0),
+    Boolean disableIncSizePruning = FALSE, Boolean disableIncScorePruning = FALSE,
     list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(),
     list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0),
-    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE, 
-    Boolean disableIncSizePruning = FALSE, Boolean disableIncScorePruning = FALSE)
+    Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE
+    )
   return(
     Matrix[Double] TK, Matrix[Double] TKC, Matrix[Double] D,
     list[unknown] L, list[unknown] metaLattice,
@@ -209,7 +210,6 @@ m_incSliceLine = function(
   # reduce dataset to relevant attributes (minSup, err>0), S reduced on-the-fly
   if( selFeat ){
     X2 = removeEmpty(target=X2, margin="cols", select=t(selCols));
-    changedX2 = removeEmpty(target=changedX2, margin="cols", select=t(selCols));
   }
 
   # lattice enumeration w/ size/error pruning, one iteration per level
@@ -219,9 +219,16 @@ m_incSliceLine = function(
   while( nrow(S) > 0 & sum(S) > 0 & level < n & level < maxL ) {
     level = level + 1;
 
+    # load one hot encoded previous lattice for the current level
+    prevLattice2 = matrix(0,0,0);
+    if(!disableIncSizePruning){
+      prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb, 
+        prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
+    }
+
     # enumerate candidate join pairs, incl size/error pruning
     nrS = nrow(S);
-    [S, minsc] = getPairedCandidates(S, minsc, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
+    [S, minsc] = getPairedCandidates(S, minsc, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe, prevLattice2, prevStats, changedX2, verbose, disableIncSizePruning)
     S2 = S;
 
     # prepare and store output lattice for next run
@@ -233,28 +240,13 @@ m_incSliceLine = function(
     }
     L = append(L, Lrep);
 
-    # load one hot encoded previous lattice for the current level
-    prevLattice2 = matrix(0,0,0);
-    if(!disableIncSizePruning){
-      prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
-        prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
-    }
-
 
     if(selFeat){
-      if(length(prevLattice2)>0 & !disableIncSizePruning){ 
-        prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
-      }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
     }
 
     if(verbose) {
         print("\nincSliceLine: level "+level+":")
-    }
-
-    # prune unchanged slices with slice size < minSup
-    if(level <= length(prevStats) & !disableIncSizePruning){
-      [S, S2] = pruneUnchangedSlices(S, S2,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
     }
 
     if(verbose) {
@@ -438,7 +430,7 @@ analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
 getPairedCandidates = function(Matrix[Double] S, Double minsc,
     Matrix[Double] R, Matrix[Double] TKC, Integer level,
     Double eAvg, Integer minSup, Double alpha, Integer n2,
-    Matrix[Double] foffb, Matrix[Double] foffe)
+    Matrix[Double] foffb, Matrix[Double] foffe, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Boolean verbose, Boolean disableIncSizePruning)
   return(Matrix[Double] P, Double minsc)
 {
   # prune invalid slices (possible without affecting overall
@@ -468,6 +460,21 @@ getPairedCandidates = function(Matrix[Double] S, Double minsc,
     se = min(P1 %*% R[,2], P2 %*% R[,2])
     sm = min(P1 %*% R[,3], P2 %*% R[,3])
     ss = min(P1 %*% R[,4], P2 %*% R[,4])
+
+    # prune unchanged slices with slice size < minSup
+    if(level <= length(prevStats) & !disableIncSizePruning){
+      I = pruneUnchangedSlices(P,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
+      if(sum(I) > 0){
+        P = removeEmpty(target=P, margin="rows", select=I == 0);
+        P12 = removeEmpty(target=P12, margin="rows", select=I == 0);
+        ss = removeEmpty(target=ss, margin="rows", select=I == 0);
+        se = removeEmpty(target=se, margin="rows", select=I == 0);
+        sm = removeEmpty(target=sm, margin="rows", select=I == 0);
+        if(verbose) {
+          print(" -- Pruning " + sum(I) +" slices that are unchanged and below min sup.");
+        }
+      }
+    }
 
     # prune invalid self joins (>1 bit per feature)
     I = matrix(1, nrow(P), 1);
@@ -646,8 +653,8 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   minsc = min(sc);
 }
 
-pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
-  return(Matrix[Double] S, Matrix[Double] S2)
+pruneUnchangedSlices = function(Matrix[Double] S2, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
+  return(Matrix[Double] unchangedAndBelowMinSupI)
 {
   unchangedS = matrix(0,0,ncol(prevLattice2));
   unchangedR = matrix(0,0,4);
@@ -669,13 +676,7 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
       unchangedAndBelowMinSup = rowSums(unchangedSizes < minSup & unchangedSizes > 0) != 0;
     }
 
-    if(sum(unchangedAndBelowMinSup) > 0){
-      S2 = removeEmpty(target=S2, margin="rows", select=unchangedAndBelowMinSup == 0);
-      S = removeEmpty(target=S, margin="rows", select=unchangedAndBelowMinSup == 0);
-      if(verbose) {
-        print(" -- Pruning " + sum(unchangedAndBelowMinSup) +" slices that are unchanged and below min sup.");
-      }
-    }
+
   }
 }
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -77,8 +77,8 @@ m_incSliceLine = function(
     Matrix[Double] indicesRemoved = matrix(0,0,0),
     Boolean verbose = FALSE, list[unknown] params = list(),
     Matrix[Double] prevFoffb = matrix(0,0,0), Matrix[Double] prevFoffe = matrix(0,0,0),
-    list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(), 
-    list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0), 
+    list[unknown] prevLattice = list(), list[unknown] metaPrevLattice = list(),
+    list[unknown] prevStats = list(), Matrix[Double] prevTK = matrix(0,0,0),
     Matrix[Double] prevTKC = matrix(0,0,0), Boolean encodeLat = TRUE,
     Int pruningStrat = 0
     )
@@ -254,7 +254,6 @@ m_incSliceLine = function(
       prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb, 
         prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
     }
-
 
     if(selFeat){
       if(length(prevLattice2)>0 & !disableIncSizePruning){ 
@@ -684,11 +683,11 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
       unchangedAndBelowMinSup = rowSums(unchangedSizes < minSup & unchangedSizes > 0) != 0;
     }
 
-    if(sum(unchangedAndBelowMinSupI) > 0){
-      S2 = removeEmpty(target=S2, margin="rows", select=unchangedAndBelowMinSupI == 0);
-      S = removeEmpty(target=S, margin="rows", select=unchangedAndBelowMinSupI == 0);
+    if(sum(unchangedAndBelowMinSup) > 0){
+      S2 = removeEmpty(target=S2, margin="rows", select=unchangedAndBelowMinSup == 0);
+      S = removeEmpty(target=S, margin="rows", select=unchangedAndBelowMinSup == 0);
       if(verbose) {
-        print(" -- Pruning " + sum(unchangedAndBelowMinSupI) +" slices that are unchanged and below min sup.");
+        print(" -- Pruning " + sum(unchangedAndBelowMinSup) +" slices that are unchanged and below min sup.");
       }
     }
   }
@@ -779,4 +778,3 @@ removeRowsByIndices = function(Matrix[Double] M, Matrix[Double] indices)
   remain = P2 %*% M;
   while(FALSE){} #prevent inlining (TODO rewrite issue)
 }
-

--- a/src/test/scripts/functions/builtin/incSliceLineFull.dml
+++ b/src/test/scripts/functions/builtin/incSliceLineFull.dml
@@ -26,6 +26,8 @@ oldE = read($3);
 addedE = read($4);
 totalE = rbind(oldE, addedE);
 indicesRemoved = read($9);
+disableIncScorePruning = $13;
+disableIncSizePruning = $14;
 
 if(nrow(indicesRemoved) > 0){
   if(as.scalar(indicesRemoved[1]) == 0){
@@ -40,7 +42,7 @@ if(nrow(indicesRemoved) > 0){
   
   # second increment
 [TK1, TKC1, D1, L1, meta1, Stats1, Xout1, eOut1, foffb2, foffe2, params] = incSliceLine(addedX=addedX, oldX = oldX, oldE = oldE, addedE=addedE, prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,
-  alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe);
+  alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, disableIncSizePruning = disableIncSizePruning, disableIncScorePruning = disableIncScorePruning);
 
 # prepare totalX and totalE for running sliceline on total data 
 if(nrow(indicesRemoved) > 0){

--- a/src/test/scripts/functions/builtin/incSliceLineFull.dml
+++ b/src/test/scripts/functions/builtin/incSliceLineFull.dml
@@ -29,6 +29,17 @@ indicesRemoved = read($9);
 disableIncScorePruning = $13;
 disableIncSizePruning = $14;
 
+if(disableIncScorePruning & disableIncSizePruning){
+  pruningStrat = 3; 
+} else if (disableIncSizePruning){
+  pruningStrat = 2;
+} else if (disableIncScorePruning){
+  pruningStrat = 1;
+} else {
+  pruningStrat = 0;
+}
+
+
 if(nrow(indicesRemoved) > 0){
   if(as.scalar(indicesRemoved[1]) == 0){
     indicesRemoved = matrix(0, 0, 0);
@@ -42,7 +53,7 @@ if(nrow(indicesRemoved) > 0){
   
   # second increment
 [TK1, TKC1, D1, L1, meta1, Stats1, Xout1, eOut1, foffb2, foffe2, params] = incSliceLine(addedX=addedX, oldX = oldX, oldE = oldE, addedE=addedE, prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,
-  alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, disableIncSizePruning = disableIncSizePruning, disableIncScorePruning = disableIncScorePruning);
+  alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, pruningStrat = pruningStrat);
 
 # prepare totalX and totalE for running sliceline on total data 
 if(nrow(indicesRemoved) > 0){


### PR DESCRIPTION
In this PR a new input variable was added to incSLiceLine to allow the selection of the main incremental pruning strategies Either both (pruningStrat = 0), only size (pruningStrat = 1), only score (pruningStrat = 2), or no pruning (pruningStrat = 3) can be selected. This is mainly necessary for experiments and testing. 