### PR TITLE
[MINOR] Bug ignore nan in test

### DIFF
--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -822,7 +822,7 @@ public class TestUtils {
 		int countErrors = 0;
 		for (int i = 0; i < rows && countErrors < 10; i++) {
 			for (int j = 0; j < cols && countErrors < 10; j++) {
-				if (!compareCellValue(expectedMatrix[i][j], actualMatrix[i][j], epsilon, true)) {
+				if (!compareCellValue(expectedMatrix[i][j], actualMatrix[i][j], epsilon, false)) {
 					message += ("\n Expected: " +expectedMatrix[i][j] +" vs actual: "+actualMatrix[i][j]+" at "+i+" "+j);
 					countErrors++;
 				}


### PR DESCRIPTION
I discovered something concerning,
the default compareMatrices function in TestUtils use a flag to compare cell values, called ignoreNaN.

When this flag is enabled we compare cells with:

```java
if( ignoreNaN && (v1.isNaN() || v1.isInfinite() || v2.isNaN() || v2.isInfinite()) )
   return true;
```

This means that all tests using cellCompare, ignore comparing if any side contains a infinite or NaN.
This flag unfortunately invalidate the result of many tests and therefore i open this PR to validate which tests are affected.

