### PR TITLE
[SYSTEMDS-3768] Fix mtx header element count and skip empty lines in JavaTest

### DIFF
--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -579,6 +579,9 @@ public class TestUtils {
 
 			line = reader.readLine(); // header line with dimension and nnz information
 
+			if (line.startsWith("%"))	// skip blank comment(%) line in mtx file
+				line = reader.readLine();
+
 			while ((line = reader.readLine()) != null) {
 				StringTokenizer st = new StringTokenizer(line, " ");
 				int i = Integer.parseInt(st.nextToken());


### PR DESCRIPTION
This PR separates part of the content from a previous PR (https://github.com/apache/systemds/pull/2103).

- `TestUtils::writeTestMatrix()`: When writing mtx files, the last number in the header should represent the number of non-zero elements in the matrix. However, in the existing JavaTest, it was showing the total number of elements, which caused an error when reading the mtx file using Python's `scipy.mmread()` function. This bug has been fixed. (Reference: https://networkrepository.com/mtx-matrix-market-format.html)

- `TestUtils::readRMatrixFromFS()`: While R writes the mtx header in 2 lines, Python's scipy writes it in 3 lines, including an additional line containing only a `%` symbol. I modified the code to skip such blank lines when reading mtx files in JavaTest, so that no errors occur.