### PR TITLE
[SYSTEMDS-3696] updated state management does not lose data throughout updates, updated pruning disabling

### DIFF
--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -52,7 +52,8 @@
 # prevTK           previous top-k slices (for incremental updates)
 # prevTKC          previous top-k scores (for incremental updates)
 # encodeLat        flag for encoding output lattice for less memory consumption
-# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 3 only max score pruning, 4 no pruning
+# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 
+#                                     3 only max score pruning, 4 only approx pruning, 5 no pruning 
 # ---------------------------------------------------------------------------------------
 #
 # OUTPUT:

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -100,9 +100,11 @@ m_incSliceLine = function(
       + " -- see documentation for more details.");
   }
 
-  disableIncScorePruning = ( pruningStrat >= 2);
-  disableIncSizePruning = ((pruningStrat == 1) | (pruningStrat >= 3));
-  disableIncMaxScorePruning = ((pruningStrat == 1) | (pruningStrat == 2) | (pruningStrat == 4));
+  enableIncScorePruning = ( pruningStrat <= 1);
+  enableIncSizePruning = ((pruningStrat == 0) | (pruningStrat == 2));
+  enableIncMaxScorePruning = ((pruningStrat == 0) | (pruningStrat == 3));
+  enableIncApproxPruning = ((pruningStrat == 0) | (pruningStrat == 4));
+
 
   t1 = time();
 
@@ -118,11 +120,11 @@ m_incSliceLine = function(
     oldE = matrix(0,0,ncol(addedE));
   }
   ## remove all rows from oldX and oldE that are in indicesRemoved
-  removedTuples = matrix(0,0,ncol(oldX));
+  removedX = matrix(0,0,ncol(oldX));
   removedE = matrix(0,0,1);
   if(length(indicesRemoved) > 0 & nrow(oldX)  > 0){
-    [oldX, removedTuples] = removeRowsByIndices( oldX, indicesRemoved);
-    [oldE, removedE] = removeRowsByIndices( oldE, indicesRemoved);
+    [oldX, removedX] = removeRowsByIndices(oldX, indicesRemoved);
+    [oldE, removedE] = removeRowsByIndices(oldE, indicesRemoved);
     if(verbose){
       print("incSliceLine: removed "+nrow(indicesRemoved)+" tuples.");
     }
@@ -158,9 +160,12 @@ m_incSliceLine = function(
   # One-hot encoding of tuples that were removed from oldX
   # combining of addedX and oldX in changedX2 facilitates simple determination of unchanged slices for pruning
   changedX2 = addedX2;
-  if(nrow(removedTuples) > 0){
-    removedTuples2 = oneHotEncodeUsingOffsets(removedTuples, foffb, foffe);
-    changedX2 = rbind(addedX2, removedTuples2);
+  removedX2 = removedX;
+  if(nrow(removedX) > 0){
+    removedX2 = oneHotEncodeUsingOffsets(removedX, foffb, foffe);
+    changedX2 = rbind(addedX2, removedX2);
+  } else {
+    removedX2 = matrix(0, 0, ncol(addedX2));
   }
   changedE = rbind(addedE, removedE);
 
@@ -182,8 +187,11 @@ m_incSliceLine = function(
   # create and score basic slices (conjunctions of 1 feature)
   maxsc = getMaxScoreAllFeatures(nrow(X2), ncol(X2), prevLattice, metaPrevLattice,
      prevStats, encodeLat, differentOffsets, alpha, eAvg, prevFoffb, prevFoffe, foffb, foffe);
-  [S, R, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, changedE,
-     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, verbose, disableIncScorePruning, disableIncMaxScorePruning);
+  maxscub = getMaxChangedScoreAllFeatures(nrow(X2), ncol(X2), addedX2, removedX2,
+     addedE, removedE, prevLattice, metaPrevLattice, prevStats, encodeLat, differentOffsets,
+     alpha, eAvg, minSup, prevFoffb, prevFoffe, foffb, foffe, enableIncApproxPruning);
+  [S, R, selCols] = createAndScoreBasicSlicesInc(X2, changedX2, prevTK2, totalE, changedE,
+     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning);
 
   # initialize lattice and statistics for incremental updates
   L1 = S;
@@ -196,10 +204,10 @@ m_incSliceLine = function(
   Stats = list(R);
 
   # initialize top-k
-  [TK, TKC] = maintainTopK(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
+  [TK, TKC] = maintainTopKInc(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
 
   if( verbose ) {
-    [maxsc2, minsc2] = analyzeTopK(TKC);
+    [maxsc2, minsc2] = analyzeTopKInc(TKC);
     print("incSliceLine: initial top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2+" (time="+(time()-t1)+")")
     D = rbind(D, t(as.matrix(list(1, n2, nrow(S), maxsc2, minsc2))));
   }
@@ -219,18 +227,18 @@ m_incSliceLine = function(
 
     # enumerate candidate join pairs, incl size/error pruning
     nrS = nrow(S);
-    S = getPairedCandidates(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
+    S = getPairedCandidatesInc(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
     S2 = S;
 
     # load one hot encoded previous lattice for the current level
     prevLattice2 = matrix(0,0,0);
-    if(!disableIncSizePruning){
+    if(enableIncSizePruning){
       prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
         prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
     }
 
     if(selFeat){
-      if(length(prevLattice2)>0 & !disableIncSizePruning){
+      if(length(prevLattice2)>0 & enableIncSizePruning){
         prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
       }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
@@ -242,7 +250,7 @@ m_incSliceLine = function(
     }
 
     # prune unchanged slices with slice size < minSup
-    if(level <= length(prevStats) & !disableIncSizePruning){
+    if(level <= length(prevStats) & enableIncSizePruning){
       npairs = nrow(S);
       [S, S2] = pruneUnchangedSlices(S, S2,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
       if(verbose) {
@@ -266,21 +274,21 @@ m_incSliceLine = function(
         parfor( i in 1:ceil(nrow(S)/tpBlksz), check=0 ) {
           beg = (i-1)*tpBlksz + 1;
           end = min(i*tpBlksz, nrow(R));
-          R[beg:end,] = evalSlice(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
+          R[beg:end,] = evalSliceInc(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
         }
       }
       else { # data-parallel
-        R = evalSlice(X2, totalE, eAvg, t(S2), level, alpha);
+        R = evalSliceInc(X2, totalE, eAvg, t(S2), level, alpha);
       }
 
       # update output statistics
       Stats = append(Stats, R);
 
       # maintain top-k after evaluation
-      [TK, TKC] = maintainTopK(S, R, TK, TKC, k, minSup, foffb, foffe);
+      [TK, TKC] = maintainTopKInc(S, R, TK, TKC, k, minSup, foffb, foffe);
 
       if(verbose) {
-        [maxsc2, minsc2] = analyzeTopK(TKC);
+        [maxsc2, minsc2] = analyzeTopKInc(TKC);
         valid = as.integer(sum(R[,2]>0 & R[,4]>=minSup));
         print(" -- valid slices after eval: "+valid+"/"+nrow(S));
         print(" -- top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2);
@@ -301,10 +309,11 @@ m_incSliceLine = function(
   }
 }
 
-createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
+createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     Matrix[Double] prevTK2, Matrix[Double] e, Matrix[Double] ep,
     Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha,
-    Double minsc, Matrix[Double] maxsc, Boolean verbose, Boolean disableIncScorePruning, Boolean disableIncMaxScorePruning)
+    Double minsc, Matrix[Double] maxsc, Matrix[Double] maxscub, Boolean verbose,
+    Boolean enableIncScorePruning, Boolean enableIncMaxScorePruning)
   return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
@@ -324,7 +333,7 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   # b) unchanged pruning
   # (valid to prune feature if its previous max score was negative or below minsc)
   selCols2 = selCols;
-  if( !disableIncMaxScorePruning ) {
+  if( enableIncMaxScorePruning ) {
     selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
   } 
 
@@ -332,6 +341,15 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
     n = as.integer(sum(selCols));
     drop = as.integer(sum(selCols) - sum(selCols2));
     print("incSliceLine: dropping "+drop+"/"+n+" unaffected features.");
+  }
+
+  # c) max score changed pruning
+  n = as.integer(sum(selCols2));
+  selCols2 = selCols2 & (maxscub >= max(0, minsc) | maxscub==-Inf);
+
+  if( verbose ) {
+    drop = as.integer(n - sum(selCols2));
+    print("incSliceLine: dropping "+drop+"/"+n+" insufficiently affected features.");
   }
 
   # working set of active slices (#attr x #slices) and top k
@@ -343,13 +361,13 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   S = table(seq(1,nrow(attr)), attr, nrow(attr), n2);
 
   # score 1-slices and create initial top-k
-  sc = score(ss, se, eAvg, alpha, nrow(X2));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
   R = cbind(sc, se, sm, ss);
 
-  # c) score pruning
+  # d) score pruning
   # compute upper bound scores for all remaining slices
-  if(minsc > -Inf & !disableIncScorePruning) {
-    ubSc = scoreUB(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
+  if(minsc > -Inf & enableIncScorePruning) {
+    ubSc = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
     selCols3 = (ubSc > max(0, minsc));
     S = removeEmpty(target=S, margin="rows", select=selCols3);
     R = removeEmpty(target=R, margin="rows", select=selCols3);
@@ -370,14 +388,14 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   }
 }
 
-score = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
+scoreInc = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
   sc = alpha * ((se/ss) / eAvg - 1) - (1-alpha) * (n/ss - 1);
   sc = replace(target=sc, pattern=NaN, replacement=-Inf);
 }
 
-scoreUB = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
+scoreUBInc = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
     Double eAvg, Integer minSup, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
@@ -393,7 +411,7 @@ scoreUB = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
 }
 
 
-maintainTopK = function(Matrix[Double] S, Matrix[Double] R,
+maintainTopKInc = function(Matrix[Double] S, Matrix[Double] R,
     Matrix[Double] TK, Matrix[Double] TKC, Integer k,
     Integer minSup, Matrix[Double] foffb, Matrix[Double] foffe)
   return(Matrix[Double] TK, Matrix[Double] TKC)
@@ -428,7 +446,7 @@ maintainTopK = function(Matrix[Double] S, Matrix[Double] R,
   }
 }
 
-analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
+analyzeTopKInc = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
   maxsc = -Inf;
   minsc = -Inf;
   if( nrow(TKC)>0 ) {
@@ -437,7 +455,7 @@ analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
   }
 }
 
-getPairedCandidates = function(Matrix[Double] S,
+getPairedCandidatesInc = function(Matrix[Double] S,
     Matrix[Double] R, Matrix[Double] TKC, Integer level,
     Double eAvg, Integer minSup, Double alpha, Integer n2,
     Matrix[Double] foffb, Matrix[Double] foffe)
@@ -499,8 +517,8 @@ getPairedCandidates = function(Matrix[Double] S,
     ubError = replace(target=ubError, pattern=Inf, replacement=0);
     ubMError = 1/rowMaxs(map * (1/t(sm)));
     ubMError = replace(target=ubMError, pattern=Inf, replacement=0);
-    ubScores = scoreUB(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
-    [maxsc, minsc] = analyzeTopK(TKC);
+    ubScores = scoreUBInc(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
+    [maxsc, minsc] = analyzeTopKInc(TKC);
 
     # score pruning
     fScores = (ubScores > minsc & ubScores > 0)
@@ -521,7 +539,7 @@ getPairedCandidates = function(Matrix[Double] S,
   }
 }
 
-evalSlice = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
+evalSliceInc = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
     Matrix[Double] tS, Integer l, Double alpha)
 
   return(Matrix[Double] R)
@@ -530,11 +548,10 @@ evalSlice = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
   I = (X %*% tS) == l;    # slice indicator
   ss = t(colSums(I));     # absolute slice size (nnz)
   se = t(t(e) %*% I);     # absolute slice error
-
   sm = t(colMaxs(I * e)); # maximum tuple error in slice
 
   # score of relative error and relative size
-  sc = score(ss, se, eAvg, alpha, nrow(X));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X));
   R = cbind(sc, se, sm, ss);
 }
 
@@ -615,7 +632,7 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   sm = t(colMaxs(I * totalE));  # maximum tuple error in slice
 
   # score slice and if applicable set min score for pruning
-  sc = score(ss, se, eAvg, alpha, nrow(X2));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
   sc = replace(target=sc, pattern=-Inf, replacement=0)
   R = cbind(sc, se, sm, ss);
   minsc = min(sc);
@@ -630,7 +647,7 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
   # a) determine unchagned slices
   # only computing unchanged slices for levels 2 and above,
   # Imat has a 1 where a slice in changedX2 belongs to a slice in prevLatAtLevel
-  if(nrow(S2) > 0 & nrow(unchangedS) > 0) {
+  if(nrow(S2) > 0 & sum(S2) > 0 & nrow(unchangedS) > 0) {
     # b) select unchanged slices that can be pruned
     I = t(colSums((changedX2 %*% t(unchangedS)) == level) == 0) # change pushdown
         & unchangedR[,4] < minSup; # minSup pushdown
@@ -724,10 +741,65 @@ getMaxScoreAllFeatures = function(Int numRows, Int numFeatures, List[Unknown] pr
       if( length(prevStats) >= level ) {
         R = as.matrix(prevStats[level]);
         # rescaling of scores according to new size of X and eAvg
-        sc = score(R[,4], R[,2], eAvg, alpha, numRows);
+        sc = scoreInc(R[,4], R[,2], eAvg, alpha, numRows);
         # robustness for S * sc creating NaNs because 0 * -Inf = NaN
         sc = replace(target=sc, pattern=-Inf, replacement=0);
         maxsc = max(maxsc, t(colMaxs(S*sc)));
+      }
+    }
+  }
+}
+
+getMaxChangedScoreAllFeatures = function(Int numRows, Int numFeatures, Matrix[Double] addedX2,
+  Matrix[Double] removedX2, Matrix[Double] addedE, Matrix[Double] removedE,
+  List[Unknown] prevLattice, List[Unknown] metaPrevLattice, List[Unknown] prevStats,
+  Boolean encodeLat, Boolean differentOffsets, Double alpha, Double eAvg, Double minSup,
+  Matrix[Double] prevFoffb, Matrix[Double] prevFoffe, Matrix[Double] foffb, Matrix[Double] foffe,
+  Boolean enableIncApproxPruning)
+  return(Matrix[Double] maxscub)
+{
+  maxscub = matrix(-Inf, numFeatures, 1);
+  if( length(prevLattice) > 0 & nrow(addedX2) < 0.05*numRows & enableIncApproxPruning ) {
+    # compute upper bounds per feature for added subset
+    ss = t(colSums(addedX2));
+    se = t(t(addedE) %*% addedX2);
+    sm = t(colMaxs(addedX2 * addedE))
+    maxscub = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, numRows);
+
+    # compute high-probability upper-bound scores per feature
+    for(level in 1:length(prevLattice)) {
+      if( length(prevStats) >= level ) {
+        S = as.matrix(prevLattice[level]);
+        if( encodeLat ) {
+          metaAtLevel = as.frame(metaPrevLattice[level]);
+          prevLatticeDec = transformIDsToSlices(S, prevFoffb, prevFoffe, metaAtLevel);
+          if( nrow(S) > 0 )
+            S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
+          else
+            S = matrix(0, 1, numFeatures);
+        }
+        else if(differentOffsets) {
+          prevLatticeDec = decodeOneHot(S, prevFoffb, prevFoffe);
+          S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
+        }
+        R = as.matrix(prevStats[level]); #(sc,se,sm,ss)
+        # compute exact deltas/slice scores, and update max scores per feature despite the
+        # exact deltas we need to consider upper bounds because new slices, previously not
+        # considered, might appear (only high probability, for hard guarantees we would
+        # need to consider previously pruned slices too)
+        dssp = rowSums((S%*%t(addedX2))==level);               # size delta plus
+        dssm = rowSums((S%*%t(removedX2))==level);             # size delta minus
+        dsep = rowSums((S%*%t(addedX2)==level)*t(addedE));     # error delta plus
+        dsem = rowSums((S%*%t(removedX2)==level)*t(removedE)); # error delta minus
+        # compute interesting extreme points
+        sc1 = scoreInc(R[,4] - dssm,        R[,2] + dsep,        eAvg, alpha, numRows);
+        sc2 = scoreInc(R[,4],               R[,2] + dsep,        eAvg, alpha, numRows);
+        sc3 = scoreInc(R[,4] + dssp,        R[,2] + dsep,        eAvg, alpha, numRows);
+        sc4 = scoreInc(R[,4] + dssp - dssm, R[,2] + dsep - dsem, eAvg, alpha, numRows);
+        sc = max(sc1, sc2, sc3, sc4);
+        # robustness for S * sc creating NaNs because 0 * -Inf = NaN
+        sc = replace(target=sc, pattern=-Inf, replacement=0);
+        maxscub = max(maxscub, t(colMaxs(S*sc)));
       }
     }
   }
@@ -765,4 +837,3 @@ removeRowsByIndices = function(Matrix[Double] M, Matrix[Double] indices)
   P2 = table(seq(1, nrow(CIX)), CIX, nrow(CIX), nrow(M))
   remain = P2 %*% M;
 }
-

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -321,7 +321,10 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
 
   # b) unchanged pruning
   # (valid to prune feature if its previous max score was negative or below minsc)
-  selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
+  selCols2 = selCols;
+  if( !disableIncScorePruning ) {
+    selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
+  } 
 
   if( verbose ) {
     n = as.integer(sum(selCols));
@@ -354,7 +357,11 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
       print("incSliceLine: dropping "+drop+"/"+n+" features below minSore = "+minsc+".");
     }
     cix = removeEmpty(target=attr, margin="rows", select=selCols3);
-    selCols = table(cix, 1, n2, 1);
+    if(sum(cix) != 0) {
+      selCols = table(cix, 1, n2, 1);
+    }else {
+      selCols = matrix(0, n2, 1);
+    }
   }
   else {
     selCols = selCols2;

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -52,8 +52,7 @@
 # prevTK           previous top-k slices (for incremental updates)
 # prevTKC          previous top-k scores (for incremental updates)
 # encodeLat        flag for encoding output lattice for less memory consumption
-# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 
-#                                     3 only max score pruning, 4 only approx pruning, 5 no pruning 
+# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 3 only max score pruning, 4 no pruning
 # ---------------------------------------------------------------------------------------
 #
 # OUTPUT:
@@ -101,11 +100,9 @@ m_incSliceLine = function(
       + " -- see documentation for more details.");
   }
 
-  enableIncScorePruning = ( pruningStrat <= 1);
-  enableIncSizePruning = ((pruningStrat == 0) | (pruningStrat == 2));
-  enableIncMaxScorePruning = ((pruningStrat == 0) | (pruningStrat == 3));
-  enableIncApproxPruning = ((pruningStrat == 0) | (pruningStrat == 4));
-  enableIncApproxPruning = TRUE;
+  disableIncScorePruning = ( pruningStrat >= 2);
+  disableIncSizePruning = ((pruningStrat == 1) | (pruningStrat >= 3));
+  disableIncMaxScorePruning = ((pruningStrat == 1) | (pruningStrat == 2) | (pruningStrat == 4));
 
   t1 = time();
 
@@ -121,11 +118,11 @@ m_incSliceLine = function(
     oldE = matrix(0,0,ncol(addedE));
   }
   ## remove all rows from oldX and oldE that are in indicesRemoved
-  removedX = matrix(0,0,ncol(oldX));
+  removedTuples = matrix(0,0,ncol(oldX));
   removedE = matrix(0,0,1);
   if(length(indicesRemoved) > 0 & nrow(oldX)  > 0){
-    [oldX, removedX] = removeRowsByIndices(oldX, indicesRemoved);
-    [oldE, removedE] = removeRowsByIndices(oldE, indicesRemoved);
+    [oldX, removedTuples] = removeRowsByIndices( oldX, indicesRemoved);
+    [oldE, removedE] = removeRowsByIndices( oldE, indicesRemoved);
     if(verbose){
       print("incSliceLine: removed "+nrow(indicesRemoved)+" tuples.");
     }
@@ -161,12 +158,9 @@ m_incSliceLine = function(
   # One-hot encoding of tuples that were removed from oldX
   # combining of addedX and oldX in changedX2 facilitates simple determination of unchanged slices for pruning
   changedX2 = addedX2;
-  removedX2 = removedX;
-  if(nrow(removedX) > 0){
-    removedX2 = oneHotEncodeUsingOffsets(removedX, foffb, foffe);
-    changedX2 = rbind(addedX2, removedX2);
-  } else {
-    removedX2 = matrix(0, 0, ncol(addedX2));
+  if(nrow(removedTuples) > 0){
+    removedTuples2 = oneHotEncodeUsingOffsets(removedTuples, foffb, foffe);
+    changedX2 = rbind(addedX2, removedTuples2);
   }
   changedE = rbind(addedE, removedE);
 
@@ -188,11 +182,8 @@ m_incSliceLine = function(
   # create and score basic slices (conjunctions of 1 feature)
   maxsc = getMaxScoreAllFeatures(nrow(X2), ncol(X2), prevLattice, metaPrevLattice,
      prevStats, encodeLat, differentOffsets, alpha, eAvg, prevFoffb, prevFoffe, foffb, foffe);
-  maxscub = getMaxChangedScoreAllFeatures(nrow(X2), ncol(X2), addedX2, removedX2,
-     addedE, removedE, prevLattice, metaPrevLattice, prevStats, encodeLat, differentOffsets,
-     alpha, eAvg, minSup, prevFoffb, prevFoffe, foffb, foffe, enableIncApproxPruning);
-  [S, R, SPr, RPr, selCols] = createAndScoreBasicSlicesInc(X2, changedX2, prevTK2, totalE, changedE,
-     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning, enableIncApproxPruning);
+  [S, R, SPr, RPr, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, changedE,
+     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, verbose, disableIncScorePruning, disableIncMaxScorePruning);
 
   # initialize lattice and statistics for incremental updates
   L1 = rbind(S, SPr);
@@ -206,10 +197,10 @@ m_incSliceLine = function(
   Stats = list(Stats1);
 
   # initialize top-k
-  [TK, TKC] = maintainTopKInc(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
+  [TK, TKC] = maintainTopK(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
 
   if( verbose ) {
-    [maxsc2, minsc2] = analyzeTopKInc(TKC);
+    [maxsc2, minsc2] = analyzeTopK(TKC);
     print("incSliceLine: initial top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2+" (time="+(time()-t1)+")")
     D = rbind(D, t(as.matrix(list(1, n2, nrow(S), maxsc2, minsc2))));
   }
@@ -229,19 +220,19 @@ m_incSliceLine = function(
 
     # enumerate candidate join pairs, incl size/error pruning
     nrS = nrow(S);
-    S = getPairedCandidatesInc(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
+    S = getPairedCandidates(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
     S2 = S;
 
     # load one hot encoded previous lattice for the current level
     prevLattice2 = matrix(0,0,0);
-    if(enableIncSizePruning){
+    if(!disableIncSizePruning){
       prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
         prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
     }
 
     prevLattice1 = prevLattice2;
     if(selFeat){
-      if(length(prevLattice2)>0 & enableIncSizePruning){
+      if(length(prevLattice2)>0 & !disableIncSizePruning){
         prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
       }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
@@ -255,7 +246,7 @@ m_incSliceLine = function(
     # prune unchanged slices with slice size < minSup
     SPr = matrix(0,0, ncol(S));
     RPr = matrix(0,0, 4);
-    if(level <= length(prevStats) & enableIncSizePruning){
+    if(level <= length(prevStats) & !disableIncSizePruning){
       npairs = nrow(S);
       [S, S2, SPr, RPr] = pruneUnchangedSlices(S, S2, prevLattice1,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
       if(verbose) {
@@ -279,11 +270,11 @@ m_incSliceLine = function(
         parfor( i in 1:ceil(nrow(S)/tpBlksz), check=0 ) {
           beg = (i-1)*tpBlksz + 1;
           end = min(i*tpBlksz, nrow(R));
-          R[beg:end,] = evalSliceInc(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
+          R[beg:end,] = evalSlice(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
         }
       }
       else { # data-parallel
-        R = evalSliceInc(X2, totalE, eAvg, t(S2), level, alpha);
+        R = evalSlice(X2, totalE, eAvg, t(S2), level, alpha);
       }
 
       # update output statistics
@@ -291,10 +282,10 @@ m_incSliceLine = function(
       Stats = append(Stats, Rrep);
 
       # maintain top-k after evaluation
-      [TK, TKC] = maintainTopKInc(S, R, TK, TKC, k, minSup, foffb, foffe);
+      [TK, TKC] = maintainTopK(S, R, TK, TKC, k, minSup, foffb, foffe);
 
       if(verbose) {
-        [maxsc2, minsc2] = analyzeTopKInc(TKC);
+        [maxsc2, minsc2] = analyzeTopK(TKC);
         valid = as.integer(sum(R[,2]>0 & R[,4]>=minSup));
         print(" -- valid slices after eval: "+valid+"/"+nrow(S));
         print(" -- top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2);
@@ -315,11 +306,10 @@ m_incSliceLine = function(
   }
 }
 
-createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
+createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
     Matrix[Double] prevTK2, Matrix[Double] e, Matrix[Double] ep,
     Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha,
-    Double minsc, Matrix[Double] maxsc, Matrix[Double] maxscub, Boolean verbose,
-    Boolean enableIncScorePruning, Boolean enableIncMaxScorePruning, Boolean enableIncApproxPruning)
+    Double minsc, Matrix[Double] maxsc, Boolean verbose, Boolean disableIncScorePruning, Boolean disableIncMaxScorePruning)
   return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] SPr, Matrix[Double] RPr, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
@@ -339,7 +329,7 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
   # b) unchanged pruning
   # (valid to prune feature if its previous max score was negative or below minsc)
   selCols2 = selCols;
-  if( enableIncMaxScorePruning ) {
+  if( !disableIncMaxScorePruning ) {
     selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
   } 
 
@@ -347,17 +337,6 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     n = as.integer(sum(selCols));
     drop = as.integer(sum(selCols) - sum(selCols2));
     print("incSliceLine: dropping "+drop+"/"+n+" unaffected features.");
-  }
-
-  # c) max score changed pruning
-  n = as.integer(sum(selCols2));
-  if( enableIncApproxPruning ) {
-    selCols2 = selCols2 & (maxscub >= max(0, minsc) | maxscub==-Inf);
-  }
-  
-  if( verbose ) {
-    drop = as.integer(n - sum(selCols2));
-    print("incSliceLine: dropping "+drop+"/"+n+" insufficiently affected features.");
   }
 
   # working set of active slices (#attr x #slices) and top k
@@ -369,7 +348,7 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
   S = table(seq(1,nrow(attr)), attr, nrow(attr), n2);
 
   # score 1-slices and create initial top-k
-  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
+  sc = score(ss, se, eAvg, alpha, nrow(X2));
   R = cbind(sc, se, sm, ss);
   SPr = matrix(0,0, n2);
   RPr = matrix(0,0, 4);
@@ -388,10 +367,10 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     RPr = cbind(scPr, sePr, smPr, ssPr);
   }
 
-  # d) score pruning
+  # c) score pruning
   # compute upper bound scores for all remaining slices
-  if(minsc > -Inf & enableIncScorePruning) {
-    ubSc = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
+  if(minsc > -Inf & !disableIncScorePruning) {
+    ubSc = scoreUB(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
     selCols3 = (ubSc > max(0, minsc));
 
     # store all pruned slices for incremental updates
@@ -422,14 +401,14 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
   }
 }
 
-scoreInc = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
+score = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
   sc = alpha * ((se/ss) / eAvg - 1) - (1-alpha) * (n/ss - 1);
   sc = replace(target=sc, pattern=NaN, replacement=-Inf);
 }
 
-scoreUBInc = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
+scoreUB = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
     Double eAvg, Integer minSup, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
@@ -445,7 +424,7 @@ scoreUBInc = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
 }
 
 
-maintainTopKInc = function(Matrix[Double] S, Matrix[Double] R,
+maintainTopK = function(Matrix[Double] S, Matrix[Double] R,
     Matrix[Double] TK, Matrix[Double] TKC, Integer k,
     Integer minSup, Matrix[Double] foffb, Matrix[Double] foffe)
   return(Matrix[Double] TK, Matrix[Double] TKC)
@@ -480,7 +459,7 @@ maintainTopKInc = function(Matrix[Double] S, Matrix[Double] R,
   }
 }
 
-analyzeTopKInc = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
+analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
   maxsc = -Inf;
   minsc = -Inf;
   if( nrow(TKC)>0 ) {
@@ -489,7 +468,7 @@ analyzeTopKInc = function(Matrix[Double] TKC) return(Double maxsc, Double minsc)
   }
 }
 
-getPairedCandidatesInc = function(Matrix[Double] S,
+getPairedCandidates = function(Matrix[Double] S,
     Matrix[Double] R, Matrix[Double] TKC, Integer level,
     Double eAvg, Integer minSup, Double alpha, Integer n2,
     Matrix[Double] foffb, Matrix[Double] foffe)
@@ -551,8 +530,8 @@ getPairedCandidatesInc = function(Matrix[Double] S,
     ubError = replace(target=ubError, pattern=Inf, replacement=0);
     ubMError = 1/rowMaxs(map * (1/t(sm)));
     ubMError = replace(target=ubMError, pattern=Inf, replacement=0);
-    ubScores = scoreUBInc(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
-    [maxsc, minsc] = analyzeTopKInc(TKC);
+    ubScores = scoreUB(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
+    [maxsc, minsc] = analyzeTopK(TKC);
 
     # score pruning
     fScores = (ubScores > minsc & ubScores > 0)
@@ -573,7 +552,7 @@ getPairedCandidatesInc = function(Matrix[Double] S,
   }
 }
 
-evalSliceInc = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
+evalSlice = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
     Matrix[Double] tS, Integer l, Double alpha)
 
   return(Matrix[Double] R)
@@ -582,10 +561,11 @@ evalSliceInc = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
   I = (X %*% tS) == l;    # slice indicator
   ss = t(colSums(I));     # absolute slice size (nnz)
   se = t(t(e) %*% I);     # absolute slice error
+
   sm = t(colMaxs(I * e)); # maximum tuple error in slice
 
   # score of relative error and relative size
-  sc = scoreInc(ss, se, eAvg, alpha, nrow(X));
+  sc = score(ss, se, eAvg, alpha, nrow(X));
   R = cbind(sc, se, sm, ss);
 }
 
@@ -666,7 +646,7 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   sm = t(colMaxs(I * totalE));  # maximum tuple error in slice
 
   # score slice and if applicable set min score for pruning
-  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
+  sc = score(ss, se, eAvg, alpha, nrow(X2));
   sc = replace(target=sc, pattern=-Inf, replacement=0)
   R = cbind(sc, se, sm, ss);
   minsc = min(sc);
@@ -684,16 +664,13 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
   # a) determine unchagned slices
   # only computing unchanged slices for levels 2 and above,
   # Imat has a 1 where a slice in changedX2 belongs to a slice in prevLatAtLevel
-  if(nrow(S2) > 0 & sum(S2) > 0 & nrow(unchangedS) > 0) {
+  if(nrow(S2) > 0 & nrow(unchangedS) > 0) {
     # b) select unchanged slices that can be pruned
     I = t(colSums((changedX2 %*% t(unchangedS)) == level) == 0) # change pushdown
         & unchangedR[,4] < minSup; # minSup pushdown
     unchangedS2 = removeEmpty(target=unchangedS, margin="rows", select=I);
-    if(sum(I) > 0){
-      SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
-      RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
-    }
-    
+    SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
+    RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
     # c) select only rows that cannot be pruned
     selCols = !rowSums((S2 %*% t(unchangedS2)) == level);
 
@@ -770,7 +747,6 @@ getMaxScoreAllFeatures = function(Int numRows, Int numFeatures, List[Unknown] pr
   if( length(prevLattice) > 0 ) {
     for(level in 1:length(prevLattice)) {
       S = as.matrix(prevLattice[level]);
-      print("nrow(S): " + nrow(S));
       if( encodeLat ) {
         metaAtLevel = as.frame(metaPrevLattice[level]);
         prevLatticeDec = transformIDsToSlices(S, prevFoffb, prevFoffe, metaAtLevel);
@@ -786,65 +762,10 @@ getMaxScoreAllFeatures = function(Int numRows, Int numFeatures, List[Unknown] pr
       if( length(prevStats) >= level ) {
         R = as.matrix(prevStats[level]);
         # rescaling of scores according to new size of X and eAvg
-        sc = scoreInc(R[,4], R[,2], eAvg, alpha, numRows);
+        sc = score(R[,4], R[,2], eAvg, alpha, numRows);
         # robustness for S * sc creating NaNs because 0 * -Inf = NaN
         sc = replace(target=sc, pattern=-Inf, replacement=0);
         maxsc = max(maxsc, t(colMaxs(S*sc)));
-      }
-    }
-  }
-}
-
-getMaxChangedScoreAllFeatures = function(Int numRows, Int numFeatures, Matrix[Double] addedX2,
-  Matrix[Double] removedX2, Matrix[Double] addedE, Matrix[Double] removedE,
-  List[Unknown] prevLattice, List[Unknown] metaPrevLattice, List[Unknown] prevStats,
-  Boolean encodeLat, Boolean differentOffsets, Double alpha, Double eAvg, Double minSup,
-  Matrix[Double] prevFoffb, Matrix[Double] prevFoffe, Matrix[Double] foffb, Matrix[Double] foffe,
-  Boolean enableIncApproxPruning)
-  return(Matrix[Double] maxscub)
-{
-  maxscub = matrix(-Inf, numFeatures, 1);
-  if( length(prevLattice) > 0 & nrow(addedX2) < 0.05*numRows & enableIncApproxPruning ) {
-    # compute upper bounds per feature for added subset
-    ss = t(colSums(addedX2));
-    se = t(t(addedE) %*% addedX2);
-    sm = t(colMaxs(addedX2 * addedE))
-    maxscub = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, numRows);
-
-    # compute high-probability upper-bound scores per feature
-    for(level in 1:length(prevLattice)) {
-      if( length(prevStats) >= level ) {
-        S = as.matrix(prevLattice[level]);
-        if( encodeLat ) {
-          metaAtLevel = as.frame(metaPrevLattice[level]);
-          prevLatticeDec = transformIDsToSlices(S, prevFoffb, prevFoffe, metaAtLevel);
-          if( nrow(S) > 0 )
-            S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
-          else
-            S = matrix(0, 1, numFeatures);
-        }
-        else if(differentOffsets) {
-          prevLatticeDec = decodeOneHot(S, prevFoffb, prevFoffe);
-          S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
-        }
-        R = as.matrix(prevStats[level]); #(sc,se,sm,ss)
-        # compute exact deltas/slice scores, and update max scores per feature despite the
-        # exact deltas we need to consider upper bounds because new slices, previously not
-        # considered, might appear (only high probability, for hard guarantees we would
-        # need to consider previously pruned slices too)
-        dssp = rowSums((S%*%t(addedX2))==level);               # size delta plus
-        dssm = rowSums((S%*%t(removedX2))==level);             # size delta minus
-        dsep = rowSums((S%*%t(addedX2)==level)*t(addedE));     # error delta plus
-        dsem = rowSums((S%*%t(removedX2)==level)*t(removedE)); # error delta minus
-        # compute interesting extreme points
-        sc1 = scoreInc(R[,4] - dssm,        R[,2] + dsep,        eAvg, alpha, numRows);
-        sc2 = scoreInc(R[,4],               R[,2] + dsep,        eAvg, alpha, numRows);
-        sc3 = scoreInc(R[,4] + dssp,        R[,2] + dsep,        eAvg, alpha, numRows);
-        sc4 = scoreInc(R[,4] + dssp - dssm, R[,2] + dsep - dsem, eAvg, alpha, numRows);
-        sc = max(sc1, sc2, sc3, sc4);
-        # robustness for S * sc creating NaNs because 0 * -Inf = NaN
-        sc = replace(target=sc, pattern=-Inf, replacement=0);
-        maxscub = max(maxscub, t(colMaxs(S*sc)));
       }
     }
   }
@@ -882,3 +803,4 @@ removeRowsByIndices = function(Matrix[Double] M, Matrix[Double] indices)
   P2 = table(seq(1, nrow(CIX)), CIX, nrow(CIX), nrow(M))
   remain = P2 %*% M;
 }
+

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -105,6 +105,7 @@ m_incSliceLine = function(
   enableIncSizePruning = ((pruningStrat == 0) | (pruningStrat == 2));
   enableIncMaxScorePruning = ((pruningStrat == 0) | (pruningStrat == 3));
   enableIncApproxPruning = ((pruningStrat == 0) | (pruningStrat == 4));
+  enableIncApproxPruning = TRUE;
 
   t1 = time();
 
@@ -190,8 +191,8 @@ m_incSliceLine = function(
   maxscub = getMaxChangedScoreAllFeatures(nrow(X2), ncol(X2), addedX2, removedX2,
      addedE, removedE, prevLattice, metaPrevLattice, prevStats, encodeLat, differentOffsets,
      alpha, eAvg, minSup, prevFoffb, prevFoffe, foffb, foffe, enableIncApproxPruning);
-  [S, R, selCols] = createAndScoreBasicSlicesInc(X2, changedX2, prevTK2, totalE, changedE,
-     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning);
+  [S, R, SPr, RPr, selCols] = createAndScoreBasicSlicesInc(X2, changedX2, prevTK2, totalE, changedE,
+     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning, enableIncApproxPruning);
 
   # initialize lattice and statistics for incremental updates
   L1 = rbind(S, SPr);
@@ -318,8 +319,8 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     Matrix[Double] prevTK2, Matrix[Double] e, Matrix[Double] ep,
     Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha,
     Double minsc, Matrix[Double] maxsc, Matrix[Double] maxscub, Boolean verbose,
-    Boolean enableIncScorePruning, Boolean enableIncMaxScorePruning)
-  return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] selCols)
+    Boolean enableIncScorePruning, Boolean enableIncMaxScorePruning, Boolean enableIncApproxPruning)
+  return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] SPr, Matrix[Double] RPr, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
   cCnts = t(colSums(X2));       # column counts
@@ -350,8 +351,10 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
 
   # c) max score changed pruning
   n = as.integer(sum(selCols2));
-  selCols2 = selCols2 & (maxscub >= max(0, minsc) | maxscub==-Inf);
-
+  if( enableIncApproxPruning ) {
+    selCols2 = selCols2 & (maxscub >= max(0, minsc) | maxscub==-Inf);
+  }
+  
   if( verbose ) {
     drop = as.integer(n - sum(selCols2));
     print("incSliceLine: dropping "+drop+"/"+n+" insufficiently affected features.");
@@ -686,8 +689,11 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
     I = t(colSums((changedX2 %*% t(unchangedS)) == level) == 0) # change pushdown
         & unchangedR[,4] < minSup; # minSup pushdown
     unchangedS2 = removeEmpty(target=unchangedS, margin="rows", select=I);
-    SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
-    RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
+    if(sum(I) > 0){
+      SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
+      RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
+    }
+    
     # c) select only rows that cannot be pruned
     selCols = !rowSums((S2 %*% t(unchangedS2)) == level);
 
@@ -764,6 +770,7 @@ getMaxScoreAllFeatures = function(Int numRows, Int numFeatures, List[Unknown] pr
   if( length(prevLattice) > 0 ) {
     for(level in 1:length(prevLattice)) {
       S = as.matrix(prevLattice[level]);
+      print("nrow(S): " + nrow(S));
       if( encodeLat ) {
         metaAtLevel = as.frame(metaPrevLattice[level]);
         prevLatticeDec = transformIDsToSlices(S, prevFoffb, prevFoffe, metaAtLevel);

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -238,6 +238,7 @@ m_incSliceLine = function(
         prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
     }
 
+    prevLattice1 = prevLattice2;
     if(selFeat){
       if(length(prevLattice2)>0 & enableIncSizePruning){
         prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
@@ -251,18 +252,20 @@ m_incSliceLine = function(
     }
 
     # prune unchanged slices with slice size < minSup
+    SPr = matrix(0,0, ncol(S));
+    RPr = matrix(0,0, 4);
     if(level <= length(prevStats) & enableIncSizePruning){
       npairs = nrow(S);
-      [S, S2] = pruneUnchangedSlices(S, S2,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
+      [S, S2, SPr, RPr] = pruneUnchangedSlices(S, S2, prevLattice1,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
       if(verbose) {
         print(" -- dropping "+(npairs-nrow(S))+"/"+npairs+" unaffected paired slice candidates ");
       }
     }
 
     # prepare and store output lattice for next run
-    Lrep = S
+    Lrep = rbind(S,SPr);
     if ( encodeLat ) {
-      [Lrep, M] = transformSlicesToIDs(S, foffb, foffe);
+      [Lrep, M] = transformSlicesToIDs(Lrep, foffb, foffe);
       metaLattice = append(metaLattice, M);
     }
     L = append(L, Lrep);
@@ -283,7 +286,8 @@ m_incSliceLine = function(
       }
 
       # update output statistics
-      Stats = append(Stats, R);
+      Rrep = rbind(R, RPr);
+      Stats = append(Stats, Rrep);
 
       # maintain top-k after evaluation
       [TK, TKC] = maintainTopKInc(S, R, TK, TKC, k, minSup, foffb, foffe);
@@ -374,7 +378,10 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     sePr = removeEmpty(target=err, margin="rows", select=!selCols2);
     smPr = removeEmpty(target=merr, margin="rows", select=!selCols2);
     SPr = table(seq(1,nrow(attrPr)), attrPr, nrow(attrPr), n2);
-    scPr = score(ssPr, sePr, eAvg, alpha, nrow(X2));  
+    # scores are currently not used for pruning 
+    # in case of future use, set scores to Inf so a slice that was not scored 
+    # in this run can be identified and does not get pruned based on score in the next run
+    scPr = matrix(Inf, nrow(SPr), 1);
     RPr = cbind(scPr, sePr, smPr, ssPr);
   }
 
@@ -662,9 +669,12 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   minsc = min(sc);
 }
 
-pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
-  return(Matrix[Double] S, Matrix[Double] S2)
+pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Double] prevLattice, Matrix[Double] prevLattice2, list[unknown] prevStats, Matrix[Double] changedX2, Int minSup, Boolean verbose, Integer level)
+  return(Matrix[Double] S, Matrix[Double] S2, Matrix[Double] SPr, Matrix[Double] RPr)
 {
+  SPr = matrix(0,0, ncol(S));
+  RPr = matrix(0,0, 4);
+
   unchangedS = prevLattice2;
   unchangedR =  as.matrix(prevStats[level])
 
@@ -676,11 +686,15 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
     I = t(colSums((changedX2 %*% t(unchangedS)) == level) == 0) # change pushdown
         & unchangedR[,4] < minSup; # minSup pushdown
     unchangedS2 = removeEmpty(target=unchangedS, margin="rows", select=I);
+    SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
+    RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
     # c) select only rows that cannot be pruned
     selCols = !rowSums((S2 %*% t(unchangedS2)) == level);
+
     if(nrow(unchangedS) > 0 & sum(selCols) < nrow(S) ){
       S2 = removeEmpty(target=S2, margin="rows", select=selCols);
       S = removeEmpty(target=S, margin="rows", select=selCols);
+
     }
   }
 }

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -52,6 +52,7 @@
 # prevTK           previous top-k slices (for incremental updates)
 # prevTKC          previous top-k scores (for incremental updates)
 # encodeLat        flag for encoding output lattice for less memory consumption
+# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 3 only max score pruning, 4 no pruning
 # ---------------------------------------------------------------------------------------
 #
 # OUTPUT:
@@ -99,8 +100,9 @@ m_incSliceLine = function(
       + " -- see documentation for more details.");
   }
 
-  disableIncScorePruning = (pruningStrat == 1 | pruningStrat == 3);
-  disableIncSizePruning = (pruningStrat >= 2);
+  disableIncScorePruning = ( pruningStrat >= 2);
+  disableIncSizePruning = (pruningStrat == 1 | pruningStrat >= 3);
+  disableIncMaxScorePruning = (pruningStrat <= 2 | pruningStrat == 4);
 
   t1 = time();
 
@@ -181,7 +183,7 @@ m_incSliceLine = function(
   maxsc = getMaxScoreAllFeatures(nrow(X2), ncol(X2), prevLattice, metaPrevLattice,
      prevStats, encodeLat, differentOffsets, alpha, eAvg, prevFoffb, prevFoffe, foffb, foffe);
   [S, R, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, changedE,
-     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, verbose, disableIncScorePruning);
+     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, verbose, disableIncScorePruning, disableIncMaxScorePruning);
 
   # initialize lattice and statistics for incremental updates
   L1 = S;
@@ -302,7 +304,7 @@ m_incSliceLine = function(
 createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
     Matrix[Double] prevTK2, Matrix[Double] e, Matrix[Double] ep,
     Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha,
-    Double minsc, Matrix[Double] maxsc, Boolean verbose, Boolean disableIncScorePruning)
+    Double minsc, Matrix[Double] maxsc, Boolean verbose, Boolean disableIncScorePruning, Boolean disableIncMaxScorePruning)
   return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
@@ -322,7 +324,7 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   # b) unchanged pruning
   # (valid to prune feature if its previous max score was negative or below minsc)
   selCols2 = selCols;
-  if( !disableIncScorePruning ) {
+  if( !disableIncMaxScorePruning ) {
     selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
   } 
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -220,14 +220,6 @@ m_incSliceLine = function(
     S = getPairedCandidates(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
     S2 = S;
 
-    # prepare and store output lattice for next run
-    Lrep = S
-    if ( encodeLat ) {
-      [Lrep, M] = transformSlicesToIDs(S, foffb, foffe);
-      metaLattice = append(metaLattice, M);
-    }
-    L = append(L, Lrep);
-
     # load one hot encoded previous lattice for the current level
     prevLattice2 = matrix(0,0,0);
     if(!disableIncSizePruning){
@@ -255,6 +247,14 @@ m_incSliceLine = function(
         print(" -- dropping "+(npairs-nrow(S))+"/"+npairs+" unaffected paired slice candidates ");
       }
     }
+
+    # prepare and store output lattice for next run
+    Lrep = S
+    if ( encodeLat ) {
+      [Lrep, M] = transformSlicesToIDs(S, foffb, foffe);
+      metaLattice = append(metaLattice, M);
+    }
+    L = append(L, Lrep);
 
     if( nrow(S) > 0 ) {
       # extract and evaluate candidate slices
@@ -559,11 +559,15 @@ oneHotEncodeUsingOffsets = function(Matrix[Double] A, Matrix[Double] foffb, Matr
       rix = removeEmpty(target=rix, margin="rows", select=ix);
       cix = removeEmpty(target=cix, margin="rows", select=ix);
     }
-    # actual one-hot encoding
-    A2 = table(rix, cix, 1, m, as.scalar(foffe[,n]), FALSE);
-  }
-  else {
-    A2 = matrix(0, 0, as.scalar(foffe[,n]));
+
+    if (sum(rix) == 0 | sum(cix) == 0) {
+      A2 = matrix(0, 0, as.scalar(foffe[, n]));
+    } else {
+      # actual one-hot encoding
+      A2 = table(rix, cix, 1, m, as.scalar(foffe[, n]), FALSE);
+    }
+  } else {
+    A2 = matrix(0, 0, as.scalar(foffe[, n]));
   }
 }
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -102,7 +102,7 @@ m_incSliceLine = function(
 
   disableIncScorePruning = ( pruningStrat >= 2);
   disableIncSizePruning = (pruningStrat == 1 | pruningStrat >= 3);
-  disableIncMaxScorePruning = (pruningStrat <= 2 | pruningStrat == 4);
+  disableIncMaxScorePruning = (pruningStrat == 1 | pruningStrat == 2 | pruningStrat == 4);
 
   t1 = time();
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -194,14 +194,15 @@ m_incSliceLine = function(
      eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning);
 
   # initialize lattice and statistics for incremental updates
-  L1 = S;
+  L1 = rbind(S, SPr);
   metaLattice = list();
   if( encodeLat ) {
-    [L1, M] = transformSlicesToIDs(S, foffb, foffe);
+    [L1, M] = transformSlicesToIDs(L1, foffb, foffe);
     metaLattice = append(metaLattice, M);
   }
   L = list(L1);
-  Stats = list(R);
+  Stats1 = rbind(R, RPr);
+  Stats = list(Stats1);
 
   # initialize top-k
   [TK, TKC] = maintainTopKInc(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
@@ -363,14 +364,37 @@ createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
   # score 1-slices and create initial top-k
   sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
   R = cbind(sc, se, sm, ss);
+  SPr = matrix(0,0, n2);
+  RPr = matrix(0,0, 4);
+
+  # store all pruned slices for incremental updates
+  if(sum(!selCols2) != 0){
+    attrPr = removeEmpty(target=seq(1,n2), margin="rows", select=!selCols2);
+    ssPr = removeEmpty(target=cCnts, margin="rows", select=!selCols2);
+    sePr = removeEmpty(target=err, margin="rows", select=!selCols2);
+    smPr = removeEmpty(target=merr, margin="rows", select=!selCols2);
+    SPr = table(seq(1,nrow(attrPr)), attrPr, nrow(attrPr), n2);
+    scPr = score(ssPr, sePr, eAvg, alpha, nrow(X2));  
+    RPr = cbind(scPr, sePr, smPr, ssPr);
+  }
 
   # d) score pruning
   # compute upper bound scores for all remaining slices
   if(minsc > -Inf & enableIncScorePruning) {
     ubSc = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
     selCols3 = (ubSc > max(0, minsc));
+
+    # store all pruned slices for incremental updates
+    if(sum(!selCols3) != 0){
+      Rremoved = removeEmpty(target=R, margin="rows", select=!selCols3);
+      Sremoved = removeEmpty(target=S, margin="rows", select=!selCols3);
+      RPr = rbind(RPr, Rremoved);
+      SPr = rbind(SPr, Sremoved);
+    }
+
     S = removeEmpty(target=S, margin="rows", select=selCols3);
     R = removeEmpty(target=R, margin="rows", select=selCols3);
+
     if( verbose ) {
       n = as.integer(sum(selCols2));
       drop = as.integer(sum(selCols2) - sum(selCols3));

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -101,8 +101,8 @@ m_incSliceLine = function(
   }
 
   disableIncScorePruning = ( pruningStrat >= 2);
-  disableIncSizePruning = (pruningStrat == 1 | pruningStrat >= 3);
-  disableIncMaxScorePruning = (pruningStrat == 1 | pruningStrat == 2 | pruningStrat == 4);
+  disableIncSizePruning = ((pruningStrat == 1) | (pruningStrat >= 3));
+  disableIncMaxScorePruning = ((pruningStrat == 1) | (pruningStrat == 2) | (pruningStrat == 4));
 
   t1 = time();
 

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -52,7 +52,8 @@
 # prevTK           previous top-k slices (for incremental updates)
 # prevTKC          previous top-k scores (for incremental updates)
 # encodeLat        flag for encoding output lattice for less memory consumption
-# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 3 only max score pruning, 4 no pruning
+# pruningStrat     pruning strategy: 0 all pruning, 1 only score pruning, 2 only size pruning, 
+#                                     3 only max score pruning, 4 only approx pruning, 5 no pruning 
 # ---------------------------------------------------------------------------------------
 #
 # OUTPUT:
@@ -100,9 +101,11 @@ m_incSliceLine = function(
       + " -- see documentation for more details.");
   }
 
-  disableIncScorePruning = ( pruningStrat >= 2);
-  disableIncSizePruning = ((pruningStrat == 1) | (pruningStrat >= 3));
-  disableIncMaxScorePruning = ((pruningStrat == 1) | (pruningStrat == 2) | (pruningStrat == 4));
+  enableIncScorePruning = ( pruningStrat <= 1);
+  enableIncSizePruning = ((pruningStrat == 0) | (pruningStrat == 2));
+  enableIncMaxScorePruning = ((pruningStrat == 0) | (pruningStrat == 3));
+  enableIncApproxPruning = ((pruningStrat == 0) | (pruningStrat == 4));
+  enableIncApproxPruning = FALSE;
 
   t1 = time();
 
@@ -118,11 +121,11 @@ m_incSliceLine = function(
     oldE = matrix(0,0,ncol(addedE));
   }
   ## remove all rows from oldX and oldE that are in indicesRemoved
-  removedTuples = matrix(0,0,ncol(oldX));
+  removedX = matrix(0,0,ncol(oldX));
   removedE = matrix(0,0,1);
   if(length(indicesRemoved) > 0 & nrow(oldX)  > 0){
-    [oldX, removedTuples] = removeRowsByIndices( oldX, indicesRemoved);
-    [oldE, removedE] = removeRowsByIndices( oldE, indicesRemoved);
+    [oldX, removedX] = removeRowsByIndices(oldX, indicesRemoved);
+    [oldE, removedE] = removeRowsByIndices(oldE, indicesRemoved);
     if(verbose){
       print("incSliceLine: removed "+nrow(indicesRemoved)+" tuples.");
     }
@@ -158,9 +161,12 @@ m_incSliceLine = function(
   # One-hot encoding of tuples that were removed from oldX
   # combining of addedX and oldX in changedX2 facilitates simple determination of unchanged slices for pruning
   changedX2 = addedX2;
-  if(nrow(removedTuples) > 0){
-    removedTuples2 = oneHotEncodeUsingOffsets(removedTuples, foffb, foffe);
-    changedX2 = rbind(addedX2, removedTuples2);
+  removedX2 = removedX;
+  if(nrow(removedX) > 0){
+    removedX2 = oneHotEncodeUsingOffsets(removedX, foffb, foffe);
+    changedX2 = rbind(addedX2, removedX2);
+  } else {
+    removedX2 = matrix(0, 0, ncol(addedX2));
   }
   changedE = rbind(addedE, removedE);
 
@@ -182,8 +188,11 @@ m_incSliceLine = function(
   # create and score basic slices (conjunctions of 1 feature)
   maxsc = getMaxScoreAllFeatures(nrow(X2), ncol(X2), prevLattice, metaPrevLattice,
      prevStats, encodeLat, differentOffsets, alpha, eAvg, prevFoffb, prevFoffe, foffb, foffe);
-  [S, R, SPr, RPr, selCols] = createAndScoreBasicSlices(X2, changedX2, prevTK2, totalE, changedE,
-     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, verbose, disableIncScorePruning, disableIncMaxScorePruning);
+  maxscub = getMaxChangedScoreAllFeatures(nrow(X2), ncol(X2), addedX2, removedX2,
+     addedE, removedE, prevLattice, metaPrevLattice, prevStats, encodeLat, differentOffsets,
+     alpha, eAvg, minSup, prevFoffb, prevFoffe, foffb, foffe, enableIncApproxPruning);
+  [S, R, SPr, RPr, selCols] = createAndScoreBasicSlicesInc(X2, changedX2, prevTK2, totalE, changedE,
+     eAvg, eAvgOld, eAvgNew, minSup, alpha, minsc, maxsc, maxscub, verbose, enableIncScorePruning, enableIncMaxScorePruning, enableIncApproxPruning);
 
   # initialize lattice and statistics for incremental updates
   L1 = rbind(S, SPr);
@@ -197,10 +206,10 @@ m_incSliceLine = function(
   Stats = list(Stats1);
 
   # initialize top-k
-  [TK, TKC] = maintainTopK(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
+  [TK, TKC] = maintainTopKInc(S, R, prevTK2, prevTKC2, k, minSup, foffb, foffe);
 
   if( verbose ) {
-    [maxsc2, minsc2] = analyzeTopK(TKC);
+    [maxsc2, minsc2] = analyzeTopKInc(TKC);
     print("incSliceLine: initial top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2+" (time="+(time()-t1)+")")
     D = rbind(D, t(as.matrix(list(1, n2, nrow(S), maxsc2, minsc2))));
   }
@@ -220,19 +229,19 @@ m_incSliceLine = function(
 
     # enumerate candidate join pairs, incl size/error pruning
     nrS = nrow(S);
-    S = getPairedCandidates(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
+    S = getPairedCandidatesInc(S, R, TKC, level, eAvg, minSup, alpha, n2, foffb, foffe);
     S2 = S;
 
     # load one hot encoded previous lattice for the current level
     prevLattice2 = matrix(0,0,0);
-    if(!disableIncSizePruning){
+    if(enableIncSizePruning){
       prevLattice2 = preparePrevLattice(prevLattice, metaPrevLattice, prevFoffb,
         prevFoffe, foffb, foffe, level, encodeLat, differentOffsets)
     }
 
     prevLattice1 = prevLattice2;
     if(selFeat){
-      if(length(prevLattice2)>0 & !disableIncSizePruning){
+      if(length(prevLattice2)>0 & enableIncSizePruning){
         prevLattice2 = removeEmpty(target=prevLattice2, margin="cols", select=t(selCols));
       }
       S2 = removeEmpty(target=S, margin="cols", select=t(selCols));
@@ -246,7 +255,7 @@ m_incSliceLine = function(
     # prune unchanged slices with slice size < minSup
     SPr = matrix(0,0, ncol(S));
     RPr = matrix(0,0, 4);
-    if(level <= length(prevStats) & !disableIncSizePruning){
+    if(level <= length(prevStats) & enableIncSizePruning){
       npairs = nrow(S);
       [S, S2, SPr, RPr] = pruneUnchangedSlices(S, S2, prevLattice1,  prevLattice2, prevStats, changedX2, minSup, verbose, level);
       if(verbose) {
@@ -270,11 +279,11 @@ m_incSliceLine = function(
         parfor( i in 1:ceil(nrow(S)/tpBlksz), check=0 ) {
           beg = (i-1)*tpBlksz + 1;
           end = min(i*tpBlksz, nrow(R));
-          R[beg:end,] = evalSlice(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
+          R[beg:end,] = evalSliceInc(X2, totalE, eAvg, t(S2[beg:end,]), level, alpha);
         }
       }
       else { # data-parallel
-        R = evalSlice(X2, totalE, eAvg, t(S2), level, alpha);
+        R = evalSliceInc(X2, totalE, eAvg, t(S2), level, alpha);
       }
 
       # update output statistics
@@ -282,10 +291,10 @@ m_incSliceLine = function(
       Stats = append(Stats, Rrep);
 
       # maintain top-k after evaluation
-      [TK, TKC] = maintainTopK(S, R, TK, TKC, k, minSup, foffb, foffe);
+      [TK, TKC] = maintainTopKInc(S, R, TK, TKC, k, minSup, foffb, foffe);
 
       if(verbose) {
-        [maxsc2, minsc2] = analyzeTopK(TKC);
+        [maxsc2, minsc2] = analyzeTopKInc(TKC);
         valid = as.integer(sum(R[,2]>0 & R[,4]>=minSup));
         print(" -- valid slices after eval: "+valid+"/"+nrow(S));
         print(" -- top-K: count="+nrow(TK)+", max="+maxsc2+", min="+minsc2);
@@ -306,10 +315,11 @@ m_incSliceLine = function(
   }
 }
 
-createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
+createAndScoreBasicSlicesInc = function(Matrix[Double] X2, Matrix[Double] X2p,
     Matrix[Double] prevTK2, Matrix[Double] e, Matrix[Double] ep,
     Double eAvg, Double eAvgOld, Double eAvgNew, Double minSup, Double alpha,
-    Double minsc, Matrix[Double] maxsc, Boolean verbose, Boolean disableIncScorePruning, Boolean disableIncMaxScorePruning)
+    Double minsc, Matrix[Double] maxsc, Matrix[Double] maxscub, Boolean verbose,
+    Boolean enableIncScorePruning, Boolean enableIncMaxScorePruning, Boolean enableIncApproxPruning)
   return(Matrix[Double] S, Matrix[Double] R, Matrix[Double] SPr, Matrix[Double] RPr, Matrix[Double] selCols)
 {
   n2 = ncol(X2);
@@ -329,7 +339,7 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   # b) unchanged pruning
   # (valid to prune feature if its previous max score was negative or below minsc)
   selCols2 = selCols;
-  if( !disableIncMaxScorePruning ) {
+  if( enableIncMaxScorePruning ) {
     selCols2 = selCols & (ncCnts > 0 | maxsc > max(0, minsc));
   } 
 
@@ -337,6 +347,19 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
     n = as.integer(sum(selCols));
     drop = as.integer(sum(selCols) - sum(selCols2));
     print("incSliceLine: dropping "+drop+"/"+n+" unaffected features.");
+  }
+  
+  if( enableIncApproxPruning ) {
+    # c) max score changed pruning
+    n = as.integer(sum(selCols2));
+    if( enableIncApproxPruning ) {
+      selCols2 = selCols2 & (maxscub >= max(0, minsc) | maxscub==-Inf);
+    }
+    
+    if( verbose ) {
+      drop = as.integer(n - sum(selCols2));
+      print("incSliceLine: dropping "+drop+"/"+n+" insufficiently affected features.");
+    }
   }
 
   # working set of active slices (#attr x #slices) and top k
@@ -348,7 +371,7 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   S = table(seq(1,nrow(attr)), attr, nrow(attr), n2);
 
   # score 1-slices and create initial top-k
-  sc = score(ss, se, eAvg, alpha, nrow(X2));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
   R = cbind(sc, se, sm, ss);
   SPr = matrix(0,0, n2);
   RPr = matrix(0,0, 4);
@@ -367,10 +390,10 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
     RPr = cbind(scPr, sePr, smPr, ssPr);
   }
 
-  # c) score pruning
+  # d) score pruning
   # compute upper bound scores for all remaining slices
-  if(minsc > -Inf & !disableIncScorePruning) {
-    ubSc = scoreUB(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
+  if(minsc > -Inf & enableIncScorePruning) {
+    ubSc = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, nrow(X2));
     selCols3 = (ubSc > max(0, minsc));
 
     # store all pruned slices for incremental updates
@@ -401,14 +424,14 @@ createAndScoreBasicSlices = function(Matrix[Double] X2, Matrix[Double] X2p,
   }
 }
 
-score = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
+scoreInc = function(Matrix[Double] ss, Matrix[Double] se, Double eAvg, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
   sc = alpha * ((se/ss) / eAvg - 1) - (1-alpha) * (n/ss - 1);
   sc = replace(target=sc, pattern=NaN, replacement=-Inf);
 }
 
-scoreUB = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
+scoreUBInc = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
     Double eAvg, Integer minSup, Double alpha, Integer n)
   return(Matrix[Double] sc)
 {
@@ -424,7 +447,7 @@ scoreUB = function(Matrix[Double] ss, Matrix[Double] se, Matrix[Double] sm,
 }
 
 
-maintainTopK = function(Matrix[Double] S, Matrix[Double] R,
+maintainTopKInc = function(Matrix[Double] S, Matrix[Double] R,
     Matrix[Double] TK, Matrix[Double] TKC, Integer k,
     Integer minSup, Matrix[Double] foffb, Matrix[Double] foffe)
   return(Matrix[Double] TK, Matrix[Double] TKC)
@@ -459,7 +482,7 @@ maintainTopK = function(Matrix[Double] S, Matrix[Double] R,
   }
 }
 
-analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
+analyzeTopKInc = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
   maxsc = -Inf;
   minsc = -Inf;
   if( nrow(TKC)>0 ) {
@@ -468,7 +491,7 @@ analyzeTopK = function(Matrix[Double] TKC) return(Double maxsc, Double minsc) {
   }
 }
 
-getPairedCandidates = function(Matrix[Double] S,
+getPairedCandidatesInc = function(Matrix[Double] S,
     Matrix[Double] R, Matrix[Double] TKC, Integer level,
     Double eAvg, Integer minSup, Double alpha, Integer n2,
     Matrix[Double] foffb, Matrix[Double] foffe)
@@ -530,8 +553,8 @@ getPairedCandidates = function(Matrix[Double] S,
     ubError = replace(target=ubError, pattern=Inf, replacement=0);
     ubMError = 1/rowMaxs(map * (1/t(sm)));
     ubMError = replace(target=ubMError, pattern=Inf, replacement=0);
-    ubScores = scoreUB(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
-    [maxsc, minsc] = analyzeTopK(TKC);
+    ubScores = scoreUBInc(ubSizes, ubError, ubMError, eAvg, minSup, alpha, n2);
+    [maxsc, minsc] = analyzeTopKInc(TKC);
 
     # score pruning
     fScores = (ubScores > minsc & ubScores > 0)
@@ -552,7 +575,7 @@ getPairedCandidates = function(Matrix[Double] S,
   }
 }
 
-evalSlice = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
+evalSliceInc = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
     Matrix[Double] tS, Integer l, Double alpha)
 
   return(Matrix[Double] R)
@@ -561,11 +584,10 @@ evalSlice = function(Matrix[Double] X, Matrix[Double] e, Double eAvg,
   I = (X %*% tS) == l;    # slice indicator
   ss = t(colSums(I));     # absolute slice size (nnz)
   se = t(t(e) %*% I);     # absolute slice error
-
   sm = t(colMaxs(I * e)); # maximum tuple error in slice
 
   # score of relative error and relative size
-  sc = score(ss, se, eAvg, alpha, nrow(X));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X));
   R = cbind(sc, se, sm, ss);
 }
 
@@ -646,7 +668,7 @@ computeLowestPrevTK = function(Matrix[Double] prevTK2, Matrix[Double] X2,
   sm = t(colMaxs(I * totalE));  # maximum tuple error in slice
 
   # score slice and if applicable set min score for pruning
-  sc = score(ss, se, eAvg, alpha, nrow(X2));
+  sc = scoreInc(ss, se, eAvg, alpha, nrow(X2));
   sc = replace(target=sc, pattern=-Inf, replacement=0)
   R = cbind(sc, se, sm, ss);
   minsc = min(sc);
@@ -664,13 +686,16 @@ pruneUnchangedSlices = function(Matrix[Double] S, Matrix[Double] S2, Matrix[Doub
   # a) determine unchagned slices
   # only computing unchanged slices for levels 2 and above,
   # Imat has a 1 where a slice in changedX2 belongs to a slice in prevLatAtLevel
-  if(nrow(S2) > 0 & nrow(unchangedS) > 0) {
+  if(nrow(S2) > 0 & sum(S2) > 0 & nrow(unchangedS) > 0) {
     # b) select unchanged slices that can be pruned
     I = t(colSums((changedX2 %*% t(unchangedS)) == level) == 0) # change pushdown
         & unchangedR[,4] < minSup; # minSup pushdown
     unchangedS2 = removeEmpty(target=unchangedS, margin="rows", select=I);
-    SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
-    RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
+    if(sum(I) > 0){
+      SPr = removeEmpty(target=prevLattice, margin="rows", select=I);
+      RPr = removeEmpty(target=unchangedR, margin="rows", select=I);
+    }
+    
     # c) select only rows that cannot be pruned
     selCols = !rowSums((S2 %*% t(unchangedS2)) == level);
 
@@ -762,10 +787,65 @@ getMaxScoreAllFeatures = function(Int numRows, Int numFeatures, List[Unknown] pr
       if( length(prevStats) >= level ) {
         R = as.matrix(prevStats[level]);
         # rescaling of scores according to new size of X and eAvg
-        sc = score(R[,4], R[,2], eAvg, alpha, numRows);
+        sc = scoreInc(R[,4], R[,2], eAvg, alpha, numRows);
         # robustness for S * sc creating NaNs because 0 * -Inf = NaN
         sc = replace(target=sc, pattern=-Inf, replacement=0);
         maxsc = max(maxsc, t(colMaxs(S*sc)));
+      }
+    }
+  }
+}
+
+getMaxChangedScoreAllFeatures = function(Int numRows, Int numFeatures, Matrix[Double] addedX2,
+  Matrix[Double] removedX2, Matrix[Double] addedE, Matrix[Double] removedE,
+  List[Unknown] prevLattice, List[Unknown] metaPrevLattice, List[Unknown] prevStats,
+  Boolean encodeLat, Boolean differentOffsets, Double alpha, Double eAvg, Double minSup,
+  Matrix[Double] prevFoffb, Matrix[Double] prevFoffe, Matrix[Double] foffb, Matrix[Double] foffe,
+  Boolean enableIncApproxPruning)
+  return(Matrix[Double] maxscub)
+{
+  maxscub = matrix(-Inf, numFeatures, 1);
+  if( length(prevLattice) > 0 & nrow(addedX2) < 0.05*numRows & enableIncApproxPruning ) {
+    # compute upper bounds per feature for added subset
+    ss = t(colSums(addedX2));
+    se = t(t(addedE) %*% addedX2);
+    sm = t(colMaxs(addedX2 * addedE))
+    maxscub = scoreUBInc(ss, se, sm, eAvg, minSup, alpha, numRows);
+
+    # compute high-probability upper-bound scores per feature
+    for(level in 1:length(prevLattice)) {
+      if( length(prevStats) >= level ) {
+        S = as.matrix(prevLattice[level]);
+        if( encodeLat ) {
+          metaAtLevel = as.frame(metaPrevLattice[level]);
+          prevLatticeDec = transformIDsToSlices(S, prevFoffb, prevFoffe, metaAtLevel);
+          if( nrow(S) > 0 )
+            S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
+          else
+            S = matrix(0, 1, numFeatures);
+        }
+        else if(differentOffsets) {
+          prevLatticeDec = decodeOneHot(S, prevFoffb, prevFoffe);
+          S = oneHotEncodeUsingOffsets(prevLatticeDec, foffb, foffe);
+        }
+        R = as.matrix(prevStats[level]); #(sc,se,sm,ss)
+        # compute exact deltas/slice scores, and update max scores per feature despite the
+        # exact deltas we need to consider upper bounds because new slices, previously not
+        # considered, might appear (only high probability, for hard guarantees we would
+        # need to consider previously pruned slices too)
+        dssp = rowSums((S%*%t(addedX2))==level);               # size delta plus
+        dssm = rowSums((S%*%t(removedX2))==level);             # size delta minus
+        dsep = rowSums((S%*%t(addedX2)==level)*t(addedE));     # error delta plus
+        dsem = rowSums((S%*%t(removedX2)==level)*t(removedE)); # error delta minus
+        # compute interesting extreme points
+        sc1 = scoreInc(R[,4] - dssm,        R[,2] + dsep,        eAvg, alpha, numRows);
+        sc2 = scoreInc(R[,4],               R[,2] + dsep,        eAvg, alpha, numRows);
+        sc3 = scoreInc(R[,4] + dssp,        R[,2] + dsep,        eAvg, alpha, numRows);
+        sc4 = scoreInc(R[,4] + dssp - dssm, R[,2] + dsep - dsem, eAvg, alpha, numRows);
+        sc = max(sc1, sc2, sc3, sc4);
+        # robustness for S * sc creating NaNs because 0 * -Inf = NaN
+        sc = replace(target=sc, pattern=-Inf, replacement=0);
+        maxscub = max(maxscub, t(colMaxs(S*sc)));
       }
     }
   }
@@ -803,4 +883,3 @@ removeRowsByIndices = function(Matrix[Double] M, Matrix[Double] indices)
   P2 = table(seq(1, nrow(CIX)), CIX, nrow(CIX), nrow(M))
   remain = P2 %*% M;
 }
-

--- a/scripts/builtin/incSliceLine.dml
+++ b/scripts/builtin/incSliceLine.dml
@@ -264,12 +264,12 @@ m_incSliceLine = function(
     }
 
     # prepare and store output lattice for next run
-    Lrep = rbind(S,SPr);
+    L1 = rbind(S,SPr);
     if ( encodeLat ) {
-      [Lrep, M] = transformSlicesToIDs(Lrep, foffb, foffe);
+      [L1, M] = transformSlicesToIDs(L1, foffb, foffe);
       metaLattice = append(metaLattice, M);
     }
-    L = append(L, Lrep);
+    L = append(L, L1);
 
     if( nrow(S) > 0 ) {
       # extract and evaluate candidate slices

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinIncSliceLineTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinIncSliceLineTest.java
@@ -344,7 +344,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 
 	@Test
 	public void testTop10SinglenodeTPFullManyAdded() {
-		runIncSliceLineTest(10, "e", false, false,99 , 1, false, false, false, ExecMode.SINGLE_NODE);
+		runIncSliceLineTest(10, "e", false, false,90 , 1, false, false, false, ExecMode.SINGLE_NODE);
 	}
 
 	@Test
@@ -359,7 +359,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 
 	@Test
 	public void testTop10SinglenodeTPFullManyAddedRemoved() {
-		runIncSliceLineTest(10, "e", false, false,99 , 1, false, true, false, ExecMode.SINGLE_NODE);
+		runIncSliceLineTest(10, "e", false, false,90 , 1, false, true, false, ExecMode.SINGLE_NODE);
 	}
 
 	@Test
@@ -419,7 +419,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 
 	@Test
 	public void testTop10HybridTPSelE2FullManyAddedRemoved() {
-		runIncSliceLineTest(10, "oe", false, true, 50, 99, false, true,  false,  ExecMode.HYBRID);
+		runIncSliceLineTest(10, "oe", false, true, 50, 90, false, true,  false,  ExecMode.HYBRID);
 	}
 
 	@Test
@@ -569,7 +569,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 
 	@Test
 	public void testTop10SinglenodeTPFullManyAddedOnlyNull() {
-		runIncSliceLineTest(10, "e", false, false,99 , 1, true, false,true, ExecMode.SINGLE_NODE);
+		runIncSliceLineTest(10, "e", false, false,90 , 1, true, false,true, ExecMode.SINGLE_NODE);
 	}
 
 	@Test
@@ -584,7 +584,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 
 	@Test
 	public void testTop10SinglenodeTPFullManyAddedOnlyNullRemoved() {
-		runIncSliceLineTest(10, "e", false, false,99 , 1, true, true,true, ExecMode.SINGLE_NODE);
+		runIncSliceLineTest(10, "e", false, false,90 , 1, true, true,true, ExecMode.SINGLE_NODE);
 	}
 
 	@Test
@@ -992,7 +992,7 @@ public class BuiltinIncSliceLineTest extends AutomatedTestBase {
 				
 		};
 
-		runIncSliceLineTest(newX, e, 10, "e", false, true, 50, 1, false, false, true, ExecMode.SINGLE_NODE, false, false);
+		runIncSliceLineTest(newX, e, 10, "e", false, true, 10, 1, false, false, true, ExecMode.SINGLE_NODE, false, false);
 	}
 
 	// @Test

--- a/src/test/scripts/functions/builtin/incSliceLineFull.dml
+++ b/src/test/scripts/functions/builtin/incSliceLineFull.dml
@@ -48,10 +48,21 @@ if(nrow(indicesRemoved) > 0){
 
 # first compute the top k slices in two increments 
   # first increment
-[TK, TKC, D, L, meta, Stats, Xout, eOut, foffb, foffe, params] = incSliceLine(addedX=oldX, addedE=oldE, k=$5,
+[TK, TKC, D, L, meta, Stats, Xout, eOut, foffb, foffe, params] = incSliceLine(addedX=oldX[1:nrow(oldX) -10], addedE=oldE[1:nrow(oldE) -10], k=$5,
   alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, verbose=$10);
-  
-  # second increment
+
+print("nrow(L[1]): " + nrow(as.matrix(L[1])));
+print("nrow(L[2]): " + nrow(as.matrix(L[2])));
+
+[TK, TKC, D, L, meta, Stats, Xout, eOut, foffb, foffe, params] = incSliceLine(addedX=oldX[nrow(oldX) -9: nrow(oldX)], oldX = oldX[1:nrow(oldX) -10], oldE = oldE[1:nrow(oldE) -10], addedE=oldE[nrow(oldE) -9: nrow(oldE)], prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,
+  alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, pruningStrat = pruningStrat);
+
+print("nrow(L[1]): " + nrow(as.matrix(L[1])));
+print("nrow(L[2]): " + nrow(as.matrix(L[2])));
+print("nrow(Stats[1]): " + nrow(as.matrix(Stats[1])));
+print("nrow(Stats[2]): " + nrow(as.matrix(Stats[2])));
+
+  # third increment
 [TK1, TKC1, D1, L1, meta1, Stats1, Xout1, eOut1, foffb2, foffe2, params] = incSliceLine(addedX=addedX, oldX = oldX, oldE = oldE, addedE=addedE, prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,
   alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, pruningStrat = pruningStrat);
 

--- a/src/test/scripts/functions/builtin/incSliceLineFull.dml
+++ b/src/test/scripts/functions/builtin/incSliceLineFull.dml
@@ -50,17 +50,22 @@ if(nrow(indicesRemoved) > 0){
   # first increment
 [TK, TKC, D, L, meta, Stats, Xout, eOut, foffb, foffe, params] = incSliceLine(addedX=oldX[1:nrow(oldX) -10], addedE=oldE[1:nrow(oldE) -10], k=$5,
   alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, verbose=$10);
-
-print("nrow(L[1]): " + nrow(as.matrix(L[1])));
-print("nrow(L[2]): " + nrow(as.matrix(L[2])));
+/*
+for(i in 1:nrow(Stats)){
+  print("nrow(L[" + i + "]): " + nrow(as.matrix(L[i])));
+  print("Stats[" + i + "]: " + nrow(as.matrix(Stats[i])));
+}*/
 
 [TK, TKC, D, L, meta, Stats, Xout, eOut, foffb, foffe, params] = incSliceLine(addedX=oldX[nrow(oldX) -9: nrow(oldX)], oldX = oldX[1:nrow(oldX) -10], oldE = oldE[1:nrow(oldE) -10], addedE=oldE[nrow(oldE) -9: nrow(oldE)], prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,
   alpha=0.95, minSup=4, tpEval=$6, selFeat=$7, encodeLat=$8, indicesRemoved=indicesRemoved, verbose=$10, params=params, prevFoffb = foffb, prevFoffe = foffe, pruningStrat = pruningStrat);
 
-print("nrow(L[1]): " + nrow(as.matrix(L[1])));
-print("nrow(L[2]): " + nrow(as.matrix(L[2])));
-print("nrow(Stats[1]): " + nrow(as.matrix(Stats[1])));
-print("nrow(Stats[2]): " + nrow(as.matrix(Stats[2])));
+/*
+for(i in 1:nrow(Stats)){
+  print("nrow(L[" + i + "]): " + nrow(as.matrix(L[i])));
+  print("Stats[" + i + "]: " + nrow(as.matrix(Stats[i])));
+}*/
+
+  # second increment
 
   # third increment
 [TK1, TKC1, D1, L1, meta1, Stats1, Xout1, eOut1, foffb2, foffe2, params] = incSliceLine(addedX=addedX, oldX = oldX, oldE = oldE, addedE=addedE, prevLattice = L, metaPrevLattice=meta, prevStats = Stats, prevTK = TK, prevTKC = TKC, k=$5,


### PR DESCRIPTION
In this PR only the individual disabling of the newly introduced max score pruning is introduced, which is needed for experimental analysis.

UPDATE:
The current state management was not working correctly for incremental updates that are based on stats and lattice from a run of incSliceLine that already depend on stats and lattice from an even earlier run. This is because the slices and stats that are pruned through incremental pruning methods are not stored for subsequent increments even though we mostly have all the necessary information. I updated the code to track the lost slices and stats and add them to the output lattice and statistics (L and Stats) lists as well. Also, currently, some tests run into errors when enabling the new approx pruning method, which is why for now I set the enabling boolean to FALSE.