### PR TITLE
[MINOR] Python API: removal of enum output_type

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -127,7 +127,7 @@ jobs:
         export SYSDS_QUIET=1
         export LOG4JPROP=$SYSTEMDS_ROOT/src/test/resources/log4j.properties
         cd src/main/python
-        unittest-parallel -t . -s tests
+        unittest-parallel -t . -s tests -v
         # python -m unittest discover -s tests -p 'test_*.py'
         echo "Exit Status: " $?
     
@@ -135,7 +135,7 @@ jobs:
       run: |
         export LOG4JPROP=$(pwd)/src/test/resources/log4j.properties
         cd src/main/python
-        unittest-parallel -t . -s tests
+        unittest-parallel -t . -s tests -v
         # python -m unittest discover -s tests -p 'test_*.py'
         echo "Exit Status: " $?
 

--- a/src/main/python/generator/resources/template_python_script_imports
+++ b/src/main/python/generator/resources/template_python_script_imports
@@ -2,7 +2,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/WoE.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/WoE.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/WoEApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/WoEApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/abstain.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/abstain.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/als.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/als.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/alsCG.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/alsCG.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/alsDS.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/alsDS.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/alsPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/alsPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/alsTopkPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/alsTopkPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/arima.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/arima.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/auc.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/auc.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/autoencoder_2layer.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/autoencoder_2layer.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/bandit.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/bandit.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/bivar.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/bivar.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/components.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/components.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/confusionMatrix.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/confusionMatrix.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/cor.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/cor.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/cox.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/cox.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/cspline.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/cspline.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/csplineCG.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/csplineCG.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/csplineDS.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/csplineDS.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/cvlm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/cvlm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/dbscan.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/dbscan.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/dbscanApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/dbscanApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/decisionTree.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/decisionTree.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/decisionTreePredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/decisionTreePredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/deepWalk.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/deepWalk.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/differenceStatistics.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/differenceStatistics.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/discoverFD.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/discoverFD.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/dist.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/dist.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/executePipeline.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/executePipeline.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/f1Score.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/f1Score.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/fdr.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/fdr.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/ffPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/ffPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/ffTrain.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/ffTrain.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/flattenQuantile.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/flattenQuantile.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/frequencyEncode.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/frequencyEncode.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/frequencyEncodeApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/frequencyEncodeApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/garch.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/garch.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/gaussianClassifier.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/gaussianClassifier.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/getAccuracy.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/getAccuracy.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/glm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/glm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/glmPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/glmPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/gmm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/gmm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/gmmPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/gmmPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/gnmf.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/gnmf.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/gridSearch.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/gridSearch.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/hospitalResidencyMatch.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/hospitalResidencyMatch.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/hyperband.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/hyperband.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_brightness.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_brightness.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_brightness_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_brightness_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_crop.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_crop.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_crop_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_crop_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_cutout.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_cutout.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_cutout_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_cutout_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_invert.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_invert.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_invert_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_invert_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_mirror.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_mirror.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_mirror_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_mirror_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_posterize.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_posterize.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_posterize_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_posterize_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_rotate.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_rotate.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_rotate_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_rotate_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_sample_pairing.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_sample_pairing.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_sample_pairing_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_sample_pairing_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_shear.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_shear.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_shear_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_shear_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_transform.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_transform.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_transform_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_transform_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_translate.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_translate.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/img_translate_linearized.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/img_translate_linearized.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/impurityMeasures.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/impurityMeasures.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByFD.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByFD.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByFDApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByFDApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByMean.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByMean.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByMeanApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByMeanApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByMedian.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByMedian.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByMedianApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByMedianApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByMode.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByMode.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/imputeByModeApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/imputeByModeApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/incSliceLine.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/incSliceLine.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 
@@ -66,6 +65,8 @@ def incSliceLine(addedX: Matrix,
     :param prevTK: previous top-k slices (for incremental updates)
     :param prevTKC: previous top-k scores (for incremental updates)
     :param encodeLat: flag for encoding output lattice for less memory consumption
+    :param pruningStrat: flag for disabling certain pruning strategies
+        (0 all, 1 all exact (score and size), 2 no score, 3 no size, 4 none)
     :return: top-k slices (k x ncol(totalX) if successful)
     :return: score, size, error of slices (k x 3)
     :return: debug matrix, populated with enumeration stats if verbose

--- a/src/main/python/systemds/operator/algorithm/builtin/intersect.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/intersect.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/km.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/km.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/kmeans.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/kmeans.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/kmeansPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/kmeansPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/knn.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/knn.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/knnGraph.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/knnGraph.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/knnbf.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/knnbf.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/l2svm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/l2svm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/l2svmPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/l2svmPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lasso.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lasso.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lenetPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lenetPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lenetTrain.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lenetTrain.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lmCG.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lmCG.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lmDS.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lmDS.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lmPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lmPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/lmPredictStats.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/lmPredictStats.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/logSumExp.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/logSumExp.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/mae.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/mae.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/mape.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/mape.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/matrixProfile.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/matrixProfile.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/mcc.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/mcc.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/mice.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/mice.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/miceApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/miceApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/mse.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/mse.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/msmape.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/msmape.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/msvm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/msvm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/msvmPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/msvmPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/multiLogReg.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/multiLogReg.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/multiLogRegPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/multiLogRegPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/na_locf.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/na_locf.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/naiveBayes.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/naiveBayes.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/naiveBayesPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/naiveBayesPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/normalize.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/normalize.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/normalizeApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/normalizeApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/nrmse.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/nrmse.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlier.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlier.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlierByArima.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlierByArima.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlierByIQR.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlierByIQR.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlierByIQRApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlierByIQRApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlierBySd.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlierBySd.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/outlierBySdApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/outlierBySdApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/pageRank.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/pageRank.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/pca.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/pca.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/pcaInverse.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/pcaInverse.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/pcaTransform.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/pcaTransform.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/pnmf.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/pnmf.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/ppca.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/ppca.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/psnr.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/psnr.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/raGroupby.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/raGroupby.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/raJoin.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/raJoin.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/raSelection.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/raSelection.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/randomForest.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/randomForest.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/randomForestPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/randomForestPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/rmse.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/rmse.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/scale.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/scale.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/scaleApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/scaleApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/scaleMinMax.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/scaleMinMax.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/selectByVarThresh.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/selectByVarThresh.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/setdiff.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/setdiff.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/sherlock.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/sherlock.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/sherlockPredict.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/sherlockPredict.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/shortestPath.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/shortestPath.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/sigmoid.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/sigmoid.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/skewness.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/skewness.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/sliceLine.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/sliceLine.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/sliceLineDebug.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/sliceLineDebug.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/slicefinder.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/slicefinder.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/smape.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/smape.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/smote.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/smote.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/softmax.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/softmax.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/split.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/split.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/splitBalanced.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/splitBalanced.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/stableMarriage.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/stableMarriage.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/statsNA.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/statsNA.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/steplm.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/steplm.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/stratstats.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/stratstats.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/symmetricDifference.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/symmetricDifference.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/tSNE.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/tSNE.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/toOneHot.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/toOneHot.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/tomeklink.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/tomeklink.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/underSampling.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/underSampling.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/union.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/union.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/univar.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/univar.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/vectorToCsv.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/vectorToCsv.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/winsorize.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/winsorize.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/winsorizeApply.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/winsorizeApply.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/xdummy1.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/xdummy1.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/xdummy2.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/xdummy2.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/xgboost.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/xgboost.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/xgboostPredictClassification.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/xgboostPredictClassification.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/algorithm/builtin/xgboostPredictRegression.py
+++ b/src/main/python/systemds/operator/algorithm/builtin/xgboostPredictRegression.py
@@ -25,7 +25,6 @@
 from typing import Dict, Iterable
 
 from systemds.operator import OperationNode, Matrix, Frame, List, MultiReturn, Scalar
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 

--- a/src/main/python/systemds/operator/nodes/combine.py
+++ b/src/main/python/systemds/operator/nodes/combine.py
@@ -22,11 +22,9 @@
 
 __all__ = ["Combine"]
 
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, Sequence
 
 from systemds.operator import OperationNode
-from systemds.script_building.dag import OutputType
-from systemds.utils.consts import VALID_INPUT_TYPES
 
 
 class Combine(OperationNode):
@@ -34,12 +32,12 @@ class Combine(OperationNode):
     def __init__(self, sds_context, func='',
                  unnamed_input_nodes: Iterable[OperationNode] = None):
         for a in unnamed_input_nodes:
-            if(a.output_type != OutputType.NONE):
+            if not a._datatype_is_none:
                 raise ValueError(
                     "Cannot combine elements that have outputs, all elements must be instances of print or write")
 
         self._outputs = {}
-        super().__init__(sds_context, func, unnamed_input_nodes, None, OutputType.NONE, False)
+        super().__init__(sds_context, func, unnamed_input_nodes, None, False)
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
                   named_input_vars: Dict[str, str]) -> str:

--- a/src/main/python/systemds/operator/nodes/frame.py
+++ b/src/main/python/systemds/operator/nodes/frame.py
@@ -32,7 +32,6 @@ from systemds.operator.operation_node import OperationNode
 from systemds.operator.nodes.multi_return import MultiReturn
 from systemds.operator.nodes.scalar import Scalar
 from systemds.operator.nodes.matrix import Matrix
-from systemds.script_building.dag import DAGNode, OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 from systemds.utils.converters import (frame_block_to_pandas,
                                        pandas_to_frame_block)
@@ -60,7 +59,7 @@ class Frame(OperationNode):
             self._pd_dataframe = None
 
         super().__init__(sds_context, operation, unnamed_input_nodes,
-                         named_input_nodes, OutputType.FRAME, is_python_local_data, brackets)
+                         named_input_nodes, is_python_local_data, brackets, is_datatype_none=False)
 
     def pass_python_data_to_prepared_script(self, sds, var_name: str, prepared_script: JavaObject) -> None:
         assert (
@@ -142,7 +141,7 @@ class Frame(OperationNode):
         """ Converts the input to a string representation.
         :return: `Scalar` containing the string.
         """
-        return Scalar(self.sds_context, 'toString', [self], kwargs, output_type=OutputType.STRING)
+        return Scalar(self.sds_context, 'toString', [self], kwargs)
 
     def __str__(self):
         return "FrameNode"

--- a/src/main/python/systemds/operator/nodes/list.py
+++ b/src/main/python/systemds/operator/nodes/list.py
@@ -27,7 +27,6 @@ import numpy as np
 from py4j.java_gateway import JavaObject
 from systemds.operator.operation_node import OperationNode
 from systemds.operator.nodes.list_access import ListAccess
-from systemds.script_building.dag import OutputType
 from systemds.utils.consts import VALID_INPUT_TYPES
 from systemds.utils.converters import numpy_to_matrix_block
 from systemds.utils.helpers import create_params_string
@@ -59,7 +58,7 @@ class List(OperationNode):
             self._outputs = {}
 
         super().__init__(sds_context, func, unnamed_input_nodes,
-                         named_input_nodes, OutputType.LIST, False)
+                         named_input_nodes, False, is_datatype_none=False)
 
     def __getitem__(self, key):
         if key in self._outputs:
@@ -74,11 +73,6 @@ class List(OperationNode):
         if self._is_numpy():
             prepared_script.setMatrix(var_name, numpy_to_matrix_block(
                 sds, self._np_array), True)  # True for reuse
-
-    def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
-                  named_input_vars: Dict[str, str]) -> str:
-        code_line = super().code_line(var_name, unnamed_input_vars, named_input_vars)
-        return code_line
 
     def compute(self, verbose: bool = False, lineage: bool = False) -> np.array:
         return super().compute(verbose, lineage)

--- a/src/main/python/systemds/operator/nodes/list_access.py
+++ b/src/main/python/systemds/operator/nodes/list_access.py
@@ -26,7 +26,6 @@ from systemds.operator.operation_node import OperationNode
 from systemds.operator.nodes.matrix import Matrix
 from systemds.operator.nodes.scalar import Scalar
 from systemds.operator.nodes.frame import Frame
-from systemds.script_building.dag import OutputType
 
 
 class ListAccess(OperationNode):
@@ -37,7 +36,7 @@ class ListAccess(OperationNode):
 
         inputs = [list_source]
         super().__init__(sds_context, None, unnamed_input_nodes=inputs,
-                         output_type=OutputType.UNKNOWN, is_python_local_data=False)
+                         is_datatype_unknown=True, is_datatype_none=False, is_python_local_data=False)
 
     def code_line(self, var_name: str, unnamed_input_vars: Sequence[str],
                   named_input_vars: Dict[str, str]) -> str:

--- a/src/main/python/systemds/operator/nodes/source.py
+++ b/src/main/python/systemds/operator/nodes/source.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, Sequence
 # since source dynamically adds code and the import is needed.
 from systemds.operator import (List, ListAccess, Matrix, MultiReturn,
                                OperationNode, Scalar)
-from systemds.script_building.dag import OutputType
 
 
 class Func(object):
@@ -54,10 +53,7 @@ class Func(object):
         output_object = self.parse_outputs()
 
         definition = f'def {self._name}(self{argument_string}):'
-        if self._outputs is None:
-            output = f'out = {output_object}(self.sds_context, {operation}, named_input_nodes=named_arguments, output_type=OutputType.NONE)'
-        else:
-            output = f'out = {output_object}(self.sds_context, {operation}, named_input_nodes=named_arguments)'
+        output = f'out = {output_object}(self.sds_context, {operation}, named_input_nodes=named_arguments)'
 
         lines = [definition,
                  named_intput_nodes, output,
@@ -135,7 +131,7 @@ class Source(OperationNode):
 
     def __init__(self, sds_context, path: str, name: str):
         super().__init__(sds_context,
-                         f'"{path}"', output_type=OutputType.IMPORT)
+                         f'"{path}"')
         self.__name = name
         functions = self.__parse_functions_from_script(path)
 

--- a/src/main/python/systemds/script_building/script.py
+++ b/src/main/python/systemds/script_building/script.py
@@ -25,7 +25,8 @@ from typing import (TYPE_CHECKING, Any, Collection, Dict, KeysView, List,
 from py4j.protocol import Py4JNetworkError
 from py4j.java_collections import JavaArray
 from py4j.java_gateway import JavaGateway, JavaObject
-from systemds.script_building.dag import DAGNode, OutputType
+
+from systemds.script_building.dag import DAGNode
 from systemds.utils.consts import VALID_INPUT_TYPES
 
 if TYPE_CHECKING:
@@ -164,8 +165,8 @@ class DMLScript:
         :param dag_root: the topmost operation of our DAG, result of operation will be output
         """
         baseOutVarString = self._dfs_dag_nodes(dag_root)
-        if dag_root.output_type != OutputType.NONE:
-            if dag_root.output_type == OutputType.MULTI_RETURN:
+        if not dag_root._datatype_is_none:
+            if str(dag_root) == "MultiReturnNode":
                 self.out_var_name = []
                 for idx, output_node in enumerate(dag_root._outputs):
                     self.add_code(

--- a/src/main/python/systemds/utils/helpers.py
+++ b/src/main/python/systemds/utils/helpers.py
@@ -85,11 +85,25 @@ def get_path_to_script_layers() -> str:
     root = os.environ.get("SYSTEMDS_ROOT")
     if root is None:
         root = get_module_dir()
-    p =  os.path.join(root, "scripts", "nn", "layers")
+    p = os.path.join(root, "scripts", "nn", "layers")
     if not os.path.exists(p):
         # Probably inside the SystemDS repository therefore go to the source nn layers.
-        p = os.path.join(root, "..", "..", "..", "..",  "scripts", "nn", "layers" )
+        p = os.path.join(root, "..", "..", "..", "..", "scripts", "nn", "layers")
     if os.path.exists(p):
         return p
     else:
         raise Exception("Invalid script layer path: " + p)
+
+
+def valuetype_from_str(val) -> str:
+    val = val.lower()
+    if val in ['double', 'float']:
+        return "double"
+    elif val in ['string', 'str']:
+        return "string"
+    elif val in ['boolean', 'bool']:
+        return "boolean"
+    elif val in ['integer', 'int']:
+        return "integer"
+    else:
+        return None

--- a/src/main/python/tests/algorithms/test_pca.py
+++ b/src/main/python/tests/algorithms/test_pca.py
@@ -25,9 +25,6 @@ import numpy as np
 from systemds.context import SystemDSContext
 from systemds.operator.algorithm import pca
 
-from systemds.operator import List
-from systemds.script_building.dag import OutputType
-
 
 class TestPCA(unittest.TestCase):
 

--- a/src/main/python/tests/list/test_list.py
+++ b/src/main/python/tests/list/test_list.py
@@ -25,9 +25,6 @@ import numpy as np
 from systemds.context import SystemDSContext
 from systemds.operator.algorithm import pca
 
-from systemds.operator import List
-from systemds.script_building.dag import OutputType
-
 
 class TestListOperations(unittest.TestCase):
 

--- a/src/main/python/tests/list/test_list_unknown.py
+++ b/src/main/python/tests/list/test_list_unknown.py
@@ -25,7 +25,6 @@ import numpy as np
 from systemds.context import SystemDSContext
 from systemds.operator import List
 from systemds.operator.algorithm import pca
-from systemds.script_building.dag import OutputType
 
 
 class TestListOperationsUnknown(unittest.TestCase):

--- a/src/main/python/tests/matrix/test_exp.py
+++ b/src/main/python/tests/matrix/test_exp.py
@@ -23,6 +23,7 @@ import unittest
 import numpy as np
 from systemds.context import SystemDSContext
 
+
 class TestEXP(unittest.TestCase):
     def setUp(self):
         self.sds = SystemDSContext()
@@ -32,31 +33,31 @@ class TestEXP(unittest.TestCase):
 
     def test_exp_basic(self):
 
-        input_matrix = np.array([[1, 2, 3, 4],
-                                 [5, 6, 7, 8],
-                                 [9, 10, 11, 12],
-                                 [13, 14, 15, 16]]) - 8
+        input_matrix = (
+            np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
+            - 8
+        )
 
         sds_input = self.sds.from_numpy(input_matrix)
         sds_result = sds_input.exp().compute()
         np_result_np = np.exp(input_matrix)
-        assert np.allclose(sds_result, np_result_np,1e-9)
+        assert np.allclose(sds_result, np_result_np, 1e-9)
 
     def test_exp_random(self):
 
-        input_matrix = np.random.random((10,10))
+        input_matrix = np.random.random((10, 10))
         sds_input = self.sds.from_numpy(input_matrix)
         sds_result = sds_input.exp().compute()
         np_result_np = np.exp(input_matrix)
-        assert np.allclose(sds_result, np_result_np,1e-9)
+        assert np.allclose(sds_result, np_result_np, 1e-9)
 
     def test_exp_scalar(self):
         for i in np.random.random(10):
             sds_input = self.sds.scalar(i)
             sds_result = sds_input.exp().compute()
             np_result_np = np.exp(i)
-            assert np.isclose(sds_result, np_result_np,1e-9)
+            assert np.isclose(sds_result, np_result_np, 1e-9)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/src/main/python/tests/matrix/test_fft.py
+++ b/src/main/python/tests/matrix/test_fft.py
@@ -38,7 +38,7 @@ class TestFFT(unittest.TestCase):
                                  [13, 14, 15, 16]])
 
         sds_input = self.sds.from_numpy(input_matrix)
-        fft_result = self.sds.fft(sds_input).compute()
+        fft_result = sds_input.fft().compute()
 
         real_part, imag_part = fft_result
 
@@ -56,7 +56,7 @@ class TestFFT(unittest.TestCase):
 
             sds_input = self.sds.from_numpy(input_matrix)
 
-            fft_result = self.sds.fft(sds_input).compute()
+            fft_result = sds_input.fft().compute()
 
             real_part, imag_part = fft_result
 
@@ -74,7 +74,7 @@ class TestFFT(unittest.TestCase):
 
             sds_input = self.sds.from_numpy(input_matrix)
 
-            fft_result = self.sds.fft(sds_input).compute()
+            fft_result = sds_input.fft().compute()
 
             real_part, imag_part = fft_result
 
@@ -91,7 +91,7 @@ class TestFFT(unittest.TestCase):
         sds_input = self.sds.from_numpy(input_matrix)
 
         with self.assertRaisesRegex(RuntimeError, "This FFT implementation is only defined for matrices with dimensions that are powers of 2."):
-            _ = self.sds.fft(sds_input).compute()
+            _ = sds_input.fft().compute()
 
     def test_ifft_basic(self):
         real_input_matrix = np.array([[1, 2, 3, 4],
@@ -107,7 +107,7 @@ class TestFFT(unittest.TestCase):
         sds_real_input = self.sds.from_numpy(real_input_matrix)
         sds_imag_input = self.sds.from_numpy(imag_input_matrix)
 
-        ifft_result = self.sds.ifft(sds_real_input, sds_imag_input).compute()
+        ifft_result = sds_real_input.ifft(sds_imag_input).compute()
 
         real_part, imag_part = ifft_result
 
@@ -133,7 +133,7 @@ class TestFFT(unittest.TestCase):
         sds_real_input = self.sds.from_numpy(real_input_matrix)
         sds_imag_input = self.sds.from_numpy(imag_input_matrix)
 
-        ifft_result = self.sds.ifft(sds_real_input, sds_imag_input).compute()
+        ifft_result = sds_real_input.ifft(sds_imag_input).compute()
 
         real_part, imag_part = ifft_result
 
@@ -157,7 +157,7 @@ class TestFFT(unittest.TestCase):
         sds_imag_input = self.sds.from_numpy(imag_input_matrix)
 
         with self.assertRaisesRegex(RuntimeError, "The second argument to IFFT cannot be an empty matrix. Provide either only a real matrix or a filled real and imaginary one."):
-            self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            sds_real_input.ifft(sds_imag_input).compute()
 
     def test_ifft_empty_2dmatrix_imag(self):
         real_input_matrix = np.array([[1, 2, 3, 4],
@@ -171,7 +171,7 @@ class TestFFT(unittest.TestCase):
         sds_imag_input = self.sds.from_numpy(imag_input_matrix)
 
         with self.assertRaisesRegex(RuntimeError, "The second argument to IFFT cannot be an empty matrix. Provide either only a real matrix or a filled real and imaginary one."):
-            self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            sds_real_input.ifft(sds_imag_input).compute()
 
     def test_ifft_random_1d(self):
         np.random.seed(123) 
@@ -185,7 +185,7 @@ class TestFFT(unittest.TestCase):
             sds_real_input = self.sds.from_numpy(np.real(np_fft_result).reshape(1, -1))
             sds_imag_input = self.sds.from_numpy(np.imag(np_fft_result).reshape(1, -1))
 
-            ifft_result = self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            ifft_result = sds_real_input.ifft(sds_imag_input).compute()
 
             real_part_result, imag_part_result = ifft_result
 
@@ -205,7 +205,7 @@ class TestFFT(unittest.TestCase):
 
         sds_real_input = self.sds.from_numpy(real)
 
-        ifft_result = self.sds.ifft(sds_real_input).compute()
+        ifft_result = sds_real_input.ifft().compute()
 
         real_part_result, imag_part_result = ifft_result
 
@@ -226,7 +226,7 @@ class TestFFT(unittest.TestCase):
 
             sds_input = self.sds.from_numpy(input_matrix)
 
-            ifft_result = self.sds.ifft(sds_input).compute()
+            ifft_result = sds_input.ifft().compute()
 
             real_part, imag_part = ifft_result
 
@@ -248,7 +248,7 @@ class TestFFT(unittest.TestCase):
             sds_real_input = self.sds.from_numpy(np.real(fft_result))
             sds_imag_input = self.sds.from_numpy(np.imag(fft_result))
 
-            ifft_result = self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            ifft_result = sds_real_input.ifft(sds_imag_input).compute()
 
             real_part, imag_part = ifft_result
 
@@ -264,19 +264,19 @@ class TestFFT(unittest.TestCase):
         sds_input = self.sds.from_numpy(input_matrix)
 
         with self.assertRaisesRegex(RuntimeError, "The first argument to FFT cannot be an empty matrix."):
-            _ = self.sds.fft(sds_input).compute()
+            _ = sds_input.fft().compute()
 
     def test_ifft_empty_matrix(self):
         input_matrix = np.array([])
         sds_input = self.sds.from_numpy(input_matrix)
 
         with self.assertRaisesRegex(RuntimeError, "The first argument to IFFT cannot be an empty matrix."):
-            _ = self.sds.ifft(sds_input).compute()
+            _ = sds_input.ifft().compute()
 
     def test_fft_single_element(self):
         input_matrix = np.array([[5]])
         sds_input = self.sds.from_numpy(input_matrix)
-        fft_result = self.sds.fft(sds_input).compute()
+        fft_result = sds_input.fft().compute()
 
         real_part, imag_part = fft_result
         np.testing.assert_array_almost_equal(real_part, [[5]], decimal=5)
@@ -285,7 +285,7 @@ class TestFFT(unittest.TestCase):
     def test_ifft_single_element(self):
         input_matrix = np.array([[5]])
         sds_input = self.sds.from_numpy(input_matrix)
-        ifft_result = self.sds.ifft(sds_input).compute()
+        ifft_result = sds_input.ifft().compute()
 
         real_part, imag_part = ifft_result
         np.testing.assert_array_almost_equal(real_part, [[5]], decimal=5)
@@ -294,7 +294,7 @@ class TestFFT(unittest.TestCase):
     def test_fft_zeros_matrix(self):
         input_matrix = np.zeros((4, 4))
         sds_input = self.sds.from_numpy(input_matrix)
-        fft_result = self.sds.fft(sds_input).compute()
+        fft_result = sds_input.fft().compute()
 
         real_part, imag_part = fft_result
         np.testing.assert_array_almost_equal(real_part, np.zeros((4, 4)), decimal=5)
@@ -303,7 +303,7 @@ class TestFFT(unittest.TestCase):
     def test_ifft_zeros_matrix(self):
         input_matrix = np.zeros((4, 4))
         sds_input = self.sds.from_numpy(input_matrix)
-        ifft_result = self.sds.ifft(sds_input).compute()
+        ifft_result = sds_input.ifft().compute()
 
         real_part, imag_part = ifft_result
         np.testing.assert_array_almost_equal(real_part, np.zeros((4, 4)), decimal=5)
@@ -317,7 +317,7 @@ class TestFFT(unittest.TestCase):
         sds_imag_input = self.sds.from_numpy(imag_part)
 
         with self.assertRaisesRegex(RuntimeError, "The real and imaginary part of the provided matrix are of different dimensions."):
-            self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            sds_real_input.ifft(sds_imag_input).compute()
 
     def test_ifft_non_power_of_two_matrix(self):
         real_part = np.random.rand(3, 5) 
@@ -327,7 +327,7 @@ class TestFFT(unittest.TestCase):
         sds_imag_input = self.sds.from_numpy(imag_part)
 
         with self.assertRaisesRegex(RuntimeError, "This IFFT implementation is only defined for matrices with dimensions that are powers of 2."):
-            _ = self.sds.ifft(sds_real_input, sds_imag_input).compute()
+            _ = sds_real_input.ifft(sds_imag_input).compute()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this PR removes the redundant information about the datatype from the python DAGNodes, the datatype can be instead inferred from the instance class and the value type directly from the Java object