### PR TITLE
[SYSTEMDS-3677] Suppress netty deprecation warnings 

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -59,6 +59,7 @@ import io.netty.handler.codec.serialization.ObjectEncoder;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.Promise;
 
+@SuppressWarnings("deprecation")
 public class FederatedData {
 	private static final Log LOG = LogFactory.getLog(FederatedData.class.getName());
 	private static final Set<InetSocketAddress> _allFedSites = new HashSet<>();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -66,6 +66,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ClassResolvers;
 
+@SuppressWarnings("deprecation")
 public class FederatedWorker {
 	protected static Logger log = Logger.getLogger(FederatedWorker.class);
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationUtils.java
@@ -75,6 +75,7 @@ import org.apache.sysds.runtime.matrix.operators.SimpleOperator;
 import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 
+@SuppressWarnings("deprecation")
 public class FederationUtils {
 	protected static Logger log = Logger.getLogger(FederationUtils.class);
 	private static final IDSequence _idSeq = new IDSequence();


### PR DESCRIPTION
This minor patch suppresses the deprecation warnings in the federated backend for the netty classes ObjectEncoder, ObjectDecoder, and ClassResolvers. These classes are deprecated without replacement. 