### PR TITLE
[MINOR] bug fix: infinity loop in rollSparse

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixReorg.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixReorg.java
@@ -2369,20 +2369,18 @@ public class LibMatrixReorg {
 		SparseBlock a = in.getSparseBlock();
 		SparseBlock c = out.getSparseBlock();
 
-		while (copyLen > 0) {
-			if (a.isEmpty(inIdx)) continue;    // skip empty rows
+		for (int i = 0; i < copyLen; i++) {
+			if (!a.isEmpty(inIdx)){
+				final int apos = a.pos(inIdx);
+				final int alen = a.size(inIdx) + apos;
+				final int[] aix = a.indexes(inIdx);
+				final double[] avals = a.values(inIdx);
 
-			final int apos = a.pos(inIdx);
-			final int alen = a.size(inIdx) + apos;
-			final int[] aix = a.indexes(inIdx);
-			final double[] avals = a.values(inIdx);
-
-			// copy only non-zero elements
-			for (int k = apos; k < alen; k++) {
-				c.set(outIdx, aix[k], avals[k]);
+				// copy only non-zero elements
+				for (int k = apos; k < alen; k++)
+					c.set(outIdx, aix[k], avals[k]);
 			}
-
-			inIdx++; outIdx++; copyLen--;
+			inIdx++; outIdx++;
 		}
 	}
 

--- a/src/main/python/tests/matrix/test_roll.py
+++ b/src/main/python/tests/matrix/test_roll.py
@@ -26,13 +26,15 @@ from scipy import sparse
 from systemds.context import SystemDSContext
 
 np.random.seed(7)
+random.seed(7)
 shape = (random.randrange(1, 25), random.randrange(1, 25))
 
 m = np.random.rand(shape[0], shape[1])
 my = np.random.rand(shape[0], 1)
 m_empty = np.asarray([[]])
-m_sparse = sparse.random(shape[0], shape[1], density=0.1, format="csr").toarray()
+m_sparse = sparse.random(shape[0], shape[1], density=0.1, format="csr", random_state=5).toarray()
 m_sparse = np.around(m_sparse, decimals=22)
+
 
 class TestRoll(unittest.TestCase):
     sds: SystemDSContext = None
@@ -60,6 +62,7 @@ class TestRoll(unittest.TestCase):
     def test_sparse_matrix(self):
         r = self.sds.from_numpy(m_sparse).roll(1).compute()
         self.assertTrue(np.allclose(r, np.roll(m_sparse, axis=0, shift=1)))
+
 
 if __name__ == "__main__":
     unittest.main(exit=False)


### PR DESCRIPTION
the rollSparse used a while loop with continue on empty rows without updating the loop variables