### PR TITLE
[SYSTEMDS-3729] Fix Federated Response in Roll Function

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/ReorgFEDInstruction.java
@@ -429,7 +429,7 @@ public class ReorgFEDInstruction extends UnaryFEDInstruction {
 				resBlock = oriBlock;
 			}
 			ec.setMatrixOutput(String.valueOf(_outputID), resBlock);
-			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS, resBlock);
+			return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS);
 		}
 
 		@Override


### PR DESCRIPTION
I previously wrote the federated `roll function` to return the result matrix block through a `federated response` for debugging purposes. Although this does not affect the computation results, it unnecessarily degrades performance, so I will remove it. 

Moving forward, I will carefully review the code before committing. I apologize for the inconvenience caused.