### PR TITLE
Restoration of Pre-FED Privacy Test Code

### DIFF
--- a/src/test/java/org/apache/sysds/test/functions/privacy/CheckedConstraintsLogTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/CheckedConstraintsLogTest.java
@@ -1,0 +1,97 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertTrue;
+//
+//import java.util.EnumMap;
+//import java.util.concurrent.atomic.LongAdder;
+//
+//import org.apache.sysds.runtime.privacy.CheckedConstraintsLog;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.junit.Test;
+//
+//@net.jcip.annotations.NotThreadSafe
+//public class CheckedConstraintsLogTest extends AutomatedTestBase {
+//
+//	@Override
+//	public void setUp() {
+//		CheckedConstraintsLog.reset();
+//	}
+//
+//	@Test
+//	public void addCheckedConstraintsNull(){
+//		CheckedConstraintsLog.addCheckedConstraints(null);
+//		assertTrue(CheckedConstraintsLog.getCheckedConstraints() != null && CheckedConstraintsLog.getCheckedConstraints().isEmpty());
+//	}
+//
+//	@Test
+//	public void addCheckedConstraintsEmpty(){
+//		EnumMap<PrivacyLevel,LongAdder> checked = new EnumMap<>(PrivacyLevel.class);
+//		CheckedConstraintsLog.addCheckedConstraints(checked);
+//		assertTrue(CheckedConstraintsLog.getCheckedConstraints() != null && CheckedConstraintsLog.getCheckedConstraints().isEmpty());
+//	}
+//
+//	@Test
+//	public void addCheckedConstraintsSingleValue(){
+//		EnumMap<PrivacyLevel,LongAdder> checked = getMap(PrivacyLevel.Private, 300);
+//		CheckedConstraintsLog.addCheckedConstraints(checked);
+//		assertEquals(300, CheckedConstraintsLog.getCheckedConstraints().get(PrivacyLevel.Private).longValue());
+//	}
+//
+//	@Test
+//	public void addCheckedConstraintsTwoValues(){
+//		EnumMap<PrivacyLevel,LongAdder> checked = getMap(PrivacyLevel.Private, 300);
+//		CheckedConstraintsLog.addCheckedConstraints(checked);
+//		EnumMap<PrivacyLevel,LongAdder> checked2 = getMap(PrivacyLevel.Private, 150);
+//		CheckedConstraintsLog.addCheckedConstraints(checked2);
+//		assertEquals(450, CheckedConstraintsLog.getCheckedConstraints().get(PrivacyLevel.Private).longValue());
+//	}
+//
+//	@Test
+//	public void addCheckedConstraintsMultipleValues(){
+//		EnumMap<PrivacyLevel,LongAdder> checked = getMap(PrivacyLevel.Private, 300);
+//		CheckedConstraintsLog.addCheckedConstraints(checked);
+//		EnumMap<PrivacyLevel,LongAdder> checked2 = getMap(PrivacyLevel.Private, 150);
+//		CheckedConstraintsLog.addCheckedConstraints(checked2);
+//		EnumMap<PrivacyLevel,LongAdder> checked3 = getMap(PrivacyLevel.PrivateAggregation, 150);
+//		CheckedConstraintsLog.addCheckedConstraints(checked3);
+//		assertTrue(CheckedConstraintsLog.getCheckedConstraints().get(PrivacyLevel.Private).longValue() == 450
+//		    && CheckedConstraintsLog.getCheckedConstraints().get(PrivacyLevel.PrivateAggregation).longValue() == 150);
+//	}
+//
+//	private static EnumMap<PrivacyLevel,LongAdder> getMap(PrivacyLevel level, long value){
+//		EnumMap<PrivacyLevel,LongAdder> checked = new EnumMap<>(PrivacyLevel.class);
+//		LongAdder valueAdder = new LongAdder();
+//		valueAdder.add(value);
+//		checked.put(level, valueAdder);
+//		return checked;
+//	}
+//
+//	@Test
+//	public void addLoadedConstraintsSingleValue(){
+//		int n = 12;
+//		for (int i = 0; i < n; i++)
+//			CheckedConstraintsLog.addLoadedConstraint(PrivacyLevel.Private);
+//		assertEquals(n, CheckedConstraintsLog.getLoadedConstraints().get(PrivacyLevel.Private).longValue());
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedLmCGTest.java
@@ -1,0 +1,145 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import org.junit.Assert;
+//import org.junit.Test;
+//
+//
+//import org.apache.sysds.common.Types.ExecMode;
+//import org.apache.sysds.common.Types.ExecType;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//
+//@net.jcip.annotations.NotThreadSafe
+//public class FederatedLmCGTest extends AutomatedTestBase
+//{
+//	private final static String TEST_NAME = "lmCGFederated";
+//	private final static String TEST_DIR = "functions/privacy/";
+//	private static final String TEST_CLASS_DIR = TEST_DIR + FederatedLmCGTest.class.getSimpleName() + "/";
+//
+//	private final static int rows = 10;
+//	private final static int cols = 3;
+//	private final static double spSparse = 0.3;
+//	private final static double spDense = 0.7;
+//
+//	@Override
+//	public void setUp() {
+//		addTestConfiguration(TEST_NAME,new TestConfiguration(TEST_CLASS_DIR, TEST_NAME,new String[]{"C"}));
+//	}
+//
+//	@Test
+//	public void testLmMatrixDenseCPlmCG1() {
+//		runLmTest(false, ExecType.CP, false);
+//	}
+//
+//	@Test
+//	public void testLmMatrixSparseCPlmCG1() {
+//		runLmTest(true, ExecType.CP, false);
+//	}
+//
+//	@Test
+//	public void testLmMatrixDenseCPlmCG2() {
+//		runLmTest(false, ExecType.CP, true);
+//	}
+//
+//	@Test
+//	public void testLmMatrixSparseCPlmCG2() {
+//		runLmTest(true, ExecType.CP, true);
+//	}
+//
+//	@Test
+//	public void testLmMatrixDenseSPlmCG() {
+//		runLmTest(false, ExecType.SPARK, true);
+//	}
+//
+//	@Test
+//	public void testLmMatrixSparseSPlmCG() {
+//		runLmTest(true, ExecType.SPARK, true);
+//	}
+//
+//	private void runLmTest(boolean sparse, ExecType instType, boolean doubleFederated)
+//	{
+//		ExecMode platformOld = setExecMode(instType);
+//
+//		try
+//		{
+//			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+//			double sparsity = sparse ? spSparse : spDense;
+//
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			Thread t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+//			Thread t2 = startLocalFedWorkerThread(port2);
+//
+//			fullDMLScriptName = HOME + "FederatedLmCG" + (doubleFederated?"2":"") + ".dml";
+//
+//			if (doubleFederated){
+//				programArgs = new String[]{
+//					"-stats", "-nvargs",
+//					"X1="+TestUtils.federatedAddress(port1, input("X1")),
+//					"X2="+TestUtils.federatedAddress(port2, input("X2")),
+//					"y1=" + TestUtils.federatedAddress(port1, input("y1")),
+//					"y2=" + TestUtils.federatedAddress(port2, input("y2")),
+//					"C="+output("C"),
+//					"r=" + rows, "c=" + cols};
+//			} else {
+//				programArgs = new String[]{
+//					"-stats", "-nvargs",
+//					"X1="+TestUtils.federatedAddress(port1, input("X1")),
+//					"X2="+TestUtils.federatedAddress(port2, input("X2")),
+//					"y=" + input("y"),
+//					"C="+output("C"),
+//					"r=" + rows, "c=" + cols};
+//			}
+//
+//			//generate actual dataset
+//			int halfRows = rows / 2;
+//			double[][] X1 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 7);
+//			writeInputMatrixWithMTD("X1", X1, false);
+//			double[][] X2 = getRandomMatrix(halfRows, cols, 0, 1, sparsity, 8);
+//			writeInputMatrixWithMTD("X2", X2, false);
+//
+//			if ( doubleFederated ){
+//				double[][] y1 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 3);
+//				double[][] y2 = getRandomMatrix(halfRows, 1, 0, 10, 1.0, 4);
+//				writeInputMatrixWithMTD("y1", y1, false);
+//				writeInputMatrixWithMTD("y2", y2, false);
+//			} else {
+//				double[][] y = getRandomMatrix(rows, 1, 0, 10, 1.0, 3);
+//				writeInputMatrixWithMTD("y", y, false);
+//			}
+//
+//			runTest(true, false, null, -1);
+//
+//			//check expected operations
+//			if( instType == ExecType.CP )
+//				Assert.assertTrue(heavyHittersContainsString("fed_mmchain"));
+//
+//			TestUtils.shutdownThreads(t1, t2);
+//		}
+//		finally {
+//			rtplatform = platformOld;
+//		}
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FederatedWorkerHandlerTest.java
@@ -1,0 +1,333 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import java.util.Arrays;
+//
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.common.Types.ExecMode;
+//import org.apache.sysds.runtime.DMLRuntimeException;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//import static org.junit.Assert.assertTrue;
+//
+//@net.jcip.annotations.NotThreadSafe
+//public class FederatedWorkerHandlerTest extends AutomatedTestBase {
+//
+//	private static final String TEST_DIR = "functions/privacy/";
+//	private static final String TEST_DIR_fed = "functions/federated/";
+//	private static final String TEST_DIR_SCALAR = TEST_DIR_fed + "matrix_scalar/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedWorkerHandlerTest.class.getSimpleName() + "/";
+//	private final static String TEST_CLASS_DIR_SCALAR = TEST_DIR + FederatedWorkerHandlerTest.class.getSimpleName() + "/";
+//	private static final String TEST_PROG_SCALAR_ADDITION_MATRIX = "FederatedScalarAdditionMatrix";
+//	private final static String AGGREGATION_TEST_NAME = "FederatedSumTest";
+//	private final static String TRANSFER_TEST_NAME = "FederatedRCBindTest";
+//	private final static String MATVECMULT_TEST_NAME = "FederatedMultiplyTest";
+//	private static final String FEDERATED_WORKER_HOST = "localhost";
+//
+//	private final static int blocksize = 1024;
+//	private final int rows = 10;
+//	private final int cols = 10;
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration("scalar", new TestConfiguration(TEST_CLASS_DIR_SCALAR, TEST_PROG_SCALAR_ADDITION_MATRIX, new String [] {"R"}));
+//		addTestConfiguration("aggregation", new TestConfiguration(TEST_CLASS_DIR, AGGREGATION_TEST_NAME, new String[] {"S.scalar", "R", "C"}));
+//		addTestConfiguration("transfer", new TestConfiguration(TEST_CLASS_DIR, TRANSFER_TEST_NAME, new String[] {"R", "C"}));
+//		addTestConfiguration("matvecmult", new TestConfiguration(TEST_CLASS_DIR, MATVECMULT_TEST_NAME, new String[] {"Z"}));
+//	}
+//
+//	@Test
+//	public void scalarPrivateTest(){
+//		scalarTest(PrivacyLevel.Private, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void scalarPrivateAggregationTest(){
+//		scalarTest(PrivacyLevel.PrivateAggregation, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void scalarNonePrivateTest(){
+//		scalarTest(PrivacyLevel.None, null);
+//	}
+//
+//	private void scalarTest(PrivacyLevel privacyLevel, Class<?> expectedException){
+//		getAndLoadTestConfiguration("scalar");
+//
+//		double[][] m = getRandomMatrix(this.rows, this.cols, -1, 1, 1.0, 1);
+//
+//		PrivacyConstraint pc = new PrivacyConstraint(privacyLevel);
+//		writeInputMatrixWithMTD("M", m, false, new MatrixCharacteristics(rows, cols, blocksize, rows * cols), pc);
+//
+//		int s = TestUtils.getRandomInt();
+//		double[][] r = new double[rows][cols];
+//		for(int i = 0; i < rows; i++) {
+//			for(int j = 0; j < cols; j++) {
+//				r[i][j] = m[i][j] + s;
+//			}
+//		}
+//		if (expectedException == null)
+//			writeExpectedMatrix("R", r);
+//
+//		runGenericScalarTest(TEST_PROG_SCALAR_ADDITION_MATRIX, s, expectedException, privacyLevel);
+//	}
+//
+//
+//	private void runGenericScalarTest(String dmlFile, int s, Class<?> expectedException, PrivacyLevel privacyLevel)
+//	{
+//		ExecMode platformOld = setExecMode(ExecMode.SINGLE_NODE);
+//
+//		try {
+//			int port = getRandomAvailablePort();
+//			Thread t = startLocalFedWorkerThread(port);
+//
+//			fullDMLScriptName = SCRIPT_DIR + TEST_DIR_SCALAR + dmlFile + ".dml";
+//			programArgs = new String[]{"-checkPrivacy", "-nvargs",
+//					"in=" + TestUtils.federatedAddress(FEDERATED_WORKER_HOST, port, input("M")),
+//					"rows=" + Integer.toString(rows), "cols=" + Integer.toString(cols),
+//					"scalar=" + Integer.toString(s),
+//					"out=" + output("R")};
+//			boolean exceptionExpected = (expectedException != null);
+//			runTest(true, exceptionExpected, expectedException, -1);
+//
+//			if ( !exceptionExpected )
+//				compareResults();
+//			TestUtils.shutdownThread(t);
+//		}
+//		finally {
+//			assertTrue("The privacy level " + privacyLevel.toString() + " should have been checked during execution",
+//				checkedPrivacyConstraintsContains(privacyLevel));
+//			resetExecMode(platformOld);
+//		}
+//	}
+//
+//	@Test
+//	public void aggregatePrivateTest() {
+//		federatedSum(Types.ExecMode.SINGLE_NODE, PrivacyLevel.Private, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void aggregatePrivateAggregationTest() {
+//		federatedSum(Types.ExecMode.SINGLE_NODE, PrivacyLevel.PrivateAggregation, null);
+//	}
+//
+//	@Test
+//	public void aggregateNonePrivateTest() {
+//		federatedSum(Types.ExecMode.SINGLE_NODE, PrivacyLevel.None, null);
+//	}
+//
+//	public void federatedSum(Types.ExecMode execMode, PrivacyLevel privacyLevel, Class<?> expectedException) {
+//		ExecMode platformOld = setExecMode(ExecMode.SINGLE_NODE);
+//
+//		try {
+//			getAndLoadTestConfiguration("aggregation");
+//			String HOME = SCRIPT_DIR + TEST_DIR_fed;
+//
+//			double[][] A = getRandomMatrix(rows/2, cols, -10, 10, 1, 1);
+//			writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows/2, cols, blocksize, (rows/2) * cols), new PrivacyConstraint(privacyLevel));
+//			int port = getRandomAvailablePort();
+//			Thread t = startLocalFedWorkerThread(port);
+//
+//			// Run reference dml script with normal matrix for Row/Col sum
+//			fullDMLScriptName = HOME + AGGREGATION_TEST_NAME + "Reference.dml";
+//			programArgs = new String[] {"-args", input("A"), input("A"), expected("R"), expected("C")};
+//			runTest(true, false, null, -1);
+//
+//			// write expected sum
+//			double sum = 0;
+//			for(double[] doubles : A) {
+//				sum += Arrays.stream(doubles).sum();
+//			}
+//
+//			if ( expectedException == null )
+//				writeExpectedScalar("S", sum);
+//
+//			TestConfiguration config = availableTestConfigurations.get("aggregation");
+//			loadTestConfiguration(config);
+//			fullDMLScriptName = HOME + AGGREGATION_TEST_NAME + ".dml";
+//			programArgs = new String[] {"-checkPrivacy", "-nvargs", "in=" + TestUtils.federatedAddress(port, input("A")), "rows=" + rows,
+//				"cols=" + cols, "out_S=" + output("S"), "out_R=" + output("R"), "out_C=" + output("C")};
+//
+//			runTest(true, (expectedException != null), expectedException, -1);
+//
+//			// compare all sums via files
+//			if ( expectedException == null )
+//				compareResults(1e-11);
+//
+//			assertTrue("The privacy level " + privacyLevel.toString() + " should have been checked during execution",
+//				checkedPrivacyConstraintsContains(privacyLevel));
+//			TestUtils.shutdownThread(t);
+//		}
+//		finally {
+//			resetExecMode(platformOld);
+//		}
+//	}
+//
+//	@Test
+//	public void transferPrivateTest() {
+//		federatedRCBind(Types.ExecMode.SINGLE_NODE, PrivacyLevel.Private, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void transferPrivateAggregationTest() {
+//		federatedRCBind(Types.ExecMode.SINGLE_NODE, PrivacyLevel.PrivateAggregation, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void transferNonePrivateTest() {
+//		federatedRCBind(Types.ExecMode.SINGLE_NODE, PrivacyLevel.None, null);
+//	}
+//
+//	public void federatedRCBind(Types.ExecMode execMode, PrivacyLevel privacyLevel, Class<?> expectedException) {
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//
+//
+//		getAndLoadTestConfiguration("transfer");
+//		String HOME = SCRIPT_DIR + TEST_DIR_fed;
+//
+//		double[][] A = getRandomMatrix(rows, cols, -10, 10, 1, 1);
+//		writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows, cols, blocksize, rows * cols), new PrivacyConstraint(privacyLevel));
+//
+//		int port = getRandomAvailablePort();
+//		Thread t = startLocalFedWorkerThread(port);
+//
+//		// we need the reference file to not be written to hdfs, so we get the correct format
+//		rtplatform = Types.ExecMode.SINGLE_NODE;
+//		// Run reference dml script with normal matrix for Row/Col sum
+//		fullDMLScriptName = HOME + TRANSFER_TEST_NAME + "Reference.dml";
+//		programArgs = new String[] {"-checkPrivacy", "-args", input("A"), expected("R"), expected("C")};
+//		runTest(true, false, null, -1);
+//
+//		// reference file should not be written to hdfs, so we set platform here
+//		rtplatform = execMode;
+//		if(rtplatform == Types.ExecMode.SPARK) {
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+//		}
+//		TestConfiguration config = availableTestConfigurations.get("transfer");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = HOME + TRANSFER_TEST_NAME + ".dml";
+//		programArgs = new String[] {"-checkPrivacy", "-nvargs",
+//			"in=" + TestUtils.federatedAddress(port, input("A")), "rows=" + rows,
+//			"cols=" + cols, "out_R=" + output("R"), "out_C=" + output("C")};
+//
+//		runTest(true, (expectedException != null), expectedException, -1);
+//
+//		// compare all sums via files
+//		if ( expectedException == null )
+//			compareResults(1e-11);
+//
+//		assertTrue("Privacy constraint with level " + privacyLevel + " should have been checked during execution",
+//			checkedPrivacyConstraintsContains(privacyLevel));
+//
+//		TestUtils.shutdownThread(t);
+//		rtplatform = platformOld;
+//		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//	}
+//
+//	@Test
+//	public void matVecMultPrivateTest() {
+//		federatedMultiply(Types.ExecMode.SINGLE_NODE, PrivacyLevel.Private, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void matVecMultPrivateAggregationTest() {
+//		federatedMultiply(Types.ExecMode.SINGLE_NODE, PrivacyLevel.PrivateAggregation, null);
+//	}
+//
+//	@Test
+//	public void matVecMultNonePrivateTest() {
+//		federatedMultiply(Types.ExecMode.SINGLE_NODE, PrivacyLevel.None, null);
+//	}
+//
+//	public void federatedMultiply(Types.ExecMode execMode, PrivacyLevel privacyLevel, Class<?> expectedException) {
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = execMode;
+//		if(rtplatform == Types.ExecMode.SPARK) {
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+//		}
+//
+//		Thread t1, t2;
+//
+//		getAndLoadTestConfiguration("matvecmult");
+//		String HOME = SCRIPT_DIR + TEST_DIR_fed;
+//
+//		// write input matrices
+//		int halfRows = rows / 2;
+//		// We have two matrices handled by a single federated worker
+//		double[][] X1 = getRandomMatrix(halfRows, cols, 0, 1, 1, 42);
+//		double[][] X2 = getRandomMatrix(halfRows, cols, 0, 1, 1, 1340);
+//		// And another two matrices handled by a single federated worker
+//		double[][] Y1 = getRandomMatrix(cols, halfRows, 0, 1, 1, 44);
+//		double[][] Y2 = getRandomMatrix(cols, halfRows, 0, 1, 1, 21);
+//
+//		writeInputMatrixWithMTD("X1", X1, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols), new PrivacyConstraint(privacyLevel));
+//		writeInputMatrixWithMTD("X2", X2, false, new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
+//		writeInputMatrixWithMTD("Y1", Y1, false, new MatrixCharacteristics(cols, halfRows, blocksize, halfRows * cols));
+//		writeInputMatrixWithMTD("Y2", Y2, false, new MatrixCharacteristics(cols, halfRows, blocksize, halfRows * cols));
+//
+//		int port1 = getRandomAvailablePort();
+//		int port2 = getRandomAvailablePort();
+//		t1 = startLocalFedWorkerThread(port1);
+//		t2 = startLocalFedWorkerThread(port2);
+//
+//		TestConfiguration config = availableTestConfigurations.get("matvecmult");
+//		loadTestConfiguration(config);
+//
+//		// Run reference dml script with normal matrix
+//		fullDMLScriptName = HOME + MATVECMULT_TEST_NAME + "Reference.dml";
+//		programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
+//			"Y2=" + input("Y2"), "Z=" + expected("Z")};
+//		runTest(true, false, null, -1);
+//
+//		// Run actual dml script with federated matrix
+//		fullDMLScriptName = HOME + MATVECMULT_TEST_NAME + ".dml";
+//		programArgs = new String[] {"-checkPrivacy",
+//			"-nvargs",
+//			"X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//			"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//			"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
+//			"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols,
+//			"hr=" + halfRows, "Z=" + output("Z")};
+//		runTest(true, (expectedException != null), expectedException, -1);
+//
+//		// compare via files
+//		if (expectedException == null)
+//			compareResults(1e-9);
+//
+//		assertTrue("Privacy constraint with level " + privacyLevel + " should have been checked during execution",
+//			checkedPrivacyConstraintsContains(privacyLevel));
+//
+//		TestUtils.shutdownThreads(t1, t2);
+//
+//		rtplatform = platformOld;
+//		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/FineGrainedPrivacyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/FineGrainedPrivacyTest.java
@@ -1,0 +1,191 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertTrue;
+//
+//import java.util.Arrays;
+//import java.util.Collection;
+//import java.util.Map;
+//
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.runtime.privacy.finegrained.DataRange;
+//import org.apache.sysds.runtime.privacy.finegrained.FineGrainedPrivacy;
+//import org.apache.sysds.runtime.privacy.finegrained.FineGrainedPrivacyList;
+//import org.apache.sysds.runtime.privacy.finegrained.FineGrainedPrivacyMap;
+//import org.junit.After;
+//import org.junit.Test;
+//import org.junit.runners.Parameterized;
+//import org.junit.runner.RunWith;
+//
+//@RunWith(Parameterized.class)
+//public class FineGrainedPrivacyTest {
+//
+//	private FineGrainedPrivacy constraints;
+//
+//	public FineGrainedPrivacyTest(FineGrainedPrivacy constraints){
+//		this.constraints = constraints;
+//	}
+//
+//	@Parameterized.Parameters
+//	public static Collection<FineGrainedPrivacy[]> FineGrainedPrivacy(){
+//		return Arrays.asList(new FineGrainedPrivacy[][] {
+//			{new FineGrainedPrivacyMap()},
+//			{new FineGrainedPrivacyList()}
+//		});
+//	}
+//
+//	@After
+//	public void setConstraintsToNull(){
+//		constraints.removeAllConstraints();
+//		constraints = null;
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelSingleConstraintCompletelyInRangeTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevel(new DataRange(new long[]{4L,4L,7L}, new long[]{5L,5L,8L}));
+//		assertTrue(outputMap.containsKey(inputDataRange));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelSingleConstraintInRangeTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevel(new DataRange(new long[]{1L,4L,7L}, new long[]{5L,5L,8L}));
+//		assertTrue(outputMap.containsKey(inputDataRange));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelSingleConstraintNotInRangeTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevel(new DataRange(new long[]{0L,4L,7L}, new long[]{2L,5L,8L}));
+//		assertFalse(outputMap.containsKey(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelMultiConstraintInRangeTest(){
+//		DataRange inputDataRange1 = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		DataRange inputDataRange2 = new DataRange(new long[]{10L,14L,12L}, new long[]{45L,23L,15L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange1, inputPrivacyLevel);
+//		constraints.put(inputDataRange2, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevel(new DataRange(new long[]{4L,3L,8L}, new long[]{50L,55L,19L}));
+//		assertTrue(outputMap.containsKey(inputDataRange1));
+//		assertTrue(outputMap.containsKey(inputDataRange2));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange1));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange2));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementSingleConstraintTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{4L,4L,7L});
+//		assertTrue(outputMap.containsKey(inputDataRange));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementOnLowerBoundSingleConstraintTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{3L,2L,7L});
+//		assertTrue(outputMap.containsKey(inputDataRange));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementOnUpperBoundSingleConstraintTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{5L,6L,9L});
+//		assertTrue(outputMap.containsKey(inputDataRange));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementSingleConstraintNotInRangeTest(){
+//		DataRange inputDataRange = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{7L,10L,1L});
+//		assertFalse(outputMap.containsKey(inputDataRange));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementDoubleConstraintInSingleTest(){
+//		DataRange inputDataRange1 = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		DataRange inputDataRange2 = new DataRange(new long[]{10L,14L,12L}, new long[]{45L,23L,15L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange1, inputPrivacyLevel);
+//		constraints.put(inputDataRange2, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{21L,17L,13L});
+//		assertTrue("inputDataRange2 should be in outputMap since element is in the range", outputMap.containsKey(inputDataRange2));
+//		assertFalse("inputDataRange1 should not be in outputMap", outputMap.containsKey(inputDataRange1));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange2));
+//	}
+//
+//	@Test
+//	public void getPrivacyLevelOfElementDoubleConstraintInBothTest(){
+//		DataRange inputDataRange1 = new DataRange(new long[]{3L,2L,7L}, new long[]{5L,6L,9L});
+//		DataRange inputDataRange2 = new DataRange(new long[]{1,1L,8L}, new long[]{45L,23L,15L});
+//		PrivacyLevel inputPrivacyLevel = PrivacyLevel.Private;
+//		constraints.put(inputDataRange1, inputPrivacyLevel);
+//		constraints.put(inputDataRange2, inputPrivacyLevel);
+//		Map<DataRange, PrivacyLevel> outputMap = constraints.getPrivacyLevelOfElement(new long[]{4L,4L,9L});
+//		assertTrue("inputDataRange2 should be in outputMap since element is in the range", outputMap.containsKey(inputDataRange2));
+//		assertTrue("inputDataRange1 should be in outputMap since element is in the range", outputMap.containsKey(inputDataRange1));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange2));
+//		assertEquals(inputPrivacyLevel, outputMap.get(inputDataRange1));
+//	}
+//
+//	@Test
+//	public void getDataRangesOfPrivacyLevelTest(){
+//		DataRange inputDataRange1 = new DataRange(new long[]{60L,30L,70L}, new long[]{90L,60L,150L});
+//		DataRange inputDataRange2 = new DataRange(new long[]{10,10L,18L}, new long[]{450L,230L,250L});
+//		DataRange inputDataRange3 = new DataRange(new long[]{300L,250L,740L}, new long[]{520L,630L,1090L});
+//		DataRange inputDataRange4 = new DataRange(new long[]{10,10L,10L}, new long[]{30L,40L,50L});
+//		PrivacyLevel inputPrivacyLevel1 = PrivacyLevel.Private;
+//		PrivacyLevel inputPrivacyLevel2 = PrivacyLevel.PrivateAggregation;
+//		constraints.put(inputDataRange1, inputPrivacyLevel1);
+//		constraints.put(inputDataRange2, inputPrivacyLevel1);
+//		constraints.put(inputDataRange3, inputPrivacyLevel2);
+//		constraints.put(inputDataRange4, inputPrivacyLevel2);
+//		DataRange[] outputDataRanges1 = constraints.getDataRangesOfPrivacyLevel(inputPrivacyLevel1);
+//		assertEquals(inputDataRange1, outputDataRanges1[0]);
+//		assertEquals(inputDataRange2, outputDataRanges1[1]);
+//		DataRange[] outputDataRanges2 = constraints.getDataRangesOfPrivacyLevel(inputPrivacyLevel2);
+//		assertEquals(inputDataRange3, outputDataRanges2[0]);
+//		assertEquals(inputDataRange4, outputDataRanges2[1]);
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/MatrixMultiplicationPropagationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/MatrixMultiplicationPropagationTest.java
@@ -1,0 +1,198 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.fail;
+//
+//import org.apache.wink.json4j.JSONException;
+//import org.junit.Test;
+//import org.apache.sysds.parser.DataExpression;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//
+//public class MatrixMultiplicationPropagationTest extends AutomatedTestBase {
+//
+//	private static final String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + MatrixMultiplicationPropagationTest.class.getSimpleName() + "/";
+//	private final int m = 20;
+//	private final int n = 20;
+//	private final int k = 20;
+//
+//	@Override
+//	public void setUp() {
+//		addTestConfiguration("MatrixMultiplicationPropagationTest",
+//			new TestConfiguration(TEST_CLASS_DIR, "MatrixMultiplicationPropagationTest", new String[]{"c"}));
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationPrivate() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.Private, true);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationNone() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.None, true);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationPrivateAggregation() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.PrivateAggregation, true);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationSecondOperandPrivate() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.Private, false);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationSecondOperandNone() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.None, false);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPropagationSecondOperandPrivateAggregation() throws JSONException {
+//		matrixMultiplicationPropagation(PrivacyLevel.PrivateAggregation, false);
+//	}
+//
+//	private void matrixMultiplicationPropagation(PrivacyLevel privacyLevel, boolean privateFirstOperand) throws JSONException {
+//
+//		TestConfiguration config = availableTestConfigurations.get("MatrixMultiplicationPropagationTest");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//		programArgs = new String[]{"-nvargs",
+//			"a=" + input("a"), "b=" + input("b"), "c=" + output("c"),
+//			"m=" + m, "n=" + n, "k=" + k};
+//
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//		double[][] b = getRandomMatrix(n, k, -1, 1, 1, -1);
+//		double[][] c = TestUtils.performMatrixMultiplication(a, b);
+//
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint(privacyLevel);
+//		MatrixCharacteristics dataCharacteristics = new MatrixCharacteristics(m,n,k,k);
+//
+//		if ( privateFirstOperand ) {
+//			writeInputMatrixWithMTD("a", a, false, dataCharacteristics, privacyConstraint);
+//			writeInputMatrix("b", b);
+//		}
+//		else {
+//			writeInputMatrix("a", a);
+//			writeInputMatrixWithMTD("b", b, false, dataCharacteristics, privacyConstraint);
+//		}
+//
+//		writeExpectedMatrix("c", c);
+//
+//		runTest(true,false,null,-1);
+//
+//		// Check that the output data is correct
+//		compareResults(1e-9);
+//
+//		// Check that the output metadata is correct
+//		if ( privacyLevel != PrivacyLevel.None ){
+//			String actualPrivacyValue = readDMLMetaDataPrivacyValue("c", OUTPUT_DIR, DataExpression.PRIVACY);
+//			assertEquals(String.valueOf(privacyLevel), actualPrivacyValue);
+//		} else exceptionExpected("c", OUTPUT_DIR);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationNoPropagation() {
+//		matrixMultiplicationNoPropagation();
+//	}
+//
+//	private void matrixMultiplicationNoPropagation() {
+//		TestConfiguration config = availableTestConfigurations.get("MatrixMultiplicationPropagationTest");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//		programArgs = new String[]{ "-nvargs",
+//			"a=" + input("a"), "b=" + input("b"), "c=" + output("c"),
+//			"m=" + m, "n=" + n, "k=" + k};
+//
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//		double[][] b = getRandomMatrix(n, k, -1, 1, 1, -1);
+//		double[][] c = TestUtils.performMatrixMultiplication(a, b);
+//
+//
+//		writeInputMatrix("a", a);
+//		writeInputMatrix("b", b);
+//		writeExpectedMatrix("c", c);
+//
+//		runTest(true,false,null,-1);
+//
+//		// Check that the output data is correct
+//		compareResults(1e-9);
+//
+//		// Check that a JSONException is thrown
+//		// because no privacy metadata should be written to c
+//		exceptionExpected("c", OUTPUT_DIR);
+//	}
+//
+//	/**
+//	 * Check that an exception is thrown when metadata of variable is read.
+//	 * @param variable name of variable
+//	 * @param dir directory of variable
+//	 */
+//	private static void exceptionExpected(String variable, String dir){
+//		String actualPrivacyValue = null;
+//		try{
+//			actualPrivacyValue = readDMLMetaDataPrivacyValue(variable, dir, DataExpression.PRIVACY);
+//		} catch (Exception e){
+//			fail("Exception occured, but JSONException was expected. The exception thrown is: " + e.getMessage());
+//			e.printStackTrace();
+//		}
+//		assert((PrivacyLevel.None.name().equals(actualPrivacyValue)));
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPrivacyInputPrivate() throws JSONException {
+//		testMatrixMultiplicationPrivacyInput(PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPrivacyInputNone() throws JSONException {
+//		testMatrixMultiplicationPrivacyInput(PrivacyLevel.None);
+//	}
+//
+//	@Test
+//	public void testMatrixMultiplicationPrivacyInputPrivateAggregation() throws JSONException {
+//		testMatrixMultiplicationPrivacyInput(PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	private void testMatrixMultiplicationPrivacyInput(PrivacyLevel privacyLevel) throws JSONException {
+//		TestConfiguration config = availableTestConfigurations.get("MatrixMultiplicationPropagationTest");
+//		loadTestConfiguration(config);
+//
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint(privacyLevel);
+//		MatrixCharacteristics dataCharacteristics = new MatrixCharacteristics(m,n,k,k);
+//
+//		writeInputMatrixWithMTD("a", a, false, dataCharacteristics, privacyConstraint);
+//
+//		if ( privacyLevel != PrivacyLevel.None ){
+//			String actualPrivacyValue = readDMLMetaDataPrivacyValue("a", INPUT_DIR, DataExpression.PRIVACY);
+//			assertEquals(String.valueOf(privacyLevel), actualPrivacyValue);
+//		} else exceptionExpected("a", INPUT_DIR);
+//
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/MatrixRuntimePropagationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/MatrixRuntimePropagationTest.java
@@ -1,0 +1,120 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.fail;
+//
+//import org.apache.sysds.parser.DataExpression;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.apache.wink.json4j.JSONException;
+//import org.junit.Test;
+//
+//public class MatrixRuntimePropagationTest extends AutomatedTestBase
+//{
+//	private static final String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + MatrixMultiplicationPropagationTest.class.getSimpleName() + "/";
+//	private final int m = 20;
+//	private final int n = 20;
+//	private final int k = 20;
+//
+//	@Override
+//	public void setUp() {
+//		addTestConfiguration("MatrixRuntimePropagationTest",
+//			new TestConfiguration(TEST_CLASS_DIR, "MatrixRuntimePropagationTest", new String[]{"c"}));
+//	}
+//
+//	@Test
+//	public void testRuntimePropagationPrivate() throws JSONException {
+//		conditionalPropagation(PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testRuntimePropagationNone() throws JSONException {
+//		conditionalPropagation(PrivacyLevel.None);
+//	}
+//
+//	@Test
+//	public void testRuntimePropagationPrivateAggregation() throws JSONException {
+//		conditionalPropagation(PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	private void conditionalPropagation(PrivacyLevel privacyLevel) throws JSONException {
+//
+//		TestConfiguration config = availableTestConfigurations.get("MatrixRuntimePropagationTest");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//		double[][] b = getRandomMatrix(n, k, -1, 1, 1, -1);
+//		double sum;
+//
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint(privacyLevel);
+//		MatrixCharacteristics dataCharacteristics = new MatrixCharacteristics(m,n,k,k);
+//
+//		writeInputMatrixWithMTD("a", a, false, dataCharacteristics, privacyConstraint);
+//		writeInputMatrix("b", b);
+//		if ( privacyLevel.equals(PrivacyLevel.Private) || privacyLevel.equals(PrivacyLevel.PrivateAggregation) ){
+//			writeExpectedMatrix("c", a);
+//			sum = TestUtils.sum(a, m, n) + 1;
+//		} else {
+//			writeExpectedMatrix("c", b);
+//			sum = TestUtils.sum(a, m, n) - 1;
+//		}
+//
+//		programArgs = new String[]{"-nvargs",
+//		"a=" + input("a"), "b=" + input("b"), "c=" + output("c"),
+//		"m=" + m, "n=" + n, "k=" + k, "s=" + sum };
+//
+//		runTest(true,false,null,-1);
+//
+//		// Check that the output data is correct
+//		compareResults(1e-9);
+//
+//		// Check that the output metadata is correct
+//		if ( privacyLevel.equals(PrivacyLevel.Private) ) {
+//			String actualPrivacyValue = readDMLMetaDataPrivacyValue("c", OUTPUT_DIR, DataExpression.PRIVACY);
+//			assertEquals(PrivacyLevel.Private.name(), actualPrivacyValue);
+//		}
+//		else if ( privacyLevel.equals(PrivacyLevel.PrivateAggregation) ){
+//			String actualPrivacyValue = readDMLMetaDataPrivacyValue("c", OUTPUT_DIR, DataExpression.PRIVACY);
+//			assertEquals(PrivacyLevel.PrivateAggregation.name(), actualPrivacyValue);
+//		}
+//		else {
+//			// Check that a JSONException is thrown
+//			// or that privacy level is set to none
+//			// because no privacy metadata should be written to c
+//			// except if the privacy written is set to private
+//			String actualPrivacyValue = null;
+//			try{
+//				actualPrivacyValue = readDMLMetaDataPrivacyValue("c", OUTPUT_DIR, DataExpression.PRIVACY);
+//			} catch (Exception e){
+//				fail("Exception occured, but JSONException was expected. The exception thrown is: " + e.getMessage());
+//				e.printStackTrace();
+//			}
+//			assert((PrivacyLevel.None.name().equals(actualPrivacyValue)));
+//		}
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/PrivacyLineageTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/PrivacyLineageTest.java
@@ -1,0 +1,86 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import org.apache.sysds.parser.DataExpression;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.finegrained.DataRange;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.junit.Assert;
+//import org.junit.Test;
+//
+//public class PrivacyLineageTest extends AutomatedTestBase {
+//
+//	private static final String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + PrivacyLineageTest.class.getSimpleName() + "/";
+//
+//	@Override public void setUp() {
+//		addTestConfiguration("LineageReuse",
+//			new TestConfiguration(TEST_CLASS_DIR, "PrivacyLineageTest", new String[]{"c"}));
+//	}
+//
+//	@Test
+//	public void propagatePrivacyWithLineageFullReuseTest() {
+//		propagationWithLineage(PrivacyConstraint.PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	private void propagationWithLineage(PrivacyConstraint.PrivacyLevel privacyLevel) {
+//
+//		TestConfiguration config = availableTestConfigurations.get("LineageReuse");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		int n = 20;
+//		int m = 20;
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//		int k = 20;
+//		double[][] b = getRandomMatrix(n, k, -1, 1, 1, -1);
+//
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint(privacyLevel);
+//		privacyConstraint.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0}, new long[]{4,4}), PrivacyConstraint.PrivacyLevel.Private);
+//		MatrixCharacteristics aCharacteristics = new MatrixCharacteristics(m, n, k, k);
+//		MatrixCharacteristics bCharacteristics = new MatrixCharacteristics(n, k, k, k);
+//
+//		writeInputMatrixWithMTD("A", a, false, aCharacteristics, privacyConstraint);
+//		writeInputMatrixWithMTD("B", b, false, bCharacteristics);
+//
+//		programArgs = new String[]{"-lineage", "reuse_full", "-nvargs",
+//			"A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//
+//		runTest(true,false,null,-1);
+//
+//		finegrainedAssertions();
+//
+//		programArgs = new String[]{"-nvargs",
+//			"A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//		runTest(true,false,null,-1);
+//
+//		finegrainedAssertions();
+//	}
+//
+//	private static void finegrainedAssertions(){
+//		String outputFineGrained = readDMLMetaDataPrivacyValue("C", OUTPUT_DIR, DataExpression.FINE_GRAINED_PRIVACY);
+//		Assert.assertEquals(
+//			"{\"Private\":[[[0,0],[0,19]],[[1,0],[1,19]],[[2,0],[2,19]],[[3,0],[3,19]],[[4,0],[4,19]]],\"PrivateAggregation\":[]}",
+//			outputFineGrained);
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/ReadWriteTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/ReadWriteTest.java
@@ -1,0 +1,216 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertNotNull;
+//
+//import java.io.FileInputStream;
+//import java.io.FileOutputStream;
+//import java.io.IOException;
+//import java.io.ObjectInputStream;
+//import java.io.ObjectOutputStream;
+//
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.meta.MetaDataAll;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.runtime.privacy.finegrained.DataRange;
+//import org.apache.sysds.runtime.privacy.finegrained.FineGrainedPrivacy;
+//import org.apache.sysds.runtime.privacy.finegrained.FineGrainedPrivacyList;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.junit.Assert;
+//import org.junit.Test;
+//
+//public class ReadWriteTest extends AutomatedTestBase {
+//
+//	private static final String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + ReadWriteTest.class.getSimpleName() + "/";
+//
+//	private final int n = 10;
+//	private final int m = 20;
+//
+//	@Override
+//	public void setUp() {
+//		addTestConfiguration("ReadWriteTest",
+//			new TestConfiguration(TEST_CLASS_DIR, "ReadWriteTest", new String[]{}));
+//		addTestConfiguration("ReadWriteTest2",
+//			new TestConfiguration(TEST_CLASS_DIR, "ReadWriteTest2", new String[]{"b"}));
+//		addTestConfiguration("serialize",
+//			new TestConfiguration(TEST_CLASS_DIR, "serialize", new String[]{}));
+//	}
+//
+//
+//	@Test
+//	public void writeFineGrainedPrivacyMetadataTest(){
+//		TestConfiguration config = availableTestConfigurations.get("ReadWriteTest");
+//		loadTestConfiguration(config);
+//
+//		writeA();
+//
+//		MetaDataAll metadata = getMetaData("a", "in/");
+//		assertNotNull(metadata.getFineGrainedPrivacy());
+//	}
+//
+//	@Test
+//	public void readAndWriteFineGrainedConstraintsTest(){
+//		TestConfiguration config = availableTestConfigurations.get("ReadWriteTest2");
+//		loadTestConfiguration(config);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		double[][] a = writeA();
+//
+//		writeExpectedMatrix("b", a);
+//		programArgs = new String[]{"-nvargs",
+//		"a=" + input("a"), "b=" + output("b"),
+//		"m=" + m, "n=" + n };
+//		runTest(true,false,null,-1);
+//		compareResults(1e-9);
+//
+//		MetaDataAll metadata = getMetaData("b");
+//		assertNotNull(metadata.getFineGrainedPrivacy());
+//	}
+//
+//	@Test
+//	public void writeAndEqualsFineGrainedConstraintsTest(){
+//		TestConfiguration config = availableTestConfigurations.get("ReadWriteTest");
+//		loadTestConfiguration(config);
+//
+//		writeA();
+//
+//		MetaDataAll metadata = getMetaData("a", "in/");
+//		assertNotNull(metadata.getFineGrainedPrivacy());
+//
+//		PrivacyConstraint expectedPC = new PrivacyConstraint();
+//		setFineGrained(expectedPC);
+//		PrivacyConstraint constraint = getPrivacyConstraintFromMetaData("a", "in/");
+//		Assert.assertEquals(expectedPC, constraint);
+//	}
+//
+//	@Test
+//	public void writeAndEqualsFineGrainedConstraintsTest2(){
+//		TestConfiguration config = availableTestConfigurations.get("ReadWriteTest");
+//		loadTestConfiguration(config);
+//
+//		writeA();
+//
+//		MetaDataAll metadata = getMetaData("a", "in/");
+//		assertNotNull(metadata.getFineGrainedPrivacy());
+//
+//		PrivacyConstraint expectedPC = new PrivacyConstraint();
+//		setFineGrained(expectedPC);
+//		expectedPC.getFineGrainedPrivacy().put(new DataRange(new long[]{12,6}, new long[]{15,8}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint = getPrivacyConstraintFromMetaData("a", "in/");
+//		Assert.assertNotEquals(expectedPC, constraint);
+//	}
+//
+//	private double[][] writeA(){
+//		int k = 15;
+//		double[][] a = getRandomMatrix(m, n, -1, 1, 1, -1);
+//
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint();
+//		setFineGrained(privacyConstraint);
+//		MatrixCharacteristics dataCharacteristics = new MatrixCharacteristics(m,n,k,k);
+//		writeInputMatrixWithMTD("a", a, false, dataCharacteristics, privacyConstraint);
+//		return a;
+//	}
+//
+//	private static void setFineGrained(PrivacyConstraint privacyConstraint){
+//		FineGrainedPrivacy fgp = privacyConstraint.getFineGrainedPrivacy();
+//		fgp.put(new DataRange(new long[]{1,2}, new long[]{5,4}), PrivacyLevel.Private);
+//		fgp.put(new DataRange(new long[]{7,1}, new long[]{9,1}), PrivacyLevel.Private);
+//		fgp.put(new DataRange(new long[]{10,5}, new long[]{10,9}), PrivacyLevel.PrivateAggregation);
+//		privacyConstraint.setFineGrainedPrivacyConstraints(fgp);
+//	}
+//
+//	@Test
+//	public void serializeTest() throws IOException {
+//		serializeBaseTest(PrivacyLevel.Private, null);
+//	}
+//
+//	@Test
+//	public void serializeFineGrainedTest() throws IOException {
+//		FineGrainedPrivacy fineGrained = new FineGrainedPrivacyList();
+//		fineGrained.put(new DataRange(new long[]{1,2,3}, new long[]{4,5,6}), PrivacyLevel.Private);
+//		serializeBaseTest(PrivacyLevel.PrivateAggregation, fineGrained);
+//	}
+//
+//	@Test
+//	public void serializeFineGrainedTest2() throws IOException {
+//		FineGrainedPrivacy fineGrained = new FineGrainedPrivacyList();
+//		fineGrained.put(new DataRange(new long[]{1,2,3}, new long[]{4,5,6}), PrivacyLevel.Private);
+//		fineGrained.put(new DataRange(new long[]{7,8,9}, new long[]{10,11,12}), PrivacyLevel.Private);
+//		serializeBaseTest(PrivacyLevel.PrivateAggregation, fineGrained);
+//	}
+//
+//	@Test
+//	public void serializeFineGrainedTest3() throws IOException {
+//		FineGrainedPrivacy fineGrained = new FineGrainedPrivacyList();
+//		fineGrained.put(new DataRange(new long[]{1,2,3}, new long[]{4,5,6}), PrivacyLevel.Private);
+//		fineGrained.put(new DataRange(new long[]{7,8,9}, new long[]{10,11,12}), PrivacyLevel.Private);
+//		serializeBaseTest(PrivacyLevel.None, fineGrained);
+//	}
+//
+//	@Test
+//	public void serializeFineGrainedTest4() throws IOException {
+//		FineGrainedPrivacy fineGrained = new FineGrainedPrivacyList();
+//		fineGrained.put(new DataRange(new long[]{1,2,3}, new long[]{4,5,6}), PrivacyLevel.PrivateAggregation);
+//		fineGrained.put(new DataRange(new long[]{7,8,9}, new long[]{10,11,12}), PrivacyLevel.PrivateAggregation);
+//		serializeBaseTest(PrivacyLevel.PrivateAggregation, fineGrained);
+//	}
+//
+//	@Test
+//	public void serializeFineGrainedTest5() throws IOException {
+//		FineGrainedPrivacy fineGrained = new FineGrainedPrivacyList();
+//		fineGrained.put(new DataRange(new long[]{1,2,3}, new long[]{4,5,6}), PrivacyLevel.PrivateAggregation);
+//		fineGrained.put(new DataRange(new long[]{7,8,9}, new long[]{10,11,12}), PrivacyLevel.Private);
+//		serializeBaseTest(PrivacyLevel.None, fineGrained);
+//	}
+//
+//	private void serializeBaseTest(PrivacyLevel privacyLevel, FineGrainedPrivacy fineGrainedPrivacy) throws IOException {
+//		TestConfiguration config = availableTestConfigurations.get("serialize");
+//		loadTestConfiguration(config);
+//
+//		//Writing
+//		PrivacyConstraint privacyConstraint = new PrivacyConstraint(privacyLevel);
+//		if ( fineGrainedPrivacy != null )
+//			privacyConstraint.setFineGrainedPrivacyConstraints(fineGrainedPrivacy);
+//		String outputPath = baseDirectory + INPUT_DIR + "serialize.ser";
+//		try (FileOutputStream fileOutput = new FileOutputStream(outputPath)){
+//			try (ObjectOutputStream outputStream = new ObjectOutputStream(fileOutput)){
+//				privacyConstraint.writeExternal(outputStream);
+//			}
+//		}
+//
+//		//Reading
+//		PrivacyConstraint loadedConstraint = new PrivacyConstraint();
+//		try (FileInputStream fileInput = new FileInputStream(outputPath)){
+//			try (ObjectInputStream inputStream = new ObjectInputStream(fileInput)){
+//				loadedConstraint.readExternal(inputStream);
+//			}
+//		}
+//
+//		//Comparing
+//		assertEquals(privacyConstraint.getPrivacyLevel(), loadedConstraint.getPrivacyLevel());
+//		assertEquals(privacyConstraint.getFineGrainedPrivacy(), loadedConstraint.getFineGrainedPrivacy());
+//	}
+//
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/ScalarPropagationTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/ScalarPropagationTest.java
@@ -1,0 +1,146 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertFalse;
+//
+//import java.util.HashMap;
+//
+//import org.apache.sysds.runtime.meta.MetaDataAll;
+//import org.junit.Test;
+//import org.apache.sysds.parser.DataExpression;
+//import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//
+//public class ScalarPropagationTest extends AutomatedTestBase
+//{
+//
+//	private final static String TEST_NAME = "ScalarPropagationTest";
+//	private final static String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + ScalarPropagationTest.class.getSimpleName() + "/";
+//	private final static String TEST_CLASS_DIR_2 = TEST_DIR + ScalarPropagationTest.class.getSimpleName() + "2/";
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] { "scalar" }));
+//		addTestConfiguration(TEST_NAME+"2", new TestConfiguration(TEST_CLASS_DIR_2, TEST_NAME+"2", new String[] { "scalar" }));
+//	}
+//
+//	@Test
+//	public void testCastAndRound() {
+//		TestConfiguration conf = getAndLoadTestConfiguration(TEST_NAME);
+//
+//		String HOME = SCRIPT_DIR + TEST_DIR;
+//		fullDMLScriptName = HOME + conf.getTestScript() + ".dml";
+//		programArgs = new String[]{"-args", input("A"), output("scalar") };
+//
+//		double scalar = 10.7;
+//		double[][] A = {{scalar}};
+//		writeInputMatrixWithMTD("A", A, true, new PrivacyConstraint(PrivacyLevel.Private));
+//
+//		double roundScalar = Math.round(scalar);
+//
+//		writeExpectedScalar("scalar", roundScalar);
+//
+//		runTest(true, false, null, -1);
+//
+//		HashMap<CellIndex, Double> map = readDMLScalarFromOutputDir("scalar");
+//		double dmlvalue = map.get(new CellIndex(1,1));
+//
+//		assertEquals("Values mismatch: DMLvalue " + dmlvalue + " != ExpectedValue " + roundScalar,
+//			roundScalar, dmlvalue, 0.001);
+//
+//		String actualPrivacyValue = readDMLMetaDataPrivacyValueCatchException("scalar", "out/", DataExpression.PRIVACY);
+//		assertEquals(String.valueOf(PrivacyLevel.Private), actualPrivacyValue);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyPrivatePrivate(){
+//		testCastAndMultiply(PrivacyLevel.Private, PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyPrivatePrivateAggregation(){
+//		testCastAndMultiply(PrivacyLevel.Private, PrivacyLevel.PrivateAggregation, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyPrivateAggregationPrivate(){
+//		testCastAndMultiply(PrivacyLevel.PrivateAggregation, PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyPrivateAggregationPrivateAggregation(){
+//		testCastAndMultiply(PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyPrivateNone(){
+//		testCastAndMultiply(PrivacyLevel.Private, PrivacyLevel.None, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void testCastAndMultiplyNoneNone(){
+//		testCastAndMultiply(PrivacyLevel.None, PrivacyLevel.None, PrivacyLevel.None);
+//	}
+//
+//	public void testCastAndMultiply(PrivacyLevel privacyLevelA, PrivacyLevel privacyLevelB, PrivacyLevel expectedPrivacyLevel) {
+//		TestConfiguration conf = getAndLoadTestConfiguration(TEST_NAME+"2");
+//
+//		String HOME = SCRIPT_DIR + TEST_DIR;
+//		fullDMLScriptName = HOME + conf.getTestScript()+ ".dml";
+//		programArgs = new String[]{"-args", input("A"), input("B"), output("scalar") };
+//
+//		double scalarA = 10.7;
+//		double scalarB = 20.1;
+//		writeInputScalar(scalarA, "A", privacyLevelA);
+//		writeInputScalar(scalarB, "B", privacyLevelB);
+//
+//		double expectedScalar = scalarA * scalarB;
+//		writeExpectedScalar("scalar", expectedScalar);
+//
+//		runTest(true, false, null, -1);
+//
+//		HashMap<CellIndex, Double> map = readDMLScalarFromOutputDir("scalar");
+//		double actualScalar = map.get(new CellIndex(1,1));
+//
+//		assertEquals("Values mismatch: DMLvalue " + actualScalar + " != ExpectedValue " + expectedScalar,
+//			expectedScalar, actualScalar, 0.001);
+//
+//		if ( expectedPrivacyLevel != PrivacyLevel.None ){
+//			String actualPrivacyValue = readDMLMetaDataPrivacyValueCatchException("scalar", "out/", DataExpression.PRIVACY);
+//			assertEquals(String.valueOf(expectedPrivacyLevel), actualPrivacyValue);
+//		} else {
+//			MetaDataAll meta = getMetaData("scalar", "out/");
+//			assertFalse( "Metadata found for output scalar with privacy constraint set, but input privacy level is none", meta.mtdExists() && meta.getPrivacy().getPrivacyLevel() != PrivacyLevel.None );
+//		}
+//	}
+//
+//	private void writeInputScalar(double value, String name, PrivacyLevel privacyLevel){
+//		double[][] M = {{value}};
+//		writeInputMatrixWithMTD(name, M, true, new PrivacyConstraint(privacyLevel));
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/BuiltinGLMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/BuiltinGLMTest.java
@@ -1,0 +1,238 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.algorithms;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.Collection;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Random;
+//
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.common.Types.ExecType;
+//import org.apache.sysds.hops.OptimizerUtils;
+//import org.apache.sysds.runtime.matrix.data.MatrixValue;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//
+///**
+// * Adapted from org.apache.sysds.test.functions.builtin.BuiltinGLMTest.
+// * Different privacy constraints are added to the input.
+// */
+//
+//@RunWith(value = Parameterized.class)
+//@net.jcip.annotations.NotThreadSafe
+//public class BuiltinGLMTest extends AutomatedTestBase
+//{
+//	protected final static String TEST_NAME = "glmTest";
+//	protected final static String TEST_DIR = "functions/builtin/";
+//	protected String TEST_CLASS_DIR = TEST_DIR + BuiltinGLMTest.class.getSimpleName() + "/";
+//	double eps = 1e-4;
+//
+//	protected int numRecords, numFeatures, distFamilyType, linkType, intercept;
+//	protected double distParam, linkPower, logFeatureVarianceDisbalance, avgLinearForm, stdevLinearForm, dispersion;
+//	protected final static boolean runAll = false;
+//
+//	public BuiltinGLMTest(int numRecords_, int numFeatures_, int distFamilyType_, double distParam_,
+//			int linkType_, double linkPower_, double logFeatureVarianceDisbalance_,
+//			double avgLinearForm_, double stdevLinearForm_, double dispersion_)
+//	{
+//		this.numRecords = numRecords_;
+//		this.numFeatures = numFeatures_;
+//		this.distFamilyType = distFamilyType_;
+//		this.distParam = distParam_;
+//		this.linkType = linkType_;
+//		this.linkPower = linkPower_;
+//		this.logFeatureVarianceDisbalance = logFeatureVarianceDisbalance_;
+//		this.avgLinearForm = avgLinearForm_;
+//		this.stdevLinearForm = stdevLinearForm_;
+//		this.dispersion = dispersion_;
+//	}
+//
+//	private void setIntercept(int intercept_)
+//	{
+//		intercept = intercept_/100;
+//	}
+//
+//	@Override
+//	public void setUp()
+//	{
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
+//	}
+//
+//	// Private
+//	@Test
+//	public void glmTestIntercept_0_CP_Private() {
+//		setIntercept(0);
+//		runtestGLM(new PrivacyConstraint(PrivacyLevel.Private), null);
+//	}
+//
+//	// PrivateAggregation
+//	@Test
+//	public void glmTestIntercept_0_CP_PrivateAggregation() {
+//		setIntercept(0);
+//		runtestGLM(new PrivacyConstraint(PrivacyLevel.PrivateAggregation), null);
+//	}
+//
+//	// None
+//	@Test
+//	public void glmTestIntercept_0_CP_None() {
+//		setIntercept(0);
+//		runtestGLM(new PrivacyConstraint(PrivacyLevel.None), null);
+//	}
+//
+//	public void runtestGLM(PrivacyConstraint privacyConstraint, Class<?> expectedException) {
+//		Types.ExecMode platformOld = setExecMode(ExecType.CP);
+//		try {
+//			int rows = numRecords;                // # of rows in the training data
+//			int cols = numFeatures;                // # of features in the training data
+//			System.out.println("------------ BEGIN " + TEST_NAME + " TEST WITH {" + rows + ", " + cols
+//				+ ", " + distFamilyType + ", " + distParam + ", " + linkType + ", " + linkPower + ", "
+//				+ intercept + ", " + logFeatureVarianceDisbalance + ", " + avgLinearForm + ", " + stdevLinearForm
+//				+ ", " + dispersion + "} ------------");
+//
+//			TestUtils.GLMDist glmdist = new TestUtils.GLMDist(distFamilyType, distParam, linkType, linkPower);
+//			glmdist.set_dispersion(dispersion);
+//
+//			loadTestConfiguration(getTestConfiguration(TEST_NAME));
+//
+//			// prepare training data set
+//			Random r = new Random(314159265);
+//			double[][] X = TestUtils.generateUnbalancedGLMInputDataX(rows, cols, logFeatureVarianceDisbalance);
+//			double[] beta = TestUtils.generateUnbalancedGLMInputDataB(X, cols, intercept, avgLinearForm, stdevLinearForm, r);
+//			double[][] y = TestUtils.generateUnbalancedGLMInputDataY(X, beta, rows, cols, glmdist, intercept, dispersion, r);
+//
+//			int defaultBlockSize = OptimizerUtils.DEFAULT_BLOCKSIZE;
+//
+//			MatrixCharacteristics mc_X = new MatrixCharacteristics(rows, cols, defaultBlockSize, -1);
+//			writeInputMatrixWithMTD("X", X, true, mc_X, privacyConstraint);
+//
+//			MatrixCharacteristics mc_y = new MatrixCharacteristics(rows, y[0].length, defaultBlockSize, -1);
+//			writeInputMatrixWithMTD("Y", y, true, mc_y, privacyConstraint);
+//
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+//			List<String> proArgs = new ArrayList<>();
+//			proArgs.add("-exec");
+//			proArgs.add(" singlenode");
+//			proArgs.add("-nvargs");
+//			proArgs.add("X=" + input("X"));
+//			proArgs.add("Y=" + input("Y"));
+//			proArgs.add("dfam=" + String.valueOf(distFamilyType));
+//			proArgs.add(((distFamilyType == 2 && distParam != 1.0) ? "yneg=" : "vpow=") + String.valueOf(distParam));
+//			proArgs.add((distFamilyType == 2 && distParam != 1.0) ? "vpow=0.0" : "yneg=0.0");
+//			proArgs.add("link=" + String.valueOf(linkType));
+//			proArgs.add("lpow=" + String.valueOf(linkPower));
+//			proArgs.add("icpt=" + String.valueOf(intercept)); // INTERCEPT - CHANGE THIS AS NEEDED
+//			proArgs.add("disp=0.0"); // DISPERSION (0.0: ESTIMATE)
+//			proArgs.add("reg=0.0"); // LAMBDA REGULARIZER
+//			proArgs.add("tol=0.000000000001"); // TOLERANCE (EPSILON)
+//			proArgs.add("moi=300");
+//			proArgs.add("mii=0");
+//			proArgs.add("B=" + output("betas_SYSTEMDS"));
+//			programArgs = proArgs.toArray(new String[proArgs.size()]);
+//
+//			fullRScriptName = HOME + TEST_NAME + ".R";
+//			rCmd = getRCmd(input("X.mtx"), input("Y.mtx"),
+//					String.valueOf(distFamilyType),
+//					String.valueOf(distParam),
+//					String.valueOf(linkType),
+//					String.valueOf(linkPower),
+//					String.valueOf(intercept),
+//					"0.000000000001",
+//					expected("betas_R"));
+//
+//			runTest(true, (expectedException != null), expectedException, -1);
+//
+//			if ( expectedException == null ){
+//
+//				double max_abs_beta = 0.0;
+//				HashMap<MatrixValue.CellIndex, Double> wTRUE = new HashMap<>();
+//				for (int j = 0; j < cols; j++) {
+//					wTRUE.put(new MatrixValue.CellIndex(j + 1, 1), Double.valueOf(beta[j]));
+//					max_abs_beta = (max_abs_beta >= Math.abs(beta[j]) ? max_abs_beta : Math.abs(beta[j]));
+//				}
+//
+//				HashMap<MatrixValue.CellIndex, Double> wSYSTEMDS_raw = readDMLMatrixFromOutputDir("betas_SYSTEMDS");
+//				HashMap<MatrixValue.CellIndex, Double> wSYSTEMDS = new HashMap<>();
+//				for (MatrixValue.CellIndex key : wSYSTEMDS_raw.keySet())
+//					if (key.column == 1)
+//						wSYSTEMDS.put(key, wSYSTEMDS_raw.get(key));
+//
+//				runRScript(true);
+//
+//				HashMap<MatrixValue.CellIndex, Double> wR = readRMatrixFromExpectedDir("betas_R");
+//
+//				if ((distParam == 0 && linkType == 1)) { // Gaussian.*
+//					//NOTE MB: Gaussian.log was the only test failing when we introduced multi-threaded
+//					//matrix multplications (mmchain). After discussions with Sasha, we decided to change the eps
+//					//because accuracy is anyway affected by various rewrites like binary to unary (-1*x->-x),
+//					//transpose-matrixmult, and dot product sum. Disabling these rewrites led to a successful
+//					//test result. Even without multi-threaded matrix mult this test was failing for different number
+//					//of rows if these rewrites are enabled. Users can turn off rewrites if high accuracy is required.
+//					//However, in the future we might also consider to use Kahan plus for aggregations in matrix mult
+//					//(at least for the final aggregation of partial results from individual threads).
+//
+//					//NOTE MB: similar issues occurred with other tests when moving to github action tests
+//					eps *= (linkPower == -1) ? 4 : 2; //Gaussian.inverse vs Gaussian.*;
+//				}
+//				TestUtils.compareMatrices(wR, wSYSTEMDS, eps * max_abs_beta, "wR", "wSYSTEMDS");
+//			}
+//		}
+//		finally {
+//			resetExecMode(platformOld);
+//		}
+//	}
+//
+//	@Parameterized.Parameters
+//	public static Collection<Object[]> data() {
+//		// SCHEMA:
+//		// #RECORDS, #FEATURES, DISTRIBUTION_FAMILY, VARIANCE_POWER or BERNOULLI_NO, LINK_TYPE, LINK_POWER,
+//		// LOG_FEATURE_VARIANCE_DISBALANCE, AVG_LINEAR_FORM, ST_DEV_LINEAR_FORM, DISPERSION
+//		Object[][] data = new Object[][] {
+//				// #RECS  #FTRS DFM VPOW  LNK LPOW   LFVD  AVGLT STDLT  DISP
+//				// Both DML and R work and compute close results:
+//				{ 1000,   50,  1,  0.0,  1,  0.0,   3.0,  10.0,  2.0,  2.5 },   // Gaussian.log
+//				{  100,   10,  1,  1.0,  1,  0.0,   3.0,   0.0,  1.0,  2.5 },   // Poisson.log
+//				{ 1000,   50,  1,  2.0,  1,  0.0,  3.0,   0.0,  2.0,  2.5 },   // Gamma.log
+//
+//				//{ 1000,   50,  2, -1.0,  1,  0.0,  3.0,  -5.0,  1.0,  1.0 },   // Bernoulli {-1, 1}.log     // Note: Y is sparse
+//				{  100,   10,  2, -1.0,  2,  0.0,  3.0,   0.0,  2.0,  1.0 },   // Bernoulli {-1, 1}.logit
+//				{  200,   10,  2, -1.0,  3,  0.0,  3.0,   0.0,  2.0,  1.0 },   // Bernoulli {-1, 1}.probit
+//
+//				{ 1000,   50,  2,  1.0,  1,  0.0,  3.0,  -5.0,  1.0,  2.5 },   // Binomial two-column.log   // Note: Y is sparse
+//				{  100,   10,  2,  1.0,  2,  0.0,  3.0,   0.0,  2.0,  2.5 },   // Binomial two-column.logit
+//				{  200,   10,  2,  1.0,  3,  0.0,  3.0,   0.0,  2.0,  2.5 },   // Binomial two-column.probit
+//		};
+//		if ( runAll )
+//			return Arrays.asList(data);
+//		else
+//			return Arrays.asList(new Object[][]{data[0]});
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/FederatedL2SVMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/FederatedL2SVMTest.java
@@ -1,0 +1,440 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.algorithms;
+//
+//import java.util.ArrayList;
+//import java.util.Collection;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.hops.OptimizerUtils;
+//import org.apache.sysds.runtime.DMLRuntimeException;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Assert;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//
+//@net.jcip.annotations.NotThreadSafe
+//@RunWith(value = Parameterized.class)
+//public class FederatedL2SVMTest extends AutomatedTestBase {
+//
+//	private final static String TEST_DIR = "functions/federated/";
+//	private final static String TEST_NAME = "FederatedL2SVMTest";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedL2SVMTest.class.getSimpleName() + "/";
+//
+//	private final static int blocksize = 1024;
+//	private int rows = 100;
+//	private int cols = 10;
+//
+//	@Parameterized.Parameter()
+//	public boolean fedOutCompilation;
+//
+//	@Parameterized.Parameters
+//	public static Collection<Object[]> data() {
+//		List<Object[]> tests = new ArrayList<>();
+//		tests.add(new Object[]{false});
+//		tests.add(new Object[]{true});
+//		return tests;
+//	}
+//
+//	@Override public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"Z"}));
+//	}
+//
+//	// PrivateAggregation Single Input
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationX1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationX2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationY()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	// Private Single Input
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateFederatedY()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private);
+//	}
+//
+//	// Setting Privacy of Matrix (Throws Exception)
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateMatrixX1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private, false, null, false,
+//			null);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateMatrixX2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private, false, null, false,
+//			null);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateMatrixY()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, null, privacyConstraints, PrivacyLevel.Private, false, null, false,
+//			null);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedAndMatrixX1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private, false,
+//			null, true, DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedAndMatrixX2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private, false,
+//			null, true, DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateFederatedAndMatrixY()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, privacyConstraints, PrivacyLevel.Private, false,
+//			null, false, null);
+//	}
+//
+//	// Privacy Level Private Combinations
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX1X2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX1Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX2Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateFederatedX1X2Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	// Privacy Level PrivateAggregation Combinations
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationFederatedX1X2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationFederatedX1Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationFederatedX2Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationFederatedX1X2Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	// Privacy Level Combinations
+//	@Test public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1X2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivatePrivateAggregationFederatedX1Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2Y()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void federatedL2SVMCPPrivatePrivateAggregationFederatedYX2()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("Y", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivatePrivateAggregationFederatedX2X1()  {
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	// Require Federated Workers to return matrix
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationX1Exception()  {
+//		rows = 1000;
+//		cols = 1;
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//
+//	@Test
+//	public void federatedL2SVMCPPrivateAggregationX2Exception()  {
+//		rows = 1000;
+//		cols = 1;
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//		federatedL2SVMNoException(Types.ExecMode.SINGLE_NODE, privacyConstraints, null,
+//			PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateX1Exception()  {
+//		rows = 1000;
+//		cols = 1;
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X1", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	@Test public void federatedL2SVMCPPrivateX2Exception()  {
+//		rows = 1000;
+//		cols = 1;
+//		Map<String, PrivacyConstraint> privacyConstraints = new HashMap<>();
+//		privacyConstraints.put("X2", new PrivacyConstraint(PrivacyLevel.Private));
+//		federatedL2SVM(Types.ExecMode.SINGLE_NODE, privacyConstraints, null, PrivacyLevel.Private, false, null, true,
+//			DMLRuntimeException.class);
+//	}
+//
+//	private void federatedL2SVMNoException(Types.ExecMode execMode,
+//		Map<String, PrivacyConstraint> privacyConstraintsFederated,
+//		Map<String, PrivacyConstraint> privacyConstraintsMatrix, PrivacyLevel expectedPrivacyLevel) {
+//		federatedL2SVM(execMode, privacyConstraintsFederated, privacyConstraintsMatrix, expectedPrivacyLevel, false,
+//			null, false, null);
+//	}
+//
+//	private void federatedL2SVM(Types.ExecMode execMode, Map<String, PrivacyConstraint> privacyConstraintsFederated,
+//		Map<String, PrivacyConstraint> privacyConstraintsMatrix, PrivacyLevel expectedPrivacyLevel, boolean exception1,
+//		Class<?> expectedException1, boolean exception2, Class<?> expectedException2) {
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = execMode;
+//		if(rtplatform == Types.ExecMode.SPARK) {
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+//		}
+//		Thread t1 = null, t2 = null;
+//
+//		try {
+//			getAndLoadTestConfiguration(TEST_NAME);
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			// write input matrices
+//			int halfRows = rows / 2;
+//			// We have two matrices handled by a single federated worker
+//			double[][] X1 = getRandomMatrix(halfRows, cols, 0, 1, 1, 42);
+//			double[][] X2 = getRandomMatrix(halfRows, cols, 0, 1, 1, 1340);
+//			double[][] Y = getRandomMatrix(rows, 1, -1, 1, 1, 1233);
+//			for(int i = 0; i < rows; i++)
+//				Y[i][0] = (Y[i][0] > 0) ? 1 : -1;
+//
+//			// Write privacy constraints of normal matrix
+//			if(privacyConstraintsMatrix != null) {
+//				writeInputMatrixWithMTD("MX1", X1, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols),
+//					privacyConstraintsMatrix.get("X1"));
+//				writeInputMatrixWithMTD("MX2", X2, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols),
+//					privacyConstraintsMatrix.get("X2"));
+//				writeInputMatrixWithMTD("MY", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows),
+//					privacyConstraintsMatrix.get("Y"));
+//			}
+//			else {
+//				writeInputMatrixWithMTD("MX1", X1, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
+//				writeInputMatrixWithMTD("MX2", X2, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
+//				writeInputMatrixWithMTD("MY", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
+//			}
+//
+//			// Write privacy constraints of federated matrix
+//			if(privacyConstraintsFederated != null) {
+//				writeInputMatrixWithMTD("X1", X1, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols),
+//					privacyConstraintsFederated.get("X1"));
+//				writeInputMatrixWithMTD("X2", X2, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols),
+//					privacyConstraintsFederated.get("X2"));
+//				writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows),
+//					privacyConstraintsFederated.get("Y"));
+//			}
+//			else {
+//				writeInputMatrixWithMTD("X1", X1, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
+//				writeInputMatrixWithMTD("X2", X2, false,
+//					new MatrixCharacteristics(halfRows, cols, blocksize, halfRows * cols));
+//				writeInputMatrixWithMTD("Y", Y, false, new MatrixCharacteristics(rows, 1, blocksize, rows));
+//			}
+//
+//			// empty script name because we don't execute any script, just start the worker
+//			fullDMLScriptName = "";
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			t1 = startLocalFedWorkerThread(port1);
+//			t2 = startLocalFedWorkerThread(port2);
+//
+//			TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
+//			loadTestConfiguration(config);
+//
+//			// Run reference dml script with normal matrix
+//			fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+//			programArgs = new String[] {"-args", input("MX1"), input("MX2"), input("MY"), "FALSE", expected("Z")};
+//			runTest(true, exception1, expectedException1, -1);
+//
+//			// Run actual dml script with federated matrix
+//			OptimizerUtils.FEDERATED_COMPILATION = fedOutCompilation;
+//			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+//			programArgs = new String[] {"-stats", "-checkPrivacy", "-nvargs",
+//				"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
+//				"in_Y=" + input("Y"), "single=FALSE", "out=" + output("Z")};
+//
+//			runTest(true, exception2, expectedException2, -1);
+//
+//			if(!(exception1 || exception2)) {
+//				compareResults(1e-9);
+//			}
+//
+//			if(expectedPrivacyLevel != null)
+//				Assert.assertTrue(checkedPrivacyConstraintsContains(expectedPrivacyLevel));
+//		}
+//		finally {
+//			TestUtils.shutdownThreads(t1, t2);
+//			rtplatform = platformOld;
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//			OptimizerUtils.FEDERATED_COMPILATION = false;
+//		}
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/GLMTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/algorithms/GLMTest.java
@@ -1,0 +1,335 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.algorithms;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.Collection;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Random;
+//
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//import org.junit.runners.Parameterized.Parameters;
+//import org.apache.sysds.hops.OptimizerUtils;
+//import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestUtils;
+//
+///**
+// * Adapted from org.apache.sysds.test.applications.GLMTest.
+// * Different privacy constraints are added to the input.
+// */
+//
+//@RunWith(value = Parameterized.class)
+//@net.jcip.annotations.NotThreadSafe
+//public class GLMTest extends AutomatedTestBase
+//{
+//	protected final static String TEST_DIR = "applications/glm/";
+//	protected final static String TEST_NAME = "GLM";
+//	protected String TEST_CLASS_DIR = TEST_DIR + GLMTest.class.getSimpleName() + "/";
+//
+//	protected int numRecords, numFeatures, distFamilyType, linkType;
+//	protected double distParam, linkPower, intercept, logFeatureVarianceDisbalance, avgLinearForm, stdevLinearForm, dispersion;
+//
+//	protected GLMType glmType;
+//	protected final static boolean runAll = false;
+//
+//	public enum GLMType {
+//		Gaussianlog,
+//		Gaussianid,
+//		Gaussianinverse,
+//		Poissonlog1,
+//		Poissonlog2,
+//		Poissonsqrt,
+//		Poissonid,
+//		Gammalog,
+//		Gammainverse,
+//		InvGaussian1mu,
+//		InvGaussianinverse,
+//		InvGaussianlog,
+//		InvGaussianid,
+//		Bernoullilog,
+//		Bernoulliid,
+//		Bernoullisqrt,
+//		Bernoullilogit1,
+//		Bernoullilogit2,
+//		Bernoulliprobit1,
+//		Bernoulliprobit2,
+//		Bernoullicloglog1,
+//		Bernoullicloglog2,
+//		Bernoullicauchit,
+//		Binomiallog,
+//		Binomialid,
+//		Binomialsqrt,
+//		Binomiallogit,
+//		Binomialprobit,
+//		Binomialcloglog,
+//		Binomialcauchit
+//	}
+//
+//	public GLMTest (int numRecords_, int numFeatures_, int distFamilyType_, double distParam_,
+//		int linkType_, double linkPower_, double intercept_, double logFeatureVarianceDisbalance_,
+//		double avgLinearForm_, double stdevLinearForm_, double dispersion_, GLMType glmType)
+//	{
+//		this.numRecords = numRecords_;
+//		this.numFeatures = numFeatures_;
+//		this.distFamilyType = distFamilyType_;
+//		this.distParam = distParam_;
+//		this.linkType = linkType_;
+//		this.linkPower = linkPower_;
+//		this.intercept = intercept_;
+//		this.logFeatureVarianceDisbalance = logFeatureVarianceDisbalance_;
+//		this.avgLinearForm = avgLinearForm_;
+//		this.stdevLinearForm = stdevLinearForm_;
+//		this.dispersion = dispersion_;
+//		this.glmType = glmType;
+//	}
+//
+//	// SUPPORTED GLM DISTRIBUTION FAMILIES AND LINKS:
+//	// -----------------------------------------------
+//	// INPUT PARAMETERS:	MEANING:			Cano-
+//	// dfam vpow link lpow  Distribution.link   nical?
+//	// -----------------------------------------------
+//	//  1   0.0   1  -1.0   Gaussian.inverse
+//	//  1   0.0   1   0.0   Gaussian.log
+//	//  1   0.0   1   1.0   Gaussian.id		  Yes
+//	//  1   1.0   1   0.0   Poisson.log		  Yes
+//	//  1   1.0   1   0.5   Poisson.sqrt
+//	//  1   1.0   1   1.0   Poisson.id
+//	//  1   2.0   1  -1.0   Gamma.inverse		Yes
+//	//  1   2.0   1   0.0   Gamma.log
+//	//  1   2.0   1   1.0   Gamma.id
+//	//  1   3.0   1  -2.0   InvGaussian.1/mu^2   Yes
+//	//  1   3.0   1  -1.0   InvGaussian.inverse
+//	//  1   3.0   1   0.0   InvGaussian.log
+//	//  1   3.0   1   1.0   InvGaussian.id
+//	//  1	*	1	*	AnyVariance.AnyLink
+//	// -----------------------------------------------
+//	//  2	*	1   0.0   Binomial.log
+//	//  2	*	2	*	Binomial.logit	   Yes
+//	//  2	*	3	*	Binomial.probit
+//	//  2	*	4	*	Binomial.cloglog
+//	//  2	*	5	*	Binomial.cauchit
+//	// -----------------------------------------------
+//
+//	@Parameters
+//	public static Collection<Object[]> data() {
+//		// SCHEMA:
+//		// #RECORDS, #FEATURES, DISTRIBUTION_FAMILY, VARIANCE_POWER or BERNOULLI_NO, LINK_TYPE, LINK_POWER,
+//		//	 INTERCEPT, LOG_FEATURE_VARIANCE_DISBALANCE, AVG_LINEAR_FORM, ST_DEV_LINEAR_FORM, DISPERSION, GLMTYPE
+//		Object[][] data = new Object[][] {
+//
+//		// THIS IS TO TEST "INTERCEPT AND SHIFT/SCALE" OPTION ("icpt=2"):
+//			{ 2000,  50,  1,  0.0,  1,  0.0,  0.01, 3.0,  10.0,  2.0,  2.5, GLMType.Gaussianlog },   	// Gaussian.log	 // CHECK DEVIANCE !!!
+//			{  100,  10,  1,  0.0,  1,  1.0,  0.01, 3.0,   0.0,  2.0,  2.5, GLMType.Gaussianid },   		// Gaussian.id
+//			{  100,  10,  1,  1.0,  1,  0.0,  0.01, 3.0,   0.0,  1.0,  2.5, GLMType.Poissonlog1 },   	// Poisson.log
+//			{ 1000,  10,  1,  1.0,  1,  0.0,  0.01, 3.0,   0.0, 50.0,  2.5, GLMType.Poissonlog2 },   	// Poisson.log			 // Pr[0|x] gets near 1
+//			{  500,  10,  1,  2.0,  1,  0.0,  0.01, 3.0,   0.0,  2.0,  2.5, GLMType.Gammalog },   		// Gamma.log
+//			{ 1000,  50,  1,  3.0,  1,  0.0,  0.5,  3.0,  -2.0,  1.0,  2.5, GLMType.InvGaussianlog },   	// InvGaussian.log
+//
+//			{  100,  10,  2, -1.0,  2,  0.0,  0.01, 3.0,   0.0,  2.0,  1.0, GLMType.Bernoullilogit1 },   // Bernoulli {-1, 1}.logit
+//			{  200,  10,  2, -1.0,  3,  0.0,  0.01, 3.0,   0.0,  2.0,  1.0, GLMType.Bernoulliprobit1 },  // Bernoulli {-1, 1}.probit
+//			{  100,  10,  2, -1.0,  4,  0.0,  0.01, 3.0,  -2.0,  1.0,  1.0, GLMType.Bernoullicloglog1 }, // Bernoulli {-1, 1}.cloglog
+//			{  200,  10,  2, -1.0,  5,  0.0,  0.01, 3.0,   0.0,  2.0,  1.0, GLMType.Bernoullicauchit },  // Bernoulli {-1, 1}.cauchit
+//		};
+//		if ( runAll )
+//			return Arrays.asList(data);
+//		else
+//			return Arrays.asList( new Object[][]{data[0]} );
+//	}
+//
+//	@Override
+//	public void setUp()
+//	{
+//		addTestConfiguration(TEST_CLASS_DIR, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateX(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.Private);
+//		Class<?> expectedException = null;
+//		testGLM(pc, null, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateAggregationX(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		Class<?> expectedException = null;
+//		testGLM(pc, null, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMNonePrivateX(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.None);
+//		Class<?> expectedException = null;
+//		testGLM(pc, null, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.Private);
+//		Class<?> expectedException = null;
+//		testGLM(null, pc, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateAggregationY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		Class<?> expectedException = null;
+//		testGLM(null, pc, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMNonePrivateY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.None);
+//		Class<?> expectedException = null;
+//		testGLM(null, pc, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateXY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.Private);
+//		testGLM(pc, pc, null);
+//	}
+//
+//	@Test
+//	public void TestGLMPrivateAggregationXY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		Class<?> expectedException = null;
+//		testGLM(pc, pc, expectedException);
+//	}
+//
+//	@Test
+//	public void TestGLMNonePrivateXY(){
+//		PrivacyConstraint pc = new PrivacyConstraint(PrivacyLevel.Private);
+//		testGLM(pc, pc, null);
+//	}
+//
+//	public void testGLM(PrivacyConstraint privacyX, PrivacyConstraint privacyY, Class<?> expectedException)
+//	{
+//		System.out.println("------------ BEGIN " + TEST_NAME + " TEST WITH {" +
+//				numRecords + ", " +
+//				numFeatures + ", " +
+//				distFamilyType + ", " +
+//				distParam + ", " +
+//				linkType + ", " +
+//				linkPower + ", " +
+//				intercept + ", " +
+//				logFeatureVarianceDisbalance + ", " +
+//				avgLinearForm + ", " +
+//				stdevLinearForm + ", " +
+//				dispersion +
+//				"} ------------");
+//		System.out.println("GLMType: " + this.glmType);
+//		System.out.println(expectedException);
+//
+//		int rows = numRecords;  // # of rows in the training data
+//		int cols = numFeatures; // # of features in the training data
+//
+//		TestUtils.GLMDist glmdist = new TestUtils.GLMDist (distFamilyType, distParam, linkType, linkPower);
+//		glmdist.set_dispersion (dispersion);
+//
+//		getAndLoadTestConfiguration(TEST_NAME);
+//
+//		// prepare training data set
+//		Random r = new Random(314159265);
+//		double[][] X = TestUtils.generateUnbalancedGLMInputDataX(rows, cols, logFeatureVarianceDisbalance);
+//		double[] beta = TestUtils.generateUnbalancedGLMInputDataB(X, cols, intercept, avgLinearForm, stdevLinearForm, r);
+//		double[][] y = TestUtils.generateUnbalancedGLMInputDataY(X, beta, rows, cols, glmdist, intercept, dispersion, r);
+//
+//		int defaultBlockSize = OptimizerUtils.DEFAULT_BLOCKSIZE;
+//
+//		MatrixCharacteristics mc_X = new MatrixCharacteristics(rows, cols, defaultBlockSize, -1);
+//		writeInputMatrixWithMTD ("X", X, true, mc_X, privacyX);
+//
+//		MatrixCharacteristics mc_y = new MatrixCharacteristics(rows, y[0].length, defaultBlockSize, -1);
+//		writeInputMatrixWithMTD ("Y", y, true, mc_y, privacyY);
+//
+//		List<String> proArgs = new ArrayList<>();
+//		proArgs.add("-nvargs");
+//		proArgs.add("dfam=" + String.format ("%d", distFamilyType));
+//		proArgs.add(((distFamilyType == 2 && distParam != 1.0) ? "yneg=" : "vpow=") + String.format ("%f", distParam));
+//		proArgs.add((distFamilyType == 2 && distParam != 1.0) ? "vpow=0.0" : "yneg=0.0");
+//		proArgs.add("link=" + String.format ("%d", linkType));
+//		proArgs.add("lpow=" + String.format ("%f", linkPower));
+//		proArgs.add("icpt=2"); // INTERCEPT - CHANGE THIS AS NEEDED
+//		proArgs.add("disp=0.0"); // DISPERSION (0.0: ESTIMATE)
+//		proArgs.add("reg=0.0"); // LAMBDA REGULARIZER
+//		proArgs.add("tol=0.000000000001"); // TOLERANCE (EPSILON)
+//		proArgs.add("moi=300");
+//		proArgs.add("mii=0");
+//		proArgs.add("X=" + input("X"));
+//		proArgs.add("Y=" + input("Y"));
+//		proArgs.add("B=" + output("betas_SYSTEMDS"));
+//		programArgs = proArgs.toArray(new String[proArgs.size()]);
+//
+//		fullDMLScriptName = "scripts/algorithms/GLM.dml";
+//
+//		rCmd = getRCmd(input("X.mtx"), input("Y.mtx"), String.format ("%d", distFamilyType), String.format ("%f", distParam),
+//				String.format ("%d", linkType), String.format ("%f", linkPower), "1" /*intercept*/, "0.000000000001" /*tolerance (espilon)*/,
+//				expected("betas_R"));
+//
+//		int expectedNumberOfJobs = -1; // 31;
+//
+//		runTest(true, (expectedException != null), expectedException, expectedNumberOfJobs);
+//
+//		if ( expectedException == null){
+//			double max_abs_beta = 0.0;
+//			HashMap<CellIndex, Double> wTRUE = new HashMap<> ();
+//			for (int j = 0; j < cols; j ++)
+//			{
+//				wTRUE.put (new CellIndex (j + 1, 1), Double.valueOf(beta [j]));
+//				max_abs_beta = (max_abs_beta >= Math.abs (beta[j]) ? max_abs_beta : Math.abs (beta[j]));
+//			}
+//
+//			HashMap<CellIndex, Double> wSYSTEMDS_raw = readDMLMatrixFromOutputDir("betas_SYSTEMDS");
+//			HashMap<CellIndex, Double> wSYSTEMDS = new HashMap<> ();
+//			for (CellIndex key : wSYSTEMDS_raw.keySet())
+//				if (key.column == 1)
+//					wSYSTEMDS.put (key, wSYSTEMDS_raw.get (key));
+//
+//			runRScript(true);
+//
+//			HashMap<CellIndex, Double> wR   = readRMatrixFromExpectedDir("betas_R");
+//
+//			double eps = 0.0001;
+//			if( (distParam==0 && linkType==1) ) { // Gaussian.*
+//				//NOTE MB: Gaussian.log was the only test failing when we introduced multi-threaded
+//				//matrix multplications (mmchain). After discussions with Sasha, we decided to change the eps
+//				//because accuracy is anyway affected by various rewrites like binary to unary (-1*x->-x),
+//				//transpose-matrixmult, and dot product sum. Disabling these rewrites led to a successful
+//				//test result. Even without multi-threaded matrix mult this test was failing for different number
+//				//of rows if these rewrites are enabled. Users can turn off rewrites if high accuracy is required.
+//				//However, in the future we might also consider to use Kahan plus for aggregations in matrix mult
+//				//(at least for the final aggregation of partial results from individual threads).
+//
+//				//NOTE MB: similar issues occurred with other tests when moving to github action tests
+//				eps *=  (linkPower==-1) ? 4 : 2; //Gaussian.inverse vs Gaussian.*;
+//			}
+//			TestUtils.compareMatrices (wR, wSYSTEMDS, eps * max_abs_beta, "wR", "wSYSTEMDS");
+//		}
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FTypeCombTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FTypeCombTest.java
@@ -1,0 +1,70 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import org.apache.sysds.hops.fedplanner.FTypes.FType;
+//import org.apache.sysds.hops.fedplanner.FederatedPlannerCostbased;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.junit.Assert;
+//import org.junit.Test;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//
+//public class FTypeCombTest extends AutomatedTestBase {
+//
+//	@Override public void setUp() {}
+//
+//	@Test
+//	public void ftypeCombTest(){
+//		List<FType> secondInput = new ArrayList<>();
+//		secondInput.add(null);
+//		List<List<FType>> inputFTypes = List.of(
+//			List.of(FType.ROW,FType.COL),
+//			secondInput,
+//			List.of(FType.BROADCAST,FType.FULL)
+//		);
+//
+//		FederatedPlannerCostbased planner = new FederatedPlannerCostbased();
+//		List<List<FType>> actualCombinations = planner.getAllCombinations(inputFTypes);
+//
+//		List<FType> expected1 = new ArrayList<>();
+//		expected1.add(FType.ROW);
+//		expected1.add(null);
+//		expected1.add(FType.BROADCAST);
+//		List<FType> expected2 = new ArrayList<>();
+//		expected2.add(FType.ROW);
+//		expected2.add(null);
+//		expected2.add(FType.FULL);
+//		List<FType> expected3 = new ArrayList<>();
+//		expected3.add(FType.COL);
+//		expected3.add(null);
+//		expected3.add(FType.BROADCAST);
+//		List<FType> expected4 = new ArrayList<>();
+//		expected4.add(FType.COL);
+//		expected4.add(null);
+//		expected4.add(FType.FULL);
+//		List<List<FType>> expectedCombinations = List.of(expected1,expected2, expected3, expected4);
+//
+//		Assert.assertEquals(expectedCombinations.size(), actualCombinations.size());
+//		for (List<FType> expectedComb : expectedCombinations)
+//			Assert.assertTrue(actualCombinations.contains(expectedComb));
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedCostEstimatorTest.java
@@ -1,0 +1,372 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import net.jcip.annotations.NotThreadSafe;
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.conf.ConfigurationManager;
+//import org.apache.sysds.conf.DMLConfig;
+//import org.apache.sysds.hops.AggBinaryOp;
+//import org.apache.sysds.hops.BinaryOp;
+//import org.apache.sysds.hops.DataOp;
+//import org.apache.sysds.hops.Hop;
+//import org.apache.sysds.hops.LiteralOp;
+//import org.apache.sysds.hops.NaryOp;
+//import org.apache.sysds.hops.ReorgOp;
+//import org.apache.sysds.hops.cost.FederatedCost;
+//import org.apache.sysds.hops.cost.FederatedCostEstimator;
+//import org.apache.sysds.hops.fedplanner.FederatedPlannerCostbased;
+//import org.apache.sysds.hops.ipa.FunctionCallGraph;
+//import org.apache.sysds.parser.DMLProgram;
+//import org.apache.sysds.parser.DMLTranslator;
+//import org.apache.sysds.parser.LanguageException;
+//import org.apache.sysds.parser.ParserFactory;
+//import org.apache.sysds.parser.ParserWrapper;
+//import org.apache.sysds.parser.StatementBlock;
+//import org.apache.sysds.runtime.instructions.fed.FEDInstruction;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.junit.After;
+//import org.junit.Assert;
+//import org.junit.Before;
+//import org.junit.BeforeClass;
+//import org.junit.Test;
+//
+//import java.io.FileNotFoundException;
+//import java.io.IOException;
+//import java.util.HashMap;
+//import java.util.HashSet;
+//import java.util.Set;
+//
+//import static org.apache.sysds.common.Types.OpOp2.MULT;
+//
+//@NotThreadSafe
+//public class FederatedCostEstimatorTest extends AutomatedTestBase {
+//
+//	private static final String TEST_DIR = "functions/privacy/fedplanning/";
+//	private static final String HOME = SCRIPT_DIR + TEST_DIR;
+//	private static final String TEST_CLASS_DIR = TEST_DIR + FederatedCostEstimatorTest.class.getSimpleName() + "/";
+//	FederatedCostEstimator fedCostEstimator = new FederatedCostEstimator();
+//
+//	private static double COMPUTE_FLOPS;
+//	private static double READ_PS;
+//	private static double NETWORK_PS;
+//
+//	@Override
+//	public void setUp() {}
+//
+//	@BeforeClass
+//	public static void storeConstants(){
+//		COMPUTE_FLOPS = FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS;
+//		READ_PS = FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS;
+//		NETWORK_PS = FederatedCostEstimator.WORKER_NETWORK_BANDWIDTH_BYTES_PS;
+//	}
+//
+//	@Before
+//	public void setConstants(){
+//		FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS = 2;
+//		FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = 10;
+//		FederatedCostEstimator.WORKER_NETWORK_BANDWIDTH_BYTES_PS = 5;
+//	}
+//
+//	@After
+//	public void resetConstants(){
+//		FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS = COMPUTE_FLOPS;
+//		FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS = READ_PS;
+//		FederatedCostEstimator.WORKER_NETWORK_BANDWIDTH_BYTES_PS = NETWORK_PS;
+//	}
+//
+//	@Test
+//	public void simpleBinary() {
+//
+//		/*
+//		 * HOP			Occurences		ComputeCost		ReadCost	ComputeCostFinal	ReadCostFinal
+//		 * ------------------------------------------------------------------------------------------
+//		 * LiteralOp	16				1				0			0.0625				0
+//		 * DataGenOp	2				100				64			6.25				6.4
+//		 * BinaryOp		1				100				1600		6.25				160
+//		 * TOSTRING		1				1				800			0.0625				80
+//		 * UnaryOp		1				1				8			0.0625				0.8
+//		 */
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//
+//		double expectedCost = computeCost + readCost;
+//		runTest("BinaryCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void simpleBinaryHopRelTest() {
+//		runHopRelTest("BinaryCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void ifElseTest(){
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//		double expectedCost = ((computeCost + readCost + 0.8 + 0.0625 + 0.0625) / 2) + 0.0625 + 0.8 + 0.0625;
+//		runTest("IfElseCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void ifElseHopRelTest(){
+//		runHopRelTest("IfElseCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void whileTest(){
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//		double expectedCost = (computeCost + readCost + 0.0625 + 0.0625 + 0.8) * StatementBlock.DEFAULT_LOOP_REPETITIONS;
+//		runTest("WhileCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void whileHopRelTest(){
+//		runHopRelTest("WhileCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void forLoopTest(){
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//		double predicateCost = 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625;
+//		double expectedCost = (computeCost + readCost + predicateCost) * 5;
+//		runTest("ForLoopCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void forLoopHopRelTest(){
+//		runHopRelTest("ForLoopCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void parForLoopTest(){
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//		double predicateCost = 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625 + 0.0625 + 0.8 + 0.0625;
+//		double expectedCost = (computeCost + readCost + predicateCost) * 5;
+//		runTest("ParForLoopCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void parForLoopHopRelTest(){
+//		runHopRelTest("ParForLoopCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void functionTest(){
+//		double computeCost = (16+2*100+100+1+1) / (FederatedCostEstimator.WORKER_COMPUTE_BANDWIDTH_FLOPS * FederatedCostEstimator.WORKER_DEGREE_OF_PARALLELISM);
+//		double readCost = (2*64+1600+800+8) / (FederatedCostEstimator.WORKER_READ_BANDWIDTH_BYTES_PS);
+//		double expectedCost = (computeCost + readCost);
+//		runTest("FunctionCostEstimatorTest.dml", false, expectedCost);
+//	}
+//
+//	@Test
+//	public void functionHopRelTest(){
+//		runHopRelTest("FunctionCostEstimatorTest.dml", false);
+//	}
+//
+//	@Test
+//	public void federatedMultiply() {
+//
+//		double literalOpCost = 10*0.0625;
+//		double naryOpCostSpecial = (0.125+2.2);
+//		double naryOpCostSpecial2 = (0.25+6.4);
+//		double naryOpCost = 4*(0.125+1.6);
+//		double reorgOpCost = 6250+80015.2+160030.4;
+//		double binaryOpMultCost = 3125+160000;
+//		double aggBinaryOpCost = 125000+160015.2+160030.4+190.4;
+//		double dataOpCost = 2*(6250+5.6);
+//		double dataOpWriteCost = 6.25+100.3;
+//
+//		double expectedCost = literalOpCost + naryOpCost + naryOpCostSpecial + naryOpCostSpecial2 + reorgOpCost
+//			+ binaryOpMultCost + aggBinaryOpCost + dataOpCost + dataOpWriteCost;
+//		runTest("FederatedMultiplyCostEstimatorTest.dml", false, expectedCost);
+//
+//		double aggBinaryActualCost = hops.stream()
+//			.filter(hop -> hop instanceof AggBinaryOp)
+//			.mapToDouble(aggHop -> aggHop.getFederatedCost().getTotal()-aggHop.getFederatedCost().getInputTotalCost())
+//			.sum();
+//		Assert.assertEquals(aggBinaryOpCost, aggBinaryActualCost, 0.0001);
+//
+//		double writeActualCost = hops.stream()
+//			.filter(hop -> hop instanceof DataOp)
+//			.mapToDouble(writeHop -> writeHop.getFederatedCost().getTotal()-writeHop.getFederatedCost().getInputTotalCost())
+//			.sum();
+//		Assert.assertEquals(dataOpWriteCost+dataOpCost, writeActualCost, 0.0001);
+//	}
+//
+//	Set<Hop> hops = new HashSet<>();
+//
+//	/**
+//	 * Recursively adds the hop and its inputs to the set of hops.
+//	 * @param hop root to be added to set of hops
+//	 */
+//	private void addHop(Hop hop){
+//		hops.add(hop);
+//		for(Hop inHop : hop.getInput()){
+//			addHop(inHop);
+//		}
+//	}
+//
+//	/**
+//	 * Sets dimensions of federated X and Y and sets binary multiplication to FOUT.
+//	 * @param prog dml program where the HOPS are modified
+//	 */
+//	private void modifyFedouts(DMLProgram prog){
+//		prog.getStatementBlocks().forEach(stmBlock -> stmBlock.getHops().forEach(this::addHop));
+//		hops.forEach(hop -> {
+//			if ( hop instanceof DataOp || (hop instanceof BinaryOp && ((BinaryOp) hop).getOp() == MULT ) ){
+//				hop.setFederatedOutput(FEDInstruction.FederatedOutput.FOUT);
+//				hop.setExecType(Types.ExecType.FED);
+//			} else {
+//				hop.setFederatedOutput(FEDInstruction.FederatedOutput.LOUT);
+//			}
+//			if ( hop.getOpString().equals("Fed Y") || hop.getOpString().equals("Fed X") ){
+//				hop.setDim1(10000);
+//				hop.setDim2(10);
+//			}
+//		});
+//	}
+//
+//	@SuppressWarnings("unused")
+//	private void printHopsInfo(){
+//		//LiteralOp
+//		long literalCount = hops.stream().filter(hop -> hop instanceof LiteralOp).count();
+//		System.out.println("LiteralOp Count: " + literalCount);
+//		//NaryOp
+//		long naryCount = hops.stream().filter(hop -> hop instanceof NaryOp).count();
+//		System.out.println("NaryOp Count " + naryCount);
+//		//ReorgOp
+//		long reorgCount = hops.stream().filter(hop -> hop instanceof ReorgOp).count();
+//		System.out.println("ReorgOp Count: " + reorgCount);
+//		//BinaryOp
+//		long binaryCount = hops.stream().filter(hop -> hop instanceof BinaryOp).count();
+//		System.out.println("Binary count: " + binaryCount);
+//		//AggBinaryOp
+//		long aggBinaryCount = hops.stream().filter(hop -> hop instanceof AggBinaryOp).count();
+//		System.out.println("AggBinaryOp Count: " + aggBinaryCount);
+//		//DataOp
+//		long dataOpCount = hops.stream().filter(hop -> hop instanceof DataOp).count();
+//		System.out.println("DataOp Count: " + dataOpCount);
+//
+//		hops.stream().map(Hop::getClass).distinct().forEach(System.out::println);
+//	}
+//
+//	private DMLProgram testSetup(String scriptFilename) throws IOException{
+//		setTestConfig(scriptFilename);
+//		String dmlScriptString = readScript(scriptFilename);
+//
+//		//parsing, dependency analysis and constructing hops (step 3 and 4 in DMLScript.java)
+//		ParserWrapper parser = ParserFactory.createParser();
+//		DMLProgram prog = parser.parse(DMLScript.DML_FILE_PATH_ANTLR_PARSER, dmlScriptString, new HashMap<>());
+//		DMLTranslator dmlt = new DMLTranslator(prog);
+//		dmlt.liveVariableAnalysis(prog);
+//		dmlt.validateParseTree(prog);
+//		dmlt.constructHops(prog);
+//		if ( scriptFilename.equals("FederatedMultiplyCostEstimatorTest.dml")){
+//			modifyFedouts(prog);
+//			dmlt.rewriteHopsDAG(prog);
+//			hops = new HashSet<>();
+//			prog.getStatementBlocks().forEach(stmBlock -> stmBlock.getHops().forEach(this::addHop));
+//		}
+//		return prog;
+//	}
+//
+//	private void compareResults(DMLProgram prog) {
+//		FederatedPlannerCostbased rewriter = new FederatedPlannerCostbased();
+//		rewriter.rewriteProgram(prog, new FunctionCallGraph(prog), null);
+//
+//		double actualCost = 0;
+//		for ( Hop root : rewriter.getTerminalHops() ){
+//			actualCost += root.getFederatedCost().getTotal();
+//		}
+//
+//
+//		rewriter.getTerminalHops().forEach(Hop::resetFederatedCost);
+//		fedCostEstimator = new FederatedCostEstimator();
+//		double expectedCost = 0;
+//		for ( Hop root : rewriter.getTerminalHops() )
+//			expectedCost += fedCostEstimator.costEstimate(root).getTotal();
+//		Assert.assertEquals(expectedCost, actualCost, 0.0001);
+//	}
+//
+//	private void runHopRelTest( String scriptFilename, boolean expectedException ) {
+//		boolean raisedException = false;
+//		try
+//		{
+//			DMLProgram prog = testSetup(scriptFilename);
+//			compareResults(prog);
+//		}
+//		catch(LanguageException ex) {
+//			raisedException = true;
+//			if(raisedException!=expectedException)
+//				ex.printStackTrace();
+//		}
+//		catch(Exception ex2) {
+//			ex2.printStackTrace();
+//			throw new RuntimeException(ex2);
+//		}
+//
+//		Assert.assertEquals("Expected exception does not match raised exception",
+//			expectedException, raisedException);
+//	}
+//
+//	private void runTest( String scriptFilename, boolean expectedException, double expectedCost ) {
+//		boolean raisedException = false;
+//		try
+//		{
+//			DMLProgram prog = testSetup(scriptFilename);
+//
+//			fedCostEstimator = new FederatedCostEstimator();
+//			FederatedCost actualCost = fedCostEstimator.costEstimate(prog);
+//			Assert.assertEquals(expectedCost, actualCost.getTotal(), 0.0001);
+//		}
+//		catch(LanguageException ex) {
+//			raisedException = true;
+//			if(raisedException!=expectedException)
+//				ex.printStackTrace();
+//		}
+//		catch(Exception ex2) {
+//			ex2.printStackTrace();
+//			throw new RuntimeException(ex2);
+//		}
+//
+//		Assert.assertEquals("Expected exception does not match raised exception",
+//			expectedException, raisedException);
+//	}
+//
+//	private void setTestConfig(String scriptFilename) throws FileNotFoundException {
+//		int index = scriptFilename.lastIndexOf(".dml");
+//		String testName = scriptFilename.substring(0, index > 0 ? index : scriptFilename.length());
+//		TestConfiguration testConfig = new TestConfiguration(TEST_CLASS_DIR, testName, new String[] {});
+//		addTestConfiguration(testName, testConfig);
+//		loadTestConfiguration(testConfig);
+//
+//		DMLConfig conf = new DMLConfig(getCurConfigFile().getPath());
+//		ConfigurationManager.setLocalConfig(conf);
+//	}
+//
+//	private static String readScript(String scriptFilename) throws IOException {
+//		return DMLScript.readDMLScript(true, HOME + scriptFilename);
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedDynamicPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedDynamicPlanningTest.java
@@ -1,0 +1,187 @@
+///*
+// *  Licensed to the Apache Software Foundation (ASF) under one
+// *  or more contributor license agreements.  See the NOTICE file
+// *  distributed with this work for additional information
+// *  regarding copyright ownership.  The ASF licenses this file
+// *  to you under the Apache License, Version 2.0 (the
+// *  "License"); you may not use this file except in compliance
+// *  with the License.  You may obtain a copy of the License at
+// *
+// *    http://www.apache.org/licenses/LICENSE-2.0
+// *
+// *  Unless required by applicable law or agreed to in writing,
+// *  software distributed under the License is distributed on an
+// *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// *  KIND, either express or implied.  See the License for the
+// *  specific language governing permissions and limitations
+// *  under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import org.apache.commons.logging.Log;
+//import org.apache.commons.logging.LogFactory;
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Test;
+//
+//import java.io.File;
+//import java.util.Arrays;
+//
+//import static org.junit.Assert.fail;
+//
+//@net.jcip.annotations.NotThreadSafe
+//public class FederatedDynamicPlanningTest extends AutomatedTestBase {
+//	private static final Log LOG = LogFactory.getLog(FederatedDynamicPlanningTest.class.getName());
+//
+//	private final static String TEST_DIR = "functions/privacy/fedplanning/";
+//	private final static String TEST_NAME = "FederatedDynamicFunctionPlanningTest";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedDynamicPlanningTest.class.getSimpleName() + "/";
+//	private static File TEST_CONF_FILE;
+//
+//	private final static int blocksize = 1024;
+//	public final int rows = 1000;
+//	public final int cols = 1000;
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"Z"}));
+//	}
+//
+//	@Test
+//	public void runDynamicFullFunctionTest() {
+//		// compared to `FederatedL2SVMPlanningTest` this does not create `fed_+*` or `fed_tsmm`, probably due to
+//		// some rewrites not being applied. Might be a bug.
+//		String[] expectedHeavyHitters = new String[] {"fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_max",
+//				"fed_1-*", "fed_>"};
+//		setTestConf("SystemDS-config-fout.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runDynamicHeuristicFunctionTest() {
+//		// compared to `FederatedL2SVMPlanningTest` this does not create `fed_+*` or `fed_tsmm`, probably due to
+//		// some rewrites not being applied. Might be a bug.
+//		String[] expectedHeavyHitters = new String[] {"fed_fedinit", "fed_ba+*"};
+//		setTestConf("SystemDS-config-heuristic.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runDynamicCostBasedFunctionTest() {
+//		// compared to `FederatedL2SVMPlanningTest` this does not create `fed_+*` or `fed_tsmm`, probably due to
+//		// some rewrites not being applied. Might be a bug.
+//		String[] expectedHeavyHitters = new String[] {"fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_max",
+//			"fed_1-*", "fed_>"};
+//		setTestConf("SystemDS-config-cost-based.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	private void setTestConf(String test_conf) {
+//		TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, test_conf);
+//	}
+//
+//	private void writeInputMatrices() {
+//		writeBinaryVector("A", 42, rows, null);
+//		writeStandardMatrix("B1", 65, rows / 2, cols, null);
+//		writeStandardMatrix("B2", 75, rows / 2, cols, null);
+//		writeStandardMatrix("C1", 13, rows, cols / 2, null);
+//		writeStandardMatrix("C2", 17, rows, cols / 2, null);
+//	}
+//
+//	private void writeBinaryVector(String matrixName, long seed, int numRows, PrivacyConstraint privacyConstraint){
+//		double[][] matrix = getRandomMatrix(numRows, 1, -1, 1, 1, seed);
+//		for(int i = 0; i < numRows; i++)
+//			matrix[i][0] = (matrix[i][0] > 0) ? 1 : -1;
+//		MatrixCharacteristics mc = new MatrixCharacteristics(numRows, 1, blocksize, numRows);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, long seed, int numRows, int numCols,
+//		PrivacyConstraint privacyConstraint) {
+//		double[][] matrix = getRandomMatrix(numRows, numCols, 0, 1, 1, seed);
+//		writeStandardMatrix(matrixName, numRows, numCols, privacyConstraint, matrix);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, int numRows, int numCols, PrivacyConstraint privacyConstraint,
+//		double[][] matrix) {
+//		MatrixCharacteristics mc = new MatrixCharacteristics(numRows, numCols, blocksize, (long) numRows * numCols);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void loadAndRunTest(String[] expectedHeavyHitters, String testName) {
+//
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = Types.ExecMode.SINGLE_NODE;
+//
+//		Thread t1 = null, t2 = null;
+//
+//		try {
+//			getAndLoadTestConfiguration(testName);
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			writeInputMatrices();
+//
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+//			t2 = startLocalFedWorkerThread(port2);
+//
+//			// Run actual dml script with federated matrix
+//			fullDMLScriptName = HOME + testName + ".dml";
+//			programArgs = new String[] {"-stats", "-nvargs",
+//				 "r=" + rows, "c=" + cols,
+//				"A=" + input("A"),
+//				"B1=" + TestUtils.federatedAddress(port1, input("B1")),
+//				"B2=" + TestUtils.federatedAddress(port2, input("B2")),
+//				"C1=" + TestUtils.federatedAddress(port1, input("C1")),
+//				"C2=" + TestUtils.federatedAddress(port2, input("C2")),
+//				"lB1=" + input("B1"),
+//				"lB2=" + input("B2"),
+//				"Z=" + output("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// Run reference dml script with normal matrix
+//			fullDMLScriptName = HOME + testName + "Reference.dml";
+//			programArgs = new String[] {"-nvargs",
+//				"r=" + rows, "c=" + cols,
+//				"A=" + input("A"),
+//				"B1=" + input("B1"),
+//				"B2=" + input("B2"),
+//				"C1=" + input("C1"),
+//				"C2=" + input("C2"),
+//				"Z=" + expected("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// compare via files
+//			compareResults(1e-9);
+//			if(!heavyHittersContainsAllString(expectedHeavyHitters))
+//				fail("The following expected heavy hitters are missing: "
+//					+ Arrays.toString(missingHeavyHitters(expectedHeavyHitters)));
+//		}
+//		finally {
+//			TestUtils.shutdownThreads(t1, t2);
+//			rtplatform = platformOld;
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//		}
+//	}
+//
+//	/**
+//	 * Override default configuration with custom test configuration to ensure scratch space and local temporary
+//	 * directory locations are also updated.
+//	 */
+//	@Override
+//	protected File getConfigTemplateFile() {
+//		// Instrumentation in this test's output log to show custom configuration file used for template.
+//		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+//		return TEST_CONF_FILE;
+//	}
+//
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedKMeansPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedKMeansPlanningTest.java
@@ -1,0 +1,167 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import org.apache.commons.logging.Log;
+//import org.apache.commons.logging.LogFactory;
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//
+//import java.io.File;
+//import java.util.Arrays;
+//
+//import static org.junit.Assert.fail;
+//
+//public class FederatedKMeansPlanningTest extends AutomatedTestBase {
+//	private static final Log LOG = LogFactory.getLog(FederatedKMeansPlanningTest.class.getName());
+//
+//	private final static String TEST_DIR = "functions/privacy/fedplanning/";
+//	private final static String TEST_NAME = "FederatedKMeansPlanningTest";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedKMeansPlanningTest.class.getSimpleName() + "/";
+//	private static File TEST_CONF_FILE;
+//
+//	private final static int blocksize = 1024;
+//	public final int rows = 1000;
+//	public final int cols = 100;
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"Z"}));
+//	}
+//
+//	@Test
+//	public void runKMeansFOUTTest(){
+//		String[] expectedHeavyHitters = new String[]{};
+//		setTestConf("SystemDS-config-fout.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runKMeansHeuristicTest(){
+//		String[] expectedHeavyHitters = new String[]{};
+//		setTestConf("SystemDS-config-heuristic.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runKMeansCostBasedTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_*", "fed_uack+", "fed_bcumoffk+"};
+//		setTestConf("SystemDS-config-cost-based.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runRuntimeTest(){
+//		String[] expectedHeavyHitters = new String[]{};
+//		TEST_CONF_FILE = new File("src/test/config/SystemDS-config.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	private void setTestConf(String test_conf){
+//		TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, test_conf);
+//	}
+//
+//	/**
+//	 * Override default configuration with custom test configuration to ensure
+//	 * scratch space and local temporary directory locations are also updated.
+//	 */
+//	@Override
+//	protected File getConfigTemplateFile() {
+//		// Instrumentation in this test's output log to show custom configuration file used for template.
+//		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+//		return TEST_CONF_FILE;
+//	}
+//
+//	private void writeInputMatrices(){
+//		writeStandardRowFedMatrix("X1", 65, null);
+//		writeStandardRowFedMatrix("X2", 75, null);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, long seed, int numRows, PrivacyConstraint privacyConstraint){
+//		double[][] matrix = getRandomMatrix(numRows, cols, 0, 1, 1, seed);
+//		writeStandardMatrix(matrixName, numRows, privacyConstraint, matrix);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, int numRows, PrivacyConstraint privacyConstraint, double[][] matrix){
+//		MatrixCharacteristics mc = new MatrixCharacteristics(numRows, cols, blocksize, (long) numRows * cols);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeStandardRowFedMatrix(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		int halfRows = rows/2;
+//		writeStandardMatrix(matrixName, seed, halfRows, privacyConstraint);
+//	}
+//
+//	private void loadAndRunTest(String[] expectedHeavyHitters, String testName){
+//
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = Types.ExecMode.SINGLE_NODE;
+//
+//		Thread t1 = null, t2 = null;
+//
+//		try {
+//			getAndLoadTestConfiguration(testName);
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			writeInputMatrices();
+//
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+//			t2 = startLocalFedWorkerThread(port2);
+//
+//			// Run actual dml script with federated matrix
+//			fullDMLScriptName = HOME + testName + ".dml";
+//			programArgs = new String[] { "-stats", "-nvargs",
+//				"X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//				"Y=" + input("Y"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// Run reference dml script with normal matrix
+//			fullDMLScriptName = HOME + testName + "Reference.dml";
+//			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"),
+//				"Y=" + input("Y"), "Z=" + expected("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// compare via files
+//			compareResults(1e-9);
+//			if (!heavyHittersContainsAllString(expectedHeavyHitters))
+//				fail("The following expected heavy hitters are missing: "
+//					+ Arrays.toString(missingHeavyHitters(expectedHeavyHitters)));
+//		}
+//		finally {
+//			TestUtils.shutdownThreads(t1, t2);
+//			rtplatform = platformOld;
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//		}
+//	}
+//
+//
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedL2SVMPlanningTest.java
@@ -1,0 +1,201 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import org.apache.commons.logging.Log;
+//import org.apache.commons.logging.LogFactory;
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//
+//import java.io.File;
+//import java.util.Arrays;
+//
+//import static org.junit.Assert.fail;
+//
+//@net.jcip.annotations.NotThreadSafe
+//public class FederatedL2SVMPlanningTest extends AutomatedTestBase {
+//	private static final Log LOG = LogFactory.getLog(FederatedL2SVMPlanningTest.class.getName());
+//
+//	private final static String TEST_DIR = "functions/privacy/fedplanning/";
+//	private final static String TEST_NAME = "FederatedL2SVMPlanningTest";
+//	private final static String TEST_NAME_2 = "FederatedL2SVMFunctionPlanningTest";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedL2SVMPlanningTest.class.getSimpleName() + "/";
+//	private static File TEST_CONF_FILE;
+//
+//	private final static int blocksize = 1024;
+//	public final int rows = 1000;
+//	public final int cols = 100;
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_2, new String[] {"Z"}));
+//	}
+//
+//	@Test
+//	public void runL2SVMFOUTTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
+//			"fed_max", "fed_1-*", "fed_tsmm", "fed_>"};
+//		setTestConf("SystemDS-config-fout.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runL2SVMHeuristicTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*"};
+//		setTestConf("SystemDS-config-heuristic.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runL2SVMCostBasedTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
+//			"fed_max", "fed_1-*", "fed_tsmm", "fed_>"};
+//		setTestConf("SystemDS-config-cost-based.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME);
+//	}
+//
+//	@Test
+//	public void runL2SVMFunctionFOUTTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
+//			"fed_max", "fed_1-*", "fed_tsmm", "fed_>"};
+//		setTestConf("SystemDS-config-fout.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME_2);
+//	}
+//
+//	@Test
+//	public void runL2SVMFunctionHeuristicTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*"};
+//		setTestConf("SystemDS-config-heuristic.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME_2);
+//	}
+//
+//	@Test
+//	public void runL2SVMFunctionCostBasedTest(){
+//		String[] expectedHeavyHitters = new String[]{ "fed_fedinit", "fed_ba+*", "fed_tak+*", "fed_+*",
+//			"fed_max", "fed_1-*", "fed_tsmm", "fed_>"};
+//		setTestConf("SystemDS-config-cost-based.xml");
+//		loadAndRunTest(expectedHeavyHitters, TEST_NAME_2);
+//	}
+//
+//	private void setTestConf(String test_conf){
+//		TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, test_conf);
+//	}
+//
+//	private void writeInputMatrices(){
+//		writeStandardRowFedMatrix("X1", 65, null);
+//		writeStandardRowFedMatrix("X2", 75, null);
+//		writeBinaryVector("Y", 44, null);
+//	}
+//
+//	private void writeBinaryVector(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		double[][] matrix = getRandomMatrix(rows, 1, -1, 1, 1, seed);
+//		for(int i = 0; i < rows; i++)
+//			matrix[i][0] = (matrix[i][0] > 0) ? 1 : -1;
+//		MatrixCharacteristics mc = new MatrixCharacteristics(rows, 1, blocksize, rows);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	@SuppressWarnings("unused")
+//	private void writeStandardMatrix(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		writeStandardMatrix(matrixName, seed, rows, privacyConstraint);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, long seed, int numRows, PrivacyConstraint privacyConstraint){
+//		double[][] matrix = getRandomMatrix(numRows, cols, 0, 1, 1, seed);
+//		writeStandardMatrix(matrixName, numRows, privacyConstraint, matrix);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, int numRows, PrivacyConstraint privacyConstraint, double[][] matrix){
+//		MatrixCharacteristics mc = new MatrixCharacteristics(numRows, cols, blocksize, (long) numRows * cols);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeStandardRowFedMatrix(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		int halfRows = rows/2;
+//		writeStandardMatrix(matrixName, seed, halfRows, privacyConstraint);
+//	}
+//
+//	private void loadAndRunTest(String[] expectedHeavyHitters, String testName){
+//
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = Types.ExecMode.SINGLE_NODE;
+//
+//		Thread t1 = null, t2 = null;
+//
+//		try {
+//			getAndLoadTestConfiguration(testName);
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			writeInputMatrices();
+//
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+//			t2 = startLocalFedWorkerThread(port2);
+//
+//			// Run actual dml script with federated matrix
+//			fullDMLScriptName = HOME + testName + ".dml";
+//			programArgs = new String[] { "-stats", "-nvargs",
+//				"X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//				"Y=" + input("Y"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// Run reference dml script with normal matrix
+//			fullDMLScriptName = HOME + testName + "Reference.dml";
+//			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"),
+//				"Y=" + input("Y"), "Z=" + expected("Z")};
+//			runTest(true, false, null, -1);
+//
+//			// compare via files
+//			compareResults(1e-9);
+//			if (!heavyHittersContainsAllString(expectedHeavyHitters))
+//				fail("The following expected heavy hitters are missing: "
+//					+ Arrays.toString(missingHeavyHitters(expectedHeavyHitters)));
+//		}
+//		finally {
+//			TestUtils.shutdownThreads(t1, t2);
+//			rtplatform = platformOld;
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//		}
+//	}
+//
+//	/**
+//	 * Override default configuration with custom test configuration to ensure
+//	 * scratch space and local temporary directory locations are also updated.
+//	 */
+//	@Override
+//	protected File getConfigTemplateFile() {
+//		// Instrumentation in this test's output log to show custom configuration file used for template.
+//		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+//		return TEST_CONF_FILE;
+//	}
+//
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/fedplanning/FederatedMultiplyPlanningTest.java
@@ -1,0 +1,333 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.fedplanning;
+//
+//import org.apache.commons.logging.Log;
+//import org.apache.commons.logging.LogFactory;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//import org.apache.sysds.api.DMLScript;
+//import org.apache.sysds.common.Types;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//
+//import java.io.File;
+//import java.util.Arrays;
+//import java.util.Collection;
+//
+//import static org.junit.Assert.fail;
+//
+//@RunWith(value = Parameterized.class)
+//@net.jcip.annotations.NotThreadSafe
+//public class FederatedMultiplyPlanningTest extends AutomatedTestBase {
+//	private static final Log LOG = LogFactory.getLog(FederatedMultiplyPlanningTest.class.getName());
+//
+//	private final static String TEST_DIR = "functions/privacy/fedplanning/";
+//	private final static String TEST_NAME = "FederatedMultiplyPlanningTest";
+//	private final static String TEST_NAME_2 = "FederatedMultiplyPlanningTest2";
+//	private final static String TEST_NAME_3 = "FederatedMultiplyPlanningTest3";
+//	private final static String TEST_NAME_4 = "FederatedMultiplyPlanningTest4";
+//	private final static String TEST_NAME_5 = "FederatedMultiplyPlanningTest5";
+//	private final static String TEST_NAME_6 = "FederatedMultiplyPlanningTest6";
+//	private final static String TEST_NAME_7 = "FederatedMultiplyPlanningTest7";
+//	private final static String TEST_NAME_8 = "FederatedMultiplyPlanningTest8";
+//	private final static String TEST_NAME_9 = "FederatedMultiplyPlanningTest9";
+//	private final static String TEST_NAME_10 = "FederatedMultiplyPlanningTest10";
+//	private final static String TEST_NAME_11 = "FederatedMultiplyPlanningTest11";
+//	private final static String TEST_NAME_12 = "FederatedMultiplyPlanningTest12";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedMultiplyPlanningTest.class.getSimpleName() + "/";
+//	private static File TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, "SystemDS-config-cost-based.xml");
+//
+//	private final static int blocksize = 1024;
+//	@Parameterized.Parameter()
+//	public int rows;
+//	@Parameterized.Parameter(1)
+//	public int cols;
+//
+//	@Override
+//	public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_2, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_2, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_3, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_3, new String[] {"Z.scalar"}));
+//		addTestConfiguration(TEST_NAME_4, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_4, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_5, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_5, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_6, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_6, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_7, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_7, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_8, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_8, new String[] {"Z.scalar"}));
+//		addTestConfiguration(TEST_NAME_9, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_9, new String[] {"Z.scalar"}));
+//		addTestConfiguration(TEST_NAME_10, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_10, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_11, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_11, new String[] {"Z"}));
+//		addTestConfiguration(TEST_NAME_12, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_12, new String[] {"Z"}));
+//	}
+//
+//	@Parameterized.Parameters
+//	public static Collection<Object[]> data() {
+//		// rows have to be even and > 1
+//		return Arrays.asList(new Object[][] {
+//			{100, 10}
+//		});
+//	}
+//
+//	@Test
+//	public void federatedMultiplyCP() {
+//		String[] expectedHeavyHitters = new String[]{"fed_*", "fed_fedinit", "fed_r'", "fed_ba+*"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedRowSum(){
+//		String[] expectedHeavyHitters = new String[]{"fed_*", "fed_r'", "fed_fedinit", "fed_ba+*", "fed_uark+"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_2, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedTernarySequence(){
+//		String[] expectedHeavyHitters = new String[]{"fed_+*", "fed_1-*", "fed_fedinit", "fed_uak+"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_3, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedAggregateBinarySequence(){
+//		cols = rows;
+//		String[] expectedHeavyHitters = new String[]{"fed_ba+*", "fed_*", "fed_fedinit"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_4, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedAggregateBinaryColFedSequence(){
+//		cols = rows;
+//		//TODO: When alignment checks have been added to getFederatedOut in AFederatedPlanner,
+//		// the following expectedHeavyHitters can be added. Until then, fed_* will not be generated.
+//		//String[] expectedHeavyHitters = new String[]{"fed_ba+*","fed_*","fed_fedinit"};
+//		String[] expectedHeavyHitters = new String[]{"fed_ba+*","fed_fedinit"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_5, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedAggregateBinarySequence2(){
+//		String[] expectedHeavyHitters = new String[]{"fed_ba+*","fed_fedinit"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_6, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyDoubleHop() {
+//		String[] expectedHeavyHitters = new String[]{"fed_*", "fed_fedinit", "fed_r'", "fed_ba+*"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_7, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyDoubleHop2() {
+//		String[] expectedHeavyHitters = new String[]{"fed_fedinit", "fed_ba+*"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_8, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyPlanningTest9(){
+//		String[] expectedHeavyHitters = new String[]{"fed_+*", "fed_1-*", "fed_fedinit", "fed_tak+*", "fed_max"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_9, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyPlanningTest10(){
+//		String[] expectedHeavyHitters = new String[]{"fed_fedinit", "fed_^2"};
+//		TEST_CONF_FILE = new File(SCRIPT_DIR + TEST_DIR, "SystemDS-config-fout.xml");
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_10, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyPlanningTest11(){
+//		String[] expectedHeavyHitters = new String[]{"fed_fedinit"};
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_11, expectedHeavyHitters);
+//	}
+//
+//	@Test
+//	public void federatedMultiplyPlanningTest12(){
+//		String[] expectedHeavyHitters = new String[]{"fed_fedinit"};
+//		rows = 30;
+//		cols = 30;
+//		federatedTwoMatricesSingleNodeTest(TEST_NAME_12, expectedHeavyHitters);
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, long seed){
+//		writeStandardMatrix(matrixName, seed, new PrivacyConstraint(PrivacyConstraint.PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	private void writeStandardMatrix(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		int halfRows = rows/2;
+//		double[][] matrix = getRandomMatrix(halfRows, cols, 0, 1, 1, seed);
+//		MatrixCharacteristics mc = new MatrixCharacteristics(halfRows, cols, blocksize, (long) halfRows * cols);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeColStandardMatrix(String matrixName, long seed){
+//		writeColStandardMatrix(matrixName, seed, new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	private void writeColStandardMatrix(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		int halfCols = cols/2;
+//		double[][] matrix = getRandomMatrix(rows, halfCols, 0, 1, 1, seed);
+//		MatrixCharacteristics mc = new MatrixCharacteristics(rows, halfCols, blocksize, (long) halfCols *rows);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeRowFederatedVector(String matrixName, long seed){
+//		writeRowFederatedVector(matrixName, seed, new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	private void writeRowFederatedVector(String matrixName, long seed, PrivacyConstraint privacyConstraint){
+//		int halfCols = cols / 2;
+//		double[][] matrix = getRandomMatrix(halfCols, 1, 0, 1, 1, seed);
+//		MatrixCharacteristics mc = new MatrixCharacteristics(halfCols, 1, blocksize, (long) halfCols *rows);
+//		writeInputMatrixWithMTD(matrixName, matrix, false, mc, privacyConstraint);
+//	}
+//
+//	private void writeInputMatrices(String testName){
+//		if ( testName.equals(TEST_NAME_5) ){
+//			writeColStandardMatrix("X1", 42);
+//			writeColStandardMatrix("X2", 1340);
+//			writeColStandardMatrix("Y1", 44, null);
+//			writeColStandardMatrix("Y2", 21, null);
+//		}
+//		else if ( testName.equals(TEST_NAME_6) ){
+//			writeColStandardMatrix("X1", 42);
+//			writeColStandardMatrix("X2", 1340);
+//			writeRowFederatedVector("Y1", 44);
+//			writeRowFederatedVector("Y2", 21);
+//		}
+//		else if ( testName.equals(TEST_NAME_8) ){
+//			writeColStandardMatrix("X1", 42, null);
+//			writeColStandardMatrix("X2", 1340, null);
+//			writeColStandardMatrix("Y1", 44, null);
+//			writeColStandardMatrix("Y2", 21, null);
+//			writeColStandardMatrix("W1", 76, null);
+//			writeColStandardMatrix("W2", 11, null);
+//		}
+//		else if ( testName.equals(TEST_NAME_10) || testName.equals(TEST_NAME_12) ){
+//			writeStandardMatrix("X1", 42, null);
+//			writeStandardMatrix("X2", 1340, null);
+//		}
+//		else {
+//			writeStandardMatrix("X1", 42);
+//			writeStandardMatrix("X2", 1340);
+//			if ( testName.equals(TEST_NAME_4) ){
+//				writeStandardMatrix("Y1", 44, null);
+//				writeStandardMatrix("Y2", 21, null);
+//			}
+//			else {
+//				writeStandardMatrix("Y1", 44);
+//				writeStandardMatrix("Y2", 21);
+//			}
+//		}
+//	}
+//
+//	private void federatedTwoMatricesSingleNodeTest(String testName, String[] expectedHeavyHitters){
+//		federatedTwoMatricesTest(Types.ExecMode.SINGLE_NODE, testName, expectedHeavyHitters);
+//	}
+//
+//	private void federatedTwoMatricesTest(Types.ExecMode execMode, String testName, String[] expectedHeavyHitters) {
+//		boolean sparkConfigOld = DMLScript.USE_LOCAL_SPARK_CONFIG;
+//		Types.ExecMode platformOld = rtplatform;
+//		rtplatform = execMode;
+//		if(rtplatform == Types.ExecMode.SPARK) {
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+//		}
+//		Thread t1 = null, t2 = null;
+//
+//		try{
+//			getAndLoadTestConfiguration(testName);
+//			String HOME = SCRIPT_DIR + TEST_DIR;
+//
+//			writeInputMatrices(testName);
+//
+//			int port1 = getRandomAvailablePort();
+//			int port2 = getRandomAvailablePort();
+//			t1 = startLocalFedWorkerThread(port1, FED_WORKER_WAIT_S);
+//			t2 = startLocalFedWorkerThread(port2);
+//
+//			// Run actual dml script with federated matrix
+//			fullDMLScriptName = HOME + testName + ".dml";
+//			programArgs = new String[] {"-stats", "-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//				"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
+//				"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+//			rewriteRealProgramArgs(testName, port1, port2);
+//			runTest(true, false, null, -1);
+//
+//			// Run reference dml script with normal matrix
+//			fullDMLScriptName = HOME + testName + "Reference.dml";
+//			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
+//				"Y2=" + input("Y2"), "Z=" + expected("Z")};
+//			rewriteReferenceProgramArgs(testName);
+//			runTest(true, false, null, -1);
+//
+//			// compare via files
+//			compareResults(1e-9);
+//			if (!heavyHittersContainsAllString(expectedHeavyHitters))
+//				fail("The following expected heavy hitters are missing: "
+//					+ Arrays.toString(missingHeavyHitters(expectedHeavyHitters)));
+//		} finally {
+//			TestUtils.shutdownThreads(t1, t2);
+//			rtplatform = platformOld;
+//			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+//		}
+//	}
+//
+//	private void rewriteRealProgramArgs(String testName, int port1, int port2){
+//		if ( testName.equals(TEST_NAME_4) || testName.equals(TEST_NAME_5) ){
+//			programArgs = new String[] {"-stats","-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//				"Y1=" + input("Y1"),
+//				"Y2=" + input("Y2"), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+//		} else if ( testName.equals(TEST_NAME_8) ){
+//			programArgs = new String[] {"-stats","-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+//				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+//				"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
+//				"Y2=" + TestUtils.federatedAddress(port2, input("Y2")),
+//				"W1=" + input("W1"),
+//				"W2=" + input("W2"),
+//				"r=" + rows, "c=" + cols, "Z=" + output("Z")};
+//		}
+//	}
+//
+//	private void rewriteReferenceProgramArgs(String testName){
+//		if ( testName.equals(TEST_NAME_8) ){
+//			programArgs = new String[] {"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
+//				"Y2=" + input("Y2"), "W1=" + input("W1"), "W2=" + input("W2"), "Z=" + expected("Z")};
+//		}
+//	}
+//
+//	/**
+//	 * Override default configuration with custom test configuration to ensure
+//	 * scratch space and local temporary directory locations are also updated.
+//	 */
+//	@Override
+//	protected File getConfigTemplateFile() {
+//		// Instrumentation in this test's output log to show custom configuration file used for template.
+//		LOG.info("This test case overrides default configuration with " + TEST_CONF_FILE.getPath());
+//		return TEST_CONF_FILE;
+//	}
+//}
+//

--- a/src/test/java/org/apache/sysds/test/functions/privacy/propagation/AppendPropagatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/propagation/AppendPropagatorTest.java
@@ -1,0 +1,996 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.propagation;
+//
+//import org.apache.sysds.runtime.instructions.cp.Data;
+//import org.apache.sysds.runtime.instructions.cp.DoubleObject;
+//import org.apache.sysds.runtime.instructions.cp.IntObject;
+//import org.apache.sysds.runtime.instructions.cp.ListObject;
+//import org.apache.sysds.runtime.instructions.cp.ScalarObject;
+//import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+//import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.runtime.privacy.finegrained.DataRange;
+//import org.apache.sysds.runtime.privacy.propagation.AppendPropagator;
+//import org.apache.sysds.runtime.privacy.propagation.CBindPropagator;
+//import org.apache.sysds.runtime.privacy.propagation.ListAppendPropagator;
+//import org.apache.sysds.runtime.privacy.propagation.ListRemovePropagator;
+//import org.apache.sysds.runtime.privacy.propagation.Propagator;
+//import org.apache.sysds.runtime.privacy.propagation.PropagatorMultiReturn;
+//import org.apache.sysds.runtime.privacy.propagation.RBindPropagator;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.apache.sysds.test.TestConfiguration;
+//import org.apache.sysds.test.TestUtils;
+//import org.junit.Assert;
+//import org.junit.Ignore;
+//import org.junit.Test;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.Map;
+//
+//public class AppendPropagatorTest extends AutomatedTestBase {
+//
+//	private final static String TEST_DIR = "functions/privacy/";
+//	private final static String TEST_NAME_RBIND = "RBindTest";
+//	private final static String TEST_NAME_CBIND = "CBindTest";
+//	private final static String TEST_NAME_STRING = "StringAppendTest";
+//	private final static String TEST_NAME_LIST = "ListAppendTest";
+//	private final static String TEST_CLASS_DIR = TEST_DIR + AppendPropagatorTest.class.getSimpleName() + "/";
+//
+//	@Override public void setUp() {
+//		TestUtils.clearAssertionInformation();
+//		addTestConfiguration(TEST_NAME_RBIND, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_RBIND, new String[] {"C"}));
+//		addTestConfiguration(TEST_NAME_CBIND, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_CBIND, new String[] {"C"}));
+//		addTestConfiguration(TEST_NAME_STRING, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_STRING, new String[] {"C"}));
+//		addTestConfiguration(TEST_NAME_LIST, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_LIST, new String[] {"C"}));
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivate1Test(){
+//		generalOnlyRBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivateAggregation1Test(){
+//		generalOnlyRBindTest(new PrivacyConstraint(PrivacyLevel.PrivateAggregation), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindNoneTest(){
+//		generalOnlyRBindTest(new PrivacyConstraint(), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivate2Test(){
+//		generalOnlyRBindTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivateAggregation2Test(){
+//		generalOnlyRBindTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivatePrivateTest(){
+//		generalOnlyRBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyRBindPrivatePrivateAggregationTest(){
+//		generalOnlyRBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivate1Test(){
+//		generalOnlyCBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivateAggregation1Test(){
+//		generalOnlyCBindTest(new PrivacyConstraint(PrivacyLevel.PrivateAggregation), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindNoneTest(){
+//		generalOnlyCBindTest(new PrivacyConstraint(), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivate2Test(){
+//		generalOnlyCBindTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivateAggregation2Test(){
+//		generalOnlyCBindTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivatePrivateTest(){
+//		generalOnlyCBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyCBindPrivatePrivateAggregationTest(){
+//		generalOnlyCBindTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivate1Test(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivateAggregation1Test(){
+//		generalOnlyCBindTest(new PrivacyConstraint(PrivacyLevel.PrivateAggregation), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendNoneTest(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(), new PrivacyConstraint());
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivate2Test(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivateAggregation2Test(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivatePrivateTest(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.Private));
+//	}
+//
+//	@Test
+//	public void generalOnlyListAppendPrivatePrivateAggregationTest(){
+//		generalOnlyListAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.PrivateAggregation));
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivate1Test(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(),
+//			PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivateAggregation1Test(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(PrivacyLevel.PrivateAggregation), new PrivacyConstraint(),
+//			PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendNoneTest(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(), new PrivacyConstraint(),
+//			PrivacyLevel.None, PrivacyLevel.None);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivate2Test(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.Private),
+//			PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivateAggregation2Test(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(), new PrivacyConstraint(PrivacyLevel.PrivateAggregation),
+//			PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivatePrivateTest(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.Private),
+//			PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void generalOnlyListRemoveAppendPrivatePrivateAggregationTest(){
+//		generalOnlyListRemoveAppendTest(new PrivacyConstraint(PrivacyLevel.Private), new PrivacyConstraint(PrivacyLevel.PrivateAggregation),
+//			PrivacyLevel.Private, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivateAndPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedRBindPrivateAndPrivateAggregate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{2,0}), PrivacyLevel.PrivateAggregation);
+//		finegrainedRBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivateAndPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedCBindPrivateAndPrivateAggregate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{2,0}), PrivacyLevel.PrivateAggregation);
+//		finegrainedCBindTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{3},new long[]{5}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivateAndPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{3},new long[]{5}), PrivacyLevel.PrivateAggregation);
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{4}), PrivacyLevel.Private);
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void finegrainedListAppendPrivateAndPrivateAggregate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{0},new long[]{0}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2},new long[]{3}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{0},new long[]{1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{3},new long[]{5}), PrivacyLevel.PrivateAggregation);
+//		finegrainedListAppendTest(constraint1, constraint2);
+//	}
+//
+//	@Test
+//	public void testFunction(){
+//		int dataLength = 9;
+//		List<Data> dataList = new ArrayList<>();
+//		for ( int i = 0; i < dataLength; i++)
+//			dataList.add(new DoubleObject(i));
+//		ListObject l = new ListObject(dataList);
+//		ListObject lCopy = l.copy();
+//		int position = 4;
+//		ListObject output = l.remove(position);
+//		Assert.assertEquals(lCopy.getData(position), output.getData().get(0));
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendNone1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.None);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{6}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{6}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivate3(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{6}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.Private);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivate4(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{4},new long[]{4}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.Private, true);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1},new long[]{2}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{3},new long[]{5}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void finegrainedListRemoveAppendPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{5},new long[]{8}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, PrivacyLevel.PrivateAggregation);
+//	}
+//
+//	@Test
+//	public void integrationRBindTestNoneNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationRBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationRBindTestPrivateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0}, new long[]{19,9}), PrivacyLevel.Private);
+//		integrationRBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationRBindTestPrivateAggregateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0}, new long[]{19,9}), PrivacyLevel.PrivateAggregation);
+//		integrationRBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationRBindTestNonePrivateAggregate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{20,0}, new long[]{49, 9}), PrivacyLevel.PrivateAggregation);
+//		integrationRBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationRBindTestNonePrivate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{20,0}, new long[]{49, 9}), PrivacyLevel.Private);
+//		integrationRBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		integrationRBindTest(constraint1, constraint2, constraint1);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		integrationRBindTest(constraint1, constraint2, constraint1);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint pcExcepted = new PrivacyConstraint();
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{21,0}, new long[]{21,1}), PrivacyLevel.Private);
+//		integrationRBindTest(constraint1, constraint2, pcExcepted);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivateAndPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExcepted = new PrivacyConstraint();
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{21,0},new long[]{21,1}), PrivacyLevel.Private);
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{22,0}, new long[]{23,1}), PrivacyLevel.PrivateAggregation);
+//		integrationRBindTest(constraint1, constraint2, pcExcepted);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{21,0},new long[]{21,1}), PrivacyLevel.Private);
+//		integrationRBindTest(constraint1, constraint2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedRBindPrivateAndPrivateAggregate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{2,0}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{20,0},new long[]{20,1}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0}, new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{21,0}, new long[]{22,0}), PrivacyLevel.PrivateAggregation);
+//		integrationRBindTest(constraint1, constraint2, pcExpected);
+//	}
+//
+//	private void integrationRBindTest(PrivacyConstraint privacyConstraint1, PrivacyConstraint privacyConstraint2,
+//		PrivacyConstraint expectedOutput){
+//		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME_RBIND);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		int rows1 = 20;
+//		int rows2 = 30;
+//		int cols = 10;
+//		double[][] A = getRandomMatrix(rows1, cols, -10, 10, 0.5, 1);
+//		double[][] B = getRandomMatrix(rows2, cols, -10, 10, 0.5, 1);
+//		writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows1, cols),  privacyConstraint1);
+//		writeInputMatrixWithMTD("B", B, false, new MatrixCharacteristics(rows2, cols),  privacyConstraint2);
+//
+//		programArgs = new String[]{"-nvargs", "A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//		runTest(true,false,null,-1);
+//
+//		PrivacyConstraint outputConstraint = getPrivacyConstraintFromMetaData("C");
+//		Assert.assertEquals(expectedOutput, outputConstraint);
+//	}
+//
+//	@Test
+//	public void integrationCBindTestNoneNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationCBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationCBindTestPrivateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0}, new long[]{9,19}), PrivacyLevel.Private);
+//		integrationCBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationCBindTestPrivateAggregateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0}, new long[]{9,19}), PrivacyLevel.PrivateAggregation);
+//		integrationCBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationCBindTestNonePrivateAggregate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,20}, new long[]{9, 49}), PrivacyLevel.PrivateAggregation);
+//		integrationCBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationCBindTestNonePrivate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,20}, new long[]{9, 49}), PrivacyLevel.Private);
+//		integrationCBindTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		integrationCBindTest(constraint1, constraint2, constraint1);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivateAndPrivateAggregate1(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		integrationCBindTest(constraint1, constraint2, constraint1);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint pcExcepted = new PrivacyConstraint();
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{1,20}, new long[]{1,21}), PrivacyLevel.Private);
+//		integrationCBindTest(constraint1, constraint2, pcExcepted);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivateAndPrivateAggregate2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExcepted = new PrivacyConstraint();
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{1,20},new long[]{1,21}), PrivacyLevel.Private);
+//		pcExcepted.getFineGrainedPrivacy().put(new DataRange(new long[]{2,20}, new long[]{3,21}), PrivacyLevel.PrivateAggregation);
+//		integrationCBindTest(constraint1, constraint2, pcExcepted);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{1,20},new long[]{1,21}), PrivacyLevel.Private);
+//		integrationCBindTest(constraint1, constraint2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationFinegrainedCBindPrivateAndPrivateAggregate12(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0},new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{2,0}), PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,0},new long[]{0,1}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0,20},new long[]{0,21}), PrivacyLevel.Private);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{2,0}, new long[]{3,1}), PrivacyLevel.PrivateAggregation);
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{1,20}, new long[]{2,20}), PrivacyLevel.PrivateAggregation);
+//		integrationCBindTest(constraint1, constraint2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationStringAppendTestNoneNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationStringAppendTest(pc1, pc2, pc1);
+//	}
+//
+//	@Test
+//	public void integrationStringAppendTestPrivateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationStringAppendTest(pc1, pc2, pc1);
+//	}
+//
+//	@Test
+//	public void integrationStringAppendTestPrivateAggregateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationStringAppendTest(pc1, pc2, pc1);
+//	}
+//
+//	@Test
+//	public void integrationStringAppendTestNonePrivateAggregate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		integrationStringAppendTest(pc1, pc2, pc2);
+//	}
+//
+//	@Test
+//	public void integrationStringAppendTestNonePrivate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		integrationStringAppendTest(pc1, pc2, pc2);
+//	}
+//
+//	@Test
+//	public void integrationListAppendTestNoneNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationListAppendTest(pc1, pc2, pc1);
+//	}
+//
+//	@Test
+//	public void integrationListAppendTestPrivateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pcExpected = new PrivacyConstraint();
+//		pcExpected.getFineGrainedPrivacy().put(new DataRange(new long[]{0}, new long[]{0}), PrivacyLevel.Private);
+//		integrationListAppendTest(pc1, pc2, pcExpected);
+//	}
+//
+//	@Test
+//	public void integrationListAppendTestPrivateAggregateNone(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.None);
+//		integrationListAppendTest(pc1, pc2, pc1);
+//	}
+//
+//	@Test
+//	public void integrationListAppendTestNonePrivateAggregate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		integrationListAppendTest(pc1, pc2, pc2);
+//	}
+//
+//	@Test
+//	public void integrationListAppendTestNonePrivate(){
+//		PrivacyConstraint pc1 = new PrivacyConstraint(PrivacyLevel.None);
+//		PrivacyConstraint pc2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		integrationListAppendTest(pc1, pc2, pc2);
+//	}
+//
+//	private static void generalOnlyRBindTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int columns = 2;
+//		int rows1 = 4;
+//		int rows2 = 3;
+//		MatrixBlock inputMatrix1 = new MatrixBlock(rows1,columns,3);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(rows2,columns,4);
+//		AppendPropagator propagator = new RBindPropagator(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Assert.assertEquals(mergedConstraint.getPrivacyLevel(), PrivacyLevel.None);
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,0}, new long[]{rows1-1,columns-1}));
+//		firstHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint1.getPrivacyLevel(),level));
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{rows1,0}, new long[]{rows1+rows2-1,columns-1}));
+//		secondHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint2.getPrivacyLevel(),level));
+//	}
+//
+//	private static void generalOnlyCBindTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int rows = 2;
+//		int columns1 = 4;
+//		int columns2 = 3;
+//		MatrixBlock inputMatrix1 = new MatrixBlock(rows,columns1,3);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(rows,columns2,4);
+//		AppendPropagator propagator = new CBindPropagator(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Assert.assertEquals(mergedConstraint.getPrivacyLevel(), PrivacyLevel.None);
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,0}, new long[]{rows-1,columns1-1}));
+//		firstHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint1.getPrivacyLevel(),level));
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,columns1}, new long[]{rows,columns1+columns2-1}));
+//		secondHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint2.getPrivacyLevel(),level));
+//	}
+//
+//	private static void generalOnlyListAppendTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int length1 = 6;
+//		List<Data> dataList1 = Arrays.asList(new Data[length1]);
+//		ListObject input1 = new ListObject(dataList1);
+//		int length2 = 11;
+//		List<Data> dataList2 = Arrays.asList(new Data[length2]);
+//		ListObject input2 = new ListObject(dataList2);
+//		Propagator propagator = new ListAppendPropagator(input1, constraint1, input2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0}, new long[]{length1-1})
+//		);
+//		firstHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint1.getPrivacyLevel(),level));
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[length1], new long[]{length1+length2-1})
+//		);
+//		secondHalfPrivacy.forEach((range,level) -> Assert.assertEquals(constraint2.getPrivacyLevel(),level));
+//	}
+//
+//	private static void generalOnlyListRemoveAppendTest(
+//		PrivacyConstraint constraint1, PrivacyConstraint constraint2, PrivacyLevel expected1, PrivacyLevel expected2){
+//		int dataLength = 9;
+//		List<Data> dataList = new ArrayList<>();
+//		for ( int i = 0; i < dataLength; i++){
+//			dataList.add(new DoubleObject(i));
+//		}
+//		ListObject inputList = new ListObject(dataList);
+//
+//		int removePositionInt = 5;
+//		ScalarObject removePosition = new IntObject(removePositionInt);
+//
+//		PropagatorMultiReturn propagator = new ListRemovePropagator(inputList, constraint1, removePosition, constraint2);
+//		PrivacyConstraint[] mergedConstraints = propagator.propagate();
+//
+//		Assert.assertEquals(expected1, mergedConstraints[0].getPrivacyLevel());
+//		Assert.assertEquals(expected2, mergedConstraints[1].getPrivacyLevel());
+//		Assert.assertFalse("The first output constraint should have no fine-grained constraints", mergedConstraints[0].hasFineGrainedConstraints());
+//		Assert.assertFalse("The second output constraint should have no fine-grained constraints", mergedConstraints[1].hasFineGrainedConstraints());
+//	}
+//
+//	private static void finegrainedRBindTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int columns = 2;
+//		int rows1 = 4;
+//		int rows2 = 3;
+//		MatrixBlock inputMatrix1 = new MatrixBlock(rows1,columns,3);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(rows2,columns,4);
+//		AppendPropagator propagator = new RBindPropagator(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Assert.assertEquals(mergedConstraint.getPrivacyLevel(), PrivacyLevel.None);
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,0}, new long[]{rows1-1,columns-1}));
+//		constraint1.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 1",
+//				firstHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{rows1,0}, new long[]{rows1+rows2-1,columns-1}));
+//		constraint2.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 2",
+//				secondHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//	}
+//
+//	private static void finegrainedCBindTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int rows = 6;
+//		int columns1 = 4;
+//		int columns2 = 3;
+//		MatrixBlock inputMatrix1 = new MatrixBlock(rows,columns1,3);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(rows,columns2,4);
+//		AppendPropagator propagator = new CBindPropagator(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Assert.assertEquals(mergedConstraint.getPrivacyLevel(), PrivacyLevel.None);
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,0}, new long[]{rows-1,columns1-1}));
+//		constraint1.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 1",
+//				firstHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0,columns1}, new long[]{rows,columns1+columns2-1}));
+//		constraint2.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 2",
+//				secondHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//	}
+//
+//	private static void finegrainedListAppendTest(PrivacyConstraint constraint1, PrivacyConstraint constraint2){
+//		int length1 = 6;
+//		List<Data> dataList1 = Arrays.asList(new Data[length1]);
+//		ListObject input1 = new ListObject(dataList1);
+//		int length2 = 11;
+//		List<Data> dataList2 = Arrays.asList(new Data[length2]);
+//		ListObject input2 = new ListObject(dataList2);
+//		Propagator propagator = new ListAppendPropagator(input1, constraint1, input2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		Assert.assertEquals(mergedConstraint.getPrivacyLevel(), PrivacyLevel.None);
+//		Map<DataRange, PrivacyLevel> firstHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{0}, new long[]{length1-1})
+//		);
+//		constraint1.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 1",
+//				firstHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//		Map<DataRange, PrivacyLevel> secondHalfPrivacy = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(
+//			new DataRange(new long[]{length1}, new long[]{length1+length2-1})
+//		);
+//		constraint2.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//			constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 2",
+//				secondHalfPrivacy.containsValue(constraint.getValue()))
+//		);
+//	}
+//
+//	private static void finegrainedListRemoveAppendTest(
+//		PrivacyConstraint constraint1, PrivacyConstraint constraint2, PrivacyLevel expectedOutput2){
+//		finegrainedListRemoveAppendTest(constraint1, constraint2, expectedOutput2, false);
+//	}
+//
+//	private static void finegrainedListRemoveAppendTest(
+//		PrivacyConstraint constraint1, PrivacyConstraint constraint2, PrivacyLevel expectedOutput2, boolean singleElementPrivacy){
+//		int dataLength = 9;
+//		List<Data> dataList = new ArrayList<>();
+//		for ( int i = 0; i < dataLength; i++){
+//			dataList.add(new DoubleObject(i));
+//		}
+//		ListObject inputList = new ListObject(dataList);
+//		int removePositionInt = 5;
+//		ScalarObject removePosition = new IntObject(removePositionInt);
+//		PropagatorMultiReturn propagator = new ListRemovePropagator(inputList, constraint1, removePosition, constraint2);
+//		PrivacyConstraint[] mergedConstraints = propagator.propagate();
+//
+//		if ( !singleElementPrivacy ){
+//			Map<DataRange, PrivacyLevel> outputPrivacy = mergedConstraints[0].getFineGrainedPrivacy().getPrivacyLevel(
+//				new DataRange(new long[]{0}, new long[]{dataLength-1})
+//			);
+//			constraint1.getFineGrainedPrivacy().getAllConstraintsList().forEach(
+//				constraint -> Assert.assertTrue("Merged constraint should contain same privacy levels as input 1",
+//					outputPrivacy.containsValue(constraint.getValue()))
+//			);
+//		}
+//
+//		Assert.assertEquals(expectedOutput2, mergedConstraints[1].getPrivacyLevel());
+//		Assert.assertFalse(mergedConstraints[1].hasFineGrainedConstraints());
+//	}
+//
+//	private void integrationCBindTest(PrivacyConstraint privacyConstraint1, PrivacyConstraint privacyConstraint2,
+//		PrivacyConstraint expectedOutput){
+//		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME_CBIND);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		int cols1 = 20;
+//		int cols2 = 30;
+//		int rows = 10;
+//		double[][] A = getRandomMatrix(rows, cols1, -10, 10, 0.5, 1);
+//		double[][] B = getRandomMatrix(rows, cols2, -10, 10, 0.5, 1);
+//		writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows, cols1),  privacyConstraint1);
+//		writeInputMatrixWithMTD("B", B, false, new MatrixCharacteristics(rows, cols2),  privacyConstraint2);
+//
+//		programArgs = new String[]{"-nvargs", "A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//		runTest(true,false,null,-1);
+//
+//		PrivacyConstraint outputConstraint = getPrivacyConstraintFromMetaData("C");
+//		Assert.assertEquals(expectedOutput, outputConstraint);
+//	}
+//
+//	private void integrationStringAppendTest(PrivacyConstraint privacyConstraint1, PrivacyConstraint privacyConstraint2,
+//		PrivacyConstraint expectedOutput){
+//		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME_STRING);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		int cols = 1;
+//		int rows = 1;
+//		double[][] A = getRandomMatrix(rows, cols, -10, 10, 0.5, 1);
+//		double[][] B = getRandomMatrix(rows, cols, -10, 10, 0.5, 1);
+//		writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows, cols),  privacyConstraint1);
+//		writeInputMatrixWithMTD("B", B, false, new MatrixCharacteristics(rows, cols),  privacyConstraint2);
+//
+//		programArgs = new String[]{"-nvargs", "A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//		runTest(true,false,null,-1);
+//
+//		PrivacyConstraint outputConstraint = getPrivacyConstraintFromMetaData("C");
+//		Assert.assertEquals(expectedOutput, outputConstraint);
+//	}
+//
+//	private void integrationListAppendTest(PrivacyConstraint privacyConstraint1, PrivacyConstraint privacyConstraint2,
+//		PrivacyConstraint expectedOutput){
+//		TestConfiguration config = getAndLoadTestConfiguration(TEST_NAME_LIST);
+//		fullDMLScriptName = SCRIPT_DIR + TEST_DIR + config.getTestScript() + ".dml";
+//
+//		int cols = 1;
+//		int rows = 5;
+//		double[][] A = getRandomMatrix(rows, cols, -10, 10, 0.5, 1);
+//		double[][] B = getRandomMatrix(rows, cols, -10, 10, 0.5, 1);
+//		writeInputMatrixWithMTD("A", A, false, new MatrixCharacteristics(rows, cols),  privacyConstraint1);
+//		writeInputMatrixWithMTD("B", B, false, new MatrixCharacteristics(rows, cols),  privacyConstraint2);
+//
+//		programArgs = new String[]{"-nvargs", "A=" + input("A"), "B=" + input("B"), "C=" + output("C")};
+//		runTest(true,false,null,-1);
+//
+//		PrivacyConstraint outputConstraint = getPrivacyConstraintFromMetaData("C");
+//		Assert.assertEquals(expectedOutput, outputConstraint);
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/propagation/CorePropagatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/propagation/CorePropagatorTest.java
@@ -1,0 +1,80 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.propagation;
+//
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.Parameterized;
+//
+//import java.util.Arrays;
+//import java.util.Collection;
+//import org.apache.sysds.runtime.privacy.propagation.PrivacyPropagator;
+//import org.apache.sysds.runtime.privacy.propagation.OperatorType;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//
+//import static org.junit.Assert.assertEquals;
+//
+//@RunWith(value = Parameterized.class)
+//public class CorePropagatorTest extends AutomatedTestBase {
+//
+//	protected PrivacyLevel[] input;
+//	protected OperatorType operatorType;
+//	protected PrivacyLevel expectedPrivacyLevel;
+//
+//	public CorePropagatorTest(PrivacyLevel[] input, OperatorType operatorType, PrivacyLevel expectedPrivacyLevel) {
+//		this.input = input;
+//		this.operatorType = operatorType;
+//		this.expectedPrivacyLevel = expectedPrivacyLevel;
+//	}
+//
+//	@Override public void setUp() {}
+//
+//	@Test
+//	public void corePropagation(){
+//		PrivacyLevel outputLevel = PrivacyPropagator.corePropagation(input, operatorType);
+//		assertEquals(expectedPrivacyLevel, outputLevel);
+//	}
+//
+//	@Parameterized.Parameters
+//	public static Collection<Object[]> data() {
+//		Object[][] data = new Object[][] {
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.Private}, OperatorType.NonAggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.Private}, OperatorType.Aggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.PrivateAggregation}, OperatorType.NonAggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.PrivateAggregation}, OperatorType.Aggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.None}, OperatorType.NonAggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.Private, PrivacyLevel.None}, OperatorType.Aggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.Private}, OperatorType.NonAggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.Private}, OperatorType.Aggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.Private}, OperatorType.NonAggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.Private}, OperatorType.Aggregate, PrivacyLevel.Private},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation}, OperatorType.NonAggregate, PrivacyLevel.PrivateAggregation},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.PrivateAggregation}, OperatorType.Aggregate, PrivacyLevel.None},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.None}, OperatorType.NonAggregate, PrivacyLevel.None},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.None}, OperatorType.Aggregate, PrivacyLevel.None},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.None}, OperatorType.NonAggregate, PrivacyLevel.PrivateAggregation},
+//			{new PrivacyLevel[]{PrivacyLevel.PrivateAggregation, PrivacyLevel.None}, OperatorType.Aggregate, PrivacyLevel.None},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.PrivateAggregation}, OperatorType.NonAggregate, PrivacyLevel.PrivateAggregation},
+//			{new PrivacyLevel[]{PrivacyLevel.None, PrivacyLevel.PrivateAggregation}, OperatorType.Aggregate, PrivacyLevel.None}
+//		};
+//		return Arrays.asList(data);
+//	}
+//}

--- a/src/test/java/org/apache/sysds/test/functions/privacy/propagation/MatrixMultiplicationPropagatorTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/privacy/propagation/MatrixMultiplicationPropagatorTest.java
@@ -1,0 +1,604 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.sysds.test.functions.privacy.propagation;
+//
+//import static org.junit.Assert.assertArrayEquals;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertTrue;
+//
+//import java.util.List;
+//import java.util.Map;
+//import java.util.stream.Stream;
+//
+//import org.apache.sysds.runtime.data.DenseBlock;
+//import org.apache.sysds.runtime.data.DenseBlockLFP64;
+//import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint;
+//import org.apache.sysds.runtime.privacy.PrivacyConstraint.PrivacyLevel;
+//import org.apache.sysds.runtime.privacy.finegrained.DataRange;
+//import org.apache.sysds.runtime.privacy.propagation.MatrixMultiplicationPropagator;
+//import org.apache.sysds.runtime.privacy.propagation.MatrixMultiplicationPropagatorNaive;
+//import org.apache.sysds.runtime.privacy.propagation.MatrixMultiplicationPropagatorPrivateFirst;
+//import org.apache.sysds.runtime.privacy.propagation.MatrixMultiplicationPropagatorPrivateFirstOptimized;
+//import org.apache.sysds.runtime.privacy.propagation.OperatorType;
+//import org.apache.sysds.test.AutomatedTestBase;
+//import org.junit.Test;
+//
+//public class MatrixMultiplicationPropagatorTest extends AutomatedTestBase {
+//
+//	@Override
+//	public void setUp() {
+//		// TODO Auto-generated method stub
+//
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmGeneralNoFineGrainedGeneralized(constraint1,constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained2(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrainedNaive(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmGeneralNoFineGrainedGeneralized(constraint1,constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained2Naive(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained3(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained3Naive(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained4(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained4Naive(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained5(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNoFineGrained5Naive(){
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.PrivateAggregation);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint(PrivacyLevel.Private);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmGeneralNoFineGrainedGeneralized(constraint1, constraint2, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneral(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneral2() {
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralNaive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneral2Naive() {
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneralPrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateGeneral2PrivateFirstOptimized() {
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		mmPropagationPrivateGeneralized(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrained(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmPropagationTestPrivateFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrainedNaive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmPropagationTestPrivateFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrainedPrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		mmPropagationTestPrivateFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrained2(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmPropagationTestPrivateFineGrained2Generalized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrained2Naive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmPropagationTestPrivateFineGrained2Generalized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivateFineGrained2PrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		mmPropagationTestPrivateFineGrained2Generalized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivatePrivateAggregationFineGrained(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		mmPropagationTestPrivatePrivateAggregationFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivatePrivateAggregationFineGrainedNaive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		mmPropagationTestPrivatePrivateAggregationFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestPrivatePrivateAggregationFineGrainedPrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		mmPropagationTestPrivatePrivateAggregationFineGrainedGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesRowTest(){
+//		int rows = 4;
+//		int cols = 2;
+//		MatrixBlock m1 = getMatrixBlock(rows, cols);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst(m1, null, null, null);
+//		OperatorType[] actual = propagator.getOperatorTypesRow();
+//		OperatorType[] expected = Stream.generate(() -> OperatorType.Aggregate).limit(rows).toArray(OperatorType[]::new);
+//		assertArrayEquals("All values should be OperatorType.Aggregate", expected, actual);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesRowNonAggTest(){
+//		int rows = 4;
+//		int cols = 2;
+//		int nonAggRow = 2;
+//		MatrixBlock m1 = getMatrixBlock(rows, cols);
+//		// Make a single row NNZ=1
+//		m1.getDenseBlock().set(nonAggRow,0,0);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst(m1, null, null, null);
+//		OperatorType[] actualArray = propagator.getOperatorTypesRow();
+//		OperatorType expected = OperatorType.NonAggregate;
+//		assertEquals("All values except one should be OperatorType.Aggregate", expected, actualArray[nonAggRow]);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesRowMultipleNonAggTest(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		getOperatorTypesRowMultipleNonAggTestGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesColTest(){
+//		int rows = 2;
+//		int cols = 3;
+//		MatrixBlock m2 = getMatrixBlock(rows, cols);
+//
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst(null, null, m2, null);
+//		OperatorType[] actual = propagator.getOperatorTypesCol();
+//		OperatorType[] expected = Stream.generate(() -> OperatorType.Aggregate).limit(cols).toArray(OperatorType[]::new);
+//		assertArrayEquals("All values should be OperatorType.Aggregate", expected, actual);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesColNonAggTest(){
+//		int rows = 2;
+//		int cols = 3;
+//		int nonAggCol = 1;
+//		MatrixBlock m2 = getMatrixBlock(rows, cols);
+//		// Make a single col NNZ=1
+//		m2.getDenseBlock().set(0,nonAggCol,0);
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst(null, null, m2, null);
+//		OperatorType[] actualArray = propagator.getOperatorTypesCol();
+//		OperatorType expected = OperatorType.NonAggregate;
+//		assertEquals("All values except one should be OperatorType.Aggregate", expected, actualArray[nonAggCol]);
+//	}
+//
+//	@Test
+//	public void getOperatorTypesColMultipleNonAggTest(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		getOperatorTypesColMultipleNonAggTestGeneralized(propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAgg(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivate(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggNaive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivateNaive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivateOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivatePrivateOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAgg2(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedColTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivate2(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedColTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAgg2Naive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedColTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivate2Naive(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedColTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAgg2PrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedColTest(PrivacyLevel.PrivateAggregation, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggPrivate2PrivateFirstOptimized(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedColTest(PrivacyLevel.Private, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColNA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, true, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColNAA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirst();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, false, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColNaiveNA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, true, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColNaiveNAA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorNaive();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, false, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColPrivateFirstOptimizedNA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, true, propagator);
+//	}
+//
+//	@Test
+//	public void mMPTestNonAggRowColPrivateFirstOptimizedNAA(){
+//		MatrixMultiplicationPropagator propagator = new MatrixMultiplicationPropagatorPrivateFirstOptimized();
+//		NonAggGeneralizedRowColTest(PrivacyLevel.PrivateAggregation, false, propagator);
+//	}
+//
+//	private static void mmGeneralNoFineGrainedGeneralized(PrivacyConstraint constraint1, PrivacyConstraint constraint2, MatrixMultiplicationPropagator propagator){
+//		MatrixBlock inputMatrix1 = new MatrixBlock(10,20,15);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(20,30,12);
+//		propagator.setFields(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		assertTrue("Privacy should be set to Private", mergedConstraint.hasPrivateElements());
+//		assertFalse("Fine grained constraint should not be propagated", mergedConstraint.hasFineGrainedConstraints());
+//	}
+//
+//	private static void mmPropagationPrivateGeneralized(PrivacyLevel fineGrainedPrivacyLevel, MatrixMultiplicationPropagator propagator){
+//		MatrixBlock inputMatrix1 = new MatrixBlock(10,20,15);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(20,30,12);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint(PrivacyLevel.Private);
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{3,8},new long[]{2,5}), fineGrainedPrivacyLevel);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		propagator.setFields(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		assertTrue("Privacy should be set to Private", mergedConstraint.hasPrivateElements());
+//		assertFalse("Fine grained constraint should not be propagated", mergedConstraint.hasFineGrainedConstraints());
+//	}
+//
+//	private static void mmPropagationTestPrivateFineGrainedGeneralized(MatrixMultiplicationPropagator propagator){
+//		MatrixBlock inputMatrix1 = new MatrixBlock(4,3,2);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(3,3,4);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		propagator.setFields(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		assertTrue("Privacy should be set to Private", mergedConstraint.hasPrivateElements());
+//		assertTrue("Fine grained constraint should not be propagated", mergedConstraint.hasFineGrainedConstraints());
+//		assertTrue("Merged constraint should not contain privacy level PrivateAggregation", mergedConstraint.getFineGrainedPrivacy().getDataRangesOfPrivacyLevel(PrivacyLevel.PrivateAggregation).length == 0);
+//		Map<DataRange, PrivacyLevel> outputElement1 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,0});
+//		Map<DataRange, PrivacyLevel> outputElement2 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,1});
+//		Map<DataRange, PrivacyLevel> outputElement3 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,2});
+//		assertEquals(1, outputElement1.size());
+//		assertEquals(1, outputElement2.size());
+//		assertEquals(1, outputElement3.size());
+//		assertTrue("Privacy level of element 1 is Private", outputElement1.containsValue(PrivacyLevel.Private));
+//		assertTrue("Privacy level of element 2 is Private", outputElement2.containsValue(PrivacyLevel.Private));
+//		assertTrue("Privacy level of element 3 is Private", outputElement3.containsValue(PrivacyLevel.Private));
+//		Map<DataRange, PrivacyLevel> expectedEmpty = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{2,0}, new long[]{3,2}));
+//		assertTrue("Any other index has no privacy constraint", expectedEmpty.isEmpty() ||
+//			(!expectedEmpty.containsValue(PrivacyLevel.Private)
+//				&& !expectedEmpty.containsValue(PrivacyLevel.PrivateAggregation)));
+//	}
+//
+//	private static void mmPropagationTestPrivatePrivateAggregationFineGrainedGeneralized(MatrixMultiplicationPropagator propagator){
+//		//Build
+//		MatrixBlock inputMatrix1 = new MatrixBlock(4,3,2);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(3,3,4);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.PrivateAggregation);
+//
+//		//Execute
+//		propagator.setFields(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//
+//		//Assert
+//		assertTrue("Privacy should be set to Private", mergedConstraint.hasPrivateElements());
+//		assertTrue("Fine grained constraint should not be propagated", mergedConstraint.hasFineGrainedConstraints());
+//		assertTrue("Merged constraint should not contain privacy level PrivateAggregation", mergedConstraint.getFineGrainedPrivacy().getDataRangesOfPrivacyLevel(PrivacyLevel.PrivateAggregation).length == 0);
+//		Map<DataRange, PrivacyLevel> outputElement1 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,0});
+//		Map<DataRange, PrivacyLevel> outputElement2 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,1});
+//		Map<DataRange, PrivacyLevel> outputElement3 = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevelOfElement(new long[]{1,2});
+//		assertEquals(1, outputElement1.size());
+//		assertEquals(1, outputElement2.size());
+//		assertEquals(1, outputElement3.size());
+//		assertTrue("Privacy level of element 1 is Private", outputElement1.containsValue(PrivacyLevel.Private));
+//		assertTrue("Privacy level of element 2 is Private", outputElement2.containsValue(PrivacyLevel.Private));
+//		assertTrue("Privacy level of element 3 is Private", outputElement3.containsValue(PrivacyLevel.Private));
+//		Map<DataRange, PrivacyLevel> expectedEmpty = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{2,0}, new long[]{3,2}));
+//		assertTrue("Any other index has no privacy constraint", expectedEmpty.isEmpty() ||
+//			(!expectedEmpty.containsValue(PrivacyLevel.Private)
+//				&& !expectedEmpty.containsValue(PrivacyLevel.PrivateAggregation)));
+//	}
+//
+//	private static void mmPropagationTestPrivateFineGrained2Generalized(MatrixMultiplicationPropagator propagator){
+//		MatrixBlock inputMatrix1 = new MatrixBlock(4,3,2);
+//		MatrixBlock inputMatrix2 = new MatrixBlock(3,3,4);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().put(new DataRange(new long[]{1,0},new long[]{1,1}), PrivacyLevel.Private);
+//		propagator.setFields(inputMatrix1, constraint1, inputMatrix2, constraint2);
+//		PrivacyConstraint mergedConstraint = propagator.propagate();
+//		assertTrue("Privacy should be set to Private", mergedConstraint.hasPrivateElements());
+//		assertTrue("Fine grained constraint should not be propagated", mergedConstraint.hasFineGrainedConstraints());
+//		assertTrue("Merged constraint should not contain privacy level PrivateAggregation", mergedConstraint.getFineGrainedPrivacy().getDataRangesOfPrivacyLevel(PrivacyLevel.PrivateAggregation).length == 0);
+//		Map<DataRange, PrivacyLevel> outputRange = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{0,0},new long[]{3,1}));
+//		assertTrue("Privacy level is Private", outputRange.containsValue(PrivacyLevel.Private));
+//		Map<DataRange, PrivacyLevel> expectedEmpty = mergedConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{0,2}, new long[]{3,2}));
+//		assertTrue("Any other index has no privacy constraint", expectedEmpty.isEmpty() ||
+//			(!expectedEmpty.containsValue(PrivacyLevel.Private)
+//				&& !expectedEmpty.containsValue(PrivacyLevel.PrivateAggregation)));
+//	}
+//
+//	private static void getOperatorTypesRowMultipleNonAggTestGeneralized(MatrixMultiplicationPropagator propagator){
+//		int rows = 4;
+//		int cols = 2;
+//		int nonAggRow = 2;
+//		MatrixBlock m1 = getMatrixBlock(rows, cols);
+//		// Make two rows NNZ=1
+//		m1.getDenseBlock().set(nonAggRow,0,0);
+//		m1.getDenseBlock().set(nonAggRow+1,0,0);
+//		propagator.setFields(m1, null, null, null);
+//		OperatorType[] actualArray = propagator.getOperatorTypesRow();
+//		OperatorType expected = OperatorType.NonAggregate;
+//		assertEquals("All values except two should be OperatorType.Aggregate", expected, actualArray[nonAggRow]);
+//		assertEquals("All values except two should be OperatorType.Aggregate", expected, actualArray[nonAggRow+1]);
+//	}
+//
+//	private static void getOperatorTypesColMultipleNonAggTestGeneralized(MatrixMultiplicationPropagator propagator){
+//		int rows = 2;
+//		int cols = 3;
+//		int nonAggCol = 1;
+//		MatrixBlock m2 = getMatrixBlock(rows, cols);
+//		// Make two cols NNZ=1
+//		m2.getDenseBlock().set(0,nonAggCol,0);
+//		m2.getDenseBlock().set(0,nonAggCol+1,0);
+//		propagator.setFields(null, null, m2, null);
+//		OperatorType[] actualArray = propagator.getOperatorTypesCol();
+//		OperatorType expected = OperatorType.NonAggregate;
+//		assertEquals("All values except two should be OperatorType.Aggregate", expected, actualArray[nonAggCol]);
+//		assertEquals("All values except two should be OperatorType.Aggregate", expected, actualArray[nonAggCol+1]);
+//	}
+//
+//	private static MatrixBlock getMatrixBlock(int rows, int cols){
+//		DenseBlock denseM = new DenseBlockLFP64(new int[]{rows,cols});
+//		for ( int r = 0; r < rows; r++ ){
+//			for ( int c = 0; c < cols; c++ ){
+//				denseM.set(r,c,r+c+1);
+//			}
+//		}
+//		return new MatrixBlock(rows,cols,denseM);
+//	}
+//
+//	private static void NonAggGeneralizedTest(PrivacyLevel privacyLevel, MatrixMultiplicationPropagator propagator){
+//		int nonAggRow = 2;
+//		MatrixBlock m1 = getMatrixBlock(4,2);
+//		MatrixBlock m2 = getMatrixBlock(2, 3);
+//		m1.getDenseBlock().set(nonAggRow,0,0);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		constraint1.getFineGrainedPrivacy().putRow(nonAggRow,2,privacyLevel);
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		propagator.setFields(m1, constraint1, m2, constraint2);
+//		PrivacyConstraint mergedPrivacyConstraint = propagator.propagate();
+//		Map<DataRange, PrivacyLevel> constraints = mergedPrivacyConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{nonAggRow,0}, new long[]{nonAggRow,1}));
+//		assertTrue("Output constraints should contain the privacy level " + privacyLevel.toString(),
+//			constraints.containsValue(privacyLevel));
+//		if ( privacyLevel == PrivacyLevel.Private)
+//			assertFalse("Output constraints should not contain the privacy level PrivateAggregation",
+//				constraints.containsValue(PrivacyLevel.PrivateAggregation));
+//		else if ( privacyLevel == PrivacyLevel.PrivateAggregation )
+//			assertFalse("Output constraints should not contain the privacy level Private",
+//				constraints.containsValue(PrivacyLevel.Private));
+//	}
+//
+//	private static void NonAggGeneralizedColTest(PrivacyLevel privacyLevel, MatrixMultiplicationPropagator propagator){
+//		int nonAggCol = 2;
+//		MatrixBlock m1 = getMatrixBlock(4,2);
+//		MatrixBlock m2 = getMatrixBlock(2, 3);
+//		m2.getDenseBlock().set(0,nonAggCol,0);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		constraint2.getFineGrainedPrivacy().putCol(nonAggCol,4,privacyLevel);
+//		propagator.setFields(m1, constraint1, m2, constraint2);
+//		PrivacyConstraint mergedPrivacyConstraint = propagator.propagate();
+//		Map<DataRange, PrivacyLevel> constraints = mergedPrivacyConstraint.getFineGrainedPrivacy().getPrivacyLevel(new DataRange(new long[]{0,nonAggCol}, new long[]{3,nonAggCol}));
+//		assertTrue("Output constraints should contain the privacy level " + privacyLevel.toString(),
+//			constraints.containsValue(privacyLevel));
+//		if ( privacyLevel == PrivacyLevel.Private)
+//			assertFalse("Output constraints should not contain the privacy level PrivateAggregation",
+//				constraints.containsValue(PrivacyLevel.PrivateAggregation));
+//		else if ( privacyLevel == PrivacyLevel.PrivateAggregation )
+//			assertFalse("Output constraints should not contain the privacy level Private",
+//				constraints.containsValue(PrivacyLevel.Private));
+//	}
+//
+//	private static void NonAggGeneralizedRowColTest(PrivacyLevel privacyLevel, boolean putElement, MatrixMultiplicationPropagator propagator){
+//		int nonAgg = 2;
+//		MatrixBlock m1 = getMatrixBlock(4,2);
+//		MatrixBlock m2 = getMatrixBlock(2, 3);
+//		m1.getDenseBlock().set(nonAgg,0,0);
+//		PrivacyConstraint constraint1 = new PrivacyConstraint();
+//		PrivacyConstraint constraint2 = new PrivacyConstraint();
+//		if (putElement)
+//			constraint2.getFineGrainedPrivacy().putElement(0,1, privacyLevel);
+//		else constraint2.getFineGrainedPrivacy().putCol(1,2,privacyLevel);
+//		propagator.setFields(m1, constraint1, m2, constraint2);
+//		PrivacyConstraint mergedPrivacyConstraint = propagator.propagate();
+//
+//		// Check output
+//		List<Map.Entry<DataRange, PrivacyLevel>> constraints = mergedPrivacyConstraint.getFineGrainedPrivacy().getAllConstraintsList();
+//		int privacyLevelSum = 0;
+//		DataRange levelRange = null;
+//		PrivacyLevel level = PrivacyLevel.None;
+//		for ( Map.Entry<DataRange, PrivacyLevel> constraint : constraints )
+//			if ( constraint.getValue() == privacyLevel ){
+//				privacyLevelSum++;
+//				levelRange = constraint.getKey();
+//				level = constraint.getValue();
+//			}
+//
+//		assertEquals("Output constraint should only contain one privacy level which is not none", 1,privacyLevelSum);
+//		assertEquals(new DataRange(new long[]{2,1},new long[]{2,1}), levelRange);
+//		assertEquals("Output constraints should contain the privacy level " + privacyLevel.toString(), privacyLevel,
+//			level);
+//	}
+//}


### PR DESCRIPTION
The test code for FED Privacy, which was previously removed in commit d9822ce9c7eb26412c00cbcaf0decc11e02ae533, has been restored. Moving forward, we plan to implement FED Privacy features incrementally in a bottom-up approach and aim to pass each of these test cases one by one as the functionality is developed.

- Currently, all FED Privacy implementations have been removed, and as a result, the restored test code cannot be compiled or executed at this stage. 
- Instead of using the `@Ignore` annotation for the tests, all restored test code has been commented out to avoid build or runtime issues.

This pull request focuses solely on restoring the test code for future development and testing purposes.