### PR TITLE
[SYSTEMDS-3701] Add additional text representations to Scuro

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -114,6 +114,8 @@ jobs:
           torch \
           librosa \
           h5py \
+          nltk \
+          gensim \
           black
 
     - name: Build Python Package

--- a/src/main/python/systemds/scuro/representations/bow.py
+++ b/src/main/python/systemds/scuro/representations/bow.py
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import pandas as pd
+from sklearn.feature_extraction.text import CountVectorizer
+
+from systemds.scuro.representations.unimodal import UnimodalRepresentation
+from systemds.scuro.representations.utils import read_data_from_file, save_embeddings
+
+
+class BoW(UnimodalRepresentation):
+    def __init__(self, ngram_range, min_df, output_file=None):
+        super().__init__("BoW")
+        self.ngram_range = ngram_range
+        self.min_df = min_df
+        self.output_file = output_file
+
+    def parse_all(self, filepath, indices):
+        vectorizer = CountVectorizer(
+            ngram_range=(1, self.ngram_range), min_df=self.min_df
+        )
+
+        segments = read_data_from_file(filepath, indices)
+        X = vectorizer.fit_transform(segments.values())
+        X = X.toarray()
+
+        if self.output_file is not None:
+            df = pd.DataFrame(X)
+            df.index = segments.keys()
+
+            save_embeddings(df, self.output_file)
+
+        return X

--- a/src/main/python/systemds/scuro/representations/glove.py
+++ b/src/main/python/systemds/scuro/representations/glove.py
@@ -1,0 +1,66 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+import nltk
+import numpy as np
+from nltk import word_tokenize
+
+from systemds.scuro.representations.unimodal import UnimodalRepresentation
+from systemds.scuro.representations.utils import read_data_from_file, save_embeddings
+
+
+def load_glove_embeddings(file_path):
+    embeddings = {}
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line in f:
+            values = line.split()
+            word = values[0]
+            vector = np.asarray(values[1:], dtype="float32")
+            embeddings[word] = vector
+    return embeddings
+
+
+class GloVe(UnimodalRepresentation):
+    def __init__(self, glove_path, output_file=None):
+        super().__init__("GloVe")
+        self.glove_path = glove_path
+        self.output_file = output_file
+
+    def parse_all(self, filepath, indices):
+        glove_embeddings = load_glove_embeddings(self.glove_path)
+        segments = read_data_from_file(filepath, indices)
+
+        embeddings = {}
+        for k, v in segments.items():
+            tokens = word_tokenize(v.lower())
+            embeddings[k] = np.mean(
+                [
+                    glove_embeddings[token]
+                    for token in tokens
+                    if token in glove_embeddings
+                ],
+                axis=0,
+            )
+
+        if self.output_file is not None:
+            save_embeddings(embeddings, self.output_file)
+
+        embeddings = np.array(list(embeddings.values()))
+        return embeddings

--- a/src/main/python/systemds/scuro/representations/tfidf.py
+++ b/src/main/python/systemds/scuro/representations/tfidf.py
@@ -1,0 +1,48 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+from systemds.scuro.representations.unimodal import UnimodalRepresentation
+from systemds.scuro.representations.utils import read_data_from_file, save_embeddings
+
+
+class TfIdf(UnimodalRepresentation):
+    def __init__(self, min_df, output_file=None):
+        super().__init__("TF-IDF")
+        self.min_df = min_df
+        self.output_file = output_file
+
+    def parse_all(self, filepath, indices):
+        vectorizer = TfidfVectorizer(min_df=self.min_df)
+
+        segments = read_data_from_file(filepath, indices)
+        X = vectorizer.fit_transform(segments.values())
+        X = X.toarray()
+
+        if self.output_file is not None:
+            df = pd.DataFrame(X)
+            df.index = segments.keys()
+
+            save_embeddings(df, self.output_file)
+
+        return X

--- a/src/main/python/systemds/scuro/representations/utils.py
+++ b/src/main/python/systemds/scuro/representations/utils.py
@@ -18,6 +18,8 @@
 # under the License.
 #
 # -------------------------------------------------------------
+import os
+import pickle
 
 import numpy as np
 
@@ -33,3 +35,39 @@ def pad_sequences(sequences, maxlen=None, dtype="float32", value=0):
         result[i, : len(data)] = data
 
     return result
+
+
+def get_segments(data, key_prefix):
+    segments = {}
+    counter = 1
+    for line in data:
+        line = line.replace("\n", "")
+        segments[key_prefix + str(counter)] = line
+        counter += 1
+
+    return segments
+
+
+def read_data_from_file(filepath, indices):
+    data = {}
+
+    is_dir = True if os.path.isdir(filepath) else False
+
+    if is_dir:
+        files = os.listdir(filepath)
+
+        # get file extension
+        _, ext = os.path.splitext(files[0])
+        for key in indices:
+            with open(filepath + key + ext) as segm:
+                data.update(get_segments(segm, key + "_"))
+    else:
+        with open(filepath) as file:
+            data.update(get_segments(file, ""))
+
+    return data
+
+
+def save_embeddings(data, file_name):
+    with open(file_name, "wb") as file:
+        pickle.dump(data, file)

--- a/src/main/python/systemds/scuro/representations/word2vec.py
+++ b/src/main/python/systemds/scuro/representations/word2vec.py
@@ -1,0 +1,65 @@
+# -------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+import numpy as np
+
+from systemds.scuro.representations.unimodal import UnimodalRepresentation
+from systemds.scuro.representations.utils import read_data_from_file, save_embeddings
+from gensim.models import Word2Vec
+from nltk.tokenize import word_tokenize
+import nltk
+
+
+def get_embedding(sentence, model):
+    vectors = []
+    for word in sentence:
+        if word in model.wv:
+            vectors.append(model.wv[word])
+
+    return np.mean(vectors, axis=0) if vectors else np.zeros(model.vector_size)
+
+
+class W2V(UnimodalRepresentation):
+    def __init__(self, vector_size, min_count, window, output_file=None):
+        super().__init__("Word2Vec")
+        self.vector_size = vector_size
+        self.min_count = min_count
+        self.window = window
+        self.output_file = output_file
+
+    def parse_all(self, filepath, indices):
+        segments = read_data_from_file(filepath, indices)
+        embeddings = {}
+        t = [word_tokenize(s.lower()) for s in segments.values()]
+        model = Word2Vec(
+            sentences=t,
+            vector_size=self.vector_size,
+            window=self.window,
+            min_count=self.min_count,
+        )
+
+        for k, v in segments.items():
+            tokenized_words = word_tokenize(v.lower())
+            embeddings[k] = get_embedding(tokenized_words, model)
+
+        if self.output_file is not None:
+            save_embeddings(embeddings, self.output_file)
+
+        return np.array(list(embeddings.values()))

--- a/src/main/python/tests/scuro/data_generator.py
+++ b/src/main/python/tests/scuro/data_generator.py
@@ -36,7 +36,7 @@ class TestDataGenerator:
         self.balanced = balanced
 
         for modality in modalities:
-            mod_path = f"{self.path}/{modality.name.lower()}"
+            mod_path = f"{self.path}/{modality.name.lower()}/"
             os.mkdir(mod_path)
             modality.file_path = mod_path
         self.labels = []


### PR DESCRIPTION
This PR adds additional text representations like Bag-of-Words, Word2Vec, TF-IDF, and Glove to Scuro. They will be used in DRSearch to find the best unimodal representations for text data. 