### PR TITLE
[MINOR] Include HASH Type in HighestCommonType

### DIFF
--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -322,10 +322,12 @@ public interface Types {
 					}
 				case FP64:
 					switch(b) {
-						case UNKNOWN:
-							return a;
+						case HASH64:
+						case HASH32:
 						case CHARACTER:
 							return STRING;
+						case UNKNOWN:
+							return a;
 						case STRING:
 							return b;
 						default:
@@ -333,6 +335,8 @@ public interface Types {
 					}
 				case FP32:
 					switch(b) {
+						case HASH64:
+						case HASH32:
 						case CHARACTER:
 							return STRING;
 						case STRING:
@@ -344,6 +348,9 @@ public interface Types {
 					}
 				case INT64:
 					switch(b) {
+						case HASH64:
+						case HASH32:
+							return b;
 						case CHARACTER:
 							return STRING;
 						case STRING:
@@ -356,6 +363,9 @@ public interface Types {
 					}
 				case INT32:
 					switch(b) {
+						case HASH64:
+						case HASH32:
+							return b;
 						case CHARACTER:
 							return STRING;
 						case STRING:
@@ -369,6 +379,9 @@ public interface Types {
 					}
 				case UINT4:
 					switch(b) {
+						case HASH64:
+						case HASH32:
+							return b;
 						case CHARACTER:
 							return STRING;
 						case STRING:
@@ -384,6 +397,9 @@ public interface Types {
 					}
 				case UINT8:
 					switch(b) {
+						case HASH64:
+						case HASH32:
+							return b;
 						case CHARACTER:
 							return STRING;
 						case STRING:

--- a/src/test/java/org/apache/sysds/test/component/misc/TypeTest.java
+++ b/src/test/java/org/apache/sysds/test/component/misc/TypeTest.java
@@ -369,6 +369,91 @@ public class TypeTest {
 	}
 
 	@Test
+	public void getHighestCommonTypeSTRING_HASH32() {
+		assertEquals(ValueType.STRING, hct(ValueType.STRING, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeSTRING_HASH64() {
+		assertEquals(ValueType.STRING, hct(ValueType.STRING, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeUINT8_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.UINT8, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeUINT4_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.UINT4, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeINT_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.INT32, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeINT64_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.INT64, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeFP32_HASH64() {
+		assertEquals(ValueType.STRING, hct(ValueType.FP32, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeFP64_HASH64() {
+		assertEquals(ValueType.STRING, hct(ValueType.FP64, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeHASH32_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.HASH32, ValueType.HASH64));
+	}
+
+	@Test
+	public void getHighestCommonTypeUINT8_HASH32() {
+		assertEquals(ValueType.HASH32, hct(ValueType.UINT8, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeUINT4_HASH32() {
+		assertEquals(ValueType.HASH32, hct(ValueType.UINT4, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeINT_HASH32() {
+		assertEquals(ValueType.HASH32, hct(ValueType.INT32, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeINT64_HASH32() {
+		assertEquals(ValueType.HASH32, hct(ValueType.INT64, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeFP32_HASH32() {
+		assertEquals(ValueType.STRING, hct(ValueType.FP32, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeFP64_HASH32() {
+		assertEquals(ValueType.STRING, hct(ValueType.FP64, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeHASH32_HASH32() {
+		assertEquals(ValueType.HASH32, hct(ValueType.HASH32, ValueType.HASH32));
+	}
+
+	@Test
+	public void getHighestCommonTypeHASH64_HASH64() {
+		assertEquals(ValueType.HASH64, hct(ValueType.HASH64, ValueType.HASH64));
+	}
+
+	@Test
 	public void isUnknownNot() {
 		assertFalse(ValueType.STRING.isUnknown());
 	}


### PR DESCRIPTION
This commit adds the HASH types to the switch statement for highestCommonType.