### PR TITLE
[MINOR] Federated timeout

### DIFF
--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -201,7 +201,7 @@ public class DMLConfig
 		_defaultVals.put(FLOATING_POINT_PRECISION, "double" );
 		_defaultVals.put(USE_SSL_FEDERATED_COMMUNICATION, "false");
 		_defaultVals.put(DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT, "10");
-		_defaultVals.put(FEDERATED_TIMEOUT,      "-1");
+		_defaultVals.put(FEDERATED_TIMEOUT,      "86400"); // default 1 day compute timeout.
 		_defaultVals.put(FEDERATED_PLANNER,      FederatedPlanner.RUNTIME.name());
 		_defaultVals.put(FEDERATED_PAR_CONN,     "-1"); // vcores
 		_defaultVals.put(FEDERATED_PAR_INST,     "-1"); // vcores

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedStatistics.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedStatistics.java
@@ -503,7 +503,8 @@ public class FederatedStatistics {
 		return new ArrayList<>(workerDataObjects.values());
 	}
 
-	public static void addEvent(EventModel event) {
+	public synchronized static void addEvent(EventModel event) { 
+		// synchronized, because multiple requests can be handled concurrently
 		workerEvents.add(event);
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -651,8 +651,7 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 		// get function and input parameters
 		try {
 			FederatedUDF udf = (FederatedUDF) request.getParam(0);
-			if(LOG.isDebugEnabled())
-				LOG.debug(udf);
+			LOG.debug(udf);
 
 			eventStage.operation = udf.getClass().getSimpleName();
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederationMap.java
@@ -26,7 +26,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -34,6 +36,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.fedplanner.FTypes.AlignType;
 import org.apache.sysds.hops.fedplanner.FTypes.FType;
 import org.apache.sysds.lops.RightIndex;
@@ -637,11 +640,25 @@ public class FederationMap {
 	 * @param forEachFunction function to execute for each pair
 	 */
 	public void forEachParallel(BiFunction<FederatedRange, FederatedData, Void> forEachFunction) {
-		ExecutorService pool = CommonThreadPool.get(_fedMap.size());
+		ExecutorService pool = Executors.newFixedThreadPool(_fedMap.size());
 		ArrayList<MappingTask> mappingTasks = new ArrayList<>();
 		for(Pair<FederatedRange, FederatedData> fedMap : _fedMap)
 			mappingTasks.add(new MappingTask(fedMap.getKey(), fedMap.getValue(), forEachFunction, _ID));
-		CommonThreadPool.invokeAndShutdown(pool, mappingTasks);
+
+		try {
+			for(Future<?> t:pool.invokeAll(mappingTasks, ConfigurationManager.getFederatedTimeout(), TimeUnit.SECONDS)){
+				if(!t.isDone())
+					throw new RuntimeException("Timeout");
+				else if(t.isCancelled())
+					throw new RuntimeException("Failed");
+			}
+		}
+		catch(InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		finally{
+			pool.shutdown();
+		}
 	}
 
 	/**
@@ -655,15 +672,25 @@ public class FederationMap {
 	 * @return the new <code>FederationMap</code>
 	 */
 	public FederationMap mapParallel(long newVarID, BiFunction<FederatedRange, FederatedData, Void> mappingFunction) {
-		ExecutorService pool = CommonThreadPool.get(_fedMap.size());
-
+		ExecutorService pool = Executors.newFixedThreadPool(_fedMap.size());
 		FederationMap fedMapCopy = copyWithNewID(_ID);
 		ArrayList<MappingTask> mappingTasks = new ArrayList<>();
 		for(Pair<FederatedRange, FederatedData> fedMap : fedMapCopy._fedMap)
 			mappingTasks.add(new MappingTask(fedMap.getKey(), fedMap.getValue(), mappingFunction, newVarID));
-		CommonThreadPool.invokeAndShutdown(pool, mappingTasks);
-		fedMapCopy._ID = newVarID;
-		return fedMapCopy;
+		try{
+			for(Future<?> t : pool.invokeAll(mappingTasks, ConfigurationManager.getFederatedTimeout(), TimeUnit.SECONDS)){
+				if(!t.isDone())
+					throw new RuntimeException("Timeout");
+				else if(t.isCancelled()){
+					throw new RuntimeException("Failed");
+				}
+			}
+			fedMapCopy._ID = newVarID;
+			return fedMapCopy;
+		}
+		catch(Exception e){
+			throw new RuntimeException(e);
+		}
 	}
 
 	public FederationMap filter(IndexRange ixrange) {

--- a/src/test/config/SystemDS-MultiTenant-config.xml
+++ b/src/test/config/SystemDS-MultiTenant-config.xml
@@ -21,6 +21,6 @@
    <!-- The timeout of the federated tests to initialize the federated matrixes -->
    <sysds.federated.initialization.timeout>30</sysds.federated.initialization.timeout>
    <!-- The timeout of each instruction sent to federated workers -->
-   <sysds.federated.timeout>128</sysds.federated.timeout>
+   <sysds.federated.timeout>16</sysds.federated.timeout>
    <sysds.local.spark>true</sysds.local.spark>
 </root>

--- a/src/test/config/SystemDS-config.xml
+++ b/src/test/config/SystemDS-config.xml
@@ -23,5 +23,5 @@
    <!-- The timeout of the federated tests to initialize the federated matrixes -->
    <sysds.federated.initialization.timeout>2</sysds.federated.initialization.timeout>
    <!-- The timeout of each instruction sent to federated workers -->
-   <sysds.federated.timeout>128</sysds.federated.timeout>
+   <sysds.federated.timeout>16</sysds.federated.timeout>
 </root>

--- a/src/test/java/org/apache/sysds/test/functions/codegen/RowVectorComparisonTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/codegen/RowVectorComparisonTest.java
@@ -128,6 +128,7 @@ public class RowVectorComparisonTest extends AutomatedTestBase
 	{	
 		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
 		ExecMode platformOld = setExecMode(instType);
+		setOutputBuffering(true);
 		
 		try
 		{

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part3/FederatedTokenizeTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part3/FederatedTokenizeTest.java
@@ -79,6 +79,7 @@ public class FederatedTokenizeTest extends AutomatedTestBase {
 
 	private void runAggregateOperationTest(ExecMode execMode) {
 		setExecMode(execMode);
+		setOutputBuffering(true);
 
 		String TEST_NAME = TEST_NAME1;
 


### PR DESCRIPTION
This commit reduce the timeout for federated tests, and enforce the timeout on federated requests. Previously we had some test cases that would infinitely run, and therefore we would not be able to decipher the log messages (because nothing would be written). This commit change it by enforcing a strict 16 seconds execution time for a single federated requests and a 1 day timeout for a default federated requests.
Previously some operations did use the federated timeout. However, it was not enforced in critical places.