### PR TITLE
[SYSTEMDS-3778] Introduce determinant computation primitives

### DIFF
--- a/src/main/java/org/apache/sysds/common/Builtins.java
+++ b/src/main/java/org/apache/sysds/common/Builtins.java
@@ -113,6 +113,7 @@ public enum Builtins {
 	DECISIONTREEPREDICT("decisionTreePredict", true),
 	DECOMPRESS("decompress", false),
 	DEEPWALK("deepWalk", true),
+	DET("det", false),
 	DETECTSCHEMA("detectSchema", false),
 	DENIALCONSTRAINTS("denialConstraints", true),
 	DIFFERENCESTATISTICS("differenceStatistics", true),

--- a/src/main/java/org/apache/sysds/common/Types.java
+++ b/src/main/java/org/apache/sysds/common/Types.java
@@ -539,7 +539,7 @@ public interface Types {
 		CAST_AS_FRAME, CAST_AS_LIST, CAST_AS_MATRIX, CAST_AS_SCALAR,
 		CAST_AS_BOOLEAN, CAST_AS_DOUBLE, CAST_AS_INT,
 		CEIL, CHOLESKY, COS, COSH, CUMMAX, CUMMIN, CUMPROD, CUMSUM,
-		CUMSUMPROD, DETECTSCHEMA, COLNAMES, EIGEN, EXISTS, EXP, FLOOR, INVERSE,
+		CUMSUMPROD, DET, DETECTSCHEMA, COLNAMES, EIGEN, EXISTS, EXP, FLOOR, INVERSE,
 		IQM, ISNA, ISNAN, ISINF, LENGTH, LINEAGE, LOG, NCOL, NOT, NROW,
 		MEDIAN, PREFETCH, PRINT, ROUND, SIN, SINH, SIGN, SOFTMAX, SQRT, STOP, _EVICT,
 		SVD, TAN, TANH, TYPEOF, TRIGREMOTE, SQRT_MATRIX_JAVA,
@@ -558,6 +558,7 @@ public interface Types {
 
 		public boolean isScalarOutput() {
 			return this == CAST_AS_SCALAR
+				|| this == DET
 				|| this == NROW || this == NCOL
 				|| this == LENGTH || this == EXISTS
 				|| this == IQM || this == LINEAGE
@@ -579,6 +580,7 @@ public interface Types {
 				case CUMPROD:         return "ucum*";
 				case CUMSUM:          return "ucumk+";
 				case CUMSUMPROD:      return "ucumk+*";
+				case DET:             return "det";
 				case DETECTSCHEMA:    return "detectSchema";
 				case MULT2:           return "*2";
 				case NOT:             return "!";

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -512,7 +512,8 @@ public class UnaryOp extends MultiThreadedHop
 		
 		//ensure cp exec type for single-node operations
 		if( _op == OpOp1.PRINT || _op == OpOp1.ASSERT || _op == OpOp1.STOP || _op == OpOp1.TYPEOF
-			|| _op == OpOp1.INVERSE || _op == OpOp1.EIGEN || _op == OpOp1.CHOLESKY || _op == OpOp1.SVD || _op == OpOp1.SQRT_MATRIX_JAVA
+			|| _op == OpOp1.INVERSE || _op == OpOp1.EIGEN || _op == OpOp1.CHOLESKY || _op == OpOp1.DET
+			||_op == OpOp1.SVD || _op == OpOp1.SQRT_MATRIX_JAVA
 			|| getInput().get(0).getDataType() == DataType.LIST || isMetadataOperation() )
 		{
 			_etype = ExecType.CP;

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
@@ -167,7 +167,7 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			hi = pushdownUnaryAggTransposeOperation(hop, hi, i); //e.g., colSums(t(X)) -> t(rowSums(X))
 			hi = pushdownCSETransposeScalarOperation(hop, hi, i);//e.g., a=t(X), b=t(X^2) -> a=t(X), b=t(X)^2 for CSE t(X)
 			hi = pushdownDetMultOperation(hop, hi, i);           //e.g., det(X%*%Y) -> det(X)*det(Y)
-			hi = pushdownDetScalarMatrixMultOperation(hop, hi, i);  //e.g., det(lambda*X) -> lambda^nrow*det(X)
+			hi = pushdownDetScalarMatrixMultOperation(hop, hi, i);  //e.g., det(lambda*X) -> lambda^nrow(X)*det(X)
 			hi = pushdownSumBinaryMult(hop, hi, i);              //e.g., sum(lambda*X) -> lambda*sum(X)
 			hi = pullupAbs(hop, hi, i);                          //e.g., abs(X)*abs(Y) --> abs(X*Y)
 			hi = simplifyUnaryPPredOperation(hop, hi, i);        //e.g., abs(ppred()) -> ppred(), others: round, ceil, floor

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteAlgebraicSimplificationStatic.java
@@ -159,12 +159,15 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			if(OptimizerUtils.ALLOW_OPERATOR_FUSION)
 				hi = simplifyMultiBinaryToBinaryOperation(hi);       //e.g., 1-X*Y -> X 1-* Y
 			hi = simplifyDistributiveBinaryOperation(hop, hi, i);//e.g., (X-Y*X) -> (1-Y)*X
+			hi = simplifyTransposeInDetOperation(hop, hi, i);    //e.g., det(t(X)) -> det(X)
 			hi = simplifyBushyBinaryOperation(hop, hi, i);       //e.g., (X*(Y*(Z%*%v))) -> (X*Y)*(Z%*%v)
 			hi = simplifyUnaryAggReorgOperation(hop, hi, i);     //e.g., sum(t(X)) -> sum(X)
 			hi = removeUnnecessaryAggregates(hi);                //e.g., sum(rowSums(X)) -> sum(X)
 			hi = simplifyBinaryMatrixScalarOperation(hop, hi, i);//e.g., as.scalar(X*s) -> as.scalar(X)*s;
 			hi = pushdownUnaryAggTransposeOperation(hop, hi, i); //e.g., colSums(t(X)) -> t(rowSums(X))
 			hi = pushdownCSETransposeScalarOperation(hop, hi, i);//e.g., a=t(X), b=t(X^2) -> a=t(X), b=t(X)^2 for CSE t(X)
+			hi = pushdownDetMultOperation(hop, hi, i);           //e.g., det(X%*%Y) -> det(X)*det(Y)
+			hi = pushdownDetScalarMatrixMultOperation(hop, hi, i);  //e.g., det(lambda*X) -> lambda^nrow*det(X)
 			hi = pushdownSumBinaryMult(hop, hi, i);              //e.g., sum(lambda*X) -> lambda*sum(X)
 			hi = pullupAbs(hop, hi, i);                          //e.g., abs(X)*abs(Y) --> abs(X*Y)
 			hi = simplifyUnaryPPredOperation(hop, hi, i);        //e.g., abs(ppred()) -> ppred(), others: round, ceil, floor
@@ -923,6 +926,29 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 	}
 
 	/**
+	 * det(t(X)) -> det(X)
+	 *
+	 * @param parent parent high-level operator
+	 * @param hi high-level operator
+	 * @param pos position
+	 * @return high-level operator
+	 */
+	private static Hop simplifyTransposeInDetOperation(Hop parent, Hop hi, int pos)
+	{
+		if(HopRewriteUtils.isUnary(hi, OpOp1.DET)
+				&& HopRewriteUtils.isReorg(hi.getInput(0), ReOrgOp.TRANS))
+		{
+			Hop operand = hi.getInput(0).getInput(0);
+			Hop uop = HopRewriteUtils.createUnary(operand, OpOp1.DET);
+			HopRewriteUtils.replaceChildReference(parent, hi, uop, pos);
+
+			LOG.debug("Applied simplifyTransposeInDetOperation.");
+			return uop;
+		}
+		return hi;
+	}
+
+	/**
 	 * t(Z)%*%(X*(Y*(Z%*%v))) -> t(Z)%*%(X*Y)*(Z%*%v)
 	 * t(Z)%*%(X+(Y+(Z%*%v))) -> t(Z)%*%((X+Y)+(Z%*%v))
 	 *
@@ -1160,6 +1186,65 @@ public class RewriteAlgebraicSimplificationStatic extends HopRewriteRule
 			}
 		}
 
+		return hi;
+	}
+
+	/**
+	 * det(X%*%Y) -> det(X)*det(Y)
+	 *
+	 * @param parent parent high-level operator
+	 * @param hi high-level operator
+	 * @param pos position
+	 * @return high-level operator
+	 */
+	private static Hop pushdownDetMultOperation(Hop parent, Hop hi, int pos) {
+		if( HopRewriteUtils.isUnary(hi, OpOp1.DET)
+				&& HopRewriteUtils.isMatrixMultiply(hi.getInput(0))
+				&& hi.getInput(0).getInput(0).isMatrix()
+				&& hi.getInput(0).getInput(1).isMatrix())
+		{
+			Hop operand1 = hi.getInput(0).getInput(0);
+			Hop operand2 = hi.getInput(0).getInput(1);
+			Hop uop1 = HopRewriteUtils.createUnary(operand1, OpOp1.DET);
+			Hop uop2 = HopRewriteUtils.createUnary(operand2, OpOp1.DET);
+			Hop bop = HopRewriteUtils.createBinary(uop1, uop2, OpOp2.MULT);
+			HopRewriteUtils.replaceChildReference(parent, hi, bop, pos);
+
+			LOG.debug("Applied pushdownDetMultOperation.");
+			return bop;
+		}
+		return hi;
+	}
+
+	/**
+	 * det(lambda*X) -> lambda^nrow*det(X)
+	 *
+	 * @param parent parent high-level operator
+	 * @param hi high-level operator
+	 * @param pos position
+	 * @return high-level operator
+	 */
+	private static Hop pushdownDetScalarMatrixMultOperation(Hop parent, Hop hi, int pos) {
+		if( HopRewriteUtils.isUnary(hi, OpOp1.DET)
+				&& HopRewriteUtils.isBinary(hi.getInput(0), OpOp2.MULT)
+				&& ((hi.getInput(0).getInput(0).isMatrix() && hi.getInput(0).getInput(1).isScalar())
+					|| (hi.getInput(0).getInput(0).isScalar() && hi.getInput(0).getInput(1).isMatrix())))
+		{
+			Hop operand1 = hi.getInput(0).getInput(0);
+			Hop operand2 = hi.getInput(0).getInput(1);
+
+			Hop lambda = (operand1.isScalar()) ? operand1 : operand2;
+			Hop matrix = (operand1.isMatrix()) ? operand1 : operand2;
+
+			Hop uopDet = HopRewriteUtils.createUnary(matrix, OpOp1.DET);
+			Hop uopNrow = HopRewriteUtils.createUnary(matrix, OpOp1.NROW);
+			Hop bopPow = HopRewriteUtils.createBinary(lambda, uopNrow, OpOp2.POW);
+			Hop bopMult = HopRewriteUtils.createBinary(bopPow, uopDet, OpOp2.MULT);
+			HopRewriteUtils.replaceChildReference(parent, hi, bopMult, pos);
+
+			LOG.debug("Applied pushdownDetScalarMatrixMultOperation.");
+			return bopMult;
+		}
 		return hi;
 	}
 

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -1302,6 +1302,17 @@ public class BuiltinFunctionExpression extends DataIdentifier {
 			output.setBlocksize(id.getBlocksize());
 			output.setValueType(id.getValueType());
 			break;
+		case DET:
+			checkNumParameters(1);
+			checkMatrixParam(getFirstExpr());
+			if ( id.getDim2() == -1 || id.getDim1() != id.getDim2() ) {
+				raiseValidateError("det requires a square matrix as first argument.", conditional, LanguageErrorCodes.INVALID_PARAMETERS);
+			}
+			output.setDataType(DataType.SCALAR);
+			output.setDimensions(0, 0);
+			output.setBlocksize(0);
+			output.setValueType(ValueType.FP64);
+			break;
 		case NROW:
 		case NCOL:
 		case LENGTH:

--- a/src/main/java/org/apache/sysds/parser/DMLTranslator.java
+++ b/src/main/java/org/apache/sysds/parser/DMLTranslator.java
@@ -2752,6 +2752,7 @@ public class DMLTranslator
 		case SQRT_MATRIX_JAVA:
 		case CHOLESKY:
 		case TYPEOF:
+		case DET:
 		case DETECTSCHEMA:
 		case COLNAMES:
 			currBuiltinOp = new UnaryOp(target.getName(), target.getDataType(),

--- a/src/main/java/org/apache/sysds/resource/cost/CPCostUtils.java
+++ b/src/main/java/org/apache/sysds/resource/cost/CPCostUtils.java
@@ -500,6 +500,7 @@ public class CPCostUtils {
 					case "cholesky":
 						costs = (1.0 / 3.0) * output.getCellsWithSparsity() * output.getCellsWithSparsity();
 						break;
+					case "det":
 					case "detectschema":
 					case "colnames":
 						throw new RuntimeException("Specific Frame operation with opcode '" + opcode + "' is not supported yet");

--- a/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/CPInstructionParser.java
@@ -210,6 +210,7 @@ public class CPInstructionParser extends InstructionParser {
 		String2CPInstructionType.put( "inverse", CPType.Unary);
 		String2CPInstructionType.put( "sqrt_matrix_java", CPType.Unary);
 		String2CPInstructionType.put( "cholesky",CPType.Unary);
+		String2CPInstructionType.put( "det", CPType.Unary);
 		String2CPInstructionType.put( "sprop", CPType.Unary);
 		String2CPInstructionType.put( "sigmoid", CPType.Unary);
 		String2CPInstructionType.put( "typeOf", CPType.Unary);

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryMatrixCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/UnaryMatrixCPInstruction.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.instructions.cp;
 
+import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
@@ -57,7 +58,13 @@ public class UnaryMatrixCPInstruction extends UnaryCPInstruction {
 		LineageItem lin = (!inObj.hasValidLineage() || !inObj.getCacheLineage().isLeaf() ||
 			CacheableData.isBelowCachingThreshold(retBlock)) ? null : 
 			getCacheLineageItem(inObj.getCacheLineage());
-		ec.setMatrixOutputAndLineage(output, retBlock, lin);
+		if (getOpcode().equals("det")){
+			var temp = ScalarObjectFactory.createScalarObject(ValueType.FP64, retBlock.get(0,0));
+			ec.setVariable(output.getName(), temp);
+		}
+		else {
+			ec.setMatrixOutputAndLineage(output, retBlock, lin);
+		}
 	}
 	
 	public LineageItem getCacheLineageItem(LineageItem input) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
@@ -80,7 +80,7 @@ public class LibCommonsMath
 	}
 	
 	public static boolean isSupportedUnaryOperation( String opcode ) {
-		return ( opcode.equals("inverse") || opcode.equals("cholesky") || opcode.equals("sqrt_matrix_java") );
+		return ( opcode.equals("inverse") || opcode.equals("cholesky") || opcode.equals("det") || opcode.equals("sqrt_matrix_java") );
 	}
 	
 	public static boolean isSupportedMultiReturnOperation( String opcode ) {
@@ -111,6 +111,8 @@ public class LibCommonsMath
 			return computeMatrixInverse(matrixInput);
 		else if (opcode.equals("cholesky"))
 			return computeCholesky(matrixInput);
+		else if (opcode.equals("det"))
+			return computeDeterminant(matrixInput);
 		else if (opcode.equals("sqrt_matrix_java"))
 			return computeSqrt(inj);
 		return null;
@@ -560,6 +562,151 @@ public class LibCommonsMath
 			CholeskyDecomposition.DEFAULT_ABSOLUTE_POSITIVITY_THRESHOLD);
 		RealMatrix rmL = cholesky.getL();
 		return DataConverter.convertToMatrixBlock(rmL.getData());
+	}
+
+	/**
+	 * Function to compute the determinant of a square matrix.
+	 * 
+	 * @param in Array2DRowRealMatrix object
+	 * @return determinant of the matrix as a 1x1 Matrixblock
+	 */
+	private static MatrixBlock computeDeterminant(Array2DRowRealMatrix in) {
+		if(!in.isSquare()) {
+			throw new DMLRuntimeException("Determinant can only be computed for a square matrix. Input matrix is rectangular");
+		}
+
+		final int useBuiltinStrategy = 0;
+		final int useGaussianStrategy = 1;
+		final int useBareissStrategy = 2;
+		final int useLaplaceStrategy = 3;
+		int computationStrategy = useBuiltinStrategy;
+
+		double determinant = 0;
+		switch (computationStrategy) {
+			case useGaussianStrategy:
+				double[][] matrix = in.getData();
+				int size = in.getRowDimension();
+				determinant = 1.0;
+				int swapCount = 0;
+
+				// create upper triangular matrix
+				for (int pivotRow = 0; pivotRow < size; pivotRow++) {
+
+					// Find a non-zero pivot in current column
+					boolean nonZeroPivotFound = false;
+					for (int swapRow = pivotRow; swapRow < size; swapRow++) {
+						if (Math.abs(matrix[swapRow][pivotRow]) > 1e-9) { // small epsilon for fp comparison
+							// Swap rows if necessary to move pivot to diagonal position
+							if (swapRow != pivotRow) {
+								double[] tempRow = matrix[swapRow];
+								matrix[swapRow] = matrix[pivotRow];
+								matrix[pivotRow] = tempRow;
+								swapCount = swapCount + 1;
+							}
+							nonZeroPivotFound = true;
+							break;
+						}
+					}
+
+					if (!nonZeroPivotFound) {
+						// one diagonal element is 0, therefore the multiplication of the
+						// diagonal elements would be zero aswell
+						determinant = 0;
+						break;
+					}
+
+					// eliminate entries below pivot
+					for (int row = pivotRow + 1; row < size; row++) {
+						double factor = matrix[row][pivotRow] / matrix[pivotRow][pivotRow];
+
+						// update the row using the elimination factor
+						for (int col = pivotRow; col < size; col++) {
+							matrix[row][col] = matrix[row][col] - (factor * matrix[pivotRow][col]);
+						}
+					}
+				}
+
+				// Calculate product of diagonal elements
+				for (int i = 0; i < size; i++) {
+					determinant = determinant * matrix[i][i];
+				}
+				if (swapCount % 2 != 0) {
+					determinant = -determinant;
+				}
+				break;
+
+			case useLaplaceStrategy:
+				int length = in.getRowDimension();
+
+				// base case 2x2 matrix
+				if (length == 2) {
+					determinant = in.getEntry(0, 0) * in.getEntry(1, 1) - in.getEntry(0, 1) * in.getEntry(1, 0);
+					break;
+				}
+
+				// laplace expansion
+				for (int col = 0; col < length; col++) {
+					if (in.getEntry(0, col) == 0) {
+						// multiplication with zero results in zero
+						continue;
+					}
+					// Build submatrix
+					Array2DRowRealMatrix subMatrix = new Array2DRowRealMatrix(length - 1, length - 1);
+					for (int i = 1; i < length; i++) { // Skip first row
+						int subCol = 0;
+						for (int j = 0; j < length; j++) {
+							if (j == col) continue; // Skip current col
+							subMatrix.setEntry(i - 1, subCol, in.getEntry(i, j));
+							subCol++;
+						}
+					}
+					// recusive determinant calculation
+					int sign = (col % 2 == 0) ? 1 : -1;
+					double subDeterminant = computeDeterminant(subMatrix).get(0, 0);
+					determinant = determinant + sign * in.getEntry(0, col) * subDeterminant;
+				}
+				break;
+
+			case useBareissStrategy:
+				int n = in.getRowDimension();
+				int sign = 1;
+				for (int k = 0; k < n - 1; k++) {
+					if (0 == in.getEntry(k, k)) {
+						boolean found = false;
+						for (int m = k + 1; m < n; m++) {
+							if (0 == in.getEntry(m, k)) { continue; }
+							found = true;
+							sign = -1*sign;
+							double[] tmp = in.getRow(m);
+							in.setRow(m, in.getRow(k));
+							in.setRow(k, tmp);
+							break;
+						}
+						if (!found) {
+							in.getEntry(n - 1, n - 1);
+							break;
+						}
+					}
+
+					for (int i = k + 1; i < n; i++) {
+						for (int j = k + 1; j < n; j++) {
+							double den = (0 == k) ? 1 : in.getEntry(k-1, k-1);
+							double num = in.getEntry(i, j)*in.getEntry(k, k) - in.getEntry(i, k)*in.getEntry(k, j);
+							in.setEntry(i, j, num/den);
+						}
+					}
+				}
+				determinant = sign * in.getEntry(n - 1, n - 1);
+				break;
+			case useBuiltinStrategy:
+			default:
+				LUDecomposition ludecompose = new LUDecomposition(in);
+				determinant = ludecompose.getDeterminant();
+		}
+
+		MatrixBlock determinantResult = new MatrixBlock(1, 1, false);
+		determinantResult.set(0, 0, determinant);
+		return determinantResult;
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
@@ -579,7 +579,7 @@ public class LibCommonsMath
 		final int useGaussianStrategy = 1;
 		final int useBareissStrategy = 2;
 		final int useLaplaceStrategy = 3;
-		int computationStrategy = useBuiltinStrategy;
+		int computationStrategy = useGaussianStrategy;
 
 		double determinant = 0;
 		switch (computationStrategy) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
@@ -579,7 +579,7 @@ public class LibCommonsMath
 		final int useGaussianStrategy = 1;
 		final int useBareissStrategy = 2;
 		final int useLaplaceStrategy = 3;
-		int computationStrategy = useGaussianStrategy;
+		int computationStrategy = useBareissStrategy;
 
 		double determinant = 0;
 		switch (computationStrategy) {

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibCommonsMath.java
@@ -579,7 +579,7 @@ public class LibCommonsMath
 		final int useGaussianStrategy = 1;
 		final int useBareissStrategy = 2;
 		final int useLaplaceStrategy = 3;
-		int computationStrategy = useBareissStrategy;
+		int computationStrategy = useBuiltinStrategy;
 
 		double determinant = 0;
 		switch (computationStrategy) {

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteDetTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteDetTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.rewrite;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.common.Types.ExecType;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.utils.Statistics;
+
+import java.util.HashMap;
+
+public class RewriteDetTest extends AutomatedTestBase 
+{
+	private static final String TEST_NAME_MIXED = "RewriteDetMixed";
+	private static final String TEST_NAME_MULT = "RewriteDetMult";
+	private static final String TEST_NAME_TRANSPOSE = "RewriteDetTranspose";
+	private static final String TEST_NAME_SCALAR_MATRIX_MULT = "RewriteDetScalarMatrixMult";
+
+	private static final String TEST_DIR = "functions/rewrite/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + RewriteDetTest.class.getSimpleName() + "/";
+
+	private final static int rows = 23;
+	private final static double _sparsityDense = 0.7;
+	private final static double _sparsitySparse = 0.2;
+	private final static double eps = 1e-8;
+	
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME_MIXED, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_MIXED, new String[] { "d" }));
+		// det(A%*%B) -> det(A)*det(B)
+		addTestConfiguration(TEST_NAME_MULT, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_MULT, new String[] { "d" }));
+		// det(t(A)) -> det(A)
+		addTestConfiguration(TEST_NAME_TRANSPOSE, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME_TRANSPOSE, new String[] { "d" }));
+		// det(lambda*A) -> lambda^ncol*det(A)
+		// This is faster, because lambda is a scalar, that can be multiplied
+		// with in logarithmic time O(log(nrow(A))), whereas lambda needs to
+		// be multiplied to every element in A, which is O(nrow(A)^2)).
+		addTestConfiguration(TEST_NAME_SCALAR_MATRIX_MULT, new TestConfiguration(
+			TEST_CLASS_DIR, TEST_NAME_SCALAR_MATRIX_MULT, new String[] { "d" }));
+	}
+
+	@Test
+	public void testRewriteDetMixedSparseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_MIXED, false, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMixedSparseRewrite() {
+		runRewriteDetTest(TEST_NAME_MIXED, true, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMixedDenseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_MIXED, false, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMixedDenseRewrite() {
+		runRewriteDetTest(TEST_NAME_MIXED, true, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMultDenseRewrite() {
+		runRewriteDetTest(TEST_NAME_MULT, true, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMultSparseRewrite() {
+		runRewriteDetTest(TEST_NAME_MULT, true, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMultDenseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_MULT, false, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetMultSparseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_MULT, false, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetTransposeSparseRewrite() {
+		runRewriteDetTest(TEST_NAME_TRANSPOSE, true, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetTransposeDenseRewrite() {
+		runRewriteDetTest(TEST_NAME_TRANSPOSE, true, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetTransposeSparseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_TRANSPOSE, false, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetTransposeDenseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_TRANSPOSE, false, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetScalarMatrixMultDenseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_SCALAR_MATRIX_MULT, false, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetScalarMatrixMultSparseNoRewrite() {
+		runRewriteDetTest(TEST_NAME_SCALAR_MATRIX_MULT, false, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetScalarMatrixMultDenseRewrite() {
+		runRewriteDetTest(TEST_NAME_SCALAR_MATRIX_MULT, true, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRewriteDetScalarMatrixMultSparseRewrite() {
+		runRewriteDetTest(TEST_NAME_SCALAR_MATRIX_MULT, true, true, ExecType.CP);
+	}
+
+	private void runRewriteDetTest(String testScriptName, boolean rewrites, boolean sparse, ExecType et) {
+		// NOTE The sparsity of the matrix is considered, because rewrite
+		// simplifications could be made if the matrix contains a lot of zeros.
+		// Furthermore, some det-algorithms perform optimizations
+		// (early termination, less recursions, ...) when the matrix is sparse.
+		// Therefore dense and sparse matrices are part of the rewrite tests.
+
+		ExecMode platformOld = setExecMode(et);
+		boolean oldFlag = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+
+		try {
+			double sparsity = (sparse) ? _sparsitySparse : _sparsityDense;
+			getAndLoadTestConfiguration(testScriptName);
+
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = rewrites;
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + testScriptName + ".dml";
+
+			boolean twoMatrixArg = testScriptName.equals(TEST_NAME_MULT);
+			boolean oneMatrixOneScalarArg = testScriptName.equals(TEST_NAME_SCALAR_MATRIX_MULT);
+			boolean twoMatrixOneScalarArg = testScriptName.equals(TEST_NAME_MIXED);
+			if (twoMatrixArg) {
+				programArgs = new String[]{"-stats", "-args", input("A"), input("B"), output("d")};
+			}
+			else if (oneMatrixOneScalarArg) {
+				programArgs = new String[]{"-stats", "-args", input("A"), input("lambda"), output("d")};
+			}
+			else if (twoMatrixOneScalarArg) {
+				programArgs = new String[]{"-stats", "-args", input("A"), input("B"), input("lambda"), output("d")};
+			}
+			else {
+				programArgs = new String[]{"-stats", "-args", input("A"), output("d")};
+			}
+
+			fullRScriptName = HOME + testScriptName + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
+	
+			double[][] A = getRandomMatrix(rows, rows, -1, 1, sparsity, 21332);
+			writeInputMatrixWithMTD("A", A, true);
+			if (twoMatrixArg) {
+				double[][] B = getRandomMatrix(rows, rows, -1, 1, sparsity, 42422);
+				writeInputMatrixWithMTD("B", B, true);
+			}
+			else if (twoMatrixOneScalarArg) {
+				double[][] B = getRandomMatrix(rows, rows, -1, 1, sparsity, 4242);
+				writeInputMatrixWithMTD("B", B, true);
+				double[][] lambda = getRandomMatrix(1, 1, -1, 1, sparsity, 121);
+				writeInputMatrixWithMTD("lambda", lambda, true);
+			}
+			else if (oneMatrixOneScalarArg) {
+				double[][] lambda = getRandomMatrix(1, 1, -1, 1, sparsity, 121);
+				writeInputMatrixWithMTD("lambda", lambda, true);
+			}
+
+			runTest(true, false, null, -1);
+			runRScript(true);
+
+			HashMap<CellIndex, Double> dmlfile = readDMLScalarFromOutputDir("d");
+			HashMap<CellIndex, Double> rfile  = readRScalarFromExpectedDir("d");
+			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
+
+			if (rewrites) {
+				Assert.assertTrue(
+                    (!testScriptName.equals(TEST_NAME_TRANSPOSE) || !heavyHittersContainsString("r'"))
+					&& (!testScriptName.equals(TEST_NAME_MULT) || Statistics.getCPHeavyHitterCount("det") == 2)
+					&& (!testScriptName.equals(TEST_NAME_SCALAR_MATRIX_MULT) || heavyHittersContainsString("^"))
+					&& (!testScriptName.equals(TEST_NAME_MIXED) || (
+						Statistics.getCPHeavyHitterCount("det") == 2 && !heavyHittersContainsString("r'") && heavyHittersContainsString("^"))));
+			}
+		}
+		finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = oldFlag;
+			resetExecMode(platformOld);
+		}
+	}
+}
+

--- a/src/test/java/org/apache/sysds/test/functions/unary/matrix/DetTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/unary/matrix/DetTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.unary.matrix;
+
+import org.junit.Test;
+import org.apache.sysds.common.Types.ExecMode;
+import org.apache.sysds.parser.LanguageException;
+import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+
+import java.util.HashMap;
+
+
+public class DetTest extends AutomatedTestBase {
+
+	private static final String TEST_DIR = "functions/unary/matrix/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + DetTest.class.getSimpleName() + "/";
+	private static final String DML_SCRIPT_NAME = "DetTest";
+	private static final String R_SCRIPT_NAME = "DetTest";
+
+	private static final String TEST_NAME_WRONG_DIM = "WrongDimensionsTest";
+	private static final String TEST_NAME_DET_TEST = "DetTest";
+
+	// The number of rows and columns should not be chosen to be too large,
+	// because the calculation of the determinant can introduce rather large
+	// floating point errors with large row sizes, because there are many
+	// floating point operations involving both multiplication and addition.
+	private final static int rows = 23;
+	private final static double _sparsityDense = 0.7;
+	private final static double _sparsitySparse = 0.2;
+	private final static double eps = 1e-8;
+	
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME_WRONG_DIM, new TestConfiguration(TEST_CLASS_DIR, DML_SCRIPT_NAME, new String[] { "d" }));
+		addTestConfiguration(TEST_NAME_DET_TEST, new TestConfiguration(TEST_CLASS_DIR, DML_SCRIPT_NAME, new String[] { "d" }) );
+	}
+
+	@Test
+	public void testWrongDimensions() {
+		int wrong_rows = 10;
+		int wrong_cols = 9;
+		
+		TestConfiguration config = availableTestConfigurations.get(TEST_NAME_WRONG_DIM);
+		loadTestConfiguration(config);
+
+		String HOME = SCRIPT_DIR + TEST_DIR;
+		fullDMLScriptName = HOME + DML_SCRIPT_NAME + ".dml";
+		programArgs = new String[]{"-args", input("A"), output("d") };
+
+		double[][] A = getRandomMatrix(wrong_rows, wrong_cols, -1, 1, 0.5, 3);
+		writeInputMatrixWithMTD("A", A, true);
+		runTest(true, true, LanguageException.class, -1);
+	}
+
+	@Test
+	public void testDetMatrixDense() {
+		runDetTest(false);
+	}
+
+	@Test
+	public void testDetMatrixSparse() {
+		runDetTest(true);
+	}
+
+	private void runDetTest(boolean sparse) {
+		ExecMode platformOld = rtplatform;
+		rtplatform = ExecMode.HYBRID;
+		
+		try {
+			double sparsity = (sparse) ? _sparsitySparse : _sparsityDense;
+			getAndLoadTestConfiguration(TEST_NAME_DET_TEST);
+			
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + DML_SCRIPT_NAME + ".dml";
+			programArgs = new String[]{"-args", input("A"), output("d")};
+			
+			fullRScriptName = HOME + R_SCRIPT_NAME + ".R";
+			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
+	
+			double[][] A = getRandomMatrix(rows, rows, -1, 1, sparsity, 7);
+			writeInputMatrixWithMTD("A", A, true);
+	
+			runTest(true, false, null, -1);
+			runRScript(true);
+		
+			HashMap<CellIndex, Double> dmlfile = readDMLScalarFromOutputDir("d");
+			HashMap<CellIndex, Double> rfile  = readRScalarFromExpectedDir("d");
+			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
+		}
+		finally {
+			rtplatform = platformOld;
+		}
+	}
+}
+

--- a/src/test/scripts/functions/rewrite/RewriteDetMixed.R
+++ b/src/test/scripts/functions/rewrite/RewriteDetMixed.R
@@ -1,0 +1,34 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A <- readMM(paste(args[1], "A.mtx", sep=""));
+B <- readMM(paste(args[1], "B.mtx", sep=""));
+tmp_lambda <- readMM(paste(args[1], "lambda.mtx", sep=""));
+lambda <- as.double(tmp_lambda[1, 1]);
+d = det(lambda*t(t(A) %*% t(B)));
+write(d, paste(args[2], "d", sep=""));

--- a/src/test/scripts/functions/rewrite/RewriteDetMixed.dml
+++ b/src/test/scripts/functions/rewrite/RewriteDetMixed.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+A = read($1);
+B = read($2);
+lambda = as.scalar(read($3));
+d = det(lambda*t(t(A)%*%t(B)));
+write(d, $4);

--- a/src/test/scripts/functions/rewrite/RewriteDetMult.R
+++ b/src/test/scripts/functions/rewrite/RewriteDetMult.R
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A <- readMM(paste(args[1], "A.mtx", sep=""))
+B <- readMM(paste(args[1], "B.mtx", sep=""))
+d = det(A) * det(B);
+write(d, paste(args[2], "d", sep="")); 

--- a/src/test/scripts/functions/rewrite/RewriteDetMult.dml
+++ b/src/test/scripts/functions/rewrite/RewriteDetMult.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+A = read($1);
+B = read($2);
+d = det(A%*%B);
+write(d, $3);

--- a/src/test/scripts/functions/rewrite/RewriteDetScalarMatrixMult.R
+++ b/src/test/scripts/functions/rewrite/RewriteDetScalarMatrixMult.R
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A <- readMM(paste(args[1], "A.mtx", sep=""));
+tmp_lambda <- readMM(paste(args[1], "lambda.mtx", sep=""));
+lambda <- as.double(tmp_lambda[1, 1]);
+d = det(lambda*A);
+write(d, paste(args[2], "d", sep=""));

--- a/src/test/scripts/functions/rewrite/RewriteDetScalarMatrixMult.dml
+++ b/src/test/scripts/functions/rewrite/RewriteDetScalarMatrixMult.dml
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+A = read($1);
+lambda = as.scalar(read($2));
+d = det(lambda*A);
+write(d, $3);

--- a/src/test/scripts/functions/rewrite/RewriteDetTranspose.R
+++ b/src/test/scripts/functions/rewrite/RewriteDetTranspose.R
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A <- readMM(paste(args[1], "A.mtx", sep=""))
+d = det(t(A))
+write(d, paste(args[2], "d", sep="")); 

--- a/src/test/scripts/functions/rewrite/RewriteDetTranspose.dml
+++ b/src/test/scripts/functions/rewrite/RewriteDetTranspose.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.rewrite.RewriteDetTest.java
+
+A = read($1);
+d = det(t(A));
+write(d, $2);

--- a/src/test/scripts/functions/unary/matrix/DetTest.R
+++ b/src/test/scripts/functions/unary/matrix/DetTest.R
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.unary.matrix.DetTest.java
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A <- readMM(paste(args[1], "A.mtx", sep=""))
+d = det(A);
+write(d, paste(args[2], "d", sep="")); 

--- a/src/test/scripts/functions/unary/matrix/DetTest.dml
+++ b/src/test/scripts/functions/unary/matrix/DetTest.dml
@@ -1,0 +1,26 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# junit test class: org.apache.sysds.test.functions.unary.matrix.DetTest.java
+
+A = read($1);
+d = det(A);
+write(d, $2);


### PR DESCRIPTION
[SYSTEMDS-3778] Introduce determinant computation primitives

This PR introduces the computation of the determinant of a matrix. It
provides different strategies of computing those determinants. Internally
it is possible to switch between calculating the determinant using the
builtin LU decomposition of the commons math library, Gaussian algorithm,
Bareiss algorithm and Laplace expansion. Furthermore, static simplification
rewrites
- `det(t(X)) -> det(X)`
- `det(X%*%Y) -> det(X)*det(Y)`
- `det(lambda*X) -> lambda^nrow(X)*det(X)`

have been implemented.

All strategies have been benchmarked using 12x12-matrices. Very large matrices
can result in the laplace algorithm to take too long. The numbers consist
of the average execution time of three runs; with different matrix seeds
(7, 233, 4242). Furthermore, it we distinguish between sparse and dense matrices,
because each algorithm has its own way of optimizing for sparse matrices.
- LU decomposition:
	- Total execution time (Dense matrix): 0.403
	- Total execution time (Sparse matrix): 0.056
- Gaussian algorithm:
	- Total execution time (Dense matrix): 0.364
	- Total execution time (Sparse matrix): 0.049
- Bareiss algorithm:
	- Total execution time (Dense matrix): 0.370
	- Total execution time (Sparse matrix): 0.054
- Laplace expansion:
	- Total execution time (Dense matrix): 0.389
	- Total execution time (Sparse matrix): 6.553

Further observations:
- The Laplace expansion is slow for big matrices and should not be used.
- Gaussian algorithm is a bit faster than Bareiss algorithm and LU
decomposition.
- Analytical observation: The Bareiss algorithm can be more accurate, if whole
numbers are used, because the divisions in the algorithm have no remainder in
that case.
- Gaussian and Bareiss algorithm have larger deviations than eps if
the matrix is transposed `(det(t(X)) in R vs det(X) in SystemDS)`. The LU
decomposition does not have this issue. This could be an indicator that
the LU decomposition is more robust against floating-point errors.
- The Gaussian algorithm has higher floating-point error than 1e-8 in
comparison to the equivalent implementation in R. It does not pass the
test with matrix size of around 30x30. LU decomposition and Bareiss
algorithm are suspected to have lower floating-point errors.

It is adviced to never use the laplace expansion, because of its inefficiency;
the runtime is factorial. Those observations lead to using using the
LU decomposition because of its higher accuracy, despite being a bit slower
than the alternatives.

The reasoning `det(lambda*X) -> lambda^nrow(X)*det(X)` as rule is, that
computing the power of a scalar can be done in logarithmic time, whereas
the multiplication of a scalar with a matrix is quadratic. Another reason
for this simplification are simplifications of examples such as
`det(lambda*t(X)) -> lambda^nrow(X)*det(X)`, which would be harder to implement
without this simplification.