### PR TITLE
[SYSTEMDS-3824] Decompressing Transpose

### DIFF
--- a/scripts/builtin/kmeans.dml
+++ b/scripts/builtin/kmeans.dml
@@ -148,6 +148,7 @@ m_kmeans = function(Matrix[Double] X, Integer k = 10, Integer runs = 10, Integer
       P = D <= minD;
       # If some records belong to multiple centroids, share them equally
       P = P / rowSums (P);
+      # P = table(seq(1,num_records), rowIndexMin(D), num_records, num_centroids)
       # Compute the column normalization factor for P
       P_denom = colSums (P);
       # Compute new centroids as weighted averages over the records

--- a/src/main/java/org/apache/sysds/hops/TernaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/TernaryOp.java
@@ -651,6 +651,8 @@ public class TernaryOp extends MultiThreadedHop
 		
 		try
 		{
+			// TODO: to rewrite is not currently not triggered if outdim are given --> getInput().size()>=3
+			// currently disabled due performance decrease
 			if( getInput().size()==2 || (getInput().size()==3 && getInput().get(2).getDataType()==DataType.SCALAR) )
 			{
 				Hop input1 = getInput().get(0);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -251,7 +251,21 @@ public class ColGroupDDC extends APreAgg implements IMapToDataGroup {
 
 	@Override
 	protected void decompressToDenseBlockTransposedSparseDictionary(DenseBlock db, int rl, int ru, SparseBlock sb) {
-		throw new NotImplementedException();
+		for(int i = rl; i < ru; i++) {
+			final int vr = _data.getIndex(i);
+			if(sb.isEmpty(vr))
+				continue;
+			final int apos = sb.pos(vr);
+			final int alen = sb.size(vr) + apos;
+			final int[] aix = sb.indexes(vr);
+			final double[] aval = sb.values(vr);
+			for(int j = apos; j < alen; j++) {
+				final int rowOut = _colIndexes.get(aix[j]);
+				final double[] c = db.values(rowOut);
+				final int off = db.pos(rowOut);
+				c[off + i] += aval[j];
+			}
+		}
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReorg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReorg.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.compress.DMLCompressionException;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.data.SparseBlockMCSR;
+import org.apache.sysds.runtime.functionobjects.SwapIndex;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
+import org.apache.sysds.runtime.util.CommonThreadPool;
+
+public class CLALibReorg {
+
+	protected static final Log LOG = LogFactory.getLog(CLALibReorg.class.getName());
+
+	public static boolean warned = false;
+
+	public static MatrixBlock reorg(CompressedMatrixBlock cmb, ReorgOperator op, MatrixBlock ret, int startRow,
+		int startColumn, int length) {
+		// SwapIndex is transpose
+		if(op.fn instanceof SwapIndex && cmb.getNumColumns() == 1) {
+			MatrixBlock tmp = cmb.decompress(op.getNumThreads());
+			long nz = tmp.setNonZeros(tmp.getNonZeros());
+			if(tmp.isInSparseFormat())
+				return LibMatrixReorg.transpose(tmp); // edge case...
+			else
+				tmp = new MatrixBlock(tmp.getNumColumns(), tmp.getNumRows(), tmp.getDenseBlockValues());
+			tmp.setNonZeros(nz);
+			return tmp;
+		}
+		else if(op.fn instanceof SwapIndex) {
+			MatrixBlock tmp = cmb.getCachedDecompressed();
+			if(tmp != null)
+				return tmp.reorgOperations(op, ret, startRow, startColumn, length);
+            // Allow transpose to be compressed output. In general we need to have a transposed flag on
+            // the compressed matrix. https://issues.apache.org/jira/browse/SYSTEMDS-3025
+			return transpose(cmb, ret, op.getNumThreads());
+		}
+		else {
+			String message = !warned ? op.getClass().getSimpleName() + " -- " + op.fn.getClass().getSimpleName() : null;
+			MatrixBlock tmp = cmb.getUncompressed(message, op.getNumThreads());
+			warned = true;
+			return tmp.reorgOperations(op, ret, startRow, startColumn, length);
+		}
+	}
+
+	private static MatrixBlock transpose(CompressedMatrixBlock cmb, MatrixBlock ret, int k) {
+
+		final long nnz = cmb.getNonZeros();
+		final int nRow = cmb.getNumRows();
+		final int nCol = cmb.getNumColumns();
+		final boolean sparseOut = MatrixBlock.evalSparseFormatInMemory(nCol,nRow, nnz);
+		if(sparseOut)
+			return transposeSparse(cmb, ret, k, nRow, nCol, nnz);
+		else
+			return transposeDense(cmb, ret, k, nRow, nCol, nnz);
+	}
+
+	private static MatrixBlock transposeSparse(CompressedMatrixBlock cmb, MatrixBlock ret, int k, int nRow, int nCol,
+		long nnz) {
+		if(ret == null)
+			ret = new MatrixBlock(nCol, nRow, true, nnz);
+		else
+			ret.reset(nCol, nRow, true, nnz);
+
+		ret.allocateAndResetSparseBlock(true, SparseBlock.Type.MCSR);
+
+		final int nColOut = ret.getNumColumns();
+
+		if(k > 1 && cmb.getColGroups().size() > 1)
+			decompressToTransposedSparseParallel((SparseBlockMCSR) ret.getSparseBlock(), cmb.getColGroups(), nColOut, k);
+		else
+			decompressToTransposedSparseSingleThread((SparseBlockMCSR) ret.getSparseBlock(), cmb.getColGroups(), nColOut);
+
+		return ret;
+	}
+
+	private static MatrixBlock transposeDense(CompressedMatrixBlock cmb, MatrixBlock ret, int k, int nRow, int nCol,
+		long nnz) {
+		if(ret == null)
+			ret = new MatrixBlock(nCol, nRow, false, nnz);
+		else
+			ret.reset(nCol, nRow, false, nnz);
+
+		// TODO: parallelize
+		ret.allocateDenseBlock();
+
+		decompressToTransposedDense(ret.getDenseBlock(), cmb.getColGroups(), nRow, 0, nRow);
+		return ret;
+	}
+
+	private static void decompressToTransposedDense(DenseBlock ret, List<AColGroup> groups, int rlen, int rl, int ru) {
+		for(int i = 0; i < groups.size(); i++) {
+			AColGroup g = groups.get(i);
+			g.decompressToDenseBlockTransposed(ret, rl, ru);
+		}
+	}
+
+	private static void decompressToTransposedSparseSingleThread(SparseBlockMCSR ret, List<AColGroup> groups,
+		int nColOut) {
+		for(int i = 0; i < groups.size(); i++) {
+			AColGroup g = groups.get(i);
+			g.decompressToSparseBlockTransposed(ret, nColOut);
+		}
+	}
+
+	private static void decompressToTransposedSparseParallel(SparseBlockMCSR ret, List<AColGroup> groups, int nColOut,
+		int k) {
+		final ExecutorService pool = CommonThreadPool.get(k);
+		try {
+			final List<Future<?>> tasks = new ArrayList<>(groups.size());
+
+			for(int i = 0; i < groups.size(); i++) {
+				final AColGroup g = groups.get(i);
+				tasks.add(pool.submit(() -> g.decompressToSparseBlockTransposed(ret, nColOut)));
+			}
+
+			for(Future<?> f : tasks)
+				f.get();
+
+		}
+		catch(Exception e) {
+			throw new DMLCompressionException("Failed to parallel decompress transpose sparse", e);
+		}
+		finally {
+			pool.shutdown();
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibRexpand.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibRexpand.java
@@ -39,6 +39,7 @@ import org.apache.sysds.runtime.compress.colgroup.mapping.AMapToData;
 import org.apache.sysds.runtime.compress.colgroup.mapping.MapToFactory;
 import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
 
@@ -71,19 +72,23 @@ public final class CLALibRexpand {
 
 		try {
 			final int[] map = new int[seqHeight];
-			int maxCol = constructInitialMapping(map, A, k);
+			Pair<Integer, Integer> meta = constructInitialMapping(map, A, k, nColOut);
+			int maxCol = meta.getKey();
+			int nZeros = meta.getValue();
 			boolean containsNull = maxCol < 0;
 			maxCol = Math.abs(maxCol);
 
+			boolean cutOff = false;
 			if(nColOut == -1)
 				nColOut = maxCol;
 			else if(nColOut < maxCol)
-				throw new DMLRuntimeException("invalid nColOut, requested: " + nColOut + " but have to be : " + maxCol);
+				cutOff = true;
 
-			final int nNulls = containsNull ? correctNulls(map, nColOut) : 0;
+			if(containsNull)
+				correctNulls(map, nColOut);
 			if(nColOut == 0) // edge case of empty zero dimension block.
 				return new MatrixBlock(seqHeight, 0, 0.0);
-			return createCompressedReturn(map, nColOut, seqHeight, nNulls, containsNull, k);
+			return createCompressedReturn(map, nColOut, seqHeight, nZeros, containsNull || cutOff, k);
 		}
 		catch(Exception e) {
 			throw new RuntimeException("Failed table seq operator", e);
@@ -139,7 +144,7 @@ public final class CLALibRexpand {
 		return nNulls;
 	}
 
-	private static int constructInitialMapping(int[] map, MatrixBlock A, int k) {
+	private static Pair<Integer,Integer> constructInitialMapping(int[] map, MatrixBlock A, int k, int maxOutCol) {
 		if(A.isEmpty() || A.isInSparseFormat())
 			throw new DMLRuntimeException("not supported empty or sparse construction of seq table");
 		final MatrixBlock Ac;
@@ -155,20 +160,23 @@ public final class CLALibRexpand {
 		try {
 
 			int blkz = Math.max((map.length / k), 1000);
-			List<Future<Integer>> tasks = new ArrayList<>();
+			List<Future<Pair<Integer,Integer>>> tasks = new ArrayList<>();
 			for(int i = 0; i < map.length; i += blkz) {
 				final int start = i;
 				final int end = Math.min(i + blkz, map.length);
-				tasks.add(pool.submit(() -> partialMapping(map, Ac, start, end)));
+				tasks.add(pool.submit(() -> partialMapping(map, Ac, start, end, maxOutCol)));
 			}
 
 			int maxCol = 0;
-			for(Future<Integer> f : tasks) {
-				int tmp = f.get();
-				if(Math.abs(tmp) > Math.abs(maxCol))
-					maxCol = tmp;
+			int zeros = 0;
+			for(Future<Pair<Integer,Integer>> f : tasks) {
+				int tmpMaxCol = f.get().getKey();
+				int tmpZeros = f.get().getValue();
+				if(Math.abs(tmpMaxCol) > Math.abs(maxCol))
+					maxCol = tmpMaxCol;
+				zeros += tmpZeros;
 			}
-			return maxCol;
+			return new Pair<Integer,Integer>(maxCol, zeros);
 		}
 		catch(Exception e) {
 			throw new DMLRuntimeException(e);
@@ -179,33 +187,32 @@ public final class CLALibRexpand {
 
 	}
 
-	private static int partialMapping(int[] map, MatrixBlock A, int start, int end) {
+	private static Pair<Integer, Integer> partialMapping(int[] map, MatrixBlock A, int start, int end, int maxOutCol) {
 
 		int maxCol = 0;
-		boolean containsNull = false;
-
+		int zeros = 0;
 		final double[] aVals = A.getDenseBlockValues();
 
 		for(int i = start; i < end; i++) {
 			final double v2 = aVals[i];
-			if(Double.isNaN(v2)) {
-				map[i] = -1; // assign temporarily to -1
-				containsNull = true;
-			}
-			else {
-				// safe casts to long for consistent behavior with indexing
-				int col = UtilFunctions.toInt(v2);
-				if(col <= 0)
-					throw new DMLRuntimeException(
+			final int colUnsafe = UtilFunctions.toInt(v2);
+			if(!Double.isNaN(v2) && colUnsafe < 0)
+				throw new DMLRuntimeException(
 						"Erroneous input while computing the contingency table (value <= zero): " + v2);
-
-				map[i] = col - 1;
-				// maintain max seen col
-				maxCol = Math.max(col, maxCol);
-			}
+			// Boolean to int conversion to avoid branch
+			final int invalid = Double.isNaN(v2) || (maxOutCol != -1 && colUnsafe > maxOutCol) ? 1 : 0;
+			// if invalid -> maxOutCol else -> colUnsafe - 1
+			final int colSafe = maxOutCol*invalid + (colUnsafe - 1)*(1 - invalid);
+			zeros += invalid;
+			maxCol = Math.max(colUnsafe, maxCol);
+			map[i] = colSafe;
 		}
 
-		return containsNull ? maxCol * -1 : maxCol;
+		if (maxOutCol == -1 && zeros > 0){
+			maxCol *= -1;
+		}
+
+		return new Pair<Integer, Integer>(maxCol, zeros);
 	}
 
 	public static boolean compressedTableSeq() {

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/CompressionCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/CompressionCPInstruction.java
@@ -138,7 +138,9 @@ public class CompressionCPInstruction extends ComputationCPInstruction {
 		else if(ec.isMatrixObject(input1.getName()))
 			processMatrixBlockCompression(ec, ec.getMatrixInput(input1.getName()), _numThreads, root);
 		else {
-			throw new NotImplementedException("Not supported other types of input for compression than frame and matrix");
+			LOG.warn("Compression on Scalar should not happen");
+			ScalarObject Scalar = ec.getScalarInput(input1);
+			ec.setScalarOutput(output.getName(),Scalar);
 		}
 	}
 

--- a/src/test/java/org/apache/sysds/test/component/compress/lib/SeqTableTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/lib/SeqTableTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.lib.CLALibRexpand;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class SeqTableTest {
 	@Test(expected = RuntimeException.class)
 	public void test_notSameDim() throws Exception {
 		MatrixBlock c = new MatrixBlock(20, 1, 0.0);
-		CLALibRexpand.rexpand(10, c);
+		LibMatrixReorg.fusedSeqRexpand(10, c, 1.0);
 	}
 
 	@Test(expected = RuntimeException.class)
@@ -52,7 +53,7 @@ public class SeqTableTest {
 	@Test(expected = RuntimeException.class)
 	public void test_toManyColumn() throws Exception {
 		MatrixBlock c = new MatrixBlock(10, 2, -1.0);
-		CLALibRexpand.rexpand(10, c);
+		LibMatrixReorg.fusedSeqRexpand(10, c, 1.0);
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressBase.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/configuration/CompressBase.java
@@ -32,6 +32,8 @@ import org.apache.sysds.utils.DMLCompressionStatistics;
 import org.apache.sysds.utils.Statistics;
 import org.junit.Assert;
 
+import java.io.ByteArrayOutputStream;
+
 public abstract class CompressBase extends AutomatedTestBase {
 	// private static final Log LOG = LogFactory.getLog(CompressBase.class.getName());
 
@@ -66,7 +68,8 @@ public abstract class CompressBase extends AutomatedTestBase {
 			fullDMLScriptName = SCRIPT_DIR + "/functions/compress/compress_" + name + ".dml";
 			programArgs = new String[] {"-stats", "100", "-nvargs", "A=" + input("A")};
 
-			String out = runTest(null).toString();
+			ByteArrayOutputStream tmp = runTest(null);
+			String out = tmp != null ? runTest(null).toString() : "";
 
 			int decompressCount = DMLCompressionStatistics.getDecompressionCount();
 			long compressionCount = (instType == ExecType.SPARK) ? Statistics
@@ -74,7 +77,8 @@ public abstract class CompressBase extends AutomatedTestBase {
 			DMLCompressionStatistics.reset();
 
 			Assert.assertEquals(out + "\ncompression count   wrong : ", compressionCount, compressionCountsExpected);
-			Assert.assertTrue(out + "\nDecompression count wrong : ",
+			Assert.assertTrue(out + "\nDecompression count wrong : " + decompressCount +
+							(decompressionCountExpected >= 0 ? " [expected: " + decompressionCountExpected+ "]" : ""),
 				decompressionCountExpected >= 0 ? decompressionCountExpected == decompressCount : decompressCount > 1);
 
 		}

--- a/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedKmeansTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/algorithms/FederatedKmeansTest.java
@@ -123,7 +123,7 @@ public class FederatedKmeansTest extends AutomatedTestBase {
 
 		// Run actual dml script with federated matrix
 		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[] {"-stats", "-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+		programArgs = new String[] {"-stats","20", "-nvargs", "in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
 			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")), "rows=" + rows, "cols=" + cols,
 			"single=" + String.valueOf(singleWorker).toUpperCase(), "runs=" + String.valueOf(runs), "out=" + output("Z")};
 


### PR DESCRIPTION
Sebastian Baunsgaard <baunsgaard@apache.org> introduced a new CLALib for Reorg, specifically Transpose

e-strauss <lathancer@gmx.de> applied minor changes:
- a manual rewrite in bultin kmeans script to use argmin (reduced runtime by 18%)
- added new decompressing transpose to DenseBlock from SparseBlock for ColGroupDDC
- fixed bug in sparsity evaluation in decompressed transposed (switch nrow w/ ncol)
- minor bug fix in regarding the cached decompression count
- fixed ctable with seq fuse rewrite fused ctable with given output dim (disaled: performance decrease, need to fix it first)
- fixed null handling in fused seq ctable
- fixed tests which passed for the wrong reason