### PR TITLE
[MINOR] Add DataTypes on memory estimates for HOPS

### DIFF
--- a/src/main/java/org/apache/sysds/hops/BinaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/BinaryOp.java
@@ -562,7 +562,7 @@ public class BinaryOp extends MultiThreadedHop {
 			else //e.g., for append,pow or after inference
 				sparsity = OptimizerUtils.getSparsity(dim1, dim2, nnz);
 			
-			ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity);
+			ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity, getDataType());
 		}
 		return ret;
 	}

--- a/src/main/java/org/apache/sysds/hops/DataGenOp.java
+++ b/src/main/java/org/apache/sysds/hops/DataGenOp.java
@@ -219,11 +219,11 @@ public class DataGenOp extends MultiThreadedHop
 			else {
 				//sparsity-aware estimation (dependent on sparse generation approach); for pure dense generation
 				//we would need to disable sparsity-awareness and estimate via sparsity=1.0
-				ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, _sparsity);
+				ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, _sparsity, getDataType());
 			}
 		}
 		else {
-			ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, 1.0);
+			ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, 1.0, getDataType());
 		}
 		
 		return ret;

--- a/src/main/java/org/apache/sysds/hops/DataOp.java
+++ b/src/main/java/org/apache/sysds/hops/DataOp.java
@@ -390,7 +390,7 @@ public class DataOp extends Hop {
 			   || _op == OpOpData.TRANSIENTREAD ) 
 			{
 				double sparsity = OptimizerUtils.getSparsity(dim1, dim2, nnz);
-				ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity);
+				ret = OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity, getDataType());
 			}
 			// output memory estimate is not required for "write" nodes (just input)
 		}

--- a/src/main/java/org/apache/sysds/hops/IndexingOp.java
+++ b/src/main/java/org/apache/sysds/hops/IndexingOp.java
@@ -204,7 +204,7 @@ public class IndexingOp extends Hop
 	{
 		// only dense right indexing supported on GPU
 		double sparsity =  isGPUEnabled() ? 1.0 : OptimizerUtils.getSparsity(dim1, dim2, nnz);
-		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity);
+		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity, getDataType());
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -827,7 +827,7 @@ public class OptimizerUtils
 		if(dt == DataType.FRAME)
 			return estimateSizeExactFrame(nrows, ncols);
 		else 
-			return estimateSizeExactSparsity(nrows, ncols, sp, dt);
+			return estimateSizeExactSparsity(nrows, ncols, sp);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
+++ b/src/main/java/org/apache/sysds/hops/OptimizerUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
@@ -63,8 +64,8 @@ import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.runtime.util.UtilFunctions;
-import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
 import org.apache.sysds.utils.MemoryEstimates;
+import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
 
 public class OptimizerUtils 
 {
@@ -820,6 +821,13 @@ public class OptimizerUtils
 	public static long estimateSizeExactSparsity(long nrows, long ncols, double sp) 
 	{
 		return MatrixBlock.estimateSizeInMemory(nrows,ncols,sp);
+	}
+
+	public static long estimateSizeExactSparsity(long nrows, long ncols, double sp, DataType dt){
+		if(dt == DataType.FRAME)
+			return estimateSizeExactFrame(nrows, ncols);
+		else 
+			return estimateSizeExactSparsity(nrows, ncols, sp, dt);
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/hops/ReorgOp.java
+++ b/src/main/java/org/apache/sysds/hops/ReorgOp.java
@@ -232,7 +232,7 @@ public class ReorgOp extends MultiThreadedHop
 	protected double computeOutputMemEstimate( long dim1, long dim2, long nnz ) {
 		//no dedicated mem estimation per op type, because always propagated via refreshSizeInformation
 		double sparsity = OptimizerUtils.getSparsity(dim1, dim2, nnz);
-		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity);
+		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity, getDataType());
 	}
 	
 	@Override

--- a/src/main/java/org/apache/sysds/hops/UnaryOp.java
+++ b/src/main/java/org/apache/sysds/hops/UnaryOp.java
@@ -366,7 +366,7 @@ public class UnaryOp extends MultiThreadedHop
 		} else {
 			sparsity = OptimizerUtils.getSparsity(dim1, dim2, nnz);
 		}
-		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity);
+		return OptimizerUtils.estimateSizeExactSparsity(dim1, dim2, sparsity, getDataType());
 	}
 	
 	@Override


### PR DESCRIPTION
This commit changes the memory estimates of many of the HOPS, to include the datatype, Indicating if the output is a frame or a Matrix. It is included because I had to make one modification to a unary Op in BWARE, and in general, it does not hurt to add to many of the Op Types (even if they do not return frame types at the moment)