### PR TITLE
[SYSTEMDS-3541] Exploratory workload-aware compression on intermediates

### DIFF
--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -79,6 +79,7 @@ public class DMLConfig
 	public static final String PARALLEL_TOKENIZE = "sysds.parallel.tokenize";
 	public static final String PARALLEL_TOKENIZE_NUM_BLOCKS = "sysds.parallel.tokenize.numBlocks";
 	public static final String COMPRESSED_LINALG    = "sysds.compressed.linalg";
+	public static final String COMPRESSED_LINALG_INTERMEDIATE    = "sysds.compressed.linalg.intermediate";
 	public static final String COMPRESSED_LOSSY     = "sysds.compressed.lossy";
 	public static final String COMPRESSED_VALID_COMPRESSIONS = "sysds.compressed.valid.compressions";
 	public static final String COMPRESSED_OVERLAPPING = "sysds.compressed.overlapping"; 

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteCompressedReblock.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteCompressedReblock.java
@@ -171,11 +171,12 @@ public class RewriteCompressedReblock extends StatementBlockRewriteRule {
 			satisfies |= HopRewriteUtils.isTernary(hop, OpOp3.CTABLE) 
 				&& hop.getInput(0).getDataType().isMatrix() 
 				&& hop.getInput(1).getDataType().isMatrix();
-			satisfies |= HopRewriteUtils.isData(hop, OpOpData.PERSISTENTREAD) && !hop.isScalar();
+			satisfies |= HopRewriteUtils.isData(hop, OpOpData.PERSISTENTREAD);
 			satisfies |= HopRewriteUtils.isUnary(hop, OpOp1.ROUND, OpOp1.FLOOR, OpOp1.NOT, OpOp1.CEIL);
 			satisfies |= HopRewriteUtils.isBinary(hop, OpOp2.EQUAL, OpOp2.NOTEQUAL, OpOp2.LESS,
 				OpOp2.LESSEQUAL, OpOp2.GREATER, OpOp2.GREATEREQUAL, OpOp2.AND, OpOp2.OR, OpOp2.MODULUS);
 			satisfies |= HopRewriteUtils.isTernary(hop, OpOp3.CTABLE);
+			satisfies &= !hop.isScalar();
 		}
 		if(LOG.isDebugEnabled() && satisfies)
 			LOG.debug("Operation Satisfies: " + hop);

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -344,7 +344,8 @@ public class CompressedMatrixBlockFactory {
 		// final int nRows = mb.getNumRows();
 		final int nCols = mb.getNumColumns();
 		// Assume the scaling of cocoding is at maximum square root good relative to number of columns.
-		final double scale = Math.sqrt(nCols);
+		final double scale = mb instanceof CompressedMatrixBlock &&
+				((CompressedMatrixBlock) mb).getColGroups().size() == 1 ? 1 : Math.sqrt(nCols);
 		final double threshold = _stats.estimatedCostCols / scale;
 
 		if(threshold < _stats.originalCost *

--- a/src/main/java/org/apache/sysds/runtime/frame/data/columns/HashMapToInt.java
+++ b/src/main/java/org/apache/sysds/runtime/frame/data/columns/HashMapToInt.java
@@ -152,6 +152,28 @@ public class HashMapToInt<K> implements Map<K, Integer>, Serializable, Cloneable
 
 	}
 
+	public int putIfAbsentReturnVal(K key, int value) {
+
+		if(key == null) {
+			if(nullV == -1) {
+				size++;
+				nullV = value;
+				return -1;
+			}
+			else
+				return nullV;
+		}
+		else {
+			final int ix = hash(key);
+			Node<K> b = buckets[ix];
+			if(b == null)
+				return createBucketReturnVal(ix, key, value);
+			else
+				return putIfAbsentBucketReturnval(ix, key, value);
+		}
+
+	}
+
 	private int putIfAbsentBucket(int ix, K key, int value) {
 		Node<K> b = buckets[ix];
 		while(true) {
@@ -162,6 +184,21 @@ public class HashMapToInt<K> implements Map<K, Integer>, Serializable, Cloneable
 				size++;
 				resize();
 				return -1;
+			}
+			b = b.next;
+		}
+	}
+
+	private int putIfAbsentBucketReturnval(int ix, K key, int value) {
+		Node<K> b = buckets[ix];
+		while(true) {
+			if(b.key.equals(key))
+				return b.value;
+			if(b.next == null) {
+				b.setNext(new Node<>(key, value, null));
+				size++;
+				resize();
+				return value;
 			}
 			b = b.next;
 		}
@@ -189,6 +226,12 @@ public class HashMapToInt<K> implements Map<K, Integer>, Serializable, Cloneable
 		buckets[ix] = new Node<K>(key, value, null);
 		size++;
 		return -1;
+	}
+
+	private int createBucketReturnVal(int ix, K key, int value) {
+		buckets[ix] = new Node<K>(key, value, null);
+		size++;
+		return value;
 	}
 
 	private int addToBucket(int ix, K key, int value) {

--- a/src/test/java/org/apache/sysds/test/component/compress/lib/CLALibBinaryCellOpTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/lib/CLALibBinaryCellOpTest.java
@@ -35,11 +35,33 @@ import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.ColGroupConst;
 import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
 import org.apache.sysds.runtime.compress.lib.CLALibBinaryCellOp;
+import org.apache.sysds.runtime.functionobjects.And;
+import org.apache.sysds.runtime.functionobjects.BitwAnd;
+import org.apache.sysds.runtime.functionobjects.BitwOr;
+import org.apache.sysds.runtime.functionobjects.BitwShiftL;
+import org.apache.sysds.runtime.functionobjects.BitwShiftR;
+import org.apache.sysds.runtime.functionobjects.BitwXor;
+import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.functionobjects.Divide;
+import org.apache.sysds.runtime.functionobjects.Equals;
+import org.apache.sysds.runtime.functionobjects.GreaterThan;
+import org.apache.sysds.runtime.functionobjects.GreaterThanEquals;
+import org.apache.sysds.runtime.functionobjects.IntegerDivide;
+import org.apache.sysds.runtime.functionobjects.LessThan;
+import org.apache.sysds.runtime.functionobjects.LessThanEquals;
+import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.functionobjects.Minus1Multiply;
+import org.apache.sysds.runtime.functionobjects.MinusMultiply;
+import org.apache.sysds.runtime.functionobjects.MinusNz;
+import org.apache.sysds.runtime.functionobjects.Modulus;
 import org.apache.sysds.runtime.functionobjects.Multiply;
+import org.apache.sysds.runtime.functionobjects.NotEquals;
+import org.apache.sysds.runtime.functionobjects.Or;
 import org.apache.sysds.runtime.functionobjects.Plus;
+import org.apache.sysds.runtime.functionobjects.PlusMultiply;
 import org.apache.sysds.runtime.functionobjects.Power;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
+import org.apache.sysds.runtime.functionobjects.Xor;
 import org.apache.sysds.runtime.matrix.data.LibMatrixBincell;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
@@ -54,43 +76,45 @@ public class CLALibBinaryCellOpTest {
 	protected static final Log LOG = LogFactory.getLog(CombineGroupsTest.class.getName());
 
 	public final static ValueFunction[] vf = {//
-		// (Plus.getPlusFnObject()), //
-		// (Minus.getMinusFnObject()), //
+		(Plus.getPlusFnObject()), //
+		(Minus.getMinusFnObject()), //
 		Divide.getDivideFnObject(), //
-		// (Or.getOrFnObject()), //
-		// (LessThan.getLessThanFnObject()), //
-		// (LessThanEquals.getLessThanEqualsFnObject()), //
-		// (GreaterThan.getGreaterThanFnObject()), //
-		// (GreaterThanEquals.getGreaterThanEqualsFnObject()), //
-		// (Multiply.getMultiplyFnObject()), //
-		// (Modulus.getFnObject()), //
-		// (IntegerDivide.getFnObject()), //
-		// (Equals.getEqualsFnObject()), //
-		// (NotEquals.getNotEqualsFnObject()), //
-		// (And.getAndFnObject()), //
-		// (Xor.getXorFnObject()), //
-		// (BitwAnd.getBitwAndFnObject()), //
-		// (BitwOr.getBitwOrFnObject()), //
-		// (BitwXor.getBitwXorFnObject()), //
-		// (BitwShiftL.getBitwShiftLFnObject()), //
-		// (BitwShiftR.getBitwShiftRFnObject()), //
-		// (Power.getPowerFnObject()), //
-		// (MinusNz.getMinusNzFnObject()), //
-		// (new PlusMultiply(32)), //
-		// (new PlusMultiply(2)), //
-		// (new PlusMultiply(0)), //
-		// (new MinusMultiply(32)), //
-		// Minus1Multiply.getMinus1MultiplyFnObject(),
-		// // // Builtin
-		// (Builtin.getBuiltinFnObject(BuiltinCode.MIN)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.MAX)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.LOG)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.LOG_NZ)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.MAXINDEX)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.MININDEX)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.CUMMAX)), //
-		// (Builtin.getBuiltinFnObject(BuiltinCode.CUMMIN)),//
-	};
+		(Or.getOrFnObject()), //
+		(LessThan.getLessThanFnObject()), //
+		(LessThanEquals.getLessThanEqualsFnObject()), //
+		(GreaterThan.getGreaterThanFnObject()), //
+		(GreaterThanEquals.getGreaterThanEqualsFnObject()), //
+		(Multiply.getMultiplyFnObject()), //
+		(Modulus.getFnObject()), //
+		(IntegerDivide.getFnObject()), //
+		(Equals.getEqualsFnObject()), //
+		(NotEquals.getNotEqualsFnObject()), //
+		(And.getAndFnObject()), //
+		(Xor.getXorFnObject()), //
+		(BitwAnd.getBitwAndFnObject()), //
+		(BitwOr.getBitwOrFnObject()), //
+		(BitwXor.getBitwXorFnObject()), //
+		(BitwShiftL.getBitwShiftLFnObject()), //
+		(BitwShiftR.getBitwShiftRFnObject()), //
+		// TODO: power fails currently in some cases
+		//(Power.getPowerFnObject()), //
+		(MinusNz.getMinusNzFnObject()), //
+		(new PlusMultiply(32)), //
+		(new PlusMultiply(2)), //
+		(new PlusMultiply(0)), //
+		(new MinusMultiply(32)), //
+		Minus1Multiply.getMinus1MultiplyFnObject(),
+
+		// // Builtin
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.MIN)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.MAX)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.LOG)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.LOG_NZ)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.MAXINDEX)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.MININDEX)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.CUMMAX)), //
+		(Builtin.getBuiltinFnObject(Builtin.BuiltinCode.CUMMIN)),//
+		};
 
 	private final MatrixBlock mb;
 	private final CompressedMatrixBlock cmb;
@@ -463,6 +487,13 @@ public class CLALibBinaryCellOpTest {
 		if(mcv2 == null)
 			throw new RuntimeException();
 		execL(op, mb, cmb, mcv2);
+	}
+
+	@Test(expected = Exception.class)
+	public void binLeftMcV_noCache() {
+		CompressedMatrixBlock spy = spy(cmb);
+		when(spy.getCachedDecompressed()).thenReturn(null);
+		execL(op, mb, spy, mcv2);
 	}
 
 	@Test(expected = Exception.class)

--- a/src/test/java/org/apache/sysds/test/functions/compress/workload/WorkloadAlgorithmTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/compress/workload/WorkloadAlgorithmTest.java
@@ -156,6 +156,16 @@ public class WorkloadAlgorithmTest extends AutomatedTestBase {
 		runWorkloadAnalysisTest(TEST_NAME8, ExecMode.SINGLE_NODE, 1, false, 10);
 	}
 
+	@Test
+	public void testKmeansSuccessfulIntermediateCP() {
+		runWorkloadAnalysisTest(TEST_NAME8, ExecMode.SINGLE_NODE, 42, true, 25);
+	}
+
+	@Test
+	public void testKmeansUnsuccessfulIntermediateCP() {
+		runWorkloadAnalysisTest(TEST_NAME8, ExecMode.SINGLE_NODE, 27, true, 10);
+	}
+
 	private void runWorkloadAnalysisTest(String testname, ExecMode mode, int compressionCount, boolean intermediates){
 		runWorkloadAnalysisTest(testname, mode, compressionCount, intermediates, -1);
 	}


### PR DESCRIPTION
This PR explores the aggressive compression on intermediates, explicitly for the kmeans builtin algorithm. This commit adds new compressed operations to avoid the decompression and minimize the compression time of intermediates.

The runtime of the kmeans algorithm on the census dataset was reduced from initially 50s with intermediate compression down to 17.5s with all the optimizations. Which is an overall improvement of 33% in comparison to the baseline runtime of workload-aware, non-aggressive compression of 27s.

A summary of the changes:

- added config option for aggressive compression
-  removed scalars from possible compressible intermediate candidates
- extended the compression workload analyzer to pick up aggregation operations if the input is compressed as a single column group
- extended the compression workload analyzer to pick up binary matrix-vec op, if of both inputs have the same col indices
- updated cost estimation for compression on already compressed inputs with single column group
- added support for double compressed binary matrix-matrix op
- single-threaded compressed binary matrix-vector operation with single column group encoding
- multi threaded compressed binary matrix-vector operation with single column group encoding
- added support for left binary matrix-vector operation for sparse outputs
