### PR TITLE
[MINOR] Remove outputdir .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,4 +58,3 @@ github:
 staging:
   profile: beta
   whoami: main
-  outputdir: docs


### PR DESCRIPTION
Currently the format of the .asf.yaml sends emails to everyone on all commits. According to https://issues.apache.org/jira/browse/INFRA-26700 the error is in our project. This commit, therefore, removes the outputdir, as specified in: https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#jekyll-cms