### PR TITLE
[SYSTEMDS-3708] Fix permutation-matrix method

### DIFF
--- a/scripts/builtin/raGroupby.dml
+++ b/scripts/builtin/raGroupby.dml
@@ -132,7 +132,22 @@ m_raGroupby = function (Matrix[Double] X, Integer col, String method)
     # Set value of final output
     Y = matrix(0, rows=numGroups, cols=totalCells)
     Y[,1] = key_unique
-    Y[,2:ncol(Y)] = matrix(Y_temp_reduce, rows=numGroups, cols=totalCells-1)
+
+    # The permutation matrix creates a structure where each group's data
+    # may not fill exactly maxRowsInGroup rows.
+    # If needed, we need to pad to the expected size first.
+    expectedRows = numGroups * maxRowsInGroup
+    actualRows = nrow(Y_temp_reduce)
+
+    if(actualRows < expectedRows) {
+      # Pad Y_temp_reduce with zeros to match expected structure
+      Y_tmp_padded = matrix(0, rows=expectedRows, cols=ncol(Y_temp_reduce))
+      Y_tmp_padded[1:actualRows,] = Y_temp_reduce
+    } else {
+      Y_tmp_padded = Y_temp_reduce
+    }
+
+    Y[,2:ncol(Y)] = matrix(Y_tmp_padded, rows=numGroups, cols=totalCells-1)
   }
 }
 

--- a/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinRaGroupbyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/builtin/part2/BuiltinRaGroupbyTest.java
@@ -80,6 +80,16 @@ public class BuiltinRaGroupbyTest extends AutomatedTestBase
 		testRaGroupbyTestwithOneGroup("permutation-matrix");
 	}
 
+	@Test
+	public void testRaGroupbyTestwithMultipleGroupRows1() {
+		testRaGroupbyTestwithMultipleGroupRows("nested-loop");
+	}
+
+	@Test
+	public void testRaGroupbyTestwithMultipleGroupRows2() {
+		testRaGroupbyTestwithMultipleGroupRows("permutation-matrix");
+	}
+
 	public void testRaGroupbyTest(String method) {
 		//generate actual dataset and variables
 		double[][] X = {
@@ -155,6 +165,41 @@ public class BuiltinRaGroupbyTest extends AutomatedTestBase
 		// Expected output matrix
 		double[][] Y = {
 				{8, 1, 2, 3, 2, 4, 7, 8, 3, 1, 3, 6, 4, 4, 7, 8, 5, 4, 8, 9, 6},
+		};
+
+		runRaGroupbyTest(X, select_col, Y, method);
+	}
+
+	public void testRaGroupbyTestwithMultipleGroupRows(String method) {
+		// Test case with multiple groups having different numbers of rows
+		// 10 rows x 5 columns, grouping by column 2
+		// Groups: 1->3 rows, 2->2 rows, 3->2 rows, 4->2 rows, 5->1 row
+		double[][] X = {
+				{1, 1, 11, 12, 13},
+				{1, 2, 21, 22, 23},
+				{1, 3, 31, 32, 33},
+				{1, 4, 41, 42, 43},
+				{2, 1, 14, 15, 16},
+				{2, 2, 24, 25, 26},
+				{2, 3, 34, 35, 36},
+				{2, 4, 44, 45, 46},
+				{2, 5, 54, 55, 56},
+				{3, 1, 17, 18, 19}};
+		int select_col = 2;
+
+		// Expected output matrix (grouping by column 2, removing column 2)
+		// Note: Groups are ordered as they appear in the unique() function output
+		// Group 1: 3 rows -> [1,11,12,13], [2,14,15,16], [3,17,18,19]
+		// Group 2: 2 rows -> [1,21,22,23], [2,24,25,26]
+		// Group 4: 2 rows -> [1,41,42,43], [2,44,45,46]
+		// Group 5: 1 row  -> [2,54,55,56]
+		// Group 3: 2 rows -> [1,31,32,33], [2,34,35,36]
+		double[][] Y = {
+				{1, 1, 11, 12, 13, 2, 14, 15, 16, 3, 17, 18, 19},
+				{2, 1, 21, 22, 23, 2, 24, 25, 26, 0, 0, 0, 0},
+				{4, 1, 41, 42, 43, 2, 44, 45, 46, 0, 0, 0, 0},
+				{5, 2, 54, 55, 56, 0, 0, 0, 0, 0, 0, 0, 0},
+				{3, 1, 31, 32, 33, 2, 34, 35, 36, 0, 0, 0, 0}
 		};
 
 		runRaGroupbyTest(X, select_col, Y, method);


### PR DESCRIPTION
Adds a test case with inputs that have multiple groups with varying row counts.

This pattern comes from a `lineorder.csv` example dataset that currently causes a runtime exception for the `permutation-matrix` approach but works for the `nested-loop` approach.

Why this happened:
- `permutation-matrix` approach allocated space assuming every group has `maxRowsInGroup` rows
- groups may have variable sizes resulting in `Y_temp_reduce` having fewer rows than the reshape expects

Changes:
- correctly pads the matrix in when groups do not all have `maxRowsInGroup` rows
- adds testcases that cover this pattern

To reproduce original crash:

`lineorder.csv`:
```
0,1,2,3,4
1.0,1.0,18238.0,155190.0,828.0
1.0,2.0,18238.0,67310.0,163.0
1.0,3.0,18238.0,63700.0,71.0
1.0,4.0,18238.0,2132.0,943.0
2.0,1.0,20612.0,106170.0,1066.0
2.0,2.0,20612.0,194509.0,602.0
2.0,3.0,20612.0,100164.0,138.0
2.0,4.0,20612.0,45803.0,1382.0
2.0,5.0,20612.0,4439.0,1684.0
3.0,1.0,13813.0,4297.0,1959.0
```

`crash.dml`:
```
path_to_lineorder = "lineorder.csv"
X  = read(path_to_lineorder, format = "csv", header=TRUE, sep = ",")
source("./scripts/builtin/raGroupby.dml") as ra_new
Y = ra_new::m_raGroupby(X, 2, "nested-loop")
print(toString(Y)) # nested-loop works
Y = ra_new::m_raGroupby(X, 2, "permutation-matrix")
print(toString(Y)) # permutation-matrix breaks
```