### PR TITLE
[SYSTEMDS-3835] Add additional context operators

### DIFF
--- a/src/main/python/systemds/scuro/__init__.py
+++ b/src/main/python/systemds/scuro/__init__.py
@@ -55,7 +55,11 @@ from systemds.scuro.representations.swin_video_transformer import SwinVideoTrans
 from systemds.scuro.representations.tfidf import TfIdf
 from systemds.scuro.representations.unimodal import UnimodalRepresentation
 from systemds.scuro.representations.wav2vec import Wav2Vec
-from systemds.scuro.representations.window_aggregation import WindowAggregation
+from systemds.scuro.representations.window_aggregation import (
+    WindowAggregation,
+    DynamicWindow,
+    StaticWindow,
+)
 from systemds.scuro.representations.word2vec import W2V
 from systemds.scuro.representations.x3d import X3D
 from systemds.scuro.models.model import Model
@@ -145,4 +149,6 @@ __all__ = [
     "RMSE",
     "Spectral",
     "AttentionFusion",
+    "DynamicWindow",
+    "StaticWindow",
 ]

--- a/src/main/python/systemds/scuro/drsearch/unimodal_optimizer.py
+++ b/src/main/python/systemds/scuro/drsearch/unimodal_optimizer.py
@@ -122,8 +122,8 @@ class UnimodalOptimizer:
 
             for context_operator_after in context_operators:
                 con_op_after = context_operator_after()
-                mod = mod.context(con_op_after)
-                self._evaluate_local(mod, [mod_op, con_op_after], local_results)
+                mod_con = mod.context(con_op_after)
+                self._evaluate_local(mod_con, [mod_op, con_op_after], local_results)
 
             return local_results
 

--- a/src/main/python/systemds/scuro/representations/fusion.py
+++ b/src/main/python/systemds/scuro/representations/fusion.py
@@ -105,6 +105,8 @@ class Fusion(Representation):
                 curr_shape = modalities[idx].data[0].shape
             if len(modalities[idx - 1].data) != len(modalities[idx].data):
                 raise f"Modality sizes don't match!"
+            elif len(curr_shape) == 1:
+                continue
             elif curr_shape[1] > max_size:
                 max_size = curr_shape[1]
 

--- a/src/main/python/tests/scuro/test_operator_registry.py
+++ b/src/main/python/tests/scuro/test_operator_registry.py
@@ -30,7 +30,11 @@ from systemds.scuro.representations.covarep_audio_features import (
 from systemds.scuro.representations.mfcc import MFCC
 from systemds.scuro.representations.swin_video_transformer import SwinVideoTransformer
 from systemds.scuro.representations.wav2vec import Wav2Vec
-from systemds.scuro.representations.window_aggregation import WindowAggregation
+from systemds.scuro.representations.window_aggregation import (
+    WindowAggregation,
+    StaticWindow,
+    DynamicWindow,
+)
 from systemds.scuro.representations.bow import BoW
 from systemds.scuro.representations.word2vec import W2V
 from systemds.scuro.representations.tfidf import TfIdf
@@ -83,7 +87,11 @@ class TestOperatorRegistry(unittest.TestCase):
 
     def test_context_operator_in_registry(self):
         registry = Registry()
-        assert registry.get_context_operators() == [WindowAggregation]
+        assert registry.get_context_operators() == [
+            WindowAggregation,
+            StaticWindow,
+            DynamicWindow,
+        ]
 
     # def test_fusion_operator_in_registry(self):
     #     registry = Registry()

--- a/src/main/python/tests/scuro/test_unimodal_optimizer.py
+++ b/src/main/python/tests/scuro/test_unimodal_optimizer.py
@@ -141,7 +141,7 @@ class TestUnimodalRepresentationOptimizer(unittest.TestCase):
 
     def test_unimodal_optimizer_for_audio_modality(self):
         audio_data, audio_md = ModalityRandomDataGenerator().create_audio_data(
-            self.num_instances, 100
+            self.num_instances, 3000
         )
         audio = UnimodalModality(
             TestDataLoader(


### PR DESCRIPTION
This patch adds two additional context operators to Scuro. The first one is a StaticWindow operator that, given a number of desired windows, defines the suitable window size and aggregates a sequence into num_window features. The second context operator is a DynamicWindow where a sequence is also aggregated into num_window features with the difference that the window size for more recent data points is smaller than the window size for more historic data points in a timeseries. 