### PR TITLE
[MINOR] Move Package Dependencies for Python Testing 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ on:
       - 'src/assembly/**'
       - 'dev/**'
     branches:
-      - main
+      - pkg_dependencies
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -110,15 +110,6 @@ jobs:
           requests \
           pandas \
           unittest-parallel \
-          torchvision \
-          transformers \
-          opencv-python \
-          torch \
-          librosa \
-          h5py \
-          gensim \
-          opt-einsum \
-          nltk
 
     - name: Build Python Package
       run: |
@@ -153,6 +144,16 @@ jobs:
     - name: Run Scuro Python Tests 
       if: ${{ matrix.test_mode == 'scuro' }}
       run: |
+        pip install \
+          torchvision \
+          transformers \
+          opencv-python \
+          torch \
+          librosa \
+          h5py \
+          gensim \
+          opt-einsum \
+          nltk
         cd src/main/python
         python -m unittest discover -s tests/scuro -p 'test_*.py'
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,6 +46,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    env: 
+      TORCH_HOME: ${{ github.workspace }}/.torch  # cache root for hub/checkpoints
     strategy:
       fail-fast: false
       matrix:
@@ -140,6 +142,16 @@ jobs:
         export PATH=$SYSTEMDS_ROOT/bin:$PATH
         cd src/main/python
         ./tests/federated/runFedTest.sh
+
+    - name: Cache Torch Hub
+      if: ${{ matrix.test_mode == 'scuro' }}
+      id: torch-cache
+      uses: actions/cache@v4
+      with:
+        path: .torch
+        key: ${{ runner.os }}-torch-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+            ${{ runner.os }}-torch-
 
     - name: Run Scuro Python Tests 
       if: ${{ matrix.test_mode == 'scuro' }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ on:
       - 'src/assembly/**'
       - 'dev/**'
     branches:
-      - pkg_dependencies
+      - main
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/src/main/python/systemds/utils/helpers.py
+++ b/src/main/python/systemds/utils/helpers.py
@@ -23,7 +23,6 @@ import os
 from importlib.util import find_spec
 from itertools import chain
 from typing import Dict, Iterable
-import torch
 from systemds.utils.consts import MODULE_NAME
 
 


### PR DESCRIPTION
This commit divides the installation of packages into a part that installs all generally needed packages and one part that is only installed for specific test runs like Scuro. Additionally, torch hub get's cached which reduces setup time. 