### PR TITLE
[MINOR] Clean up of isDebugEnabled() usages

### DIFF
--- a/src/main/java/org/apache/sysds/api/DMLScript.java
+++ b/src/main/java/org/apache/sysds/api/DMLScript.java
@@ -39,8 +39,7 @@ import java.util.Scanner;
 import org.apache.commons.cli.AlreadySelectedException;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.sysds.common.Types.ExecMode;
@@ -178,7 +177,7 @@ public class DMLScript
 	public static boolean VALIDATOR_IGNORE_ISSUES = false;
 
 	public static String _uuid = IDHandler.createDistributedUniqueID();
-	private static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(DMLScript.class);
 
 	///////////////////////////////
 	// public external interface
@@ -630,14 +629,9 @@ public class DMLScript
 	}
 	
 	private static void printStartExecInfo(String dmlScriptString) {
-		boolean info = LOG.isInfoEnabled();
-		boolean debug = LOG.isDebugEnabled();
-		if(info)
-			LOG.info("BEGIN DML run " + getDateTime());
-		if(debug)
-			LOG.debug("DML script: \n" + dmlScriptString);
-		if(info)
-			LOG.info("Process id:  " + IDHandler.getProcessID());
+		LOG.info("BEGIN DML run {}", getDateTime());
+		LOG.debug("DML script: \n{}", dmlScriptString);
+		LOG.info("Process id:  {}", IDHandler.getProcessID());
 	}
 
 	private static void registerForMonitoring() {

--- a/src/main/java/org/apache/sysds/hops/DataOp.java
+++ b/src/main/java/org/apache/sysds/hops/DataOp.java
@@ -19,13 +19,14 @@
 
 package org.apache.sysds.hops;
 
+import static org.apache.sysds.parser.DataExpression.FED_RANGES;
+
 import java.util.HashMap;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.DataType;
+import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.common.Types.OpOpData;
 import org.apache.sysds.common.Types.ValueType;
@@ -35,22 +36,21 @@ import org.apache.sysds.hops.rewrite.HopRewriteUtils;
 import org.apache.sysds.lops.Data;
 import org.apache.sysds.lops.Federated;
 import org.apache.sysds.lops.Lop;
-import org.apache.sysds.common.Types.ExecType;
 import org.apache.sysds.lops.LopsException;
 import org.apache.sysds.lops.Sql;
 import org.apache.sysds.lops.Tee;
 import org.apache.sysds.parser.DataExpression;
-import static org.apache.sysds.parser.DataExpression.FED_RANGES;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject.UpdateType;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
 import org.apache.sysds.runtime.util.LocalFileUtils;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 /**
  *  A DataOp can be either a persistent read/write or transient read/write - writes will always have at least one input,
  *  but all types can have parameters (e.g., for csv literals of delimiter, header, etc).
  */
 public class DataOp extends Hop {
-	private static final Log LOG =  LogFactory.getLog(DataOp.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(DataOp.class);
 	private OpOpData _op;
 	private String _fileName = null;
 	
@@ -130,9 +130,7 @@ public class DataOp extends Hop {
 			String s = e.getKey();
 			Hop input = e.getValue();
 			getInput().add(input);
-			if (LOG.isDebugEnabled()){
-				LOG.debug(String.format("%15s - %s",s,input));
-			}
+			LOG.debug("{%15s} - {%s}", s, input);
 			input.getParent().add(this);
 
 			_paramIndexMap.put(s, index);

--- a/src/main/java/org/apache/sysds/hops/codegen/SpoofCompiler.java
+++ b/src/main/java/org/apache/sysds/hops/codegen/SpoofCompiler.java
@@ -19,11 +19,23 @@
 
 package org.apache.sysds.hops.codegen;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.AggOp;
 import org.apache.sysds.common.Types.DataType;
@@ -97,24 +109,11 @@ import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.matrix.data.Pair;
 import org.apache.sysds.utils.Explain;
 import org.apache.sysds.utils.NativeHelper;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.CodegenStatistics;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map.Entry;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
 public class SpoofCompiler {
-	private static final Log LOG = LogFactory.getLog(SpoofCompiler.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(SpoofCompiler.class);
 
 	//internal configuration flags
 	public static CompilerType JAVA_COMPILER           = CompilerType.JANINO;
@@ -538,22 +537,21 @@ public class SpoofCompiler {
 							LOG.warn("CPlan " + tmp.getValue().getVarname() + " not supported by SPOOF CUDA");
 					}
 
-					//explain debug output cplans or generated source code
-					if( LOG.isInfoEnabled() || DMLScript.EXPLAIN.isHopsType(recompile) ) {
-						LOG.info("Codegen EXPLAIN (generated cplan for HopID: " + cplan.getKey() + 
-							", line "+tmp.getValue().getBeginLine() + ", hash="+tmp.getValue().hashCode()+"):");
-						LOG.info(tmp.getValue().getClassname()
-							+ Explain.explainCPlan(cplan.getValue().getValue()));
+					// explain debug output cplans or generated source code
+					// (explicit guard: Explain.explainCPlan is expensive and evaluated eagerly)
+					if(LOG.isInfoEnabled()) {
+						LOG.info("Codegen EXPLAIN (generated cplan for HopID: {}, line {}, hash={}):", cplan.getKey(),
+							tmp.getValue().getBeginLine(), tmp.getValue().hashCode());
+						LOG.info(tmp.getValue().getClassname() + Explain.explainCPlan(cplan.getValue().getValue()));
 					}
-					if( LOG.isInfoEnabled() || DMLScript.EXPLAIN.isRuntimeType(recompile) ) {
-						LOG.info("JAVA Codegen EXPLAIN (generated code for HopID: " + cplan.getKey() +
-							", line "+tmp.getValue().getBeginLine() + ", hash="+tmp.getValue().hashCode()+"):");
+					if(LOG.isInfoEnabled()) {
+						LOG.info("JAVA Codegen EXPLAIN (generated code for HopID: {}, line {}, hash={}):",
+							cplan.getKey(), tmp.getValue().getBeginLine(), tmp.getValue().hashCode());
 						LOG.info(CodegenUtils.printWithLineNumber(src));
-						
-						if(API == GeneratorAPI.CUDA) {
-							LOG.info("CUDA Codegen EXPLAIN (generated code for HopID: " + cplan.getKey() +
-									", line " + tmp.getValue().getBeginLine() + ", hash=" + tmp.getValue().hashCode() + "):");
 
+						if(API == GeneratorAPI.CUDA) {
+							LOG.info("CUDA Codegen EXPLAIN (generated code for HopID: {}, line {}, hash={}):",
+								cplan.getKey(), tmp.getValue().getBeginLine(), tmp.getValue().hashCode());
 							LOG.info(CodegenUtils.printWithLineNumber(src_cuda));
 						}
 					}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteInjectOOCTee.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteInjectOOCTee.java
@@ -26,6 +26,7 @@ import org.apache.sysds.hops.DataOp;
 import org.apache.sysds.hops.Hop;
 import org.apache.sysds.hops.ReorgOp;
 import org.apache.sysds.parser.StatementBlock;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ import java.util.Set;
  * {@code TeeOp}, and safely rewire the graph.
  */
 public class RewriteInjectOOCTee extends StatementBlockRewriteRule {
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(RewriteInjectOOCTee.class);
 
 	public static boolean APPLY_ONLY_XtX_PATTERN = false;
 
@@ -138,10 +140,8 @@ public class RewriteInjectOOCTee extends StatementBlockRewriteRule {
 		}
 
 		int consumerCount = sharedInput.getParent().size();
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Inject tee for hop " + sharedInput.getHopID() + " ("
-				+ sharedInput.getName() + "), consumers=" + consumerCount);
-		}
+		LOG.debug("Inject tee for hop {} ({}), consumers={}", sharedInput.getHopID(), sharedInput.getName(),
+			consumerCount);
 
 		// Take a defensive copy of consumers before modifying the graph
 		ArrayList<Hop> consumers = new ArrayList<>(sharedInput.getParent());
@@ -161,10 +161,7 @@ public class RewriteInjectOOCTee extends StatementBlockRewriteRule {
 		handledHop.put(sharedInput.getHopID(), teeOp);
 		rewrittenHops.add(sharedInput.getHopID());
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Created tee hop " + teeOp.getHopID() + " -> "
-				+ teeOp.getName());
-		}
+		LOG.debug("Created tee hop {} -> {}", teeOp.getHopID(), teeOp.getName());
 	}
 
 	@SuppressWarnings("unused")
@@ -275,12 +272,9 @@ public class RewriteInjectOOCTee extends StatementBlockRewriteRule {
 
 		if (HopRewriteUtils.isData(hop, OpOpData.TEE) && hop.getInput().size() == 1) {
 			Hop teeInput = hop.getInput().get(0);
-			if (HopRewriteUtils.isData(teeInput, OpOpData.TEE)) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Remove redundant tee hop " + hop.getHopID()
-						+ " (" + hop.getName() + ") -> " + teeInput.getHopID()
-						+ " (" + teeInput.getName() + ")");
-				}
+			if(HopRewriteUtils.isData(teeInput, OpOpData.TEE)) {
+				LOG.debug("Remove redundant tee hop {} ({}) -> {} ({})", hop.getHopID(), hop.getName(),
+					teeInput.getHopID(), teeInput.getName());
 				HopRewriteUtils.rewireAllParentChildReferences(hop, teeInput);
 				HopRewriteUtils.removeAllChildReferences(hop);
 			}

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -27,8 +27,6 @@ import java.util.concurrent.Future;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.compress.cocode.CoCoderFactory;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.AColGroupValue;
@@ -55,6 +53,7 @@ import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.utils.DMLCompressionStatistics;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.Timing;
 
 /**
@@ -62,7 +61,7 @@ import org.apache.sysds.utils.stats.Timing;
  */
 public class CompressedMatrixBlockFactory {
 
-	private static final Log LOG = LogFactory.getLog(CompressedMatrixBlockFactory.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(CompressedMatrixBlockFactory.class);
 
 	/** Global lock serializing all async compressions to bound concurrent compression memory/CPU. */
 	private static final Object asyncCompressLock = new Object();
@@ -341,7 +340,7 @@ public class CompressedMatrixBlockFactory {
 		if(CompressedMatrixBlock.debug) {
 			final double afterComp = mb.sum(k).getDouble(0, 0);
 			final double deltaSum = Math.abs(orgSum - afterComp);
-			LOG.debug("compression Sum: Before:" + orgSum + " after: " + afterComp + " |delta|: " + deltaSum);
+			LOG.debug("compression Sum: Before:{} after: {} |delta|: {}", orgSum, afterComp, deltaSum);
 		}
 
 		return new ImmutablePair<>(res, _stats);
@@ -356,8 +355,8 @@ public class CompressedMatrixBlockFactory {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("Logging all individual columns estimated cost:");
 			for(CompressedSizeInfoColGroup g : compressionGroups.getInfo())
-				LOG.trace(String.format("Cost: %8.0f Size: %16.0f %15s", costEstimator.getCost(g), g.getMinSize(),
-					g.getColumns()));
+				LOG.trace("Cost: {%8.0f} Size: {%16.0f} {%15s}", costEstimator.getCost(g), g.getMinSize(),
+					g.getColumns());
 		}
 
 		_stats.estimatedSizeCols = compressionGroups.memoryEstimate();
@@ -381,16 +380,14 @@ public class CompressedMatrixBlockFactory {
 		else {
 			// abort compression
 			compressionGroups = null;
-			if(LOG.isInfoEnabled()) {
-				LOG.info("Aborting before co-code, because the compression looks bad");
-				LOG.info("Threshold was set to : " + threshold + " but it was above original " + _stats.originalCost);
-				LOG.info("Original size       : " + _stats.originalSize);
-				LOG.info("single col size     : " + _stats.estimatedSizeCols);
-				LOG.debug(String.format("--compressed size:   %16d", _stats.originalSize));
-				if(!(costEstimator instanceof MemoryCostEstimator)) {
-					LOG.info("original cost      : " + _stats.originalCost);
-					LOG.info("single col cost    : " + _stats.estimatedCostCols);
-				}
+			LOG.info("Aborting before co-code, because the compression looks bad");
+			LOG.info("Threshold was set to : {} but it was above original {}", threshold, _stats.originalCost);
+			LOG.info("Original size       : {}", _stats.originalSize);
+			LOG.info("single col size     : {}", _stats.estimatedSizeCols);
+			LOG.debug("compressed size:   {%16d}", _stats.originalSize);
+			if(!(costEstimator instanceof MemoryCostEstimator)) {
+				LOG.info("original cost      : {}", _stats.originalCost);
+				LOG.info("single col cost    : {}", _stats.estimatedCostCols);
 			}
 		}
 	}
@@ -408,15 +405,13 @@ public class CompressedMatrixBlockFactory {
 		if(_stats.estimatedCostCoCoded > _stats.originalCost) {
 			// abort compression
 			compressionGroups = null;
-			if(LOG.isInfoEnabled()) {
-				LOG.info("Aborting after co-code, because the compression looks bad");
-				LOG.info("co-code size      : " + _stats.estimatedSizeCoCoded);
-				LOG.info("original size     : " + _stats.originalSize);
-				if(!(costEstimator instanceof MemoryCostEstimator)) {
-					LOG.info("original cost    : " + _stats.originalCost);
-					LOG.info("single col cost  : " + _stats.estimatedCostCols);
-					LOG.info("co-code cost     : " + _stats.estimatedCostCoCoded);
-				}
+			LOG.info("Aborting after co-code, because the compression looks bad");
+			LOG.info("co-code size      : {}", _stats.estimatedSizeCoCoded);
+			LOG.info("original size     : {}", _stats.originalSize);
+			if(!(costEstimator instanceof MemoryCostEstimator)) {
+				LOG.info("original cost    : {}", _stats.originalCost);
+				LOG.info("single col cost  : {}", _stats.estimatedCostCols);
+				LOG.info("co-code cost     : {}", _stats.estimatedCostCoCoded);
 			}
 		}
 	}
@@ -483,15 +478,15 @@ public class CompressedMatrixBlockFactory {
 		_stats.setColGroupsCounts(res.getColGroups());
 
 		if(_stats.compressedCost > _stats.originalCost) {
-			LOG.info("--dense size:        " + _stats.denseSize);
-			LOG.info("--original size:     " + _stats.originalSize);
-			LOG.info("--compressed size:   " + _stats.compressedSize);
-			LOG.info("--compression ratio: " + _stats.getRatio());
-			LOG.info("--original Cost:     " + _stats.originalCost);
-			LOG.info("--Compressed Cost:   " + _stats.compressedCost);
-			LOG.info("--Cost Ratio:        " + _stats.getCostRatio());
-			LOG.debug("--col groups types   " + _stats.getGroupsTypesString());
-			LOG.debug("--col groups sizes   " + _stats.getGroupsSizesString());
+			LOG.info("--dense size:        {}", _stats.denseSize);
+			LOG.info("--original size:     {}", _stats.originalSize);
+			LOG.info("--compressed size:   {}", _stats.compressedSize);
+			LOG.info("--compression ratio: {}", _stats.getRatio());
+			LOG.info("--original Cost:     {}", _stats.originalCost);
+			LOG.info("--Compressed Cost:   {}", _stats.compressedCost);
+			LOG.info("--Cost Ratio:        {}", _stats.getCostRatio());
+			LOG.debug("--col groups types   {}", _stats.getGroupsTypesString());
+			LOG.debug("--col groups sizes   {}", _stats.getGroupsSizesString());
 			logLengths();
 			LOG.info("Abort block compression because cost ratio is less than 1. ");
 			res = null;
@@ -509,7 +504,7 @@ public class CompressedMatrixBlockFactory {
 	}
 
 	private Pair<MatrixBlock, CompressionStatistics> abortCompression() {
-		LOG.warn("Compression aborted at phase: " + phase);
+		LOG.warn("Compression aborted at phase: {}", phase);
 		if(mb instanceof CompressedMatrixBlock && mb.getInMemorySize() > _stats.denseSize) {
 			MatrixBlock ucmb = ((CompressedMatrixBlock) mb).getUncompressed("Decompressing for abort: ", k);
 			return new ImmutablePair<>(ucmb, _stats);
@@ -537,13 +532,11 @@ public class CompressedMatrixBlockFactory {
 	}
 
 	private void logInit() {
-		if(LOG.isDebugEnabled()) {
-			LOG.debug("--Seed used for comp : " + compSettings.seed);
-			LOG.debug(String.format("--number columns to compress: %10d", mb.getNumColumns()));
-			LOG.debug(String.format("--number rows to compress   : %10d", mb.getNumRows()));
-			LOG.debug(String.format("--sparsity                  : %10.5f", mb.getSparsity()));
-			LOG.debug(String.format("--nonZeros                  : %10d", mb.getNonZeros()));
-		}
+		LOG.debug("--Seed used for comp : {}", compSettings.seed);
+		LOG.debug("--number columns to compress: {%10d}", mb.getNumColumns());
+		LOG.debug("--number rows to compress   : {%10d}", mb.getNumRows());
+		LOG.debug("--sparsity                  : {%10.5f}", mb.getSparsity());
+		LOG.debug("--nonZeros                  : {%10d}", mb.getNonZeros());
 	}
 
 	private void logPhase() {
@@ -557,20 +550,22 @@ public class CompressedMatrixBlockFactory {
 			else {
 				switch(phase) {
 					case 0:
-						LOG.debug("--compression phase " + phase + " Classify  : " + getLastTimePhase());
-						LOG.debug("--Individual Columns Estimated Compression: " + _stats.estimatedSizeCols);
+						LOG.debug("--compression phase {} Classify  : {}", phase, getLastTimePhase());
+						LOG.debug("--Individual Columns Estimated Compression: {}", _stats.estimatedSizeCols);
 						if(mb instanceof CompressedMatrixBlock) {
 							LOG.debug("--Recompressing already compressed MatrixBlock");
 						}
 						break;
 					case 1:
-						LOG.debug("--compression phase " + phase + " Grouping  : " + getLastTimePhase());
-						LOG.debug("Grouping using: " + compSettings.columnPartitioner);
-						LOG.debug("Cost Calculated using: " + costEstimator);
-						LOG.debug("--Cocoded Columns estimated Compression:" + _stats.estimatedSizeCoCoded);
+						LOG.debug("--compression phase {} Grouping  : {}", phase, getLastTimePhase());
+						LOG.debug("Grouping using: {}", compSettings.columnPartitioner);
+						LOG.debug("Cost Calculated using: {}", costEstimator);
+						LOG.debug("--Cocoded Columns estimated Compression:{}", _stats.estimatedSizeCoCoded);
 						if(compressionGroups.getInfo().size() < 1000) {
-							LOG.debug("--Cocoded Columns estimated nr distinct:" + compressionGroups.getEstimatedDistinct());
-							LOG.debug("--Cocoded Columns nr columns           :" + compressionGroups.getNrColumnsString());
+							LOG.debug("--Cocoded Columns estimated nr distinct:{}",
+								compressionGroups.getEstimatedDistinct());
+							LOG.debug("--Cocoded Columns nr columns           :{}",
+								compressionGroups.getNrColumnsString());
 						}
 						else {
 							LOG.debug(
@@ -578,33 +573,32 @@ public class CompressedMatrixBlockFactory {
 						}
 						break;
 					case 2:
-						LOG.debug("--compression phase " + phase + " Transpose : " + getLastTimePhase());
-						LOG.debug("Did transpose: " + compSettings.transposed);
+						LOG.debug("--compression phase {} Transpose : {}", phase, getLastTimePhase());
+						LOG.debug("Did transpose: {}", compSettings.transposed);
 						break;
 					case 3:
-						LOG.debug("--compression phase " + phase + " Compress  : " + getLastTimePhase());
-						LOG.debug("--compressed initial actual size:" + _stats.compressedInitialSize);
+						LOG.debug("--compression phase {} Compress  : {}", phase, getLastTimePhase());
+						LOG.debug("--compressed initial actual size:{}", _stats.compressedInitialSize);
 						break;
 					case 4:
 					default:
-						LOG.debug("--num col groups:    " + res.getColGroups().size());
-						LOG.debug("--compression phase  " + phase + " Cleanup   : " + getLastTimePhase());
-						LOG.debug("--col groups types   " + _stats.getGroupsTypesString());
-						LOG.debug("--col groups sizes   " + _stats.getGroupsSizesString());
-						LOG.debug("--input was compressed " + (mb instanceof CompressedMatrixBlock));
-						LOG.debug(String.format("--dense size:        %16d", _stats.denseSize));
-						LOG.debug(String.format("--sparse size:       %16d", _stats.sparseSize));
-						LOG.debug(String.format("--original size:     %16d", _stats.originalSize));
-						LOG.debug(String.format("--compressed size:   %16d", _stats.compressedSize));
-						LOG.debug(String.format("--compression ratio: %4.3f", _stats.getRatio()));
-						LOG.debug(String.format("--Dense       ratio: %4.3f", _stats.getDenseRatio()));
+						LOG.debug("--num col groups:    {}", res.getColGroups().size());
+						LOG.debug("--compression phase  {} Cleanup   : {}", phase, getLastTimePhase());
+						LOG.debug("--col groups types   {}", _stats.getGroupsTypesString());
+						LOG.debug("--col groups sizes   {}", _stats.getGroupsSizesString());
+						LOG.debug("--input was compressed {}", (mb instanceof CompressedMatrixBlock));
+						LOG.debug("--dense size:        {%16d}", _stats.denseSize);
+						LOG.debug("--sparse size:       {%16d}", _stats.sparseSize);
+						LOG.debug("--original size:     {%16d}", _stats.originalSize);
+						LOG.debug("--compressed size:   {%16d}", _stats.compressedSize);
+						LOG.debug("--compression ratio: {%4.3f}", _stats.getRatio());
+						LOG.debug("--Dense       ratio: {%4.3f}", _stats.getDenseRatio());
 						if(!(costEstimator instanceof MemoryCostEstimator)) {
-							LOG.debug(String.format("--original cost:     %5.2E", _stats.originalCost));
-							LOG.debug(String.format("--single col cost:   %5.2E", _stats.estimatedCostCols));
-							LOG.debug(String.format("--cocode cost:       %5.2E", _stats.estimatedCostCoCoded));
-							LOG.debug(String.format("--actual cost:       %5.2E", _stats.compressedCost));
-							LOG.debug(
-								String.format("--relative cost:     %1.4f", (_stats.compressedCost / _stats.originalCost)));
+							LOG.debug("--original cost:     {%5.2E}", _stats.originalCost);
+							LOG.debug("--single col cost:   {%5.2E}", _stats.estimatedCostCols);
+							LOG.debug("--cocode cost:       {%5.2E}", _stats.estimatedCostCoCoded);
+							LOG.debug("--actual cost:       {%5.2E}", _stats.compressedCost);
+							LOG.debug("--relative cost:     {%1.4f}", (_stats.compressedCost / _stats.originalCost));
 						}
 						logLengths();
 				}
@@ -620,20 +614,19 @@ public class CompressedMatrixBlockFactory {
 			for(AColGroup colGroup : res.getColGroups())
 				lengths[i++] = colGroup.getNumValues();
 
-			LOG.debug("--compressed colGroup dictionary sizes: " + Arrays.toString(lengths));
-			LOG.debug("--compressed colGroup nr columns      : " + constructNrColumnString(res.getColGroups()));
+			LOG.debug("--compressed colGroup dictionary sizes: {}", Arrays.toString(lengths));
+			LOG.debug("--compressed colGroup nr columns      : {}", constructNrColumnString(res.getColGroups()));
 		}
 		if(LOG.isTraceEnabled()) {
 			for(AColGroup colGroup : res.getColGroups()) {
 				if(colGroup.estimateInMemorySize() < 1000)
 					LOG.trace(colGroup);
 				else {
-					LOG.trace(
-						"--colGroups type       : " + colGroup.getClass().getSimpleName() + " size: "
-							+ colGroup.estimateInMemorySize()
-							+ ((colGroup instanceof AColGroupValue) ? "  numValues :"
-								+ ((AColGroupValue) colGroup).getNumValues() : "")
-							+ "  colIndexes : " + colGroup.getColIndices());
+					LOG.trace("--colGroups type       : {} size: {}{} colIndexes : {}",
+						colGroup.getClass().getSimpleName(), colGroup.estimateInMemorySize(),
+						(colGroup instanceof AColGroupValue) ? "  numValues :"
+							+ ((AColGroupValue) colGroup).getNumValues() + " " : "",
+						colGroup.getColIndices());
 				}
 			}
 		}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/caching/CacheableData.java
@@ -28,8 +28,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.LongStream;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.DataType;
@@ -67,6 +65,7 @@ import org.apache.sysds.runtime.ooc.stream.SourceOOCStreamable;
 import org.apache.sysds.runtime.util.HDFSTool;
 import org.apache.sysds.runtime.util.LocalFileUtils;
 import org.apache.sysds.runtime.util.UtilFunctions;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.Statistics;
 import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
 
@@ -86,7 +85,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 	private static final long serialVersionUID = -413810592207212835L;
 
 	/** Global logging instance for all subclasses of CacheableData */
-	protected static final Log LOG = LogFactory.getLog(CacheableData.class.getName());
+	protected static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(CacheableData.class);
 
 	// global constant configuration parameters
 	public static final long CACHING_THRESHOLD = (long)Math.max(4*1024, //obj not s.t. caching
@@ -905,15 +904,13 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 	 * @param formatProperties file format properties
 	 */
 	public synchronized void exportData (String fName, String outputFormat, int replication, FileFormatProperties formatProperties) {
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Export data "+hashCode()+" "+fName);
+		LOG.trace("Export data {} {}", hashCode(), fName);
 		long t0 = DMLScript.STATISTICS ? System.nanoTime() : 0;
 		//prevent concurrent modifications
 		if ( !isAvailableToRead() )
 			throw new DMLRuntimeException("MatrixObject not available to read.");
 
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Exporting " + this.getDebugName() + " to " + fName + " in format " + outputFormat);
+		LOG.trace("Exporting {} to {} in format {}", this.getDebugName(), fName, outputFormat);
 		
 		if( DMLScript.USE_ACCELERATOR && _gpuObjects != null ) {
 			boolean copiedFromGPU = false;
@@ -1043,8 +1040,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 		else 
 		{
 			//CASE 4: data already in hdfs (do nothing, no need for export)
-			if( LOG.isTraceEnabled() )
-				LOG.trace(this.getDebugName() + ": Skip export to hdfs since data already exists.");
+			LOG.trace("{}: Skip export to hdfs since data already exists.", this.getDebugName());
 		}
 		
 		_hdfsFileExists = true;
@@ -1076,14 +1072,14 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 	 */
 	protected void restoreBlobIntoMemory() {
 		String cacheFilePathAndName = getCacheFilePathAndName();
-		long begin = LOG.isTraceEnabled() ? System.currentTimeMillis() : 0;
-		
-		if( LOG.isTraceEnabled() )
-			LOG.trace ("CACHE: Restoring matrix...  " + hashCode() + "  HDFS path: " + 
-						(_hdfsFileName == null ? "null" : _hdfsFileName) + ", Restore from path: " + cacheFilePathAndName);
-				
-		if (_data != null)
-			throw new DMLRuntimeException(cacheFilePathAndName + " : Cannot restore on top of existing in-memory data.");
+		long begin = LOG.currentTimeMillisIfTraceEnabled();
+
+		LOG.trace("CACHE: Restoring matrix...  {}  HDFS path: {} Restore from path: {}", hashCode(), _hdfsFileName,
+			cacheFilePathAndName);
+
+		if(_data != null)
+			throw new DMLRuntimeException(
+				cacheFilePathAndName + " : Cannot restore on top of existing in-memory data.");
 
 		try {
 			_data = readBlobFromCache(cacheFilePathAndName);
@@ -1091,13 +1087,12 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 		catch (IOException e) {
 			throw new DMLRuntimeException(cacheFilePathAndName + " : Restore failed.", e);	
 		}
-		
-		//check for success
-		if (_data == null)
-			throw new DMLRuntimeException (cacheFilePathAndName + " : Restore failed.");
-		
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Restoring matrix - COMPLETED ... " + (System.currentTimeMillis()-begin) + " msec.");
+
+		// check for success
+		if(_data == null)
+			throw new DMLRuntimeException(cacheFilePathAndName + " : Restore failed.");
+
+		LOG.trace("Restoring matrix - COMPLETED ... {} msec.", LOG.currentTimeMillisIfTraceEnabled() - begin);
 	}
 
 	protected abstract T readBlobFromCache(String fname)
@@ -1110,20 +1105,18 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 	 */
 	public final void freeEvictedBlob() {
 		String cacheFilePathAndName = getCacheFilePathAndName();
-		long begin = LOG.isTraceEnabled() ? System.currentTimeMillis() : 0;
-		if( LOG.isTraceEnabled() )
-			LOG.trace("CACHE: Freeing evicted matrix...  " + hashCode() + "  HDFS path: " + 
-				(_hdfsFileName == null ? "null" : _hdfsFileName) + " Eviction path: " + cacheFilePathAndName);
-		
+		long begin = LOG.currentTimeMillisIfTraceEnabled();
+		LOG.trace("CACHE: Freeing evicted matrix...  {}  HDFS path: {} Eviction path: {}", hashCode(), _hdfsFileName,
+			cacheFilePathAndName);
+
 		if(isCachingActive()) {
 			if (OptimizerUtils.isUMMEnabled())
 				UnifiedMemoryManager.deleteBlock(cacheFilePathAndName);
 			else
 				LazyWriteBuffer.deleteBlock(cacheFilePathAndName);
 		}
-		
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Freeing evicted matrix - COMPLETED ... " + (System.currentTimeMillis()-begin) + " msec.");
+
+		LOG.trace("Freeing evicted matrix - COMPLETED ... {} msec.", LOG.currentTimeMillisIfTraceEnabled() - begin);
 	}
 
 	protected boolean isBelowCachingThreshold() {
@@ -1175,8 +1168,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 
 	// Federated read
 	protected T readBlobFromFederated(FederationMap fedMap) throws IOException {
-		if( LOG.isDebugEnabled() ) //common if instructions keep federated outputs
-			LOG.debug("Pulling data from federated sites");
+		LOG.debug("Pulling data from federated sites");
 		MetaDataFormat iimd = (MetaDataFormat) _metaData;
 		DataCharacteristics dc = iimd.getDataCharacteristics();
 		return readBlobFromFederated(fedMap, dc.getDims());
@@ -1295,8 +1287,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 				throw new DMLRuntimeException("MODIFY-MODIFY not allowed.");
 		}
 
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Acquired lock on " + getDebugName() + ", status: " + _cacheStatus.name() );
+		LOG.trace("Acquired lock on {} status: {}", getDebugName(), _cacheStatus.name());
 	}
 
 	
@@ -1331,8 +1322,7 @@ public abstract class CacheableData<T extends CacheBlock<?>> extends Data
 				break;
 		}
 		
-		if( LOG.isTraceEnabled() )
-			LOG.trace("Released lock on " + getDebugName() + ", status: " + _cacheStatus.name());
+		LOG.trace("Released lock on {} status: {}", getDebugName(), _cacheStatus.name());
 		
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -27,8 +27,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.sysds.api.DMLScript;
@@ -75,6 +73,7 @@ import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.runtime.meta.MetaDataAll;
 import org.apache.sysds.runtime.meta.MetaDataFormat;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.Statistics;
 import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
 import org.apache.sysds.utils.stats.ParamServStatistics;
@@ -90,7 +89,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
  * execution contexts at the federated sites too
  */
 public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
-	private static final Log LOG = LogFactory.getLog(FederatedWorkerHandler.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(FederatedWorkerHandler.class);
 
 	/** The Federated Lookup Table of the current Federated Worker. */
 	private final FederatedLookupTable _flt;
@@ -290,11 +289,8 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 	}
 
 	private static void logRequests(FederatedRequest request, int nrRequest, int totalRequests) {
-		if(LOG.isDebugEnabled()) {
-			LOG.debug("Executing command " + (nrRequest + 1) + "/" + totalRequests + ": " + request.getType().name());
-			if(LOG.isTraceEnabled()) 
-				LOG.trace("full command: " + request.toString());
-		}
+		LOG.debug("Executing command {}/{}: {}", nrRequest + 1, totalRequests, request.getType().name());
+		LOG.trace("full command: {}", request);
 	}
 
 	private FederatedResponse executeCommand(FederatedRequest request, ExecutionContextMap ecm, EventStageModel eventStage)

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/FederatedPSControlThread.java
@@ -34,8 +34,7 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.parser.DataIdentifier;
 import org.apache.sysds.parser.Statement;
@@ -77,7 +76,7 @@ import org.apache.sysds.utils.stats.Timing;
 
 public class FederatedPSControlThread extends PSWorker implements Callable<Void> {
 	private static final long serialVersionUID = 6846648059569648791L;
-	protected static final Log LOG = LogFactory.getLog(ParamServer.class.getName());
+	protected static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(ParamServer.class);
 
 	private FederatedData _featuresData;
 	private FederatedData _labelsData;
@@ -147,11 +146,9 @@ public class FederatedPSControlThread extends PSWorker implements Callable<Void>
 		if(_runtimeBalancing == PSRuntimeBalancing.BASELINE)
 			_cycleStartAt0 = true;
 
-		if( LOG.isInfoEnabled() ) {
-			LOG.info("Setup config for worker " + this.getWorkerName());
-			LOG.info("Batch size: " + _batchSize + " possible batches: " + _possibleBatchesPerLocalEpoch
-					+ " batches to run: " + _numBatchesPerEpoch + " weighting factor: " + _weightingFactor);
-		}
+		LOG.info("Setup config for worker {}", this.getWorkerName());
+		LOG.info("Batch size: {} possible batches: {} batches to run: {} weighting factor: {}", _batchSize,
+			_possibleBatchesPerLocalEpoch, _numBatchesPerEpoch, _weightingFactor);
 
 		// serialize program
 		// create program blocks for the instruction filtering

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/ParamServer.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/paramserv/ParamServer.java
@@ -30,8 +30,6 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.DataType;
 import org.apache.sysds.parser.DMLProgram;
@@ -48,12 +46,13 @@ import org.apache.sysds.runtime.instructions.cp.FunctionCallCPInstruction;
 import org.apache.sysds.runtime.instructions.cp.ListObject;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.RightScalarOperator;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.ParamServStatistics;
 import org.apache.sysds.utils.stats.Timing;
 
 public abstract class ParamServer
 {
-	protected static final Log LOG = LogFactory.getLog(ParamServer.class.getName());
+	protected static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(ParamServer.class);
 	protected static final boolean ACCRUE_BSP_GRADIENTS = true;
 
 	// worker input queues and global model
@@ -203,10 +202,8 @@ public abstract class ParamServer
 
 	protected synchronized void updateGlobalGradients(int workerID, ListObject gradients) {
 		try {
-			if(LOG.isDebugEnabled()) {
-				LOG.debug(String.format("Successfully pulled the gradients [size:%d kb] of worker_%d.",
-					gradients.getDataSize() / 1024, workerID));
-			}
+			LOG.debug("Successfully pulled the gradients [size:{} kb] of worker_{}.", gradients.getDataSize() / 1024,
+				workerID);
 
 			switch(_updateType) {
 				case BSP: {
@@ -230,8 +227,7 @@ public abstract class ParamServer
 						((_freq == Statement.PSFrequency.EPOCH && ((float) ++_syncCounter % _numWorkers) == 0) ||
 						(_freq == Statement.PSFrequency.BATCH && ((float) ++_syncCounter / _numWorkers) % _numBatchesPerEpoch == 0)) ||
 						(_freq == Statement.PSFrequency.NBATCHES)) {
-						if(LOG.isInfoEnabled())
-							LOG.info("[+] PARAMSERV: completed PSEUDO EPOCH (ASP) " + _epochCounter);
+						LOG.info("[+] PARAMSERV: completed PSEUDO EPOCH (ASP) {}", _epochCounter);
 
 						time_epoch();
 
@@ -283,8 +279,7 @@ public abstract class ParamServer
 		}
 
 		if(finishedEpoch()) {
-			if(LOG.isInfoEnabled())
-				LOG.info("[+] PARAMSERV: completed EPOCH " + _epochCounter);
+			LOG.info("[+] PARAMSERV: completed EPOCH {}", _epochCounter);
 
 			time_epoch();
 
@@ -298,8 +293,7 @@ public abstract class ParamServer
 		// Broadcast the updated model
 		broadcastModel(_finishedStates);
 		resetFinishedStates();
-		if(LOG.isDebugEnabled())
-			LOG.debug("Global parameter is broadcasted successfully.");
+		LOG.debug("Global parameter is broadcasted successfully.");
 	}
 
 	private void tagStragglers() {
@@ -353,10 +347,8 @@ public abstract class ParamServer
 
 	protected synchronized void updateAverageModel(int workerID, ListObject model) {
 		try {
-			if(LOG.isDebugEnabled()) {
-				LOG.debug(String.format("Successfully pulled the models [size:%d kb] of worker_%d.",
-					model.getDataSize() / 1024, workerID));
-			}
+			LOG.debug("Successfully pulled the models [size:{} kb] of worker_{}.", model.getDataSize() / 1024,
+				workerID);
 			Timing tAgg = DMLScript.STATISTICS ? new Timing(true) : null;
 
 			switch(_updateType) {
@@ -429,8 +421,7 @@ public abstract class ParamServer
 		if(_numBatchesPerEpoch != -1 && (_freq == Statement.PSFrequency.EPOCH ||
 			(_freq == Statement.PSFrequency.BATCH && ++_syncCounter % _numBatchesPerEpoch == 0))) {
 
-			if(LOG.isInfoEnabled())
-				LOG.info("[+] PARAMSERV: completed EPOCH " + _epochCounter);
+			LOG.info("[+] PARAMSERV: completed EPOCH {}", _epochCounter);
 			time_epoch();
 			if(_validationPossible) {
 				validate();
@@ -443,8 +434,7 @@ public abstract class ParamServer
 			broadcastModel(true);
 		else
 			broadcastModel(workerBroadcastMask);
-		if(LOG.isDebugEnabled())
-			LOG.debug("Global parameter is broadcasted successfully ");
+		LOG.debug("Global parameter is broadcasted successfully");
 	}
 
 	protected ListObject weightModels(ListObject params, int numWorkers) {
@@ -550,11 +540,10 @@ public abstract class ParamServer
 			double current_total_validation_time = ParamServStatistics.getValidationTime();
 			double time_to_epoch = current_total_execution_time - current_total_validation_time;
 
-			if (LOG.isInfoEnabled())
-				if(_validationPossible)
-					LOG.info("[+] PARAMSERV: epoch timer (excl. validation): " + time_to_epoch / 1000 + " secs.");
-				else
-					LOG.info("[+] PARAMSERV: epoch timer: " + time_to_epoch / 1000 + " secs.");
+			if(_validationPossible)
+				LOG.info("[+] PARAMSERV: epoch timer (excl. validation): {} secs.", time_to_epoch / 1000);
+			else
+				LOG.info("[+] PARAMSERV: epoch timer: {} secs.", time_to_epoch / 1000);
 		}
 	}
 
@@ -576,8 +565,7 @@ public abstract class ParamServer
 		ParamservUtils.cleanupListObject(_ec, Statement.PS_MODEL);
 
 		// Log validation results
-		if (LOG.isInfoEnabled())
-			LOG.info("[+] PARAMSERV: validation-loss: " + loss + " validation-accuracy: " + accuracy);
+		LOG.info("[+] PARAMSERV: validation-loss: {} validation-accuracy: {}", loss, accuracy);
 
 		if(tValidate != null)
 			ParamServStatistics.accValidationTime((long) tValidate.stop());

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/CompressionCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/CompressionCPInstruction.java
@@ -23,8 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
 import org.apache.sysds.runtime.compress.CompressionStatistics;
@@ -39,7 +38,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 
 public class CompressionCPInstruction extends ComputationCPInstruction {
-	private static final Log LOG = LogFactory.getLog(CompressionCPInstruction.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(CompressionCPInstruction.class);
 
 	private final int _singletonLookupID;
 	private final int _numThreads;
@@ -197,8 +196,7 @@ public class CompressionCPInstruction extends ComputationCPInstruction {
 		if(LOG.isTraceEnabled())
 			LOG.trace(compResult.getRight());
 		MatrixBlock out = compResult.getLeft();
-		if(LOG.isInfoEnabled())
-			LOG.info("Compression output class: " + out.getClass().getSimpleName());
+		LOG.info("Compression output class: {}", out.getClass().getSimpleName());
 		// Set output and release input
 		ec.releaseMatrixInput(input1.getName());
 		ec.setMatrixOutput(output.getName(), out);
@@ -216,8 +214,7 @@ public class CompressionCPInstruction extends ComputationCPInstruction {
 		if(LOG.isTraceEnabled())
 			LOG.trace(compResult.getRight());
 		MatrixBlock out = compResult.getLeft();
-		if(LOG.isInfoEnabled())
-			LOG.info("Compression output class: " + out.getClass().getSimpleName());
+		LOG.info("Compression output class: {}", out.getClass().getSimpleName());
 		// Set output and release input
 		ec.releaseMatrixInput(input1.getName());
 		ec.releaseMatrixInput(input2.getName());
@@ -229,8 +226,7 @@ public class CompressionCPInstruction extends ComputationCPInstruction {
 		if(LOG.isTraceEnabled())
 			LOG.trace(compResult.getRight());
 		MatrixBlock out = compResult.getLeft();
-		if(LOG.isInfoEnabled())
-			LOG.info("Compression output class: " + out.getClass().getSimpleName());
+		LOG.info("Compression output class: {}", out.getClass().getSimpleName());
 		// Set output and release input
 		ec.releaseMatrixInput(input1.getName());
 		if (input2.isMatrix()) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/MultiReturnParameterizedBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/MultiReturnParameterizedBuiltinCPInstruction.java
@@ -37,8 +37,11 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.transform.encode.EncoderFactory;
 import org.apache.sysds.runtime.transform.encode.MultiColumnEncoder;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 public class MultiReturnParameterizedBuiltinCPInstruction extends ComputationCPInstruction {
+	private static final ParameterizedLogger LOG = ParameterizedLogger
+		.getLogger(MultiReturnParameterizedBuiltinCPInstruction.class);
 	protected final ArrayList<CPOperand> _outputs;
 	protected final boolean _metaReturn;
 	
@@ -106,9 +109,8 @@ public class MultiReturnParameterizedBuiltinCPInstruction extends ComputationCPI
 		ec.setMatrixOutput(getOutput(0).getName(), data);
 		ec.setFrameOutput(getOutput(1).getName(), meta);
 		
-		if(LOG.isDebugEnabled())
-			// debug the size of the output metadata.
-			LOG.debug("Memory size of metadata: " + meta.getInMemorySize());
+		if(LOG.isDebugEnabled()) // guard the eager evaluation of getInMemorySize
+			LOG.debug("Memory size of metadata: {}", meta.getInMemorySize());
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/ParamservBuiltinCPInstruction.java
@@ -56,8 +56,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.spark.network.server.TransportServer;
 import org.apache.spark.util.LongAccumulator;
 import org.apache.sysds.api.DMLScript;
@@ -92,12 +90,13 @@ import org.apache.sysds.runtime.controlprogram.paramserv.homomorphicEncryption.P
 import org.apache.sysds.runtime.controlprogram.paramserv.rpc.PSRpcFactory;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.util.ProgramConverter;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
 import org.apache.sysds.utils.stats.ParamServStatistics;
 import org.apache.sysds.utils.stats.Timing;
 
 public class ParamservBuiltinCPInstruction extends ParameterizedBuiltinCPInstruction {
-	private static final Log LOG = LogFactory.getLog(ParamservBuiltinCPInstruction.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(ParamservBuiltinCPInstruction.class);
 
 	public static final int DEFAULT_BATCH_SIZE = 64;
 	private static final PSFrequency DEFAULT_UPDATE_FREQUENCY = PSFrequency.EPOCH;
@@ -159,14 +158,12 @@ public class ParamservBuiltinCPInstruction extends ParameterizedBuiltinCPInstruc
 		int nbatches = getNbatches();
 		int numBackupWorkers = getNumBackupWorkers();
 
-		if( LOG.isInfoEnabled() ) {
-			LOG.info("[+] Update Type: " + updateType);
-			LOG.info("[+] Frequency: " + freq);
-			LOG.info("[+] Data Partitioning: " + federatedPSScheme);
-			LOG.info("[+] Runtime Balancing: " + runtimeBalancing);
-			LOG.info("[+] Weighting: " + weighting);
-			LOG.info("[+] Seed: " + seed);
-		}
+		LOG.info("[+] Update Type: {}", updateType);
+		LOG.info("[+] Frequency: {}", freq);
+		LOG.info("[+] Data Partitioning: {}", federatedPSScheme);
+		LOG.info("[+] Runtime Balancing: {}", runtimeBalancing);
+		LOG.info("[+] Weighting: {}", weighting);
+		LOG.info("[+] Seed: {}", seed);
 		if (tSetup != null)
 			ParamServStatistics.accSetupTime((long) tSetup.stop());
 
@@ -611,12 +608,11 @@ public class ParamservBuiltinCPInstruction extends ParameterizedBuiltinCPInstruc
 			.doPartitioning(workers.size(), features.acquireReadAndRelease(), labels.acquireReadAndRelease());
 		List<MatrixObject> pfs = result.pFeatures;
 		List<MatrixObject> pls = result.pLabels;
-		if (pfs.size() < workers.size()) {
-			if (LOG.isWarnEnabled()) {
-				LOG.warn(String.format("There is only %d batches of data but has %d workers. "
-					+ "Hence, reset the number of workers with %d.", pfs.size(), workers.size(), pfs.size()));
-			}
-			if (getUpdateType().isSBP() && pfs.size() <= getNumBackupWorkers()) {
+		if(pfs.size() < workers.size()) {
+			LOG.warn(
+				"There is only {} batches of data but has {} workers. " + "Hence, reset the number of workers with {}.",
+				pfs.size(), workers.size(), pfs.size());
+			if(getUpdateType().isSBP() && pfs.size() <= getNumBackupWorkers()) {
 				throw new DMLRuntimeException(
 					"Effective number of workers is smaller or equal to the number of backup workers."
 						+ " Change partitioning scheme to OVERLAP_RESHUFFLE, decrease number of backup workers or increase number of rows in dataset.");

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/InitFEDInstruction.java
@@ -35,8 +35,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types;
 import org.apache.sysds.conf.ConfigurationManager;
@@ -64,10 +62,11 @@ import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageTraceable;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.DataCharacteristics;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 public class InitFEDInstruction extends FEDInstruction implements LineageTraceable {
 
-	private static final Log LOG = LogFactory.getLog(InitFEDInstruction.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(InitFEDInstruction.class);
 
 	public static final String FED_MATRIX_IDENTIFIER = "matrix";
 	public static final String FED_FRAME_IDENTIFIER = "frame";
@@ -139,7 +138,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 			if( dat instanceof StringObject ) {
 				String address = ((StringObject) dat).getStringValue();
 				if(addCheck.contains(address))
-					LOG.warn("Federated data contains address duplicates: " + addresses);
+					LOG.warn("Federated data contains address duplicates: {}", addresses);
 				addCheck.add(address);
 			}
 
@@ -235,7 +234,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 			if(dat instanceof StringObject) {
 				String address = ((StringObject) dat).getStringValue();
 				if(addCheck.contains(address))
-					LOG.warn("Federated data contains address duplicates: " + addresses);
+					LOG.warn("Federated data contains address duplicates: {}", addresses);
 				addCheck.add(address);
 			}
 
@@ -423,8 +422,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		try {
 			int timeout = ConfigurationManager.getDMLConfig()
 				.getIntValue(DMLConfig.DEFAULT_FEDERATED_INITIALIZATION_TIMEOUT);
-			if( LOG.isDebugEnabled() )
-				LOG.debug("Federated Initialization with timeout: " + timeout);
+			LOG.debug("Federated Initialization with timeout: {}", timeout);
 			for(Pair<FederatedData, Future<FederatedResponse>> idResponse : idResponses) {
 				// wait for initialization and check dimensions
 				FederatedResponse re = idResponse.getRight().get(timeout, TimeUnit.SECONDS);
@@ -447,8 +445,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		output.getFedMapping().setType(rowPartitioned &&
 			colPartitioned ? FType.FULL : rowPartitioned ? FType.ROW : colPartitioned ? FType.COL : FType.OTHER);
 
-		if(LOG.isDebugEnabled())
-			LOG.debug("Fed map Inited:" + output.getFedMapping());
+		LOG.debug("Fed map Inited:{}", output.getFedMapping());
 	}
 
 	public static void federateFrame(FrameObject output, List<Pair<FederatedRange, FederatedData>> workers) {
@@ -511,8 +508,7 @@ public class InitFEDInstruction extends FEDInstruction implements LineageTraceab
 		output.getFedMapping().setType(rowPartitioned &&
 			colPartitioned ? FType.FULL : rowPartitioned ? FType.ROW : colPartitioned ? FType.COL : FType.OTHER);
 
-		if(LOG.isDebugEnabled())
-			LOG.debug("Fed map Inited: " + output.getFedMapping());
+		LOG.debug("Fed map Inited: {}", output.getFedMapping());
 	}
 
 	private static void handleFedFrameResponse(Types.ValueType[] schema, FederatedData federatedData,

--- a/src/main/java/org/apache/sysds/runtime/io/MatrixReaderFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/io/MatrixReaderFactory.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.runtime.io;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.FileFormat;
 import org.apache.sysds.conf.CompilerConfig.ConfigType;
 import org.apache.sysds.conf.ConfigurationManager;
@@ -28,17 +26,17 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.io.ReaderCompressed;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 public class MatrixReaderFactory {
-	private static final Log LOG = LogFactory.getLog(MatrixReaderFactory.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(MatrixReaderFactory.class);
+
 	public static MatrixReader createMatrixReader(FileFormat fmt) {
 		MatrixReader reader = null;
 		boolean par = ConfigurationManager.getCompilerConfigFlag(ConfigType.PARALLEL_CP_READ_TEXTFORMATS);
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
 
-		if (LOG.isDebugEnabled()){
-			LOG.debug("reading parallel: " + par + " mcsr: " + mcsr);
-		}
+		LOG.debug("reading parallel: {} mcsr: {}", par, mcsr);
 
 		switch(fmt) {
 			case TEXT:
@@ -99,9 +97,7 @@ public class MatrixReaderFactory {
 		boolean par = ConfigurationManager.getCompilerConfigFlag(ConfigType.PARALLEL_CP_READ_TEXTFORMATS);
 		boolean mcsr = MatrixBlock.DEFAULT_SPARSEBLOCK == SparseBlock.Type.MCSR;
 
-		if (LOG.isDebugEnabled()){
-			LOG.debug("reading parallel: " + par + " mcsr: " + mcsr);
-		}
+		LOG.debug("reading parallel: {} mcsr: {}", par, mcsr);
 
 		switch(fmt) {
 			case TEXT:

--- a/src/main/java/org/apache/sysds/runtime/lineage/LineageRewriteReuse.java
+++ b/src/main/java/org/apache/sysds/runtime/lineage/LineageRewriteReuse.java
@@ -24,8 +24,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Opcodes;
 import org.apache.sysds.common.Types.AggOp;
@@ -66,6 +64,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.meta.MetaData;
 import org.apache.sysds.utils.Explain;
 import org.apache.sysds.utils.Explain.ExplainType;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 public class LineageRewriteReuse
 {
@@ -74,7 +73,7 @@ public class LineageRewriteReuse
 	private static ExecutionContext _lrEC = null;
 	private static boolean _disableReuse = true;
 	private static long _computeTime = 0;
-	private static final Log LOG = LogFactory.getLog(LineageRewriteReuse.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(LineageRewriteReuse.class);
 	
 	public static boolean executeRewrites (Instruction curr, ExecutionContext ec)
 	{
@@ -167,8 +166,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteTsmmCbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteTsmmCbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		
 		// cleanup buffer pool
@@ -209,8 +207,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteTsmmCbindOnes APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteTsmmCbindOnes APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -254,8 +251,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteTsmmRbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteTsmmRbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -318,8 +314,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteTsmm2Cbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteTsmm2Cbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -389,8 +384,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteTsmm2CbindSameLeft APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteTsmm2CbindSameLeft APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -435,8 +429,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteMetMulRbindLeft APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteMetMulRbindLeft APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -481,8 +474,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteMatMulCbindRight APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteMatMulCbindRight APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -516,8 +508,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteMatMulCbindRightOnes APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteMatMulCbindRightOnes APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -573,8 +564,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteElementMulRbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteElementMulRbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -630,8 +620,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -687,8 +676,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteElementMulCbind APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -740,8 +728,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 
 		// generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewriteIndexingMatMul APPLIED");
+		LOG.debug("LINEAGE REWRITE rewriteIndexingMatMul APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		// Keep reuse enabled
 		_disableReuse = false;
@@ -801,8 +788,7 @@ public class LineageRewriteReuse
 		DataOp lrwWrite = HopRewriteUtils.createTransientWrite(LR_VAR, lrwHop);
 		
 		// Generate runtime instructions
-		if (LOG.isDebugEnabled())
-			LOG.debug("LINEAGE REWRITE rewritePcaTsmm APPLIED");
+		LOG.debug("LINEAGE REWRITE rewritePcaTsmm APPLIED");
 		ArrayList<Instruction> inst = genInst(lrwWrite, lrwec);
 		_disableReuse = true;
 
@@ -1221,8 +1207,8 @@ public class LineageRewriteReuse
 		ArrayList<Instruction> newInst = Recompiler.recompileHopsDag(hops, ec.getVariables(), null, true, true, 0);
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("COMPENSATION PLAN: ");
-			LOG.debug("EXPLAIN LINEAGE REWRITE (HOP) \n" + Explain.explain(hops,1));
-			LOG.debug("EXPLAIN LINEAGE REWRITE (INSTRUCTION) \n" + Explain.explain(newInst,1));
+			LOG.debug("EXPLAIN LINEAGE REWRITE (HOP) \n{}", Explain.explain(hops, 1));
+			LOG.debug("EXPLAIN LINEAGE REWRITE (INSTRUCTION) \n{}", Explain.explain(newInst, 1));
 		}
 		return newInst;
 	}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/KMVSketch.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/sketch/countdistinctapprox/KMVSketch.java
@@ -20,8 +20,6 @@
 package org.apache.sysds.runtime.matrix.data.sketch.countdistinctapprox;
 
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.data.DenseBlock;
@@ -32,6 +30,7 @@ import org.apache.sysds.runtime.matrix.data.sketch.CountDistinctSketch;
 import org.apache.sysds.runtime.matrix.operators.CountDistinctOperatorTypes;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.utils.Hash;
+import org.apache.sysds.utils.ParameterizedLogger;
 
 /**
  * KMV synopsis(for k minimum values) Distinct-Value Estimation
@@ -45,7 +44,7 @@ import org.apache.sysds.utils.Hash;
  */
 public class KMVSketch extends CountDistinctSketch {
 
-	private static final Log LOG = LogFactory.getLog(KMVSketch.class.getName());
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(KMVSketch.class);
 
 	public KMVSketch(Operator op) {
 		super(op);
@@ -73,13 +72,10 @@ public class KMVSketch extends CountDistinctSketch {
 
 			SmallestPriorityQueue spq = getKSmallestHashes(blkIn, k, M);
 
-			if(LOG.isDebugEnabled()) {
-				LOG.debug("M not forced to int size: " + tmp);
-				LOG.debug("M: " + M);
-				LOG.debug("M: " + M);
-				LOG.debug("kth smallest hash:" + spq.peek());
-				LOG.debug("spq: " + spq);
-			}
+			LOG.debug("M not forced to int size: {}", tmp);
+			LOG.debug("M: {}", M);
+			LOG.debug("kth smallest hash: {}", spq.peek());
+			LOG.debug("spq: {}", spq);
 
 
 			long res = countDistinctValuesKMV(spq, k, M, D);
@@ -197,11 +193,9 @@ public class KMVSketch extends CountDistinctSketch {
 			double estimate = (k - 1) / U_k;
 			double ceilEstimate = Math.min(estimate, D);
 
-			if(LOG.isDebugEnabled()) {
-				LOG.debug("U_k : " + U_k);
-				LOG.debug("Estimate: " + estimate);
-				LOG.debug("Ceil worst case: " + D);
-			}
+			LOG.debug("U_k : {}", U_k);
+			LOG.debug("Estimate: {}", estimate);
+			LOG.debug("Ceil worst case: {}", D);
 			res = Math.round(ceilEstimate);
 		}
 

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/ColumnEncoderDummycode.java
@@ -35,10 +35,12 @@ import org.apache.sysds.runtime.data.SparseBlockMCSR;
 import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.DependencyTask;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.TransformStatistics;
 
 public class ColumnEncoderDummycode extends ColumnEncoder {
 	private static final long serialVersionUID = 5832130477659116489L;
+	private static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(ColumnEncoderDummycode.class);
 
 	/** The number of columns outputted from this column group. */ 
 	public int _domainSize = -1; 
@@ -224,10 +226,7 @@ public class ColumnEncoderDummycode extends ColumnEncoder {
 
 			if(distinct != -1) {
 				_domainSize = Math.max(1, distinct);
-				if(LOG.isDebugEnabled()){
-
-					LOG.debug("DummyCoder for column: " + _colID + " has domain size: " + _domainSize);
-				}
+				LOG.debug("DummyCoder for column: {} has domain size: {}", _colID, _domainSize);
 			}
 		}
 	}

--- a/src/main/java/org/apache/sysds/runtime/transform/encode/CompressedEncode.java
+++ b/src/main/java/org/apache/sysds/runtime/transform/encode/CompressedEncode.java
@@ -29,8 +29,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.Types.ValueType;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
@@ -64,10 +62,11 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.transform.encode.ColumnEncoderBin.BinMethod;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
+import org.apache.sysds.utils.ParameterizedLogger;
 import org.apache.sysds.utils.stats.Timing;
 
 public class CompressedEncode {
-	protected static final Log LOG = LogFactory.getLog(CompressedEncode.class.getName());
+	protected static final ParameterizedLogger LOG = ParameterizedLogger.getLogger(CompressedEncode.class);
 
 	/** Row parallelization threshold for parallel creation of AMapToData for compression */
 	public static int ROW_PARALLELIZATION_THRESHOLD = 10000;
@@ -205,9 +204,9 @@ public class CompressedEncode {
 	private AColGroup encode(ColumnEncoderComposite c) throws Exception {
 		final Timing t = new Timing();
 		AColGroup g = executeEncode(c);
-		if(LOG.isDebugEnabled())
-			LOG.debug(String.format("Encode: columns: %4d estimateDistinct: %6d distinct: %6d size: %6d time: %10f",
-				c._colID, c._estNumDistincts, g.getNumValues(), g.estimateInMemorySize(), t.stop()));
+		if(LOG.isDebugEnabled()) // guard the eager evaluation of estimateInMemorySize
+			LOG.debug("Encode: columns: {%4d} estimateDistinct: {%6d} distinct: {%6d} size: {%6d} time: {%10f}",
+				c._colID, c._estNumDistincts, g.getNumValues(), g.estimateInMemorySize(), t.stop());
 		return g;
 	}
 
@@ -721,8 +720,7 @@ public class CompressedEncode {
 
 		nnz.addAndGet(combinedNNZ);
 		ret.setNonZeros(combinedNNZ);
-		if(LOG.isDebugEnabled())
-			LOG.debug("Combining of : " + ucg.size() + " uncompressed columns Time: " + t.stop());
+		LOG.debug("Combining of : {} uncompressed columns Time: {}", ucg.size(), t.stop());
 
 		return ColGroupUncompressed.create(ret, combinedCols);
 	}
@@ -769,16 +767,15 @@ public class CompressedEncode {
 	}
 
 	private void logging(MatrixBlock mb) {
-		if(LOG.isDebugEnabled()) {
-			LOG.debug(String.format("Uncompressed transform encode Dense size:   %16d", mb.estimateSizeDenseInMemory()));
-			LOG.debug(String.format("Uncompressed transform encode Sparse size:  %16d", mb.estimateSizeSparseInMemory()));
-			LOG.debug(String.format("Compressed transform encode size:           %16d", mb.estimateSizeInMemory()));
-
-			double ratio = Math.min(mb.estimateSizeDenseInMemory(), mb.estimateSizeSparseInMemory()) /
-				mb.estimateSizeInMemory();
-			double denseRatio = mb.estimateSizeDenseInMemory() / mb.estimateSizeInMemory();
-			LOG.debug(String.format("Compression ratio: %10.3f", ratio));
-			LOG.debug(String.format("Dense ratio:       %10.3f", denseRatio));
-		}
+		if(!LOG.isDebugEnabled()) // guard the eager evaluation of the size estimates
+			return;
+		LOG.debug("Uncompressed transform encode Dense size:   {%16d}", mb.estimateSizeDenseInMemory());
+		LOG.debug("Uncompressed transform encode Sparse size:  {%16d}", mb.estimateSizeSparseInMemory());
+		LOG.debug("Compressed transform encode size:           {%16d}", mb.estimateSizeInMemory());
+		double ratio = Math.min(mb.estimateSizeDenseInMemory(), mb.estimateSizeSparseInMemory()) /
+			mb.estimateSizeInMemory();
+		double denseRatio = mb.estimateSizeDenseInMemory() / mb.estimateSizeInMemory();
+		LOG.debug("Compression ratio: {%10.3f}", ratio);
+		LOG.debug("Dense ratio:       {%10.3f}", denseRatio);
 	}
 }

--- a/src/main/java/org/apache/sysds/utils/ParameterizedLogger.java
+++ b/src/main/java/org/apache/sysds/utils/ParameterizedLogger.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.utils;
+
+import java.util.IllegalFormatException;
+import java.util.Locale;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Logger adapter for commons-logging with lightweight '{}' parameter formatting. In addition to SLF4J-style '{}'
+ * placeholders, '{%fmt}' placeholders apply a {@link String#format} spec to the argument, e.g. {@code LOG.debug("ratio:
+ * {%10.3f}", ratio)}. Note that arguments are still evaluated eagerly at the call site, so keep an explicit
+ * {@code isDebugEnabled()} guard around calls with expensive arguments.
+ */
+public class ParameterizedLogger {
+	private final Log _log;
+
+	public ParameterizedLogger(Log log) {
+		_log = log;
+	}
+
+	public static ParameterizedLogger getLogger(Class<?> cls) {
+		return new ParameterizedLogger(LogFactory.getLog(cls.getName()));
+	}
+
+	public long currentTimeMillisIfTraceEnabled() {
+		return _log.isTraceEnabled() ? System.currentTimeMillis() : 0;
+	}
+
+	public boolean isTraceEnabled() {
+		return _log.isTraceEnabled();
+	}
+
+	public boolean isDebugEnabled() {
+		return _log.isDebugEnabled();
+	}
+
+	public boolean isInfoEnabled() {
+		return _log.isInfoEnabled();
+	}
+
+	public void trace(String pattern, Object... args) {
+		if(_log.isTraceEnabled())
+			_log.trace(format(pattern, args));
+	}
+
+	public void trace(Object message) {
+		_log.trace(message);
+	}
+
+	public void debug(String pattern, Object... args) {
+		if(_log.isDebugEnabled())
+			_log.debug(format(pattern, args));
+	}
+
+	public void debug(Object message) {
+		_log.debug(message);
+	}
+
+	public void debug(Object message, Throwable t) {
+		_log.debug(message, t);
+	}
+
+	public void info(String pattern, Object... args) {
+		if(_log.isInfoEnabled())
+			_log.info(format(pattern, args));
+	}
+
+	public void info(Object message) {
+		_log.info(message);
+	}
+
+	public void warn(String pattern, Object... args) {
+		if(_log.isWarnEnabled())
+			_log.warn(format(pattern, args));
+	}
+
+	public void warn(Object message) {
+		_log.warn(message);
+	}
+
+	public void error(String pattern, Object... args) {
+		if(_log.isErrorEnabled())
+			_log.error(format(pattern, args));
+	}
+
+	public void error(Object message) {
+		_log.error(message);
+	}
+
+	public void error(Object message, Throwable t) {
+		_log.error(message, t);
+	}
+
+	/**
+	 * Substitutes {@code {}} and {@code {%fmt}} placeholders in {@code pattern} with {@code args}. Non-empty braces
+	 * that aren't a {@code String.format} spec (e.g. {@code {n}}) are left intact, and any unconsumed args are appended
+	 * as {@code  [arg]} — keep call sites strict if accidental drift matters. Invalid {@code {%fmt}} specs fall back to
+	 * {@code String.valueOf(arg)} so a log call never throws.
+	 */
+	public static String format(String pattern, Object... args) {
+		if(pattern == null)
+			return "null";
+		if(args == null || args.length == 0)
+			return pattern;
+
+		StringBuilder sb = new StringBuilder(pattern.length() + args.length * 16);
+		int argIx = 0;
+		int start = 0;
+		int search = 0;
+		int open;
+		while((open = pattern.indexOf('{', search)) >= 0 && argIx < args.length) {
+			int close = pattern.indexOf('}', open + 1);
+			if(close < 0)
+				break;
+
+			boolean defaultPlaceholder = close == open + 1;
+			boolean stringFormatPlaceholder = !defaultPlaceholder && pattern.charAt(open + 1) == '%';
+			if(!defaultPlaceholder && !stringFormatPlaceholder) {
+				search = open + 1;
+				continue;
+			}
+
+			sb.append(pattern, start, open);
+			if(defaultPlaceholder)
+				sb.append(args[argIx++]);
+			else
+				sb.append(formatArgument(pattern.substring(open + 1, close), args[argIx++]));
+			start = close + 1;
+			search = start;
+		}
+		sb.append(pattern, start, pattern.length());
+
+		while(argIx < args.length) {
+			sb.append(" [");
+			sb.append(args[argIx++]);
+			sb.append(']');
+		}
+
+		return sb.toString();
+	}
+
+	private static String formatArgument(String format, Object arg) {
+		try {
+			return String.format(Locale.ROOT, format, arg);
+		}
+		catch(IllegalFormatException ex) {
+			return String.valueOf(arg);
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/utils/ParameterizedLoggerTest.java
+++ b/src/test/java/org/apache/sysds/test/component/utils/ParameterizedLoggerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.logging.Log;
+import org.apache.sysds.utils.ParameterizedLogger;
+import org.junit.Test;
+
+public class ParameterizedLoggerTest {
+
+	@Test
+	public void testFormat() {
+		assertEquals("null", ParameterizedLogger.format(null));
+		assertEquals("pattern", ParameterizedLogger.format("pattern"));
+		assertEquals("a=7 b=      7 c=   3.14000 d=              hi",
+			ParameterizedLogger.format("a={} b={%7d} c={%10.5f} d={%16s}", 7, 7, 3.14, "hi"));
+		assertEquals("x=12", ParameterizedLogger.format("x={%q}", 12));
+		assertEquals("prefix {skip} 1 [2]", ParameterizedLogger.format("prefix {skip} {}", 1, 2));
+		assertEquals("a=1 b={}", ParameterizedLogger.format("a={} b={}", 1));
+		assertEquals("v=null", ParameterizedLogger.format("v={}", new Object[] {null}));
+	}
+
+	@Test
+	public void testDispatchAndGuards() {
+		RecordingLog log = new RecordingLog();
+		ParameterizedLogger plog = new ParameterizedLogger(log);
+
+		log.debugEnabled = false;
+		plog.debug("x={%5d}", 3);
+		assertNull(log.lastMessage);
+
+		log.debugEnabled = true;
+		plog.debug("x={%5d}", 3);
+		assertEquals("x=    3", log.lastMessage);
+
+		plog.debug("plain");
+		assertEquals("plain", log.lastMessage);
+
+		Throwable t = new RuntimeException("boom");
+		plog.debug("dbg2", t);
+		assertEquals("dbg2", log.lastMessage);
+		assertSame(t, log.lastThrowable);
+	}
+
+	@Test
+	public void testFactoryAndLevelPassthrough() {
+		assertNotNull(ParameterizedLogger.getLogger(ParameterizedLoggerTest.class));
+
+		RecordingLog log = new RecordingLog();
+		ParameterizedLogger plog = new ParameterizedLogger(log);
+
+		log.traceEnabled = false;
+		assertEquals(0, plog.currentTimeMillisIfTraceEnabled());
+		assertEquals(false, plog.isTraceEnabled());
+
+		log.traceEnabled = true;
+		assertTrue(plog.currentTimeMillisIfTraceEnabled() > 0);
+		assertTrue(plog.isTraceEnabled());
+
+		log.debugEnabled = true;
+		assertTrue(plog.isDebugEnabled());
+
+		log.infoEnabled = true;
+		assertTrue(plog.isInfoEnabled());
+	}
+
+	@Test
+	public void testLevelGuards() {
+		RecordingLog log = new RecordingLog();
+		ParameterizedLogger plog = new ParameterizedLogger(log);
+
+		log.traceEnabled = false;
+		plog.trace("t={}", 1);
+		assertNull(log.lastMessage);
+		log.traceEnabled = true;
+		plog.trace("t={}", 1);
+		assertEquals("t=1", log.lastMessage);
+
+		log.lastMessage = null;
+		log.infoEnabled = false;
+		plog.info("i={}", 2);
+		assertNull(log.lastMessage);
+		log.infoEnabled = true;
+		plog.info("i={}", 2);
+		assertEquals("i=2", log.lastMessage);
+
+		log.lastMessage = null;
+		log.warnEnabled = false;
+		plog.warn("w={}", 3);
+		assertNull(log.lastMessage);
+		log.warnEnabled = true;
+		plog.warn("w={}", 3);
+		assertEquals("w=3", log.lastMessage);
+
+		log.lastMessage = null;
+		log.errorEnabled = false;
+		plog.error("e={}", 4);
+		assertNull(log.lastMessage);
+		log.errorEnabled = true;
+		plog.error("e={}", 4);
+		assertEquals("e=4", log.lastMessage);
+	}
+
+	private static final class RecordingLog implements Log {
+		boolean traceEnabled;
+		boolean debugEnabled;
+		boolean infoEnabled = true;
+		boolean warnEnabled = true;
+		boolean errorEnabled = true;
+		Object lastMessage;
+		Throwable lastThrowable;
+
+		private void record(Object message, Throwable t) {
+			lastMessage = message;
+			lastThrowable = t;
+		}
+
+		@Override
+		public boolean isTraceEnabled() {
+			return traceEnabled;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return debugEnabled;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return infoEnabled;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return warnEnabled;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return errorEnabled;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return true;
+		}
+
+		@Override
+		public void trace(Object message) {
+			record(message, null);
+		}
+
+		@Override
+		public void trace(Object message, Throwable t) {
+			record(message, t);
+		}
+
+		@Override
+		public void debug(Object message) {
+			record(message, null);
+		}
+
+		@Override
+		public void debug(Object message, Throwable t) {
+			record(message, t);
+		}
+
+		@Override
+		public void info(Object message) {
+			record(message, null);
+		}
+
+		@Override
+		public void info(Object message, Throwable t) {
+			record(message, t);
+		}
+
+		@Override
+		public void warn(Object message) {
+			record(message, null);
+		}
+
+		@Override
+		public void warn(Object message, Throwable t) {
+			record(message, t);
+		}
+
+		@Override
+		public void error(Object message) {
+			record(message, null);
+		}
+
+		@Override
+		public void error(Object message, Throwable t) {
+			record(message, t);
+		}
+
+		@Override
+		public void fatal(Object message) {
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+		}
+	}
+}


### PR DESCRIPTION
This PR is a followup to #2432 .
We have 131 Usages of LOG.isDebugEnabled() 
```bash
grep -rnF "LOG.isDebugEnabled" src/main/java/org/apache/sysds | wc -l
131
```
This PR adds a new utils for Parameterized Logging
```java
LOG.debug("Begin Function {%15d}", fkey);
// instead of
if(LOG.isDebugEnabled){
    LOG.debug(String.format("Begin Function %15d", fkey))
}
```

This helps with readability and simplifies code coverage

