### PR TITLE
[MINOR] Upgrade Surefire to 3.5.2 and harden fork shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<slf4j.version>2.0.11</slf4j.version>
 		<log4j.version>2.22.1</log4j.version>
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
-		<maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
 		<maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
@@ -410,6 +410,10 @@
 					<reuseForks>false</reuseForks>
 					<!-- Kill hung test forks before CI cancels the whole job. -->
 					<forkedProcessTimeoutInSeconds>${test-forkedProcessTimeout}</forkedProcessTimeoutInSeconds>
+					<!-- Force-kill forks that still have live threads after the test class completes. -->
+					<forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
+					<!-- Let forks detect a dead parent and self-terminate. -->
+					<enableProcessChecker>native</enableProcessChecker>
 					<!-- <reportFormat>brief</reportFormat> -->
 					<trimStackTrace>true</trimStackTrace>
 					<rerunFailingTestsCount>${rerun.failing.tests.count}</rerunFailingTestsCount>


### PR DESCRIPTION
- Bump maven-surefire-plugin from 3.0.0 to 3.5.2.
- Switch the fork <-> Surefire control channel to TCP via SurefireForkNodeFactory. The default pipe-based channel can deadlock on fork shutdown when child threads are still writing to stdout/err (SUREFIRE-1722).
- Add forkedProcessExitTimeoutInSeconds=30 so a fork that still has live non-daemon threads after its test class completes is forcibly killed instead of stalling the run.
- Enable enableProcessChecker=native so each fork detects a dead parent and self-terminates, and Surefire can more reliably kill stuck forks on Linux.

These changes target the intermittent ~26 minute hangs between test classes seen in the `component.c` suite.