### PR TITLE
[MINOR][CI] Reduce surefire per-fork test timeout from 1380s to 600s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,11 @@
 		<test-parallel>classes</test-parallel>
 		<test-threadCount>2</test-threadCount>
 		<test-forkCount>1C</test-forkCount>
-		<!-- Per-fork timeout in seconds; kills hung forks before the 30 min CI cap. -->
-		<test-forkedProcessTimeout>1380</test-forkedProcessTimeout>
+		<!-- Per-fork timeout in seconds; kills hung forks before the 30 min CI cap.
+		     Kept well below the cap minus the time spent on earlier forks so the
+		     timeout actually fires (and names the hung test) instead of letting CI
+		     cancel the whole job first. -->
+		<test-forkedProcessTimeout>600</test-forkedProcessTimeout>
 		<rerun.failing.tests.count>2</rerun.failing.tests.count>
 		<jacoco.skip>false</jacoco.skip>
 		<checkstyle.skip>true</checkstyle.skip>


### PR DESCRIPTION
The per-fork timeout existed to kill a hung test fork before the 30 min CI cap, so the offending test is named in the log instead of GitHub cancelling the whole job. At 1380s the timeout fired ~23 min after a fork started, but earlier forks already consumed ~8 min of the run, so the timeout would only trigger after the 30 min cap had cancelled the job. As a result hung forks were never reported.

Lowering to 600s keeps a large margin below the cap regardless of when in the run a fork hangs, while staying well above the slowest observed test class (~35s), so legitimate tests are not killed.