### PR TITLE
[MINOR] Fix CholeskyTest crash when residual is exactly zero

### DIFF
--- a/src/test/java/org/apache/sysds/test/functions/unary/matrix/CholeskyTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/unary/matrix/CholeskyTest.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.apache.sysds.api.DMLScript;
 import org.apache.sysds.common.Types.ExecMode;
-import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixValue.CellIndex;
 import org.apache.sysds.runtime.meta.MatrixCharacteristics;
 import org.apache.sysds.test.AutomatedTestBase;
@@ -110,8 +109,9 @@ public class CholeskyTest extends AutomatedTestBase
 			//run tests and compare results
 			runTest(true, false, null, -1);
 			HashMap<CellIndex, Double> dmlOut = readDMLMatrixFromOutputDir("D");
-			MatrixValue.CellIndex index = dmlOut.keySet().iterator().next();
-			double d = dmlOut.get(index);
+			// D is the 1x1 residual sum(A-B); an exact 0.0 result is not written to
+			// the sparse output, so an empty map corresponds to a perfect residual.
+			double d = dmlOut.isEmpty() ? 0.0 : dmlOut.values().iterator().next();
 			Assert.assertEquals(0, d, 1e-5);
 		}
 		finally {


### PR DESCRIPTION
CholeskyTest reconstructs A from its Cholesky factor and asserts that the 1x1 residual D = sum(A-B) is approximately zero. The output was read back with dmlOut.keySet().iterator().next(), which assumes at least one cell is present. When the residual is exactly 0.0, the sparse text writer omits the cell entirely, so the result map comes back empty and the iterator throws NoSuchElementException. A perfect reconstruction therefore caused the test to error out instead of pass.

This is not data-dependent flakiness: the input matrix is already seeded, so A is identical on every run. The variability comes from the reduction order of sum(A-B), which differs across Spark partitions and CP threads. Because floating-point addition is not associative, the residual lands on either an exact 0.0 (empty output) or a tiny non-zero value depending on execution, which is why only some runs (notably testLargeCholeskyDenseSP) failed. The fix treats an empty output as 0.0, making the assertion robust to both outcomes, and drops the now-unused MatrixValue import.

Error: https://github.com/apache/systemds/actions/runs/27172521960/job/80214522399 