### PR TITLE
[MINOR][CI] Fix leaked threads hanging Java test forks

### DIFF
--- a/.github/workflows/javaTests.yml
+++ b/.github/workflows/javaTests.yml
@@ -50,7 +50,10 @@ concurrency:
 jobs:
   java_tests:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # Job cap kept above the per-fork surefire timeout (test-forkedProcessTimeout,
+    # 600s) so surefire can kill hung forks and finish the remaining tests in a
+    # suite before GitHub Actions cancels the whole job.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javaTests.yml
+++ b/.github/workflows/javaTests.yml
@@ -51,9 +51,8 @@ jobs:
   java_tests:
     runs-on: ubuntu-24.04
     # Job cap kept above the per-fork surefire timeout (test-forkedProcessTimeout,
-    # 600s) so surefire can kill hung forks and finish the remaining tests in a
-    # suite before GitHub Actions cancels the whole job.
-    timeout-minutes: 60
+    # 600s) so surefire can kill a hung fork before GitHub Actions cancels the job.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/dev/release/src/test/java/org/apache/sysds/validation/Utility.java
+++ b/dev/release/src/test/java/org/apache/sysds/validation/Utility.java
@@ -185,6 +185,7 @@ public class Utility
 		try {
 			exitValue = process.waitFor();
 		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
 			debugPrint(Constants.DEBUG_ERROR, "Program interrunpted: " + ie);
 		}
 		debugPrint(Constants.DEBUG_CODE, "Program '" + String.join(" ", command) + "' exited with exit status " + exitValue, strOutputFile);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -65,6 +65,7 @@ import io.netty.handler.codec.serialization.ObjectEncoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 @SuppressWarnings("deprecation")
 public class FederatedWorker {
@@ -99,9 +100,14 @@ public class FederatedWorker {
 		LOG.info("Setting up Federated Worker on port " + _port);
 		int par_conn = ConfigurationManager.getDMLConfig().getIntValue(DMLConfig.FEDERATED_PAR_CONN);
 		final int EVENT_LOOP_THREADS = (par_conn > 0) ? par_conn : InfrastructureAnalyzer.getLocalParallelism();
-		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
+		// Use daemon threads for the Netty event loops. When the worker runs in-JVM (e.g. in tests)
+		// this guarantees a leaked worker can never keep the JVM alive after the owning thread is
+		// gone. In a standalone worker process the main thread keeps the JVM alive and drives the
+		// lifecycle, so daemon event loops have no effect on production shutdown.
+		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1,
+			new DefaultThreadFactory("fed-worker-boss", true));
 		ThreadPoolExecutor workerTPE = new ThreadPoolExecutor(1, Integer.MAX_VALUE, 10, TimeUnit.SECONDS,
-			new SynchronousQueue<Runnable>(true));
+			new SynchronousQueue<Runnable>(true), new DefaultThreadFactory("fed-worker-pool", true));
 		NioEventLoopGroup workerGroup = new NioEventLoopGroup(EVENT_LOOP_THREADS, workerTPE);
 
 		final boolean ssl = ConfigurationManager.isFederatedSSL();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -100,10 +100,7 @@ public class FederatedWorker {
 		LOG.info("Setting up Federated Worker on port " + _port);
 		int par_conn = ConfigurationManager.getDMLConfig().getIntValue(DMLConfig.FEDERATED_PAR_CONN);
 		final int EVENT_LOOP_THREADS = (par_conn > 0) ? par_conn : InfrastructureAnalyzer.getLocalParallelism();
-		// Use daemon threads for the Netty event loops. When the worker runs in-JVM (e.g. in tests)
-		// this guarantees a leaked worker can never keep the JVM alive after the owning thread is
-		// gone. In a standalone worker process the main thread keeps the JVM alive and drives the
-		// lifecycle, so daemon event loops have no effect on production shutdown.
+		// Daemon event loops so a leaked in-JVM (test) worker cannot block JVM exit.
 		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1,
 			new DefaultThreadFactory("fed-worker-boss", true));
 		ThreadPoolExecutor workerTPE = new ThreadPoolExecutor(1, Integer.MAX_VALUE, 10, TimeUnit.SECONDS,

--- a/src/main/java/org/apache/sysds/runtime/ooc/cache/OOCMatrixIOHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/ooc/cache/OOCMatrixIOHandler.java
@@ -148,7 +148,8 @@ public class OOCMatrixIOHandler implements OOCIOHandler {
 					_q[i].close();
 				}
 			}
-			catch(InterruptedException ignored) {
+			catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
 			}
 		}
 		_writeExec.getQueue().clear();
@@ -174,7 +175,8 @@ public class OOCMatrixIOHandler implements OOCIOHandler {
 			int i = (int)(q % WRITER_SIZE);
 			_q[i].enqueueIfOpen(new Tuple2<>(block, future));
 		}
-		catch(InterruptedException ignored) {
+		catch(InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 
 		return future;

--- a/src/main/java/org/apache/sysds/runtime/util/CommonThreadPool.java
+++ b/src/main/java/org/apache/sysds/runtime/util/CommonThreadPool.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -141,9 +142,24 @@ public class CommonThreadPool implements ExecutorService {
 				incorrectPoolUse = true;
 			}
 
-			return Executors.newFixedThreadPool(k);
+			return Executors.newFixedThreadPool(k, daemonThreadFactory());
 
 		}
+	}
+
+	/**
+	 * Thread factory that produces daemon threads. The ForkJoinPool-backed pools already use daemon
+	 * threads; the fallback {@link Executors#newFixedThreadPool} and {@link Executors#newCachedThreadPool}
+	 * pools default to non-daemon threads, which can keep the JVM (e.g. a surefire test fork) alive
+	 * if a caller forgets to shut the pool down. Making them daemon keeps that behavior uniform.
+	 */
+	private static ThreadFactory daemonThreadFactory() {
+		final ThreadFactory base = Executors.defaultThreadFactory();
+		return r -> {
+			Thread t = base.newThread(r);
+			t.setDaemon(true);
+			return t;
+		};
 	}
 
 	/**
@@ -180,7 +196,7 @@ public class CommonThreadPool implements ExecutorService {
 			// It is guaranteed not to be shut down because of the synchronized barrier
 			return asyncPool;
 		else {
-			asyncPool = Executors.newCachedThreadPool();
+			asyncPool = Executors.newCachedThreadPool(daemonThreadFactory());
 			return asyncPool;
 		}
 	}

--- a/src/test/java/org/apache/sysds/performance/generators/GenMatrices.java
+++ b/src/test/java/org/apache/sysds/performance/generators/GenMatrices.java
@@ -72,7 +72,7 @@ public class GenMatrices implements IGenerate<MatrixBlock> {
 				}
 			}
 			catch(InterruptedException e) {
-				e.printStackTrace();
+				Thread.currentThread().interrupt();
 			}
 		});
 	}

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -1939,6 +1939,9 @@ public abstract class AutomatedTestBase {
 				LOG.error("Exception in startup of federated worker", e);
 			}
 		});
+		// Daemon so a worker left running by a failed/forgetful test cannot keep the
+		// surefire fork JVM alive and stall CI until the job-level timeout.
+		t.setDaemon(true);
 		t.start();
 		return t;
 	}
@@ -1979,6 +1982,9 @@ public abstract class AutomatedTestBase {
 				LOG.error("Exception in startup of federated worker on port " + port, e);
 			}
 		});
+		// Daemon so a worker left running by a failed/forgetful test cannot keep the
+		// surefire fork JVM alive and stall CI until the job-level timeout.
+		t.setDaemon(true);
 		t.start();
 		FederatedWorkerUtils.waitForWorker(t, port, FED_WORKER_WAIT);
 		return t;

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -3489,15 +3489,23 @@ public class TestUtils {
 		}
 	}
 
+	/** Upper bound (ms) on how long {@link #shutdownThread(Thread)} waits for a worker to stop. */
+	private static final long THREAD_SHUTDOWN_JOIN_MS = 30_000;
+
 	public static void shutdownThread(Thread t) {
 		// kill the worker
 		if( t != null ) {
 			t.interrupt();
 			try {
-				t.join();
+				// Bounded join: workers are daemon threads, so even if one ignores the interrupt
+				// we must not block cleanup (and the JVM) indefinitely waiting for it.
+				t.join(THREAD_SHUTDOWN_JOIN_MS);
+				if( t.isAlive() )
+					LOG.warn("Federated worker thread " + t.getName()
+						+ " did not stop within " + THREAD_SHUTDOWN_JOIN_MS + "ms; leaving it as a daemon.");
 			}
 			catch (InterruptedException e) {
-				e.printStackTrace();
+				Thread.currentThread().interrupt();
 			}
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/TestUtils.java
+++ b/src/test/java/org/apache/sysds/test/TestUtils.java
@@ -3522,7 +3522,8 @@ public class TestUtils {
 					forciblyDestroyed.waitFor(); // Wait until it's definitely terminated
 				}
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+				LOG.warn("Interrupted while shutting down federated worker process", e);
+				Thread.currentThread().interrupt();
 			}
 		}
 	}

--- a/src/test/java/org/apache/sysds/test/functions/federated/monitoring/FederatedBackendPerformanceTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/monitoring/FederatedBackendPerformanceTest.java
@@ -91,8 +91,11 @@ public class FederatedBackendPerformanceTest extends FederatedMonitoringTestBase
 			taskFutures.forEach(res -> {
 				try {
 					Assert.assertEquals("Stats parsed correctly", res.get().statusCode(), 200);
-				} catch (InterruptedException | ExecutionException e) {
-					e.printStackTrace();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					Assert.fail("Interrupted while fetching statistics: " + e.getMessage());
+				} catch (ExecutionException e) {
+					Assert.fail("Failed to fetch statistics: " + e.getMessage());
 				}
 			});
 

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part5/FederatedMatrixScalarOperationsTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part5/FederatedMatrixScalarOperationsTest.java
@@ -209,7 +209,7 @@ public class FederatedMatrixScalarOperationsTest extends AutomatedTestBase {
 			compareResults();
 		}
 		catch(InterruptedException e) {
-			e.printStackTrace();
+			Thread.currentThread().interrupt();
 			assert (false);
 		}
 		finally {

--- a/src/test/java/org/apache/sysds/test/functions/lineage/FedFullReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/FedFullReuseTest.java
@@ -105,50 +105,52 @@ public class FedFullReuseTest extends AutomatedTestBase {
 		Lineage.resetInternalState();
 		Thread[] workers = startLocalFedWorkerThreads(new int[] {port1, port2}, otherargs, FED_WORKER_WAIT);
 
-		TestConfiguration config = availableTestConfigurations.get(test);
-		loadTestConfiguration(config);
+		try {
+			TestConfiguration config = availableTestConfigurations.get(test);
+			loadTestConfiguration(config);
 
-		// Run reference dml script with normal matrix. Reuse of ba+*.
-		fullDMLScriptName = HOME + test + "Reference.dml";
-		programArgs = new String[] {"-stats", "-lineage", "reuse_full",
-			"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
-			"Y2=" + input("Y2"), "Z=" + expected("Z")};
-		runTest(true, false, null, -1);
-		long mmCount = Statistics.getCPHeavyHitterCount(Opcodes.MMULT.toString());
+			// Run reference dml script with normal matrix. Reuse of ba+*.
+			fullDMLScriptName = HOME + test + "Reference.dml";
+			programArgs = new String[] {"-stats", "-lineage", "reuse_full",
+				"-nvargs", "X1=" + input("X1"), "X2=" + input("X2"), "Y1=" + input("Y1"),
+				"Y2=" + input("Y2"), "Z=" + expected("Z")};
+			runTest(true, false, null, -1);
+			long mmCount = Statistics.getCPHeavyHitterCount(Opcodes.MMULT.toString());
 
-		// Run actual dml script with federated matrix
-		// The fed workers reuse ba+*
-		fullDMLScriptName = HOME + test + ".dml";
-		programArgs = new String[] {"-stats","-lineage", "reuse_full",
-			"-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"X2=" + TestUtils.federatedAddress(port2, input("X2")),
-			"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
-			"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
-		runTest(true, false, null, -1);
-		long mmCount_fed = Statistics.getCPHeavyHitterCount(Opcodes.MMULT.toString());
-		long fedMMCount = Statistics.getCPHeavyHitterCount("fed_ba+*");
+			// Run actual dml script with federated matrix
+			// The fed workers reuse ba+*
+			fullDMLScriptName = HOME + test + ".dml";
+			programArgs = new String[] {"-stats","-lineage", "reuse_full",
+				"-nvargs", "X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"Y1=" + TestUtils.federatedAddress(port1, input("Y1")),
+				"Y2=" + TestUtils.federatedAddress(port2, input("Y2")), "r=" + rows, "c=" + cols, "Z=" + output("Z")};
+			runTest(true, false, null, -1);
+			long mmCount_fed = Statistics.getCPHeavyHitterCount(Opcodes.MMULT.toString());
+			long fedMMCount = Statistics.getCPHeavyHitterCount("fed_ba+*");
 
-		// compare results 
-		compareResults(1e-9);
-		// compare matrix multiplication count
-		// #federated execution of ba+* = #threads times #non-federated execution of ba+* (after reuse) 
-		Assert.assertTrue("Violated reuse count: "+mmCount_fed+" == "+mmCount*2, 
-				mmCount_fed == mmCount * 2); // #threads = 2
-		switch(test) {
-			case TEST_NAME1:
-				// If the o/p is federated, fed_ba+* will be called everytime
-				// but the workers should be able to reuse ba+*
-				assertTrue(fedMMCount > mmCount_fed);
-				break;
-			case TEST_NAME2:
-				// If the o/p is non-federated, fed_ba+* will be called once
-				// and each worker will call ba+* once.
-				assertTrue(fedMMCount < mmCount_fed);
-				break;
+			// compare results 
+			compareResults(1e-9);
+			// compare matrix multiplication count
+			// #federated execution of ba+* = #threads times #non-federated execution of ba+* (after reuse) 
+			Assert.assertTrue("Violated reuse count: "+mmCount_fed+" == "+mmCount*2, 
+					mmCount_fed == mmCount * 2); // #threads = 2
+			switch(test) {
+				case TEST_NAME1:
+					// If the o/p is federated, fed_ba+* will be called everytime
+					// but the workers should be able to reuse ba+*
+					assertTrue(fedMMCount > mmCount_fed);
+					break;
+				case TEST_NAME2:
+					// If the o/p is non-federated, fed_ba+* will be called once
+					// and each worker will call ba+* once.
+					assertTrue(fedMMCount < mmCount_fed);
+					break;
+			}
 		}
-
-
-		TestUtils.shutdownThreads(workers);
+		finally {
+			TestUtils.shutdownThreads(workers);
+		}
 	}
 
 }

--- a/src/test/java/org/apache/sysds/test/functions/lineage/FedUDFReuseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/FedUDFReuseTest.java
@@ -110,43 +110,45 @@ public class FedUDFReuseTest extends AutomatedTestBase {
 		Lineage.resetInternalState();
 		Thread[] workers = startLocalFedWorkerThreads(new int[] {port1, port2, port3, port4}, otherargs, FED_WORKER_WAIT);
 
-		rtplatform = execMode;
-		if(rtplatform == ExecMode.SPARK) {
-			System.out.println(7);
-			DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+		try {
+			rtplatform = execMode;
+			if(rtplatform == ExecMode.SPARK) {
+				System.out.println(7);
+				DMLScript.USE_LOCAL_SPARK_CONFIG = true;
+			}
+			TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
+			loadTestConfiguration(config);
+
+			// Run reference dml script with normal matrix
+			fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
+			programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-args", 
+				input("X1"), input("X2"), input("X3"), input("X4"),
+				Boolean.toString(rowPartitioned).toUpperCase(), expected("S")};
+			runTest(null);
+
+			// Run actual dml script with federated matrix
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-nvargs",
+				"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
+				"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
+				"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
+				"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + cols,
+				"rP=" + Boolean.toString(rowPartitioned).toUpperCase(), "out_S=" + output("S")};
+
+			runTest(null);
+
+			// compare via files
+			compareResults(1e-9);
+			// check if lowertri is federated
+			Assert.assertTrue(heavyHittersContainsString("fed_lowertri"));
+			// assert reuse count
+			Assert.assertTrue(LineageCacheStatistics.getInstHits() > 0);
 		}
-		TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
-		loadTestConfiguration(config);
-
-		// Run reference dml script with normal matrix
-		fullDMLScriptName = HOME + TEST_NAME + "Reference.dml";
-		programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-args", 
-			input("X1"), input("X2"), input("X3"), input("X4"),
-			Boolean.toString(rowPartitioned).toUpperCase(), expected("S")};
-		runTest(null);
-
-		// Run actual dml script with federated matrix
-		fullDMLScriptName = HOME + TEST_NAME + ".dml";
-		programArgs = new String[] {"-lineage", "reuse_full", "-stats", "100", "-nvargs",
-			"in_X1=" + TestUtils.federatedAddress(port1, input("X1")),
-			"in_X2=" + TestUtils.federatedAddress(port2, input("X2")),
-			"in_X3=" + TestUtils.federatedAddress(port3, input("X3")),
-			"in_X4=" + TestUtils.federatedAddress(port4, input("X4")), "rows=" + rows, "cols=" + cols,
-			"rP=" + Boolean.toString(rowPartitioned).toUpperCase(), "out_S=" + output("S")};
-
-		runTest(null);
-
-		// compare via files
-		compareResults(1e-9);
-		// check if lowertri is federated
-		Assert.assertTrue(heavyHittersContainsString("fed_lowertri"));
-		// assert reuse count
-		Assert.assertTrue(LineageCacheStatistics.getInstHits() > 0);
-
-		TestUtils.shutdownThreads(workers);
-
-		rtplatform = platformOld;
-		DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		finally {
+			TestUtils.shutdownThreads(workers);
+			rtplatform = platformOld;
+			DMLScript.USE_LOCAL_SPARK_CONFIG = sparkConfigOld;
+		}
 	}
 }
 

--- a/src/test/java/org/apache/sysds/test/functions/lineage/LineageFedReuseAlg.java
+++ b/src/test/java/org/apache/sysds/test/functions/lineage/LineageFedReuseAlg.java
@@ -69,6 +69,7 @@ public class LineageFedReuseAlg extends AutomatedTestBase {
 		getAndLoadTestConfiguration(TEST_NAME);
 		String HOME = SCRIPT_DIR + TEST_DIR;
 
+		Thread[] workers = null;
 		try {
 			// generated lm data
 			MatrixBlock X = MatrixBlock.randOperations(rows, cols, 1.0, 0, 1, "uniform", 7);
@@ -93,7 +94,7 @@ public class LineageFedReuseAlg extends AutomatedTestBase {
 			int port3 = getRandomAvailablePort();
 			int port4 = getRandomAvailablePort();
 			String[] otherargs = new String[] {"-lineage", "reuse_full"};
-			Thread[] workers = startLocalFedWorkerThreads(new int[] {port1, port2}, otherargs, FED_WORKER_WAIT);
+			workers = startLocalFedWorkerThreads(new int[] {port1, port2}, otherargs, FED_WORKER_WAIT);
 
 			TestConfiguration config = availableTestConfigurations.get(TEST_NAME);
 			loadTestConfiguration(config);
@@ -134,10 +135,9 @@ public class LineageFedReuseAlg extends AutomatedTestBase {
 			assertTrue(fed_tsmmCount > fed_tsmmCount_reuse);
 			assertTrue(mmCount > mmCount_reuse);
 			assertTrue(fed_mmCount > fed_mmCount_reuse);
-
-			TestUtils.shutdownThreads(workers);
 		}
 		finally {
+			TestUtils.shutdownThreads(workers);
 			resetExecMode(oldExec);
 			ColumnEncoderRecode.SORT_RECODE_MAP = oldSort;
 		}

--- a/src/test/java/org/apache/sysds/test/usertest/Base.java
+++ b/src/test/java/org/apache/sysds/test/usertest/Base.java
@@ -98,7 +98,7 @@ public class Base {
 			t.join();
 		}
 		catch(InterruptedException e) {
-			e.printStackTrace();
+			Thread.currentThread().interrupt();
 		}
 
 		System.setOut(old);


### PR DESCRIPTION
## Prevent leaked threads from hanging Java test forks in CI

Several Java test suites (most visibly `**.component.c**` and `data.misc/lineage`) intermittently ran until the GitHub Actions job timeout even though the tests themselves had completed. The cause was **leaked non-daemon threads keeping the surefire fork JVM alive**, so the fork never exited and the job stalled until cancelled. There were two sources: in-JVM federated workers (`FederatedWorker`'s Netty event loops and the test-side worker wrapper threads were non-daemon), and `CommonThreadPool`'s fallback pools — when called off the main thread, it returned `Executors.newFixedThreadPool`/`newCachedThreadPool`, which default to non-daemon threads, while only the ForkJoinPool-backed variants were already daemon.

This PR makes those threads daemon at the source: `FederatedWorker` now creates its Netty event-loop groups with a daemon thread factory, and `CommonThreadPool` routes its fixed/cached fallbacks through one too, so daemon behavior is uniform across all pool variants. On the test side, `AutomatedTestBase` marks spawned worker threads as daemon, `TestUtils.shutdownThread` bounds its `join` (30s, warns on stragglers, restores the interrupt flag), and the lineage tests (`LineageFedReuseAlg`, `FedFullReuseTest`, `FedUDFReuseTest`) now shut workers down in a `finally` block so failures no longer leak workers (the large line counts there are just reindentation from the `try/finally` wrap). The `javaTests.yml` job cap stays at 30 minutes, with a comment documenting why it sits above the 600s per-fork surefire timeout, which remains the backstop for genuine hangs.