### PR TITLE
[MINOR] test use deterministic alphabetical test run order in surefire

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,93 +51,9 @@ if [ "$compile_transient_failure" = true ]; then
 else
 	echo "No transient Maven repository error detected; no retry needed."
 fi
-
-# --- Hung-fork diagnostics -------------------------------------------------
-# Some fork JVMs finish their tests but never exit (the JVM stays alive while
-# surefire waits, eventually hitting the job timeout). The thread leak is not a
-# live non-daemon Java thread (verified locally), so the stall happens at JVM
-# shutdown -- a blocking shutdown hook or a stuck native frame. Neither is
-# visible after the fork is killed, so we snapshot the fork's stacks the moment
-# it goes idle, before surefire force-kills it.
-#
-# Detection: the surefire fork (its command line contains "surefirebooter")
-# burns CPU while running tests; if its cumulative CPU time stops advancing for
-# a sustained window while the process is still alive, it is stalled. We then
-# emit Java (jstack -l), native (jstack -m), and per-thread kernel wait-channel
-# (/proc/<pid>/task/*/wchan) snapshots to the job log and to target artifacts.
-dump_dir="/github/workspace/target/thread-dumps"
-mkdir -p "$dump_dir"
-jstack_bin="$JAVA_HOME/bin/jstack"
-
-hung_fork_watchdog() {
-	local poll=3 idle_limit=12          # dump after ~12s of zero CPU progress
-	local last_pid="" last_cpu=-1 idle=0 dumps=0
-	while true; do
-		sleep "$poll"
-		# Locate the current surefire fork via its command line. Use bash string
-		# matching (not grep) so the scan never matches its own helper process.
-		local pid="" p cl
-		for p in /proc/[0-9]*; do
-			[ -r "$p/cmdline" ] || continue
-			cl=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
-			case "$cl" in
-				*surefirebooter*) pid="${p#/proc/}"; break ;;
-			esac
-		done
-		if [ -z "$pid" ]; then last_pid=""; last_cpu=-1; idle=0; continue; fi
-
-		# Cumulative CPU (utime+stime, clock ticks) from /proc/<pid>/stat.
-		local stat rest cpu
-		stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
-		rest=${stat#*") "}
-		# shellcheck disable=SC2086
-		set -- $rest
-		cpu=$(( ${12} + ${13} ))
-
-		if [ "$pid" != "$last_pid" ]; then
-			last_pid="$pid"; last_cpu="$cpu"; idle=0; dumps=0; continue
-		fi
-		if [ "$cpu" = "$last_cpu" ]; then
-			idle=$(( idle + poll ))
-		else
-			idle=0; last_cpu="$cpu"
-		fi
-
-		if [ "$idle" -ge "$idle_limit" ] && [ "$dumps" -lt 3 ]; then
-			local ts f
-			ts=$(date +%H%M%S)
-			f="$dump_dir/stall_${pid}_${ts}.txt"
-			{
-				echo "================ STALLED SUREFIRE FORK ================"
-				echo "time=$(date +%H:%M:%S) pid=$pid cpu_ticks=$cpu idle>=${idle}s dump#$((dumps+1))"
-				echo "--- cmdline ---"; tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null; echo
-				echo "--- /proc/$pid/status (State/Threads) ---"
-				grep -E '^(State|Threads):' "/proc/$pid/status" 2>/dev/null
-				echo "--- per-thread kernel wait channel (tid comm wchan) ---"
-				for t in /proc/$pid/task/*; do
-					echo "  ${t##*/} $(cat "$t/comm" 2>/dev/null) $(cat "$t/wchan" 2>/dev/null)"
-				done
-				echo "--- jstack -l (live attach: Java threads + locks) ---"
-				"$jstack_bin" -l "$pid" 2>&1
-				echo "--- jstack -F -l (forced: works when the JVM is unresponsive) ---"
-				"$jstack_bin" -F -l "$pid" 2>&1
-				echo "--- jstack -m (mixed Java+native frames) ---"
-				"$jstack_bin" -m "$pid" 2>&1
-				echo "======================================================"
-			} 2>&1 | tee -a "$f"
-			dumps=$(( dumps + 1 ))
-		fi
-	done
-}
-
-hung_fork_watchdog &
-watchdog_pid=$!
-
 mvn -ntp -B test -D maven.test.skip=false -D automatedtestbase.outputbuffering=true -D test=$1 2>&1 \
 	| stdbuf -oL grep -Ev "already exists in destination.|Using incubator" \
 	| tee $log
-
-kill "$watchdog_pid" 2>/dev/null
 
 
 grep_args="SUCCESS"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,9 +51,93 @@ if [ "$compile_transient_failure" = true ]; then
 else
 	echo "No transient Maven repository error detected; no retry needed."
 fi
+
+# --- Hung-fork diagnostics -------------------------------------------------
+# Some fork JVMs finish their tests but never exit (the JVM stays alive while
+# surefire waits, eventually hitting the job timeout). The thread leak is not a
+# live non-daemon Java thread (verified locally), so the stall happens at JVM
+# shutdown -- a blocking shutdown hook or a stuck native frame. Neither is
+# visible after the fork is killed, so we snapshot the fork's stacks the moment
+# it goes idle, before surefire force-kills it.
+#
+# Detection: the surefire fork (its command line contains "surefirebooter")
+# burns CPU while running tests; if its cumulative CPU time stops advancing for
+# a sustained window while the process is still alive, it is stalled. We then
+# emit Java (jstack -l), native (jstack -m), and per-thread kernel wait-channel
+# (/proc/<pid>/task/*/wchan) snapshots to the job log and to target artifacts.
+dump_dir="/github/workspace/target/thread-dumps"
+mkdir -p "$dump_dir"
+jstack_bin="$JAVA_HOME/bin/jstack"
+
+hung_fork_watchdog() {
+	local poll=3 idle_limit=12          # dump after ~12s of zero CPU progress
+	local last_pid="" last_cpu=-1 idle=0 dumps=0
+	while true; do
+		sleep "$poll"
+		# Locate the current surefire fork via its command line. Use bash string
+		# matching (not grep) so the scan never matches its own helper process.
+		local pid="" p cl
+		for p in /proc/[0-9]*; do
+			[ -r "$p/cmdline" ] || continue
+			cl=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+			case "$cl" in
+				*surefirebooter*) pid="${p#/proc/}"; break ;;
+			esac
+		done
+		if [ -z "$pid" ]; then last_pid=""; last_cpu=-1; idle=0; continue; fi
+
+		# Cumulative CPU (utime+stime, clock ticks) from /proc/<pid>/stat.
+		local stat rest cpu
+		stat=$(cat "/proc/$pid/stat" 2>/dev/null) || continue
+		rest=${stat#*") "}
+		# shellcheck disable=SC2086
+		set -- $rest
+		cpu=$(( ${12} + ${13} ))
+
+		if [ "$pid" != "$last_pid" ]; then
+			last_pid="$pid"; last_cpu="$cpu"; idle=0; dumps=0; continue
+		fi
+		if [ "$cpu" = "$last_cpu" ]; then
+			idle=$(( idle + poll ))
+		else
+			idle=0; last_cpu="$cpu"
+		fi
+
+		if [ "$idle" -ge "$idle_limit" ] && [ "$dumps" -lt 3 ]; then
+			local ts f
+			ts=$(date +%H%M%S)
+			f="$dump_dir/stall_${pid}_${ts}.txt"
+			{
+				echo "================ STALLED SUREFIRE FORK ================"
+				echo "time=$(date +%H:%M:%S) pid=$pid cpu_ticks=$cpu idle>=${idle}s dump#$((dumps+1))"
+				echo "--- cmdline ---"; tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null; echo
+				echo "--- /proc/$pid/status (State/Threads) ---"
+				grep -E '^(State|Threads):' "/proc/$pid/status" 2>/dev/null
+				echo "--- per-thread kernel wait channel (tid comm wchan) ---"
+				for t in /proc/$pid/task/*; do
+					echo "  ${t##*/} $(cat "$t/comm" 2>/dev/null) $(cat "$t/wchan" 2>/dev/null)"
+				done
+				echo "--- jstack -l (live attach: Java threads + locks) ---"
+				"$jstack_bin" -l "$pid" 2>&1
+				echo "--- jstack -F -l (forced: works when the JVM is unresponsive) ---"
+				"$jstack_bin" -F -l "$pid" 2>&1
+				echo "--- jstack -m (mixed Java+native frames) ---"
+				"$jstack_bin" -m "$pid" 2>&1
+				echo "======================================================"
+			} 2>&1 | tee -a "$f"
+			dumps=$(( dumps + 1 ))
+		fi
+	done
+}
+
+hung_fork_watchdog &
+watchdog_pid=$!
+
 mvn -ntp -B test -D maven.test.skip=false -D automatedtestbase.outputbuffering=true -D test=$1 2>&1 \
 	| stdbuf -oL grep -Ev "already exists in destination.|Using incubator" \
 	| tee $log
+
+kill "$watchdog_pid" 2>/dev/null
 
 
 grep_args="SUCCESS"

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,10 @@
 					<!-- 1C means the number of threads times 1 possible maximum forks for testing-->
 					<forkCount>${test-forkCount}</forkCount>
 					<reuseForks>false</reuseForks>
+					<!-- Deterministic class ordering so a hang reproduces at the same
+					     boundary across CI and local runs (default filesystem order
+					     varies by machine, which hid the component-c fork hang). -->
+					<runOrder>alphabetical</runOrder>
 					<!-- Kill hung test forks before CI cancels the whole job. -->
 					<forkedProcessTimeoutInSeconds>${test-forkedProcessTimeout}</forkedProcessTimeoutInSeconds>
 					<!-- Force-kill forks that still have live threads after the test class completes. -->


### PR DESCRIPTION
Set surefire runOrder to alphabetical so test classes execute in the same sequence on every machine.

This makes local reproduction of tests easier.