### PR TITLE
[SYSTEMDS-3946] Enable sending of large (>2GiB) FederatedRequests and…

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.sysds.runtime.util.CommonThreadPool;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
+	private static final Object END_OF_STREAM = new Object();
+	// stop reading at QUEUE_DEPTH, resume at half: gap avoids autoRead thrash
+	private static final int LOW_WATERMARK = FederatedChunkProtocol.QUEUE_DEPTH / 2;
+
+	private final BlockingQueue<Object> _payloads = new LinkedBlockingQueue<>();
+	private boolean _started;
+	private volatile boolean _throttled;
+
+	@Override
+	protected void decode(ChannelHandlerContext ctx, ByteBuf frame, List<Object> out) {
+		startReader(ctx);
+		byte type = frame.readByte();
+		int len = frame.readInt();
+		switch(type) {
+			case FederatedChunkProtocol.TYPE_DATA:
+				_payloads.add(readBytes(frame, len));
+				break;
+			case FederatedChunkProtocol.TYPE_END:
+				_payloads.add(END_OF_STREAM);
+				break;
+			case FederatedChunkProtocol.TYPE_ERROR:
+				_payloads.add(new IOException(frame.toString(frame.readerIndex(), len, StandardCharsets.UTF_8)));
+				break;
+		}
+		if(_payloads.size() >= FederatedChunkProtocol.QUEUE_DEPTH) {
+			_throttled = true;
+			ctx.channel().config().setAutoRead(false);
+		}
+	}
+
+	private void startReader(ChannelHandlerContext ctx) {
+		if(_started)
+			return;
+		_started = true;
+		CommonThreadPool.getDynamicPool().execute(() -> runDeserializer(ctx));
+	}
+
+	private void runDeserializer(ChannelHandlerContext ctx) {
+		try(ObjectInputStream ois = objectInputStream(new PayloadInputStream(this, ctx))) {
+			Object msg = ois.readObject();
+			ctx.channel().eventLoop().execute(() -> ctx.fireChannelRead(msg));
+		}
+		catch(Throwable t) {
+			ctx.channel().eventLoop().execute(() -> ctx.fireExceptionCaught(t));
+		}
+	}
+
+	private Object nextPayload() throws InterruptedException {
+		return _payloads.take();
+	}
+
+	private void resumeReadingIfDrained(ChannelHandlerContext ctx) {
+		if(_throttled && _payloads.size() <= LOW_WATERMARK) {
+			_throttled = false;
+			ctx.channel().eventLoop().execute(() -> ctx.channel().config().setAutoRead(true));
+		}
+	}
+
+	private static ObjectInputStream objectInputStream(InputStream in) throws IOException {
+		return new ObjectInputStream(in) {
+			@Override
+			protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+				try {
+					return Class.forName(desc.getName(), false, ClassLoader.getSystemClassLoader());
+				}
+				catch(ClassNotFoundException e) {
+					return super.resolveClass(desc);
+				}
+			}
+		};
+	}
+
+	private static byte[] readBytes(ByteBuf frame, int len) {
+		byte[] bytes = new byte[len];
+		frame.readBytes(bytes);
+		return bytes;
+	}
+
+	private static final class PayloadInputStream extends InputStream {
+		private static final byte[] EMPTY = new byte[0];
+
+		private final FederatedChunkDecoder _decoder;
+		private final ChannelHandlerContext _ctx;
+		private byte[] _current = EMPTY;
+		private int _pos;
+		private boolean _eof;
+
+		PayloadInputStream(FederatedChunkDecoder decoder, ChannelHandlerContext ctx) {
+			_decoder = decoder;
+			_ctx = ctx;
+		}
+
+		@Override
+		public int read() throws IOException {
+			if(!ensureCurrent())
+				return -1;
+			return _current[_pos++] & 0xff;
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) throws IOException {
+			if(!ensureCurrent())
+				return -1;
+			int n = Math.min(len, _current.length - _pos);
+			System.arraycopy(_current, _pos, b, off, n);
+			_pos += n;
+			return n;
+		}
+
+		private boolean ensureCurrent() throws IOException {
+			while(_pos == _current.length) {
+				if(_eof)
+					return false;
+				Object next = take();
+				if(next == END_OF_STREAM) {
+					_eof = true;
+					return false;
+				}
+				if(next instanceof Throwable)
+					throw new IOException((Throwable) next);
+				_current = (byte[]) next;
+				_pos = 0;
+			}
+			return true;
+		}
+
+		private Object take() throws IOException {
+			try {
+				Object next = _decoder.nextPayload();
+				_decoder.resumeReadingIfDrained(_ctx);
+				return next;
+			}
+			catch(InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IOException(e);
+			}
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
@@ -44,19 +44,19 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 	private volatile boolean _throttled;
 
 	@Override
-	protected void decode(ChannelHandlerContext ctx, ByteBuf frame, List<Object> out) {
+	protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> out) {
 		startReader(ctx);
-		byte type = frame.readByte();
-		int len = frame.readInt();
+		byte type = buf.readByte();
+		int len = buf.readInt();
 		switch(type) {
 			case FederatedChunkProtocol.TYPE_DATA:
-				_payloads.add(readBytes(frame, len));
+				_payloads.add(readBytes(buf, len));
 				break;
 			case FederatedChunkProtocol.TYPE_END:
 				_payloads.add(END_OF_STREAM);
 				break;
 			case FederatedChunkProtocol.TYPE_ERROR:
-				_payloads.add(new IOException(frame.toString(frame.readerIndex(), len, StandardCharsets.UTF_8)));
+				_payloads.add(new IOException(buf.toString(buf.readerIndex(), len, StandardCharsets.UTF_8)));
 				break;
 		}
 		if(_payloads.size() >= FederatedChunkProtocol.QUEUE_DEPTH) {
@@ -73,7 +73,7 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 	}
 
 	private void runDeserializer(ChannelHandlerContext ctx) {
-		try(ObjectInputStream ois = objectInputStream(new PayloadInputStream(this, ctx))) {
+		try(ObjectInputStream ois = getObjectInputStream(new PayloadInputStream(this, ctx))) {
 			Object msg = ois.readObject();
 			ctx.channel().eventLoop().execute(() -> ctx.fireChannelRead(msg));
 		}
@@ -93,7 +93,7 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		}
 	}
 
-	private static ObjectInputStream objectInputStream(InputStream in) throws IOException {
+	private static ObjectInputStream getObjectInputStream(InputStream in) throws IOException {
 		return new ObjectInputStream(in) {
 			@Override
 			protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
@@ -107,9 +107,9 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		};
 	}
 
-	private static byte[] readBytes(ByteBuf frame, int len) {
+	private static byte[] readBytes(ByteBuf buf, int len) {
 		byte[] bytes = new byte[len];
-		frame.readBytes(bytes);
+		buf.readBytes(bytes);
 		return bytes;
 	}
 

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkDecoder.java
@@ -58,6 +58,9 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 			case FederatedChunkProtocol.TYPE_ERROR:
 				_payloads.add(new IOException(buf.toString(buf.readerIndex(), len, StandardCharsets.UTF_8)));
 				break;
+			default:
+				_payloads.add(new IOException("Unknown federated chunk frame type: " + type));
+				break;
 		}
 		if(_payloads.size() >= FederatedChunkProtocol.QUEUE_DEPTH) {
 			_throttled = true;
@@ -65,6 +68,11 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		}
 	}
 
+	/**
+	 * Start the deserializer on a pool thread, at most once per channel.
+	 *
+	 * @param ctx handler context
+	 */
 	private void startReader(ChannelHandlerContext ctx) {
 		if(_started)
 			return;
@@ -72,6 +80,12 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		CommonThreadPool.getDynamicPool().execute(() -> runDeserializer(ctx));
 	}
 
+	/**
+	 * Read one object from the queued payloads and fire it up the pipeline. A failure is fired as an exception on the
+	 * event loop instead.
+	 *
+	 * @param ctx handler context
+	 */
 	private void runDeserializer(ChannelHandlerContext ctx) {
 		try(ObjectInputStream ois = getObjectInputStream(new PayloadInputStream(this, ctx))) {
 			Object msg = ois.readObject();
@@ -82,10 +96,21 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		}
 	}
 
+	/**
+	 * Take the next queued payload, blocking until one arrives.
+	 *
+	 * @return payload bytes, the end of stream marker or a queued failure
+	 * @throws InterruptedException on interrupt while the queue is empty
+	 */
 	private Object nextPayload() throws InterruptedException {
 		return _payloads.take();
 	}
 
+	/**
+	 * Re-enable channel reads once the payload queue has drained to the low watermark.
+	 *
+	 * @param ctx handler context
+	 */
 	private void resumeReadingIfDrained(ChannelHandlerContext ctx) {
 		if(_throttled && _payloads.size() <= LOW_WATERMARK) {
 			_throttled = false;
@@ -93,6 +118,13 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 		}
 	}
 
+	/**
+	 * Create an object input stream using the system class loader.
+	 *
+	 * @param in stream of payload bytes
+	 * @return object input stream
+	 * @throws IOException on stream header failure
+	 */
 	private static ObjectInputStream getObjectInputStream(InputStream in) throws IOException {
 		return new ObjectInputStream(in) {
 			@Override
@@ -144,6 +176,13 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 			return n;
 		}
 
+		/**
+		 * Advance to the next payload when the current one is exhausted. A queued failure is rethrown as an
+		 * IOException.
+		 *
+		 * @return true if bytes are available, false at end of stream
+		 * @throws IOException on a queued failure or on interrupt
+		 */
 		private boolean ensureCurrent() throws IOException {
 			while(_pos == _current.length) {
 				if(_eof)
@@ -161,6 +200,12 @@ public class FederatedChunkDecoder extends MessageToMessageDecoder<ByteBuf> {
 			return true;
 		}
 
+		/**
+		 * Take the next payload and resume reading if the queue has drained.
+		 *
+		 * @return payload bytes, the end of stream marker or a queued failure
+		 * @throws IOException on interrupt
+		 */
 		private Object take() throws IOException {
 			try {
 				Object next = _decoder.nextPayload();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
@@ -32,34 +32,17 @@ import org.apache.sysds.runtime.util.CommonThreadPool;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOutboundHandlerAdapter;
-import io.netty.channel.ChannelPromise;
 import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
-public class FederatedChunkEncoder extends ChannelOutboundHandlerAdapter {
-	private final int _chunkSize;
+public final class FederatedChunkEncoder {
 
-	public FederatedChunkEncoder() {
-		this(FederatedChunkProtocol.DEFAULT_CHUNK_SIZE);
+	private FederatedChunkEncoder() {
 	}
 
-	public FederatedChunkEncoder(int chunkSize) {
-		_chunkSize = chunkSize;
-	}
-
-	static ChunkedInput<ByteBuf> chunkedInput(Serializable msg, int chunkSize, ByteBufAllocator alloc,
+	public static ChunkedInput<ByteBuf> chunkedInput(Serializable msg, int chunkSize, ByteBufAllocator alloc,
 		ChunkedWriteHandler writer) {
 		return new SerializedChunks(msg, chunkSize, alloc, writer);
-	}
-
-	@Override
-	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-		if(msg instanceof Serializable)
-			ctx.write(new SerializedChunks((Serializable) msg, _chunkSize, ctx.alloc(),
-				ctx.pipeline().get(ChunkedWriteHandler.class)), promise);
-		else
-			ctx.write(msg, promise);
 	}
 
 	private static final class SerializedChunks implements ChunkedInput<ByteBuf> {

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import org.apache.sysds.runtime.util.CommonThreadPool;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.stream.ChunkedInput;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+public class FederatedChunkEncoder extends ChannelOutboundHandlerAdapter {
+	private final int _chunkSize;
+
+	public FederatedChunkEncoder() {
+		this(FederatedChunkProtocol.DEFAULT_CHUNK_SIZE);
+	}
+
+	public FederatedChunkEncoder(int chunkSize) {
+		_chunkSize = chunkSize;
+	}
+
+	static ChunkedInput<ByteBuf> chunkedInput(Serializable msg, int chunkSize, ByteBufAllocator alloc,
+		ChunkedWriteHandler writer) {
+		return new SerializedChunks(msg, chunkSize, alloc, writer);
+	}
+
+	@Override
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		if(msg instanceof Serializable)
+			ctx.write(new SerializedChunks((Serializable) msg, _chunkSize, ctx.alloc(),
+				ctx.pipeline().get(ChunkedWriteHandler.class)), promise);
+		else
+			ctx.write(msg, promise);
+	}
+
+	private static final class SerializedChunks implements ChunkedInput<ByteBuf> {
+		private final BlockingQueue<ByteBuf> _frames = new ArrayBlockingQueue<>(FederatedChunkProtocol.QUEUE_DEPTH);
+		private final ByteBufAllocator _alloc;
+		private final ChunkedWriteHandler _writer;
+		private volatile boolean _closed;
+		private boolean _done;
+
+		SerializedChunks(Serializable msg, int chunkSize, ByteBufAllocator alloc, ChunkedWriteHandler writer) {
+			_alloc = alloc;
+			_writer = writer;
+			CommonThreadPool.getDynamicPool().execute(() -> produceFrames(msg, chunkSize));
+		}
+
+		private void produceFrames(Serializable msg, int chunkSize) {
+			try(FrameOutputStream out = new FrameOutputStream(this, _alloc, chunkSize);
+				ObjectOutputStream oos = new ObjectOutputStream(out)) {
+				oos.writeObject(msg);
+				oos.flush();
+				out.flushFrame();
+				enqueueControlFrame(controlFrame(FederatedChunkProtocol.TYPE_END));
+			}
+			catch(Throwable t) {
+				enqueueControlFrame(errorFrame(t));
+			}
+		}
+
+		private ByteBuf controlFrame(byte type) {
+			return _alloc.buffer(FederatedChunkProtocol.HEADER_LEN).writeByte(type).writeInt(0);
+		}
+
+		private ByteBuf errorFrame(Throwable t) {
+			byte[] cause = String.valueOf(t).getBytes(StandardCharsets.UTF_8);
+			return _alloc.buffer(FederatedChunkProtocol.HEADER_LEN + cause.length)
+				.writeByte(FederatedChunkProtocol.TYPE_ERROR).writeInt(cause.length).writeBytes(cause);
+		}
+
+		void enqueueFrame(ByteBuf frame) throws InterruptedException {
+			if(_closed) {
+				frame.release();
+				return;
+			}
+			_frames.put(frame);
+			_writer.resumeTransfer();
+		}
+
+		private void enqueueControlFrame(ByteBuf frame) {
+			try {
+				enqueueFrame(frame);
+			}
+			catch(InterruptedException e) {
+				frame.release();
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		@Override
+		public ByteBuf readChunk(ByteBufAllocator allocator) {
+			if(_done)
+				return null;
+			ByteBuf frame = _frames.poll();
+			if(frame == null)
+				return null;
+			_done = frame.getByte(frame.readerIndex()) != FederatedChunkProtocol.TYPE_DATA;
+			return frame;
+		}
+
+		@Override
+		public ByteBuf readChunk(ChannelHandlerContext ctx) {
+			return readChunk(ctx.alloc());
+		}
+
+		@Override
+		public boolean isEndOfInput() {
+			return _done;
+		}
+
+		@Override
+		public long length() {
+			return -1;
+		}
+
+		@Override
+		public long progress() {
+			return 0;
+		}
+
+		@Override
+		public void close() {
+			_closed = true;
+			ByteBuf frame;
+			while((frame = _frames.poll()) != null)
+				frame.release();
+		}
+	}
+
+	private static final class FrameOutputStream extends OutputStream {
+		private final SerializedChunks _sink;
+		private final ByteBufAllocator _alloc;
+		private final byte[] _buffer;
+		private int _len;
+
+		FrameOutputStream(SerializedChunks sink, ByteBufAllocator alloc, int chunkSize) {
+			_sink = sink;
+			_alloc = alloc;
+			_buffer = new byte[chunkSize];
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			_buffer[_len++] = (byte) b;
+			if(_len == _buffer.length)
+				flushFrame();
+		}
+
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			while(len > 0) {
+				int n = Math.min(len, _buffer.length - _len);
+				System.arraycopy(b, off, _buffer, _len, n);
+				_len += n;
+				off += n;
+				len -= n;
+				if(_len == _buffer.length)
+					flushFrame();
+			}
+		}
+
+		void flushFrame() throws IOException {
+			if(_len == 0)
+				return;
+			ByteBuf frame = _alloc.buffer(FederatedChunkProtocol.HEADER_LEN + _len)
+				.writeByte(FederatedChunkProtocol.TYPE_DATA).writeInt(_len).writeBytes(_buffer, 0, _len);
+			_len = 0;
+			try {
+				_sink.enqueueFrame(frame);
+			}
+			catch(InterruptedException e) {
+				frame.release();
+				Thread.currentThread().interrupt();
+				throw new IOException(e);
+			}
+		}
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkEncoder.java
@@ -40,6 +40,16 @@ public final class FederatedChunkEncoder {
 	private FederatedChunkEncoder() {
 	}
 
+	/**
+	 * Create a chunked input over the serialized form of the given message. Serialization starts immediately on a pool
+	 * thread.
+	 *
+	 * @param msg       message to serialize
+	 * @param chunkSize payload bytes per data frame
+	 * @param alloc     allocator for the frame buffers
+	 * @param writer    write handler resumed when a frame becomes available
+	 * @return chunked input over the serialized message
+	 */
 	public static ChunkedInput<ByteBuf> chunkedInput(Serializable msg, int chunkSize, ByteBufAllocator alloc,
 		ChunkedWriteHandler writer) {
 		return new SerializedChunks(msg, chunkSize, alloc, writer);
@@ -52,12 +62,27 @@ public final class FederatedChunkEncoder {
 		private volatile boolean _closed;
 		private boolean _done;
 
+		/**
+		 * Create the frame source and start serialization on a pool thread.
+		 *
+		 * @param msg       message to serialize
+		 * @param chunkSize payload bytes per data frame
+		 * @param alloc     allocator for the frame buffers
+		 * @param writer    write handler resumed when a frame becomes available
+		 */
 		SerializedChunks(Serializable msg, int chunkSize, ByteBufAllocator alloc, ChunkedWriteHandler writer) {
 			_alloc = alloc;
 			_writer = writer;
 			CommonThreadPool.getDynamicPool().execute(() -> produceFrames(msg, chunkSize));
 		}
 
+		/**
+		 * Serialize the message into data frames followed by an end frame. A failure is turned into an error frame
+		 * instead.
+		 *
+		 * @param msg       message to serialize
+		 * @param chunkSize payload bytes per data frame
+		 */
 		private void produceFrames(Serializable msg, int chunkSize) {
 			try(FrameOutputStream out = new FrameOutputStream(this, _alloc, chunkSize);
 				ObjectOutputStream oos = new ObjectOutputStream(out)) {
@@ -71,16 +96,34 @@ public final class FederatedChunkEncoder {
 			}
 		}
 
+		/**
+		 * Create a header only frame of the given type.
+		 *
+		 * @param type frame type
+		 * @return control frame with an empty payload
+		 */
 		private ByteBuf controlFrame(byte type) {
 			return _alloc.buffer(FederatedChunkProtocol.HEADER_LEN).writeByte(type).writeInt(0);
 		}
 
+		/**
+		 * Create an error frame whose payload is the UTF-8 text of the failure.
+		 *
+		 * @param t serialization failure
+		 * @return error frame
+		 */
 		private ByteBuf errorFrame(Throwable t) {
 			byte[] cause = String.valueOf(t).getBytes(StandardCharsets.UTF_8);
 			return _alloc.buffer(FederatedChunkProtocol.HEADER_LEN + cause.length)
 				.writeByte(FederatedChunkProtocol.TYPE_ERROR).writeInt(cause.length).writeBytes(cause);
 		}
 
+		/**
+		 * Append a frame to the queue and resume the write handler. A frame arriving after close is released instead.
+		 *
+		 * @param frame frame to append
+		 * @throws InterruptedException on interrupt while the queue is full
+		 */
 		void enqueueFrame(ByteBuf frame) throws InterruptedException {
 			if(_closed) {
 				frame.release();
@@ -90,6 +133,11 @@ public final class FederatedChunkEncoder {
 			_writer.resumeTransfer();
 		}
 
+		/**
+		 * Append a control frame, releasing it on interrupt.
+		 *
+		 * @param frame frame to append
+		 */
 		private void enqueueControlFrame(ByteBuf frame) {
 			try {
 				enqueueFrame(frame);
@@ -146,6 +194,13 @@ public final class FederatedChunkEncoder {
 		private final byte[] _buffer;
 		private int _len;
 
+		/**
+		 * Create a stream that buffers written bytes and emits one data frame per full chunk.
+		 *
+		 * @param sink      chunked input receiving the frames
+		 * @param alloc     allocator for the frame buffers
+		 * @param chunkSize payload bytes per data frame
+		 */
 		FrameOutputStream(SerializedChunks sink, ByteBufAllocator alloc, int chunkSize) {
 			_sink = sink;
 			_alloc = alloc;
@@ -172,6 +227,11 @@ public final class FederatedChunkEncoder {
 			}
 		}
 
+		/**
+		 * Emit the buffered bytes as one data frame or nothing when the buffer is empty.
+		 *
+		 * @throws IOException on interrupt while the queue is full
+		 */
 		void flushFrame() throws IOException {
 			if(_len == 0)
 				return;

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
@@ -26,12 +26,13 @@ final class FederatedChunkProtocol {
 	static final byte TYPE_END = 1;
 	static final byte TYPE_ERROR = 2;
 
-	static final byte MARKER_LEGACY = 0;
+	static final byte MARKER_OBJECT_ENCODER = 0;
 	static final byte MARKER_CHUNKED = 1;
-	static final long STREAM_THRESHOLD = 1536L << 20; // ~1.5 GB: route below this through the legacy object codec
+
+	static final long STREAM_THRESHOLD = 2000L << 20;
 
 	static final int HEADER_LEN = 5;
-	static final int DEFAULT_CHUNK_SIZE = 1 << 20; // 1 MB payload per frame
+	static final int DEFAULT_CHUNK_SIZE = 1 << 22;
 	static final int QUEUE_DEPTH = 16;
 
 	static final int LENGTH_FIELD_OFFSET = 1;
@@ -44,9 +45,10 @@ final class FederatedChunkProtocol {
 	}
 
 	static LengthFieldBasedFrameDecoder newFrameDecoder() {
-		return new LengthFieldBasedFrameDecoder(maxFrameLength(DEFAULT_CHUNK_SIZE),
-			LENGTH_FIELD_OFFSET, LENGTH_FIELD_LENGTH, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP);
+		return new LengthFieldBasedFrameDecoder(maxFrameLength(DEFAULT_CHUNK_SIZE), LENGTH_FIELD_OFFSET,
+			LENGTH_FIELD_LENGTH, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP);
 	}
 
-	private FederatedChunkProtocol() {}
+	private FederatedChunkProtocol() {
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+
+final class FederatedChunkProtocol {
+	static final byte TYPE_DATA = 0;
+	static final byte TYPE_END = 1;
+	static final byte TYPE_ERROR = 2;
+
+	static final byte MARKER_LEGACY = 0;
+	static final byte MARKER_CHUNKED = 1;
+	static final long STREAM_THRESHOLD = 1536L << 20; // ~1.5 GB: route below this through the legacy object codec
+
+	static final int HEADER_LEN = 5;
+	static final int DEFAULT_CHUNK_SIZE = 1 << 20; // 1 MB payload per frame
+	static final int QUEUE_DEPTH = 16;
+
+	static final int LENGTH_FIELD_OFFSET = 1;
+	static final int LENGTH_FIELD_LENGTH = 4;
+	static final int LENGTH_ADJUSTMENT = 0;
+	static final int INITIAL_BYTES_TO_STRIP = 0;
+
+	static int maxFrameLength(int chunkSize) {
+		return chunkSize + HEADER_LEN;
+	}
+
+	static LengthFieldBasedFrameDecoder newFrameDecoder() {
+		return new LengthFieldBasedFrameDecoder(maxFrameLength(DEFAULT_CHUNK_SIZE),
+			LENGTH_FIELD_OFFSET, LENGTH_FIELD_LENGTH, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP);
+	}
+
+	private FederatedChunkProtocol() {}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedChunkProtocol.java
@@ -40,10 +40,21 @@ final class FederatedChunkProtocol {
 	static final int LENGTH_ADJUSTMENT = 0;
 	static final int INITIAL_BYTES_TO_STRIP = 0;
 
+	/**
+	 * Get the largest frame a chunk of the given size can produce.
+	 *
+	 * @param chunkSize payload bytes per data frame
+	 * @return frame size including the header
+	 */
 	static int maxFrameLength(int chunkSize) {
 		return chunkSize + HEADER_LEN;
 	}
 
+	/**
+	 * Create a length based frame decoder for the chunked wire format.
+	 *
+	 * @return frame decoder sized for the default chunk size
+	 */
 	static LengthFieldBasedFrameDecoder newFrameDecoder() {
 		return new LengthFieldBasedFrameDecoder(maxFrameLength(DEFAULT_CHUNK_SIZE), LENGTH_FIELD_OFFSET,
 			LENGTH_FIELD_LENGTH, LENGTH_ADJUSTMENT, INITIAL_BYTES_TO_STRIP);

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -22,7 +22,6 @@ package org.apache.sysds.runtime.controlprogram.federated;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.Serializable;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -37,9 +36,11 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ChannelFutureListener;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
@@ -60,11 +61,11 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest.Reques
 import org.apache.sysds.runtime.controlprogram.paramserv.NetworkTrafficCounter;
 import org.apache.sysds.runtime.controlprogram.caching.CacheBlock;
 import org.apache.sysds.conf.DMLConfig;
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.serialization.ObjectEncoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Promise;
@@ -205,6 +206,7 @@ public class FederatedData {
 				createWorkGroup();
 			b.group(workerGroup);
 			b.channel(NioSocketChannel.class);
+			b.option(ChannelOption.ALLOW_HALF_CLOSURE, true);
 			final DataRequestHandler handler = new DataRequestHandler();
 			// Client Netty
 
@@ -213,7 +215,12 @@ public class FederatedData {
 			ChannelFuture f = b.connect(address).sync();
 			Promise<FederatedResponse> promise = f.channel().eventLoop().newPromise();
 			handler.setPromise(promise);
-			f.channel().writeAndFlush(request);
+			f.channel().writeAndFlush(request).addListener((ChannelFutureListener) future -> {
+                if (!future.isSuccess()) {
+                    LOG.error("Federated network write failed: " + future.cause().getMessage());
+                    promise.setFailure(future.cause());
+                }
+            });
 
 			return handler.getProm();
 		}
@@ -256,9 +263,11 @@ public class FederatedData {
 					cp.addLast(new ReadTimeoutHandler(timeout));
 
 				compressionStrategy.ifPresent(strategy -> cp.addLast(strategy.left));
-				cp.addLast(FederationUtils.decoder());
+				cp.addLast(new FederatedFormatDetector());
 				compressionStrategy.ifPresent(strategy -> cp.addLast(strategy.right));
-				cp.addLast(new FederatedRequestEncoder());
+				cp.addLast(new ChunkedWriteHandler());
+				cp.addLast(new ObjectEncoder());
+				cp.addLast(new FederatedFormatEncoder());
 				cp.addLast(handler);
 			}
 		};
@@ -323,6 +332,15 @@ public class FederatedData {
 			ctx.close();
 		}
 
+		@Override
+		public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+			// Fail (rather than leave hanging) any request whose connection closed before its response
+			// was delivered, so a waiting caller gets an exception instead of blocking until timeout.
+			if(_prom != null && !_prom.isDone())
+				_prom.tryFailure(new IOException("Channel closed before federated response was received"));
+			super.channelInactive(ctx);
+		}
+
 		public Promise<FederatedResponse> getProm() {
 			return _prom;
 		}
@@ -337,32 +355,6 @@ public class FederatedData {
 		sb.append(" " + _address.toString());
 		sb.append(":" + _filepath);
 		return sb.toString();
-	}
-
-	public static class FederatedRequestEncoder extends ObjectEncoder {
-		@Override
-		protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, Serializable msg, boolean preferDirect)
-			throws Exception {
-			int initCapacity = 256; // default initial capacity
-			if(msg instanceof FederatedRequest[]) {
-				initCapacity = 0;
-				try {
-					for(FederatedRequest fr : (FederatedRequest[]) msg) {
-						int frSize = Math.toIntExact(fr.estimateSerializationBufferSize());
-						if(Integer.MAX_VALUE - initCapacity < frSize) // summed sizes exceed integer limits
-							throw new ArithmeticException("Overflow.");
-						initCapacity += frSize;
-					}
-				}
-				catch(ArithmeticException ae) { // size of federated request exceeds integer limits
-					initCapacity = Integer.MAX_VALUE;
-				}
-			}
-			if(preferDirect)
-				return ctx.alloc().ioBuffer(initCapacity);
-			else
-				return ctx.alloc().heapBuffer(initCapacity);
-		}
 	}
 
 	/**

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedData.java
@@ -216,11 +216,11 @@ public class FederatedData {
 			Promise<FederatedResponse> promise = f.channel().eventLoop().newPromise();
 			handler.setPromise(promise);
 			f.channel().writeAndFlush(request).addListener((ChannelFutureListener) future -> {
-                if (!future.isSuccess()) {
-                    LOG.error("Federated network write failed: " + future.cause().getMessage());
-                    promise.setFailure(future.cause());
-                }
-            });
+				if(!future.isSuccess()) {
+					LOG.error("Federated network write failed: " + future.cause().getMessage());
+					promise.setFailure(future.cause());
+				}
+			});
 
 			return handler.getProm();
 		}
@@ -263,7 +263,7 @@ public class FederatedData {
 					cp.addLast(new ReadTimeoutHandler(timeout));
 
 				compressionStrategy.ifPresent(strategy -> cp.addLast(strategy.left));
-				cp.addLast(new FederatedFormatDetector());
+				cp.addLast(new FederatedFormatDecoder());
 				compressionStrategy.ifPresent(strategy -> cp.addLast(strategy.right));
 				cp.addLast(new ChunkedWriteHandler());
 				cp.addLast(new ObjectEncoder());

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatDecoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatDecoder.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
-public final class FederatedFormatDetector extends ByteToMessageDecoder {
+public final class FederatedFormatDecoder extends ByteToMessageDecoder {
 	@Override
 	protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
 		if(in.readableBytes() < 1)

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatDetector.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatDetector.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+public final class FederatedFormatDetector extends ByteToMessageDecoder {
+	@Override
+	protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+		if(in.readableBytes() < 1)
+			return;
+		byte marker = in.readByte();
+		ChannelPipeline cp = ctx.pipeline();
+		if(marker == FederatedChunkProtocol.MARKER_CHUNKED) {
+			cp.addAfter(ctx.name(), "FederatedFrameDecoder", FederatedChunkProtocol.newFrameDecoder());
+			cp.addAfter("FederatedFrameDecoder", "FederatedChunkDecoder", new FederatedChunkDecoder());
+		}
+		else {
+			cp.addAfter(ctx.name(), "FederatedObjectDecoder", FederationUtils.decoder());
+		}
+		cp.remove(this);
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.controlprogram.federated;
+
+import java.io.Serializable;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+public class FederatedFormatEncoder extends ChannelOutboundHandlerAdapter {
+	private final int _chunkSize;
+	private final long _streamThreshold;
+
+	public FederatedFormatEncoder() {
+		this(FederatedChunkProtocol.DEFAULT_CHUNK_SIZE, FederatedChunkProtocol.STREAM_THRESHOLD);
+	}
+
+	public FederatedFormatEncoder(int chunkSize, long streamThreshold) {
+		_chunkSize = chunkSize;
+		_streamThreshold = streamThreshold;
+	}
+
+	@Override
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+		if(!(msg instanceof Serializable)) {
+			ctx.write(msg, promise);
+			return;
+		}
+		if(estimateSize(msg) >= _streamThreshold) {
+			ctx.write(markerBuffer(ctx, FederatedChunkProtocol.MARKER_CHUNKED), ctx.voidPromise());
+			ctx.write(FederatedChunkEncoder.chunkedInput((Serializable) msg, _chunkSize, ctx.alloc(),
+				ctx.pipeline().get(ChunkedWriteHandler.class)), promise);
+		}
+		else {
+			ctx.write(markerBuffer(ctx, FederatedChunkProtocol.MARKER_LEGACY), ctx.voidPromise());
+			ctx.write(msg, promise);
+		}
+	}
+
+	private static ByteBuf markerBuffer(ChannelHandlerContext ctx, byte type) {
+		return ctx.alloc().buffer(1).writeByte(type);
+	}
+
+	private static long estimateSize(Object msg) {
+		if(msg instanceof FederatedResponse)
+			return ((FederatedResponse) msg).estimateSerializationBufferSize();
+		if(msg instanceof FederatedRequest)
+			return ((FederatedRequest) msg).estimateSerializationBufferSize();
+		if(msg instanceof FederatedRequest[]) {
+			long size = 0;
+			for(FederatedRequest request : (FederatedRequest[]) msg)
+				size += request.estimateSerializationBufferSize();
+			return size;
+		}
+		return 0;
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
@@ -21,6 +21,8 @@ package org.apache.sysds.runtime.controlprogram.federated;
 
 import java.io.Serializable;
 
+import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -46,32 +48,25 @@ public class FederatedFormatEncoder extends ChannelOutboundHandlerAdapter {
 			ctx.write(msg, promise);
 			return;
 		}
-		if(estimateSize(msg) >= _streamThreshold) {
+		if(useObjectEncoder(msg)) {
+			ctx.write(markerBuffer(ctx, FederatedChunkProtocol.MARKER_OBJECT_ENCODER), ctx.voidPromise());
+			ctx.write(msg, promise);
+		}
+		else {
 			ctx.write(markerBuffer(ctx, FederatedChunkProtocol.MARKER_CHUNKED), ctx.voidPromise());
 			ctx.write(FederatedChunkEncoder.chunkedInput((Serializable) msg, _chunkSize, ctx.alloc(),
 				ctx.pipeline().get(ChunkedWriteHandler.class)), promise);
 		}
-		else {
-			ctx.write(markerBuffer(ctx, FederatedChunkProtocol.MARKER_LEGACY), ctx.voidPromise());
-			ctx.write(msg, promise);
-		}
+	}
+
+	private boolean useObjectEncoder(Object msg) {
+		if(ReuseCacheType.isNone() || !(msg instanceof FederatedResponse))
+			return false;
+		FederatedResponse resp = (FederatedResponse) msg;
+		return resp.isLineageReusable() && resp.estimateSerializationBufferSize() < _streamThreshold;
 	}
 
 	private static ByteBuf markerBuffer(ChannelHandlerContext ctx, byte type) {
 		return ctx.alloc().buffer(1).writeByte(type);
-	}
-
-	private static long estimateSize(Object msg) {
-		if(msg instanceof FederatedResponse)
-			return ((FederatedResponse) msg).estimateSerializationBufferSize();
-		if(msg instanceof FederatedRequest)
-			return ((FederatedRequest) msg).estimateSerializationBufferSize();
-		if(msg instanceof FederatedRequest[]) {
-			long size = 0;
-			for(FederatedRequest request : (FederatedRequest[]) msg)
-				size += request.estimateSerializationBufferSize();
-			return size;
-		}
-		return 0;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedFormatEncoder.java
@@ -59,13 +59,28 @@ public class FederatedFormatEncoder extends ChannelOutboundHandlerAdapter {
 		}
 	}
 
+	/**
+	 * Check whether a message must take the object encoder path.
+	 *
+	 * @param msg outbound message
+	 * @return true if lineage reuse is enabled and the message is a reusable response below the stream threshold
+	 */
 	private boolean useObjectEncoder(Object msg) {
+		// no streaming for lineage cacheable responses: LineageCache.putSerializedObject
+		// needs one INT_MAX bounded byte[] that the chunked path never materializes
 		if(ReuseCacheType.isNone() || !(msg instanceof FederatedResponse))
 			return false;
 		FederatedResponse resp = (FederatedResponse) msg;
 		return resp.isLineageReusable() && resp.estimateSerializationBufferSize() < _streamThreshold;
 	}
 
+	/**
+	 * Create a one byte buffer holding the given format marker.
+	 *
+	 * @param ctx  handler context supplying the allocator
+	 * @param type marker byte
+	 * @return buffer holding the marker
+	 */
 	private static ByteBuf markerBuffer(ChannelHandlerContext ctx, byte type) {
 		return ctx.alloc().buffer(1).writeByte(type);
 	}

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedResponse.java
@@ -121,6 +121,10 @@ public class FederatedResponse implements Serializable {
 		return _linItem;
 	}
 
+	public boolean isLineageReusable() {
+		return _linItem != null && _data != null && _data.length != 0 && _data[0] instanceof CacheBlock<?>;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -218,7 +218,7 @@ public class FederatedWorker {
 					cp.addLast("CompressionDecodingStartStatistics", new CompressionDecoderStartStatisticsHandler());
 					compressionStrategy.ifPresent(strategy -> cp.addLast("CompressionDecoder", strategy.left));
 					cp.addLast("CompressionDecoderEndStatistics", new CompressionDecoderEndStatisticsHandler());
-					cp.addLast("FederatedFormatDetector", new FederatedFormatDetector());
+					cp.addLast("FederatedFormatDecoder", new FederatedFormatDecoder());
 					cp.addLast("CompressionEncodingEndStatistics", new CompressionEncoderEndStatisticsHandler());
 					compressionStrategy.ifPresent(strategy -> cp.addLast("CompressionEncoder", strategy.right));
 					cp.addLast("CompressionEncodingStartStatistics", new CompressionEncoderStartStatisticsHandler());

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorker.java
@@ -59,9 +59,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.codec.serialization.ClassResolvers;
-import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -219,14 +218,13 @@ public class FederatedWorker {
 					cp.addLast("CompressionDecodingStartStatistics", new CompressionDecoderStartStatisticsHandler());
 					compressionStrategy.ifPresent(strategy -> cp.addLast("CompressionDecoder", strategy.left));
 					cp.addLast("CompressionDecoderEndStatistics", new CompressionDecoderEndStatisticsHandler());
-					cp.addLast("ObjectDecoder",
-						new ObjectDecoder(Integer.MAX_VALUE,
-							ClassResolvers.weakCachingResolver(ClassLoader.getSystemClassLoader())));
+					cp.addLast("FederatedFormatDetector", new FederatedFormatDetector());
 					cp.addLast("CompressionEncodingEndStatistics", new CompressionEncoderEndStatisticsHandler());
 					compressionStrategy.ifPresent(strategy -> cp.addLast("CompressionEncoder", strategy.right));
 					cp.addLast("CompressionEncodingStartStatistics", new CompressionEncoderStartStatisticsHandler());
-					cp.addLast("ObjectEncoder", new ObjectEncoder());
-					cp.addLast(FederationUtils.decoder(), new FederatedResponseEncoder());
+					cp.addLast("ChunkedWriteHandler", new ChunkedWriteHandler());
+					cp.addLast("FederatedResponseEncoder", new FederatedResponseEncoder());
+					cp.addLast("FederatedFormatEncoder", new FederatedFormatEncoder());
 					cp.addLast(new FederatedWorkerHandler(_flt, _frc, _fan, networkTimer));
 				}
 			};

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.channels.ClosedChannelException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
@@ -734,15 +735,19 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 
 	private static class CloseListener implements ChannelFutureListener {
 		@Override
-		public void operationComplete(ChannelFuture channelFuture) throws InterruptedException {
-			if(!channelFuture.isSuccess()) {
-				LOG.error("Federated Worker Write failed");
-				channelFuture.channel().writeAndFlush(new FederatedResponse(ResponseType.ERROR,
-					new FederatedWorkerHandlerException("Error while sending response."))).channel().close().sync();
+		public void operationComplete(ChannelFuture channelFuture) {
+			if(channelFuture.isSuccess()) {
+				channelFuture.channel().close();
+				return;
 			}
-			else {
-				channelFuture.channel().close().sync();
+			Throwable cause = channelFuture.cause();
+			if(cause instanceof ClosedChannelException || !channelFuture.channel().isActive()) {
+				channelFuture.channel().close();
+				return;
 			}
+			LOG.error("Federated Worker Write failed", cause);
+			channelFuture.channel().writeAndFlush(new FederatedResponse(ResponseType.ERROR,
+				new FederatedWorkerHandlerException("Error while sending response."))).addListener(ChannelFutureListener.CLOSE);
 		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
+++ b/src/main/java/org/apache/sysds/runtime/controlprogram/federated/FederatedWorkerHandler.java
@@ -746,8 +746,10 @@ public class FederatedWorkerHandler extends ChannelInboundHandlerAdapter {
 				return;
 			}
 			LOG.error("Federated Worker Write failed", cause);
-			channelFuture.channel().writeAndFlush(new FederatedResponse(ResponseType.ERROR,
-				new FederatedWorkerHandlerException("Error while sending response."))).addListener(ChannelFutureListener.CLOSE);
+			channelFuture.channel()
+				.writeAndFlush(new FederatedResponse(ResponseType.ERROR,
+					new FederatedWorkerHandlerException("Error while sending response.")))
+				.addListener(ChannelFutureListener.CLOSE);
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.federated;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sysds.runtime.controlprogram.federated.FederatedChunkDecoder;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedChunkEncoder;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse.ResponseType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.compression.JdkZlibEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+public class FederatedChunkCodecTest {
+	private static final int CHUNK_SIZE = 4096; // tiny on purpose: forces a multi-frame stream
+	private static final int MAX_FRAME = 1 << 20; // 1 MB: frame-decoder ceiling, must exceed CHUNK_SIZE + header
+	private static final int PAYLOAD_DOUBLES = 20000; // ~160 KB serialized, many CHUNK_SIZE frames
+
+	@Test
+	public void roundTripPlainSplitsIntoManyFrames() throws Exception {
+		FederatedResponse original = sampleResponse();
+		List<ByteBuf> frames = encode(original, false);
+		Assert.assertTrue("expected multiple frames", frames.size() > 2);
+		assertSamePayload(original, decode(frames, false));
+	}
+
+	@Test
+	public void roundTripThroughCompression() throws Exception {
+		FederatedResponse original = sampleResponse();
+		assertSamePayload(original, decode(encode(original, true), true));
+	}
+
+	private static FederatedResponse sampleResponse() {
+		double[] data = new double[PAYLOAD_DOUBLES];
+		for(int i = 0; i < data.length; i++)
+			data[i] = i;
+		return new FederatedResponse(ResponseType.SUCCESS, data);
+	}
+
+	private static List<ByteBuf> encode(FederatedResponse response, boolean compress) throws Exception {
+		EmbeddedChannel channel = compress
+			? new EmbeddedChannel(new JdkZlibEncoder(ZlibWrapper.ZLIB), new ChunkedWriteHandler(), chunkEncoder())
+			: new EmbeddedChannel(new ChunkedWriteHandler(), chunkEncoder());
+		channel.config().setWriteBufferHighWaterMark(MAX_FRAME * 64);
+		List<ByteBuf> frames = new ArrayList<>();
+		ChannelFuture done = channel.write(response);
+		channel.flush();
+		pumpOutbound(channel, done, frames);
+		return frames;
+	}
+
+	private static ChannelOutboundHandlerAdapter chunkEncoder() {
+		return new ChannelOutboundHandlerAdapter() {
+			@Override
+			public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+				ctx.write(FederatedChunkEncoder.chunkedInput((Serializable) msg, CHUNK_SIZE, ctx.alloc(),
+					ctx.pipeline().get(ChunkedWriteHandler.class)), promise);
+			}
+		};
+	}
+
+	private static void pumpOutbound(EmbeddedChannel channel, ChannelFuture done, List<ByteBuf> out) throws Exception {
+		for(int i = 0; i < 800; i++) {
+			channel.runPendingTasks();
+			drainOutbound(channel, out);
+			if(done.isDone())
+				break;
+			Thread.sleep(2);
+		}
+		drainOutbound(channel, out);
+	}
+
+	private static void drainOutbound(EmbeddedChannel channel, List<ByteBuf> out) {
+		ByteBuf buf;
+		while((buf = channel.readOutbound()) != null)
+			out.add(buf);
+	}
+
+	private static FederatedResponse decode(List<ByteBuf> frames, boolean compress) throws Exception {
+		EmbeddedChannel channel = compress
+			? new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.ZLIB), frameDecoder(), new FederatedChunkDecoder())
+			: new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
+		for(ByteBuf frame : frames)
+			channel.writeInbound(frame);
+		return awaitResponse(channel);
+	}
+
+	private static LengthFieldBasedFrameDecoder frameDecoder() {
+		return new LengthFieldBasedFrameDecoder(MAX_FRAME, 1, 4, 0, 0);
+	}
+
+	private static FederatedResponse awaitResponse(EmbeddedChannel channel) throws InterruptedException {
+		for(int i = 0; i < 200; i++) {
+			channel.runPendingTasks();
+			FederatedResponse response = channel.readInbound();
+			if(response != null)
+				return response;
+			Thread.sleep(5);
+		}
+		throw new AssertionError("no decoded response");
+	}
+
+	private static void assertSamePayload(FederatedResponse expected, FederatedResponse actual) throws Exception {
+		Assert.assertNotNull(actual);
+		Assert.assertTrue(actual.isSuccessful());
+		Assert.assertArrayEquals((double[]) expected.getData()[0], (double[]) actual.getData()[0], 0.0);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
@@ -19,8 +19,11 @@
 
 package org.apache.sysds.test.component.federated;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.sysds.runtime.controlprogram.federated.FederatedChunkDecoder;
@@ -30,7 +33,10 @@ import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse.Respo
 import org.junit.Assert;
 import org.junit.Test;
 
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -40,12 +46,18 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.compression.JdkZlibDecoder;
 import io.netty.handler.codec.compression.JdkZlibEncoder;
 import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
 public class FederatedChunkCodecTest {
 	private static final int CHUNK_SIZE = 4096; // tiny on purpose: forces a multi-frame stream
 	private static final int MAX_FRAME = 1 << 20; // 1 MB: frame-decoder ceiling, must exceed CHUNK_SIZE + header
 	private static final int PAYLOAD_DOUBLES = 20000; // ~160 KB serialized, many CHUNK_SIZE frames
+	private static final int QUEUED_DOUBLES = 2000; // ~16 KB serialized, few enough frames to never block the queue
+	// mirrors the package-private FederatedChunkProtocol, which this test cannot import
+	private static final byte TYPE_DATA = 0;
+	private static final byte TYPE_ERROR = 2;
+	private static final int HEADER_LEN = 5;
 
 	@Test
 	public void roundTripPlainSplitsIntoManyFrames() throws Exception {
@@ -61,14 +73,83 @@ public class FederatedChunkCodecTest {
 		assertSamePayload(original, decode(encode(original, true), true));
 	}
 
+	@Test
+	public void producerFailureEmitsErrorFrame() throws Exception {
+		List<ByteBuf> frames = encode(new Unserializable(), false);
+		Assert.assertFalse("expected an error frame", frames.isEmpty());
+		ByteBuf last = frames.get(frames.size() - 1);
+		Assert.assertEquals(TYPE_ERROR, last.getByte(0));
+		Assert.assertTrue(frameMessage(last).contains("NotSerializableException"));
+		for(ByteBuf frame : frames)
+			frame.release();
+	}
+
+	@Test
+	public void errorFrameSurfacesAsException() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
+		channel.writeInbound(errorFrame("remote failure"));
+		Throwable caught = awaitException(channel);
+		Assert.assertTrue("expected an IOException, got " + caught, caught instanceof IOException);
+		Assert.assertTrue(String.valueOf(caught).contains("remote failure"));
+	}
+
+	@Test
+	public void closeReleasesQueuedFrames() throws Exception {
+		RecordingAllocator alloc = new RecordingAllocator();
+		EmbeddedChannel channel = new EmbeddedChannel(new ChunkedWriteHandler());
+		ChunkedInput<ByteBuf> input = FederatedChunkEncoder.chunkedInput(sampleResponse(QUEUED_DOUBLES), CHUNK_SIZE,
+			alloc, channel.pipeline().get(ChunkedWriteHandler.class));
+		awaitProducerFinished(alloc);
+		input.close();
+		for(ByteBuf frame : alloc.frames())
+			Assert.assertEquals("frame left unreleased by close()", 0, frame.refCnt());
+	}
+
 	private static FederatedResponse sampleResponse() {
-		double[] data = new double[PAYLOAD_DOUBLES];
+		return sampleResponse(PAYLOAD_DOUBLES);
+	}
+
+	private static FederatedResponse sampleResponse(int doubles) {
+		double[] data = new double[doubles];
 		for(int i = 0; i < data.length; i++)
 			data[i] = i;
 		return new FederatedResponse(ResponseType.SUCCESS, data);
 	}
 
-	private static List<ByteBuf> encode(FederatedResponse response, boolean compress) throws Exception {
+	private static ByteBuf errorFrame(String message) {
+		byte[] cause = message.getBytes(StandardCharsets.UTF_8);
+		return Unpooled.buffer(HEADER_LEN + cause.length).writeByte(TYPE_ERROR).writeInt(cause.length)
+			.writeBytes(cause);
+	}
+
+	private static String frameMessage(ByteBuf frame) {
+		return frame.toString(HEADER_LEN, frame.getInt(1), StandardCharsets.UTF_8);
+	}
+
+	private static Throwable awaitException(EmbeddedChannel channel) throws InterruptedException {
+		for(int i = 0; i < 200; i++) {
+			channel.runPendingTasks();
+			try {
+				channel.checkException();
+			}
+			catch(Throwable t) {
+				return t;
+			}
+			Thread.sleep(5);
+		}
+		throw new AssertionError("no exception propagated");
+	}
+
+	private static void awaitProducerFinished(RecordingAllocator alloc) throws InterruptedException {
+		for(int i = 0; i < 200; i++) {
+			if(alloc.sawFinalFrame())
+				return;
+			Thread.sleep(5);
+		}
+		throw new AssertionError("producer did not finish");
+	}
+
+	private static List<ByteBuf> encode(Serializable response, boolean compress) throws Exception {
 		EmbeddedChannel channel = compress ? new EmbeddedChannel(new JdkZlibEncoder(ZlibWrapper.ZLIB),
 			new ChunkedWriteHandler(), chunkEncoder()) : new EmbeddedChannel(new ChunkedWriteHandler(), chunkEncoder());
 		channel.config().setWriteBufferHighWaterMark(MAX_FRAME * 64);
@@ -133,5 +214,52 @@ public class FederatedChunkCodecTest {
 		Assert.assertNotNull(actual);
 		Assert.assertTrue(actual.isSuccessful());
 		Assert.assertArrayEquals((double[]) expected.getData()[0], (double[]) actual.getData()[0], 0.0);
+	}
+
+	private static class Unserializable implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final Object _payload = new Object();
+
+		@Override
+		public String toString() {
+			return String.valueOf(_payload);
+		}
+	}
+
+	private static final class RecordingAllocator extends AbstractByteBufAllocator {
+		private final List<ByteBuf> _frames = Collections.synchronizedList(new ArrayList<>());
+
+		@Override
+		protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+			return record(UnpooledByteBufAllocator.DEFAULT.heapBuffer(initialCapacity, maxCapacity));
+		}
+
+		@Override
+		protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+			return record(UnpooledByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity));
+		}
+
+		@Override
+		public boolean isDirectBufferPooled() {
+			return false;
+		}
+
+		private ByteBuf record(ByteBuf buf) {
+			_frames.add(buf);
+			return buf;
+		}
+
+		List<ByteBuf> frames() {
+			return _frames;
+		}
+
+		boolean sawFinalFrame() {
+			synchronized(_frames) {
+				for(ByteBuf frame : _frames)
+					if(frame.isReadable() && frame.getByte(0) != TYPE_DATA)
+						return true;
+			}
+			return false;
+		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
@@ -86,11 +86,18 @@ public class FederatedChunkCodecTest {
 
 	@Test
 	public void errorFrameSurfacesAsException() throws Exception {
-		EmbeddedChannel channel = new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
-		channel.writeInbound(errorFrame("remote failure"));
-		Throwable caught = awaitException(channel);
+		Throwable caught = writeAndAwaitException(errorFrame("remote failure"));
 		Assert.assertTrue("expected an IOException, got " + caught, caught instanceof IOException);
 		Assert.assertTrue(String.valueOf(caught).contains("remote failure"));
+	}
+
+	@Test
+	public void unknownFrameTypeSurfacesAsException() throws Exception {
+		byte unknownType = 7; // not part of the protocol, must fail fast instead of stalling
+		ByteBuf unknownTypeFrame = Unpooled.buffer(HEADER_LEN).writeByte(unknownType).writeInt(0);
+		Throwable caught = writeAndAwaitException(unknownTypeFrame);
+		Assert.assertTrue("expected an IOException, got " + caught, caught instanceof IOException);
+		Assert.assertTrue(String.valueOf(caught).contains("Unknown federated chunk frame type: " + unknownType));
 	}
 
 	@Test
@@ -124,6 +131,19 @@ public class FederatedChunkCodecTest {
 
 	private static String frameMessage(ByteBuf frame) {
 		return frame.toString(HEADER_LEN, frame.getInt(1), StandardCharsets.UTF_8);
+	}
+
+	private static Throwable writeAndAwaitException(ByteBuf frame) throws InterruptedException {
+		EmbeddedChannel channel = new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
+		try {
+			// the deserializer thread reports the failure asynchronously: writeInbound throws it if it already arrived,
+			// otherwise awaitException below waits for it
+			channel.writeInbound(frame);
+		}
+		catch(Throwable t) {
+			return t;
+		}
+		return awaitException(channel);
 	}
 
 	private static Throwable awaitException(EmbeddedChannel channel) throws InterruptedException {

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedChunkCodecTest.java
@@ -69,9 +69,8 @@ public class FederatedChunkCodecTest {
 	}
 
 	private static List<ByteBuf> encode(FederatedResponse response, boolean compress) throws Exception {
-		EmbeddedChannel channel = compress
-			? new EmbeddedChannel(new JdkZlibEncoder(ZlibWrapper.ZLIB), new ChunkedWriteHandler(), chunkEncoder())
-			: new EmbeddedChannel(new ChunkedWriteHandler(), chunkEncoder());
+		EmbeddedChannel channel = compress ? new EmbeddedChannel(new JdkZlibEncoder(ZlibWrapper.ZLIB),
+			new ChunkedWriteHandler(), chunkEncoder()) : new EmbeddedChannel(new ChunkedWriteHandler(), chunkEncoder());
 		channel.config().setWriteBufferHighWaterMark(MAX_FRAME * 64);
 		List<ByteBuf> frames = new ArrayList<>();
 		ChannelFuture done = channel.write(response);
@@ -108,9 +107,8 @@ public class FederatedChunkCodecTest {
 	}
 
 	private static FederatedResponse decode(List<ByteBuf> frames, boolean compress) throws Exception {
-		EmbeddedChannel channel = compress
-			? new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.ZLIB), frameDecoder(), new FederatedChunkDecoder())
-			: new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
+		EmbeddedChannel channel = compress ? new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.ZLIB), frameDecoder(),
+			new FederatedChunkDecoder()) : new EmbeddedChannel(frameDecoder(), new FederatedChunkDecoder());
 		for(ByteBuf frame : frames)
 			channel.writeInbound(frame);
 		return awaitResponse(channel);

--- a/src/test/java/org/apache/sysds/test/component/federated/FederatedFormatRoutingTest.java
+++ b/src/test/java/org/apache/sysds/test/component/federated/FederatedFormatRoutingTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.federated;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sysds.api.DMLScript;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedFormatDecoder;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedFormatEncoder;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse.ResponseType;
+import org.apache.sysds.runtime.lineage.LineageCacheConfig.ReuseCacheType;
+import org.apache.sysds.runtime.lineage.LineageItem;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.serialization.ObjectEncoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+public class FederatedFormatRoutingTest {
+	private static final int CHUNK_SIZE = 4096; // tiny on purpose: forces a multi-frame chunk stream
+	private static final long THRESHOLD_NEVER = Long.MAX_VALUE; // size guard never trips
+	private static final long THRESHOLD_ALWAYS = 1; // size guard always trips -> stream
+	private static final int PAYLOAD_DOUBLES = 20000; // ~160 KB serialized
+	private static final byte MARKER_OBJECT_ENCODER = 0;
+	private static final byte MARKER_CHUNKED = 1;
+
+	@Test
+	public void nonCacheableRoutesChunked() throws Exception {
+		// plain double[] payload is not lineage-cacheable -> streams regardless of threshold
+		FederatedResponse original = sampleResponse();
+		List<ByteBuf> wire = encode(original, THRESHOLD_NEVER);
+		Assert.assertEquals(MARKER_CHUNKED, marker(wire));
+
+		EmbeddedChannel in = new EmbeddedChannel(new FederatedFormatDecoder());
+		FederatedResponse decoded = decode(in, wire);
+		Assert.assertNotNull(in.pipeline().get("FederatedChunkDecoder"));
+		assertDetectorRemoved(in);
+		assertSamePayload(original, decoded);
+	}
+
+	@Test
+	public void lineageCacheableRoutesObjectEncoder() throws Exception {
+		ReuseCacheType prev = DMLScript.LINEAGE_REUSE;
+		DMLScript.LINEAGE_REUSE = ReuseCacheType.REUSE_FULL;
+		try {
+			List<ByteBuf> wire = encode(cacheableResponse(), THRESHOLD_NEVER);
+			Assert.assertEquals(MARKER_OBJECT_ENCODER, marker(wire));
+
+			EmbeddedChannel in = new EmbeddedChannel(new FederatedFormatDecoder());
+			FederatedResponse decoded = decode(in, wire);
+			Assert.assertNotNull(in.pipeline().get("FederatedObjectDecoder"));
+			assertDetectorRemoved(in);
+			Assert.assertTrue(decoded.isSuccessful());
+		}
+		finally {
+			DMLScript.LINEAGE_REUSE = prev;
+		}
+	}
+
+	@Test
+	public void lineageCacheableOverThresholdRoutesChunked() throws Exception {
+		ReuseCacheType prev = DMLScript.LINEAGE_REUSE;
+		DMLScript.LINEAGE_REUSE = ReuseCacheType.REUSE_FULL;
+		try {
+			List<ByteBuf> wire = encode(cacheableResponse(), THRESHOLD_ALWAYS);
+			Assert.assertEquals(MARKER_CHUNKED, marker(wire));
+		}
+		finally {
+			DMLScript.LINEAGE_REUSE = prev;
+		}
+	}
+
+	@Test
+	public void reuseDisabledCacheableRoutesChunked() throws Exception {
+		// cacheable payload but lineage reuse off -> no cache to feed -> streams
+		ReuseCacheType prev = DMLScript.LINEAGE_REUSE;
+		DMLScript.LINEAGE_REUSE = ReuseCacheType.NONE;
+		try {
+			List<ByteBuf> wire = encode(cacheableResponse(), THRESHOLD_NEVER);
+			Assert.assertEquals(MARKER_CHUNKED, marker(wire));
+		}
+		finally {
+			DMLScript.LINEAGE_REUSE = prev;
+		}
+	}
+
+	private static FederatedResponse sampleResponse() {
+		double[] data = new double[PAYLOAD_DOUBLES];
+		for(int i = 0; i < data.length; i++)
+			data[i] = i;
+		return new FederatedResponse(ResponseType.SUCCESS, data);
+	}
+
+	private static FederatedResponse cacheableResponse() {
+		MatrixBlock mb = new MatrixBlock(16, 16, 1.0);
+		return new FederatedResponse(ResponseType.SUCCESS, new Object[] {mb}, new LineageItem("routing-test"));
+	}
+
+	private static List<ByteBuf> encode(FederatedResponse response, long threshold) throws Exception {
+		EmbeddedChannel out = new EmbeddedChannel(new ChunkedWriteHandler(), new ObjectEncoder(),
+			new FederatedFormatEncoder(CHUNK_SIZE, threshold));
+		out.config().setWriteBufferHighWaterMark((CHUNK_SIZE + 64) * 64);
+		List<ByteBuf> wire = new ArrayList<>();
+		ChannelFuture done = out.write(response);
+		out.flush();
+		for(int i = 0; i < 800; i++) {
+			out.runPendingTasks();
+			drainInto(out, wire);
+			if(done.isDone())
+				break;
+			Thread.sleep(2);
+		}
+		drainInto(out, wire);
+		return wire;
+	}
+
+	private static void drainInto(EmbeddedChannel out, List<ByteBuf> wire) {
+		ByteBuf buf;
+		while((buf = out.readOutbound()) != null)
+			wire.add(buf);
+	}
+
+	private static byte marker(List<ByteBuf> wire) {
+		ByteBuf first = wire.get(0);
+		Assert.assertEquals("marker is a standalone 1-byte frame", 1, first.readableBytes());
+		return first.getByte(first.readerIndex());
+	}
+
+	private static FederatedResponse decode(EmbeddedChannel in, List<ByteBuf> wire) throws Exception {
+		for(ByteBuf buf : wire)
+			in.writeInbound(buf);
+		for(int i = 0; i < 200; i++) {
+			in.runPendingTasks();
+			FederatedResponse response = in.readInbound();
+			if(response != null)
+				return response;
+			Thread.sleep(5);
+		}
+		throw new AssertionError("no decoded response");
+	}
+
+	private static void assertDetectorRemoved(EmbeddedChannel in) {
+		Assert.assertNull("detector must remove itself after the first message",
+			in.pipeline().get(FederatedFormatDecoder.class));
+	}
+
+	private static void assertSamePayload(FederatedResponse expected, FederatedResponse actual) throws Exception {
+		Assert.assertNotNull(actual);
+		Assert.assertTrue(actual.isSuccessful());
+		Assert.assertArrayEquals((double[]) expected.getData()[0], (double[]) actual.getData()[0], 0.0);
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/federated/network/FederatedMaxPayloadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/network/FederatedMaxPayloadTest.java
@@ -20,7 +20,6 @@
 package org.apache.sysds.test.functions.federated.network;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
@@ -58,9 +57,6 @@ public class FederatedMaxPayloadTest extends AutomatedTestBase {
 
 			Future<FederatedResponse> response = FederatedData.executeFederatedOperation(address, request);
 			Assert.assertTrue("Network send was not successful.", response.get().isSuccessful());
-		}
-		catch(ExecutionException e) {
-			Assert.fail("Federated transfer failed: " + e.getMessage());
 		}
 		catch(Exception e) {
 			Assert.fail("Federated transfer failed: " + e.getMessage());

--- a/src/test/java/org/apache/sysds/test/functions/federated/network/FederatedMaxPayloadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/network/FederatedMaxPayloadTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.federated.network;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.sysds.runtime.controlprogram.federated.FederatedData;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedRequest;
+import org.apache.sysds.runtime.controlprogram.federated.FederatedResponse;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("heavy: client+worker share one JVM, so it holds two ~2GB matrix copies. Needs a ~9GB fork "
+	+ "heap; -DargLine is ignored here (pom uses @{argLine}), so bump the pom 'argLine' property "
+	+ "(e.g. -Xmx9g) to run manually. Verified green: 2.158GB streamed end-to-end past the 2GB Netty cap.")
+public class FederatedMaxPayloadTest extends AutomatedTestBase {
+
+	private final static String TEST_NAME = "FederatedMaxPayloadTest";
+	private final static String TEST_DIR = "functions/federated/network/";
+	private final static String TEST_CLASS_DIR = TEST_DIR + FederatedMaxPayloadTest.class.getSimpleName() + "/";
+
+	@Override
+	public void setUp() {
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {""}));
+	}
+
+	@Test
+	public void transferOverTwoGigabytePayload() {
+		int port = getRandomAvailablePort();
+		startLocalFedWorkerThread(port);
+		try {
+			MatrixBlock mb = denseMatrixExceedingTwoGigabytes();
+			InetSocketAddress address = new InetSocketAddress("localhost", port);
+			FederatedRequest request = new FederatedRequest(FederatedRequest.RequestType.PUT_VAR, 1, mb);
+
+			Future<FederatedResponse> response = FederatedData.executeFederatedOperation(address, request);
+			Assert.assertTrue("Network send was not successful.", response.get().isSuccessful());
+		}
+		catch(ExecutionException e) {
+			Assert.fail("Federated transfer failed: " + e.getMessage());
+		}
+		catch(Exception e) {
+			Assert.fail("Federated transfer failed: " + e.getMessage());
+		}
+		finally {
+			FederatedData.clearFederatedWorkers();
+		}
+	}
+
+	private static MatrixBlock denseMatrixExceedingTwoGigabytes() {
+		int rows = 30000;
+		int cols = 8950;
+		MatrixBlock mb = new MatrixBlock(rows, cols, false);
+		mb.allocateDenseBlock();
+		mb.setNonZeros((long) rows * cols);
+		return mb;
+	}
+}


### PR DESCRIPTION
Federated transfers previously failed for payloads above 2 GiB. Netty's frame length field is a signed 32-bit integer, so a single request or response is capped at `Integer.MAX_VALUE` bytes.

This patch adds a streaming chunked codec. The sender splits a serialized payload into bounded frames and the receiver reassembles them, so the size of one logical message on the wire is no longer limited by a single frame.

## Wire format

Every message is preceded by a one byte format marker, so the receiver knows which decoder to use: `MARKER_OBJECT_ENCODER` or `MARKER_CHUNKED`. A chunked message then follows as a sequence of frames:

```
1 byte   frame type (TYPE_DATA, TYPE_END, TYPE_ERROR)
4 bytes  payload length, big endian
n bytes  payload
```

`FederatedChunkEncoder` serializes on a pool thread and feeds frames through Netty's `ChunkedWriteHandler`. `FederatedChunkDecoder` reassembles frames into an `ObjectInputStream` that the deserializer consumes as they arrive. Neither side ever materializes the whole payload as a single array, while transferring.

Backpressure runs in both directions: a sender that outruns the socket and a receiver that outruns the deserializer each pause until the other side catches up, so a 4 GB message still holds only about 64 MB in memory at a time when transferring.

## Routing

`FederatedFormatEncoder.useObjectEncoder()` uses the legacy `ObjectEncoder` only when the lineage cache is active and the message is a lineage cacheable `FederatedResponse` below `STREAM_THRESHOLD`, which is 2000 MiB or 1.953 GiB. The
lineage cache is off by default, so **in a default configuration every message takes the chunked path**.

Why the legacy encoder is kept at all: the lineage serialization cache (`LineageCache.putSerializedObject`) stores an entire serialized response as one `INT_MAX` bounded `byte[]` and only the `ObjectEncoder` path produces that array. Streaming never materializes it. So the legacy path survives for exactly the case that requires it and for nothing else.

A size guard is still needed because that `byte[]` cannot exceed `INT_MAX`, so a response too large for it has to stream whether or not it is cacheable.

The guard is deliberately 2000 MiB rather than `INT_MAX - 1`. It sees an estimate of the raw payload, but the wire adds a measured 0.4883% of framing, so a payload gated at `INT_MAX - 1` overflows by about 10 MB. The wire was measured to reach `Integer.MAX_VALUE` at a raw payload of about 1.990 GiB, and 2000 MiB sits around 38 MiB under that.

## Experiments

One client and one worker on the same host, timed as the client's `Total elapsed time` over an elementwise operation on a federated matrix, so the matrix crosses the codec. AMD Ryzen 5 4600H, 12 cores, 11 GB RAM, OpenJDK
17.0.10 on WSL2, both JVMs at `-Xmx8g -Xms1g -Xmn256m`.

<img width="1132" height="796" alt="fig1_performance" src="https://github.com/user-attachments/assets/000903fd-6459-4529-9548-330740940bb4" />


| payload | object encoder | chunked | ratio |
|---|---|---|---|
| 80 KB | 1.398 ± 0.059 s | 1.439 ± 0.065 s | 0.97x |
| 8 MB | 2.218 ± 0.080 s | 2.238 ± 0.074 s | 0.99x |
| 512 MB | 86.142 ± 3.802 s | 20.527 ± 2.138 s | **4.20x faster** |
| 1 GiB | 324.350 ± 6.497 s | 64.478 ± 5.273 s | **5.03x faster** |

n = 15 for 80 KB and 8 MB, n = 3 for 512 MB and 1 GiB. Small payloads require extra runs since their effect size matches the background noise between runs. At 512 MB and 1 GiB the gap is 4x to 5x, far outside the spread, and one 1 GiB pair already costs about 6.5 minutes.

**Small payloads: no measurable regression.** Chunked is 2.9 % slower at 80 KB and 0.9 % at 8 MB, both within the run to run noise. The overhead is fixed per message, so it does not grow with the payload.

**Large payloads.** The object encoder holds the whole message as one contiguous buffer at both ends and cannot start sending before serialization finishes. The chunked codec overlaps the two and never holds more than the frame queue, so cost stays close to linear and memory stays bounded.

**Different baseline.** These figures supersede an earlier table in this thread, which compared against an outdated baseline.

## Chunk size

4 MB (`1 << 22`), from a sweep over 256K, 1M, 4M and 8M across four payloads, 48 runs. Median `fed_+` in seconds, the federated instruction time, not the full round trip of the table above:

<img width="1118" height="796" alt="fig2_chunk_size" src="https://github.com/user-attachments/assets/e2b0ffc4-d545-4600-8d9d-a470713302ff" />

*Median `fed_+` against chunk size, as a percentage faster than the 256 KB chunk, one line per payload. 80 KB is not drawn, it is one frame at every chunk size.*

| payload | frames at 256K / 1M / 4M / 8M | 256K | 1M | 4M | 8M |
|---|---|---|---|---|---|
| 0.08 MB | 1 / 1 / 1 / 1 | 0.755 | 0.787 | 0.900 | 0.835 |
| 8 MB | 31 / 8 / 2 / 1 | 1.208 | 1.165 | 1.099 | 1.066 |
| 512 MB | 1954 / 489 / 123 / 62 | 10.707 | 10.203 | 10.013 | 10.443 |
| 1074 MB | 4096 / 1024 / 256 / 128 | 17.439 | 16.020 | 15.578 | 15.917 |

4 MB wins at 512 MB and at 1074 MB and holds as the payload doubles, while 8M gives part of that back (4.3 % slower at 512 MB, 2.2 % at 1074 MB) and 256K pays too much framing overhead. 8M leads the 8 MB row only because the payload fits in one frame there, and 0.08 MB is one frame at every size, so neither row says anything about chunking. 4 MB also caps buffering in flight at 64 MB.

## Above the 2 GiB cap

The range the codec exists for. One run per size, on a different macOS host with about 20 GB of usable RAM and a lighter workload, so these absolute numbers do not compare with the round trip table further up. The trend within the
table is the point:

<img width="1173" height="796" alt="fig3_memory" src="https://github.com/user-attachments/assets/973c9ae9-8864-44cd-a221-952aae7d8617" />


*Peak resident memory of the worker against payload size, above the 2 GiB single frame cap with a 2x payload reference line. Sampled every 0.4 s, 1 run per payload.*

| payload | round trip | throughput | peak worker RSS |
|---|---|---|---|
| 2.2 GB | 11.56 s | 190 MB/s | 5961 MB |
| 2.6 GB | 14.26 s | 182 MB/s | 7689 MB |
| 3.0 GB | 16.14 s | 186 MB/s | 6744 MB |
| 4.0 GB | 25.74 s | 155 MB/s | 9795 MB |

All correct, 0 exceptions, 0 OOM. Throughput stays flat and peak worker RSS stays at 2.2x to 3.0x the payload, which is the workload's own two copies, the received matrix plus the result, with no serialization buffer on top. The object encoder
cannot reach this range at all, it fails at about 1.99 GiB.

## Known limitations

* Every measurement above is a sequential single client round trip. Because routing now sends essentially all traffic through the chunked path with two extra pool tasks per message, behavior under many concurrent small requests is not yet measured.
* The lineage serialization cache still requires the legacy encoder, so the `ObjectEncoder` path cannot be removed until that cache can accept a streamed response.
