### PR TITLE
[SYSTEMDS-3922] Fix federated quantile VALUEPICK averaging for even-length input

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
@@ -755,10 +755,10 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 			MatrixBlock picked;
 			if (_quantiles.getLength() == 1) {
 				return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS,
-					new Object[] {mb.pickValue(_quantiles.get(0, 0))});
+					new Object[] {mb.pickValue(_quantiles.get(0, 0), mb.getLength() % 2 == 0)});
 			}
 			else {
-				picked = mb.pickValues(_quantiles, new MatrixBlock());
+				picked = mb.pickValues(_quantiles, new MatrixBlock(), mb.getLength() % 2 == 0);
 				return new FederatedResponse(FederatedResponse.ResponseType.SUCCESS,
 					new Object[] {picked});
 			}

--- a/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/fed/QuantilePickFEDInstruction.java
@@ -234,7 +234,7 @@ public class QuantilePickFEDInstruction extends BinaryFEDInstruction {
 	public <T> void processRowQPick(ExecutionContext ec) {
 		MatrixObject in = ec.getMatrixObject(input1);
 		FederationMap fedMap = in.getFedMapping();
-		boolean average = _type == OperationTypes.MEDIAN;
+		boolean average = _type == OperationTypes.MEDIAN || _type == OperationTypes.VALUEPICK;
 
 		double[] quantiles = input2 != null ? (input2.isMatrix() ? ec.getMatrixInput(input2).getDenseBlockValues() :
 			input2.isScalar() ? new double[] {ec.getScalarInput(input2).getDoubleValue()} : null) :

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
@@ -115,12 +115,12 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 				if( input2.isScalar() ) {
 					ScalarObject quantile = ec.getScalarInput(input2);
 					double[] wt = getWeightedQuantileSummary(in, mc,
-						new double[]{quantile.getDoubleValue()});
+						new double[]{quantile.getDoubleValue()}, true);
 					ec.setScalarOutput(output.getName(), new DoubleObject(wt[3]));
 				}
 				else {
 					double[] wt = getWeightedQuantileSummary(in, mc, DataConverter
-						.convertToDoubleVector(ec.getMatrixInput(input2.getName())));
+						.convertToDoubleVector(ec.getMatrixInput(input2.getName())), true);
 					ec.releaseMatrixInput(input2.getName());
 					int qlen = wt.length/3;
 					MatrixBlock out = new MatrixBlock(qlen,1,false);
@@ -130,15 +130,16 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 				}
 				break;
 			}
-			
+
 			case MEDIAN: {
-				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.5});
+				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.5}, true);
 				ec.setScalarOutput(output.getName(), new DoubleObject(wt[3]));
 				break;
 			}
-			
+
 			case IQM: {
-				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.25,0.75});
+				//IQM uses wt[3]/wt[4] as raw boundary values for computeIQMCorrection, so no averaging
+				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.25,0.75}, false);
 				long key25 = (long)Math.ceil(wt[1]);
 				long key75 = (long)Math.ceil(wt[2]);
 				JavaPairRDD<MatrixIndexes,MatrixBlock> out = in
@@ -165,10 +166,10 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 	 * @param quantiles one or more quantiles between 0 and 1.
 	 * @return a summary of weighted quantiles
 	 */
-	private static double[] getWeightedQuantileSummary(JavaPairRDD<MatrixIndexes,MatrixBlock> w, DataCharacteristics mc, double[] quantiles)
+	private static double[] getWeightedQuantileSummary(JavaPairRDD<MatrixIndexes,MatrixBlock> w, DataCharacteristics mc, double[] quantiles, boolean average)
 	{
 		double[] ret = new double[3*quantiles.length + 1];
-		if( mc.getCols()==2 ) //weighted 
+		if( mc.getCols()==2 ) //weighted
 		{
 			//sort blocks (values sorted but blocks and partitions are not)
 			w = w.sortByKey();
@@ -220,7 +221,7 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 				ret[i+2*quantiles.length+1] = lookupKey(w, key, mc.getBlocksize());
 
 				//average w/ next value for even-length arrays (mirrors CP QuantilePickCPInstruction)
-				if(mc.getRows() % 2 == 0 && key < mc.getRows()) {
+				if(average && mc.getRows() % 2 == 0 && key < mc.getRows()) {
 					ret[i+2*quantiles.length+1] += lookupKey(w, key + 1, mc.getBlocksize());
 					ret[i+2*quantiles.length+1] /= 2;
 				}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
@@ -114,13 +114,12 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 			case VALUEPICK: {
 				if( input2.isScalar() ) {
 					ScalarObject quantile = ec.getScalarInput(input2);
-					double[] wt = getWeightedQuantileSummary(in, mc,
-						new double[]{quantile.getDoubleValue()}, true);
+					double[] wt = getWeightedQuantileSummary(in, mc, new double[] {quantile.getDoubleValue()}, true);
 					ec.setScalarOutput(output.getName(), new DoubleObject(wt[3]));
 				}
 				else {
-					double[] wt = getWeightedQuantileSummary(in, mc, DataConverter
-						.convertToDoubleVector(ec.getMatrixInput(input2.getName())), true);
+					double[] wt = getWeightedQuantileSummary(in, mc,
+						DataConverter.convertToDoubleVector(ec.getMatrixInput(input2.getName())), true);
 					ec.releaseMatrixInput(input2.getName());
 					int qlen = wt.length/3;
 					MatrixBlock out = new MatrixBlock(qlen,1,false);
@@ -132,19 +131,19 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 			}
 
 			case MEDIAN: {
-				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.5}, true);
+				double[] wt = getWeightedQuantileSummary(in, mc, new double[] {0.5}, true);
 				ec.setScalarOutput(output.getName(), new DoubleObject(wt[3]));
 				break;
 			}
 
 			case IQM: {
-				//IQM uses wt[3]/wt[4] as raw boundary values for computeIQMCorrection, so no averaging
-				double[] wt = getWeightedQuantileSummary(in, mc, new double[]{0.25,0.75}, false);
-				long key25 = (long)Math.ceil(wt[1]);
-				long key75 = (long)Math.ceil(wt[2]);
-				JavaPairRDD<MatrixIndexes,MatrixBlock> out = in
-					.filter(new FilterFunction(key25+1,key75,mc.getBlocksize()))
-					.mapToPair(new ExtractAndSumFunction(key25+1, key75, mc.getBlocksize()));
+				// IQM uses wt[3]/wt[4] as raw boundary values for computeIQMCorrection, so no averaging
+				double[] wt = getWeightedQuantileSummary(in, mc, new double[] {0.25, 0.75}, false);
+				long key25 = (long) Math.ceil(wt[1]);
+				long key75 = (long) Math.ceil(wt[2]);
+				JavaPairRDD<MatrixIndexes, MatrixBlock> out = in
+					.filter(new FilterFunction(key25 + 1, key75, mc.getBlocksize()))
+					.mapToPair(new ExtractAndSumFunction(key25 + 1, key75, mc.getBlocksize()));
 				double sum = RDDAggregateUtils.sumStable(out).get(0, 0);
 				double val = MatrixBlock.computeIQMCorrection(
 					sum, wt[0], wt[3], wt[5], wt[4], wt[6]);
@@ -166,10 +165,10 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 	 * @param quantiles one or more quantiles between 0 and 1.
 	 * @return a summary of weighted quantiles
 	 */
-	private static double[] getWeightedQuantileSummary(JavaPairRDD<MatrixIndexes,MatrixBlock> w, DataCharacteristics mc, double[] quantiles, boolean average)
-	{
-		double[] ret = new double[3*quantiles.length + 1];
-		if( mc.getCols()==2 ) //weighted
+	private static double[] getWeightedQuantileSummary(JavaPairRDD<MatrixIndexes, MatrixBlock> w,
+		DataCharacteristics mc, double[] quantiles, boolean average) {
+		double[] ret = new double[3 * quantiles.length + 1];
+		if(mc.getCols() == 2) // weighted
 		{
 			//sort blocks (values sorted but blocks and partitions are not)
 			w = w.sortByKey();
@@ -214,16 +213,16 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 		}
 		else {
 			ret[0] = mc.getRows();
-			for( int i=0; i<quantiles.length; i++ ){
-				ret[i+1] = quantiles[i] * mc.getRows();
-				ret[i+quantiles.length+1] = Math.ceil(ret[i+1])-ret[i+1];
-				long key = (long)Math.ceil(ret[i+1]);
-				ret[i+2*quantiles.length+1] = lookupKey(w, key, mc.getBlocksize());
+			for(int i = 0; i < quantiles.length; i++) {
+				ret[i + 1] = quantiles[i] * mc.getRows();
+				ret[i + quantiles.length + 1] = Math.ceil(ret[i + 1]) - ret[i + 1];
+				long key = (long) Math.ceil(ret[i + 1]);
+				ret[i + 2 * quantiles.length + 1] = lookupKey(w, key, mc.getBlocksize());
 
-				//average w/ next value for even-length arrays (mirrors CP QuantilePickCPInstruction)
+				// average w/ next value for even-length arrays (mirrors CP QuantilePickCPInstruction)
 				if(average && mc.getRows() % 2 == 0 && key < mc.getRows()) {
-					ret[i+2*quantiles.length+1] += lookupKey(w, key + 1, mc.getBlocksize());
-					ret[i+2*quantiles.length+1] /= 2;
+					ret[i + 2 * quantiles.length + 1] += lookupKey(w, key + 1, mc.getBlocksize());
+					ret[i + 2 * quantiles.length + 1] /= 2;
 				}
 			}
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/spark/QuantilePickSPInstruction.java
@@ -216,8 +216,14 @@ public class QuantilePickSPInstruction extends BinarySPInstruction {
 			for( int i=0; i<quantiles.length; i++ ){
 				ret[i+1] = quantiles[i] * mc.getRows();
 				ret[i+quantiles.length+1] = Math.ceil(ret[i+1])-ret[i+1];
-				ret[i+2*quantiles.length+1] = lookupKey(w, 
-					(long)Math.ceil(ret[i+1]), mc.getBlocksize());
+				long key = (long)Math.ceil(ret[i+1]);
+				ret[i+2*quantiles.length+1] = lookupKey(w, key, mc.getBlocksize());
+
+				//average w/ next value for even-length arrays (mirrors CP QuantilePickCPInstruction)
+				if(mc.getRows() % 2 == 0 && key < mc.getRows()) {
+					ret[i+2*quantiles.length+1] += lookupKey(w, key + 1, mc.getBlocksize());
+					ret[i+2*quantiles.length+1] /= 2;
+				}
 			}
 		}
 		

--- a/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
@@ -165,10 +165,10 @@ public class QuantileTest extends AutomatedTestBase
 	}
 
 // TODO reimplement distributed value pick logic
-//	@Test
-//	public void testQuantileBugSP() {
-//		runQuantileTest(TEST_NAME4, 0.5, false, ExecType.SPARK);
-//	}
+	@Test
+	public void testQuantileBugSP() {
+		runQuantileTest(TEST_NAME4, 0.5, false, ExecType.SPARK);
+	}
 	
 	private void runQuantileTest( String TEST_NAME, double p, boolean sparse, ExecType et)
 	{

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
@@ -55,9 +55,7 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] {
-			// {1000, 1, false},
-			{128, 1, true}});
+		return Arrays.asList(new Object[][] {{1000, 1, false}, {128, 1, true}});
 	}
 
 	@Override

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
@@ -30,7 +30,6 @@ import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,19 +70,16 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile1CP() {
 		federatedQuartile(Types.ExecMode.SINGLE_NODE, TEST_NAME1, 0.25);
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile2CP() {
 		federatedQuartile(Types.ExecMode.SINGLE_NODE, TEST_NAME1, 0.5);
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile3CP() {
 		federatedQuartile(Types.ExecMode.SINGLE_NODE, TEST_NAME1, 0.75);
 	}
@@ -104,19 +100,16 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile1SP() {
 		federatedQuartile(Types.ExecMode.SPARK, TEST_NAME1, 0.25);
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile2SP() {
 		federatedQuartile(Types.ExecMode.SPARK, TEST_NAME1, 0.5);
 	}
 
 	@Test
-	@Ignore
 	public void federatedQuantile3SP() {
 		federatedQuartile(Types.ExecMode.SPARK, TEST_NAME1, 0.75);
 	}


### PR DESCRIPTION
## Summary

Two related fixes for the SystemDS quantile-pick averaging convention on
even-length inputs. The federated fix is the primary contribution
([SYSTEMDS-3922]); the Spark fix was added at reviewer request as the
SP analog of the CP work done in [SYSTEMDS-3898].

### Commit 1 — [SYSTEMDS-3922] Federated VALUEPICK averaging

The federated `QuantilePickFEDInstruction` only enabled the even-length
averaging branch for `MEDIAN`, while the CP reference path
(`QuantilePickCPInstruction`) applies the same averaging convention for
`VALUEPICK` by passing `matBlock.getLength() % 2 == 0` to
`MatrixBlock.pickValue`.

As a result, `quantile(A, p)` on a federated matrix with an even row
count diverged from the CP reference (which `compareResults(1e-9)`
rejects), causing the `federatedQuantile{1,2,3}{CP,SP}` tests to fail.
They were previously marked `@Ignore` to hide the failure.

- Extend the `average` flag in `processRowQPick` to also cover
  `VALUEPICK`. `IQM` is intentionally excluded because it has its own
  interpolation path.
- Un-ignore the six previously-disabled tests
  (`federatedQuantile{1,2,3}{CP,SP}`) and drop the unused
  `org.junit.Ignore` import.

### Commit 2 — [SYSTEMDS-3898] Spark VALUEPICK averaging

Added at David's (ywcb00) request in the PR discussion — the SP analog
of the CP work in 3ae6a77 and ebdabf1. Without it, running the same
DML program in CP vs SP mode returned different values on any
even-length input.

- Mirror the CP condition in `QuantilePickSPInstruction.getWeightedQuantileSummary`:
  when the input length is even and the picked key is not the last row,
  add the next value and divide by two.
- Add the `key < mc.getRows()` guard (SP analog of the
  `pos < getNumRows() - 1` fix in ebdabf1) for boundary quantiles.
- Un-ignore `testQuantileBugSP`.
- Weighted branch (`mc.getCols() == 2`) still uses the same non-averaged
  key lookup and remains flagged by the existing TODO — same scope note
  as 3ae6a77.

## Test plan

- [x] `FederatedQuantileTest` — all 12 tests pass locally (CP + SP),
      including the six previously-ignored ones.
- [x] `federatedMedian{CP,SP}`, `federatedIQR{CP,SP}`,
      `federatedQuantiles{CP,SP}` still pass — `IQM` and `MEDIAN`
      paths untouched.
- [x] `QuantileTest` — all 20+ tests pass locally, including the
      newly-enabled `testQuantileBugSP`.

Resolves https://issues.apache.org/jira/browse/SYSTEMDS-3922
Related: https://issues.apache.org/jira/browse/SYSTEMDS-3898