### PR TITLE
[BWARE] Add sort support to compressed column groups

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -65,6 +65,7 @@ import org.apache.sysds.runtime.compress.lib.CLALibReshape;
 import org.apache.sysds.runtime.compress.lib.CLALibRexpand;
 import org.apache.sysds.runtime.compress.lib.CLALibScalar;
 import org.apache.sysds.runtime.compress.lib.CLALibSlice;
+import org.apache.sysds.runtime.compress.lib.CLALibSort;
 import org.apache.sysds.runtime.compress.lib.CLALibSquash;
 import org.apache.sysds.runtime.compress.lib.CLALibTSMM;
 import org.apache.sysds.runtime.compress.lib.CLALibTernaryOp;
@@ -847,9 +848,8 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	@Override
-	public MatrixBlock sortOperations(MatrixValue weights, MatrixBlock result) {
-		MatrixBlock right = getUncompressed(weights);
-		return getUncompressed("sortOperations").sortOperations(right, result);
+	public MatrixBlock sortOperations(MatrixValue weights, MatrixBlock result, int k) {
+		return CLALibSort.sort(this, weights, result, k);
 	}
 
 	@Override

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/AColGroup.java
@@ -974,6 +974,16 @@ public abstract class AColGroup implements Serializable {
 		return splitReshape(multiplier, nRow, nColOrg);
 	}
 
+	/**
+	 * Sort the values of the column group according to double comparison operations and return as another compressed
+	 * group.
+	 * 
+	 * This sorting assumes that the column group is sorted independently of everything else.
+	 * 
+	 * @return The sorted group
+	 */
+	public abstract AColGroup sort();
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupConst.java
@@ -769,4 +769,9 @@ public class ColGroupConst extends ADictBasedColGroup implements IContainDefault
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns) {
 		return ColGroupConst.create(newColumnIDs, _dict.sliceColumns(selectedColumns, getNumCols()));
 	}
+
+	@Override
+	public AColGroup sort() {
+		return this;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDC.java
@@ -1178,4 +1178,23 @@ public class ColGroupDDC extends APreAgg implements IMapToDataGroup {
 	public AColGroup convertToDDCLZW() {
 		return ColGroupDDCLZW.create(_colIndexes, _dict, _data, null);
 	}
+
+	@Override
+	public AColGroup sort() {
+		// TODO restore support for run length encoding to exploit the runs
+
+		int[] counts = getCounts();
+		// get the sort index
+		int[] r = _dict.sort();
+
+		AMapToData m = MapToFactory.create(_data.size(), counts.length);
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			for(int j = 0; j < counts[r[i]]; j++) {
+				m.set(off++, r[i]);
+			}
+		}
+
+		return ColGroupDDC.create(_colIndexes, _dict, m, counts);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCFOR.java
@@ -571,4 +571,23 @@ public class ColGroupDDCFOR extends AMorphingMMColGroup implements IFrameOfRefer
 		sb.append(Arrays.toString(_reference));
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		// TODO restore support for run length encoding.
+
+		int[] counts = getCounts();
+		// get the sort index
+		int[] r = _dict.sort();
+
+		AMapToData m = MapToFactory.create(_data.size(), counts.length);
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			for(int j = 0; j < counts[r[i]]; j++) {
+				m.set(off++, r[i]);
+			}
+		}
+
+		return ColGroupDDCFOR.create(_colIndexes, _dict, m, counts, _reference);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCLZW.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupDDCLZW.java
@@ -1022,4 +1022,10 @@ public class ColGroupDDCLZW extends APreAgg implements IMapToDataGroup {
 		ColGroupDDC g = (ColGroupDDC) convertToDDC();
 		return g.removeEmptyColsSubset(newColumnIDs, selectedColumns);
 	}
+
+	@Override
+	public AColGroup sort() {
+		ColGroupDDC g = (ColGroupDDC) convertToDDC();
+		return g.sort();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupEmpty.java
@@ -488,4 +488,9 @@ public class ColGroupEmpty extends AColGroupCompressed
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns){
 		return new ColGroupEmpty(newColumnIDs);
 	}
+
+	@Override
+	public AColGroup sort() {
+		return this;
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupLinearFunctional.java
@@ -750,4 +750,9 @@ public class ColGroupLinearFunctional extends AColGroupCompressed {
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns){
 		throw new NotImplementedException("Unimplemented method 'removeEmptyColumns'");
 	}
+
+	@Override
+	public AColGroup sort() {
+		throw new NotImplementedException("Unimplemented method 'sort'");
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupOLE.java
@@ -741,4 +741,9 @@ public class ColGroupOLE extends AColGroupOffset {
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns){
 		throw new NotImplementedException("Unimplemented method 'removeEmptyColumns'");
 	}
+
+	@Override
+	public AColGroup sort() {
+		throw new NotImplementedException();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupRLE.java
@@ -1200,4 +1200,9 @@ public class ColGroupRLE extends AColGroupOffset {
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns){
 		throw new NotImplementedException("Unimplemented method 'removeEmptyColumns'");
 	}
+
+	@Override
+	public AColGroup sort() {
+		throw new NotImplementedException();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDC.java
@@ -903,4 +903,50 @@ public class ColGroupSDC extends ASDC implements IMapToDataGroup {
 		sb.append(_data.toString());
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// TODO restore support for run length encoding.
+
+		final int[] counts = getCounts();
+		// get the sort index
+		final int[] r = _dict.sort();
+
+		// find default value position.
+		// todo use binary search for minor improvements.
+		final double def = _defaultTuple[0];
+		int defIdx = counts.length;
+		for(int i = 0; i < r.length; i++) {
+			if(_dict.getValue(r[i], 0, 1) >= def) {
+				defIdx = i;
+				break;
+			}
+		}
+
+		int nondefault = _data.size();
+		int defaultLength = _numRows - nondefault;
+		AMapToData m = MapToFactory.create(nondefault, counts.length);
+		int[] offsets = new int[nondefault];
+
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			if(i < defIdx) {
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off;
+					m.set(off++, r[i]);
+				}
+			}
+			else {// if( i >= defIdx){
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off + defaultLength;
+					m.set(off++, r[i]);
+				}
+			}
+		}
+
+		AOffset o = OffsetFactory.createOffset(offsets);
+		return ColGroupSDC.create(_colIndexes, _numRows, _dict, _defaultTuple, o, m, counts);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCFOR.java
@@ -651,4 +651,49 @@ public class ColGroupSDCFOR extends ASDC implements IMapToDataGroup, IFrameOfRef
 		return sb.toString();
 	}
 
+	@Override
+	public AColGroup sort() {
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// TODO restore support for run length encoding.
+
+		final int[] counts = getCounts();
+		// get the sort index
+		final int[] r = _dict.sort();
+
+		// find default value position.
+		// todo use binary search for minor improvements.
+		int defIdx = counts.length;
+		for(int i = 0; i < r.length; i++) {
+			if(_dict.getValue(r[i], 0, 1) >= 0) {
+				defIdx = i;
+				break;
+			}
+		}
+
+		int nondefault = _data.size();
+		int defaultLength = _numRows - nondefault;
+		AMapToData m = MapToFactory.create(nondefault, counts.length);
+		int[] offsets = new int[nondefault];
+
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			if(i < defIdx) {
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off;
+					m.set(off++, r[i]);
+				}
+			}
+			else {// if( i >= defIdx){
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off + defaultLength;
+					m.set(off++, r[i]);
+				}
+			}
+		}
+
+		AOffset o = OffsetFactory.createOffset(offsets);
+		return ColGroupSDCFOR.create(_colIndexes, _numRows, _dict, o, m, counts, _reference);
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -746,4 +746,47 @@ public class ColGroupSDCSingle extends ASDC {
 		sb.append(_indexes.toString());
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// TODO restore support for run length encoding.
+
+		final int[] counts = getCounts();
+		// get the sort index
+		final int[] r = _dict.sort();
+
+		// find default value position.
+		// todo use binary search for minor improvements.
+		final double def = _defaultTuple[0];
+		int defIdx = counts.length;
+		int nondefault = 0;
+		for(int i = 0; i < r.length; i++) {
+			if(defIdx == counts.length && _dict.getValue(r[i], 0, 1) >= def) {
+				defIdx = i;
+			}
+			nondefault += counts[i];
+		}
+
+		int defaultLength = _numRows - nondefault;
+		int[] offsets = new int[nondefault];
+
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			if(i < defIdx) {
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off;
+				}
+			}
+			else {// if( i >= defIdx){
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off + defaultLength;
+				}
+			}
+		}
+
+		AOffset o = OffsetFactory.createOffset(offsets);
+		return ColGroupSDCSingle.create(_colIndexes, _numRows, _dict, _defaultTuple, o, counts);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingle.java
@@ -751,40 +751,17 @@ public class ColGroupSDCSingle extends ASDC {
 	public AColGroup sort() {
 		if(getNumCols() > 1)
 			throw new NotImplementedException();
-		// TODO restore support for run length encoding.
 
+		// Only a single non-default value exists, so sorting is a contiguous block of that value placed before the
+		// default values if it is smaller than the default, and after them otherwise.
 		final int[] counts = getCounts();
-		// get the sort index
-		final int[] r = _dict.sort();
+		final int nondefault = counts[0];
+		final int defaultLength = _numRows - nondefault;
+		final int base = _dict.getValue(0, 0, 1) >= _defaultTuple[0] ? defaultLength : 0;
 
-		// find default value position.
-		// todo use binary search for minor improvements.
-		final double def = _defaultTuple[0];
-		int defIdx = counts.length;
-		int nondefault = 0;
-		for(int i = 0; i < r.length; i++) {
-			if(defIdx == counts.length && _dict.getValue(r[i], 0, 1) >= def) {
-				defIdx = i;
-			}
-			nondefault += counts[i];
-		}
-
-		int defaultLength = _numRows - nondefault;
-		int[] offsets = new int[nondefault];
-
-		int off = 0;
-		for(int i = 0; i < counts.length; i++) {
-			if(i < defIdx) {
-				for(int j = 0; j < counts[r[i]]; j++) {
-					offsets[off] = off;
-				}
-			}
-			else {// if( i >= defIdx){
-				for(int j = 0; j < counts[r[i]]; j++) {
-					offsets[off] = off + defaultLength;
-				}
-			}
-		}
+		final int[] offsets = new int[nondefault];
+		for(int j = 0; j < nondefault; j++)
+			offsets[j] = base + j;
 
 		AOffset o = OffsetFactory.createOffset(offsets);
 		return ColGroupSDCSingle.create(_colIndexes, _numRows, _dict, _defaultTuple, o, counts);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -1076,39 +1076,17 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 	public AColGroup sort() {
 		if(getNumCols() > 1)
 			throw new NotImplementedException();
-		// TODO restore support for run length encoding.
 
+		// Only a single non-default value exists, so sorting is a contiguous block of that value placed before the
+		// zeros (default) if it is negative, and after the zeros otherwise.
 		final int[] counts = getCounts();
-		// get the sort index
-		final int[] r = _dict.sort();
+		final int nondefault = counts[0];
+		final int defaultLength = _numRows - nondefault;
+		final int base = _dict.getValue(0, 0, 1) >= 0 ? defaultLength : 0;
 
-		// find default value position.
-		// todo use binary search for minor improvements.
-		int defIdx = counts.length;
-		int nondefault = 0;
-		for(int i = 0; i < r.length; i++) {
-			if(defIdx == counts.length && _dict.getValue(r[i], 0, 1) >= 0) {
-				defIdx = i;
-			}
-			nondefault += counts[i];
-		}
-
-		int defaultLength = _numRows - nondefault;
-		int[] offsets = new int[nondefault];
-
-		int off = 0;
-		for(int i = 0; i < counts.length; i++) {
-			if(i < defIdx) {
-				for(int j = 0; j < counts[r[i]]; j++) {
-					offsets[off] = off;
-				}
-			}
-			else {// if( i >= defIdx){
-				for(int j = 0; j < counts[r[i]]; j++) {
-					offsets[off] = off + defaultLength;
-				}
-			}
-		}
+		final int[] offsets = new int[nondefault];
+		for(int j = 0; j < nondefault; j++)
+			offsets[j] = base + j;
 
 		AOffset o = OffsetFactory.createOffset(offsets);
 		return ColGroupSDCSingleZeros.create(_colIndexes, _numRows, _dict, o, counts);

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCSingleZeros.java
@@ -1071,4 +1071,46 @@ public class ColGroupSDCSingleZeros extends ASDCZero {
 		sb.append(_indexes.toString());
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// TODO restore support for run length encoding.
+
+		final int[] counts = getCounts();
+		// get the sort index
+		final int[] r = _dict.sort();
+
+		// find default value position.
+		// todo use binary search for minor improvements.
+		int defIdx = counts.length;
+		int nondefault = 0;
+		for(int i = 0; i < r.length; i++) {
+			if(defIdx == counts.length && _dict.getValue(r[i], 0, 1) >= 0) {
+				defIdx = i;
+			}
+			nondefault += counts[i];
+		}
+
+		int defaultLength = _numRows - nondefault;
+		int[] offsets = new int[nondefault];
+
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			if(i < defIdx) {
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off;
+				}
+			}
+			else {// if( i >= defIdx){
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off + defaultLength;
+				}
+			}
+		}
+
+		AOffset o = OffsetFactory.createOffset(offsets);
+		return ColGroupSDCSingleZeros.create(_colIndexes, _numRows, _dict, o, counts);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupSDCZeros.java
@@ -1113,4 +1113,49 @@ public class ColGroupSDCZeros extends ASDCZero implements IMapToDataGroup {
 		sb.append(_data);
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// TODO restore support for run length encoding.
+
+		final int[] counts = getCounts();
+		// get the sort index
+		final int[] r = _dict.sort();
+
+		// find default value position.
+		// todo use binary search for minor improvements.
+		int defIdx = counts.length;
+		for(int i = 0; i < r.length; i++) {
+			if(_dict.getValue(r[i], 0, 1) >= 0) {
+				defIdx = i;
+				break;
+			}
+		}
+
+		int nondefault = _data.size();
+		int defaultLength = _numRows - nondefault;
+		AMapToData m = MapToFactory.create(nondefault, counts.length);
+		int[] offsets = new int[nondefault];
+
+		int off = 0;
+		for(int i = 0; i < counts.length; i++) {
+			if(i < defIdx) {
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off;
+					m.set(off++, r[i]);
+				}
+			}
+			else {// if( i >= defIdx){
+				for(int j = 0; j < counts[r[i]]; j++) {
+					offsets[off] = off + defaultLength;
+					m.set(off++, r[i]);
+				}
+			}
+		}
+
+		AOffset o = OffsetFactory.createOffset(offsets);
+		return ColGroupSDCZeros.create(_colIndexes, _numRows, _dict, o, m, counts);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -1331,4 +1331,9 @@ public class ColGroupUncompressed extends AColGroup {
 
 		return sb.toString();
 	}
+
+	@Override
+	public AColGroup sort() {
+		return new ColGroupUncompressed(_data.sortOperations(), _colIndexes);
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressed.java
@@ -56,6 +56,7 @@ import org.apache.sysds.runtime.functionobjects.CM;
 import org.apache.sysds.runtime.functionobjects.Multiply;
 import org.apache.sysds.runtime.functionobjects.ReduceAll;
 import org.apache.sysds.runtime.functionobjects.ReduceRow;
+import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.functionobjects.ValueFunction;
 import org.apache.sysds.runtime.instructions.cp.CmCovObject;
 import org.apache.sysds.runtime.matrix.data.LibMatrixMult;
@@ -65,6 +66,7 @@ import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.matrix.operators.AggregateUnaryOperator;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.runtime.matrix.operators.CMOperator;
+import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.runtime.matrix.operators.ScalarOperator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
@@ -1334,6 +1336,11 @@ public class ColGroupUncompressed extends AColGroup {
 
 	@Override
 	public AColGroup sort() {
-		return new ColGroupUncompressed(_data.sortOperations(), _colIndexes);
+		if(getNumCols() > 1)
+			throw new NotImplementedException();
+		// sortOperations builds a value/weight table for quantiles; for an ascending column sort we reorder the rows.
+		MatrixBlock sorted = _data.reorgOperations(new ReorgOperator(new SortIndex(1, false, false), 1),
+			new MatrixBlock(), 0, 0, 0);
+		return create(sorted, _colIndexes);
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressedArray.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/ColGroupUncompressedArray.java
@@ -293,4 +293,9 @@ public class ColGroupUncompressedArray extends AColGroup {
 	protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns){
 		throw new NotImplementedException("Unimplemented method 'removeEmptyColumns'");
 	}
+
+	@Override
+	public AColGroup sort() {
+		throw new NotImplementedException("Unimplemented method 'sort'");
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/AIdentityDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/AIdentityDictionary.java
@@ -19,6 +19,7 @@
 
 package org.apache.sysds.runtime.compress.colgroup.dictionary;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.runtime.compress.DMLCompressionException;
 
 public abstract class AIdentityDictionary extends ACachingMBDictionary {
@@ -73,5 +74,10 @@ public abstract class AIdentityDictionary extends ACachingMBDictionary {
 		for(int i = 0; i < defaultTuple.length; i++)
 			ret[ret.length - 1] *= defaultTuple[i];
 		return ret;
+	}
+
+	@Override 
+	public int[] sort(){
+		throw new NotImplementedException();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DeltaDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/DeltaDictionary.java
@@ -142,4 +142,9 @@ public class DeltaDictionary extends ADictionary {
 	public IDictionary sliceColumns(IntArrayList selectedColumns, int nCol){
 		throw new NotImplementedException();
 	}
+
+	@Override
+	public int[] sort() {
+		throw new NotImplementedException();
+	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/Dictionary.java
@@ -1348,4 +1348,67 @@ public class Dictionary extends ACachingMBDictionary {
 		return getMBDict(nCol).sliceColumns(selectedColumns, nCol);
 	}
 
+	@Override
+	public int[] sort() {
+		return sort(_values);
+	}
+
+	protected static int[] sort(double[] values) {
+		int[] indices = new int[values.length];
+		for(int i = 0; i < indices.length; i++) {
+			indices[i] = i;
+		}
+
+		// quicksort with stack
+		int[] stack = new int[values.length];
+
+		int top = -1;
+		stack[++top] = 0;
+		stack[++top] = values.length - 1;
+
+		while(top >= 0) {
+			int high = stack[top--];
+			int low = stack[top--];
+
+			if(low < high) {
+
+				int pivotIndex = partition(indices, values, low, high);
+				// Left side
+				if(pivotIndex - 1 > low) {
+					stack[++top] = low;
+					stack[++top] = pivotIndex - 1;
+				}
+
+				// Right side
+				if(pivotIndex + 1 < high) {
+					stack[++top] = pivotIndex + 1;
+					stack[++top] = high;
+				}
+			}
+		}
+
+		return indices;
+	}
+
+	private static int partition(int[] indices, double[] values, int low, int high) {
+		double pivotValue = values[indices[high]];
+		int i = low - 1;
+
+		for(int j = low; j < high; j++) {
+			if(values[indices[j]] <= pivotValue) {
+				i++;
+				swap(indices, i, j);
+			}
+		}
+
+		swap(indices, i + 1, high);
+		return i + 1;
+	}
+
+	private static void swap(int[] arr, int i, int j) {
+		int tmp = arr[i];
+		arr[i] = arr[j];
+		arr[j] = tmp;
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/IDictionary.java
@@ -1062,4 +1062,13 @@ public interface IDictionary {
 	 */
 	public IDictionary sliceColumns(IntArrayList selectedColumns, int nCol);
 
+	/**
+	 * Sort the values of this dictionary via an index of how the values mapped previously.
+	 * 
+	 * In practice this design means we can reuse the previous dictionary for the resulting column group
+	 * 
+	 * @return The sorted index.
+	 */
+	public int[] sort();
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/MatrixBlockDictionary.java
@@ -2845,4 +2845,13 @@ public class MatrixBlockDictionary extends ADictionary {
 		return ret;
 	}
 
+	@Override
+	public int[] sort() {
+		if(_data.getNumColumns() > 1)
+			throw new RuntimeException("Not supported sort on multicolumn dictionaries");
+		_data.sparseToDense();
+
+		return Dictionary.sort(_data.getDenseBlockValues());
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/PlaceHolderDict.java
@@ -107,4 +107,9 @@ public class PlaceHolderDict extends ADictionary {
 		throw new RuntimeException("Invalid call");
 	}
 
+	@Override
+	public int[] sort() {
+		throw new RuntimeException("Invalid call");
+	}
+
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/colgroup/dictionary/QDictionary.java
@@ -23,6 +23,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.runtime.compress.utils.IntArrayList;
 import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -281,5 +282,10 @@ public class QDictionary extends ACachingMBDictionary {
 	@Override
 	public IDictionary sliceColumns(IntArrayList selectedColumns, int nCol) {
 		return getMBDict().sliceColumns(selectedColumns, nCol);
+	}
+
+	@Override
+	public int[] sort() {
+		throw new NotImplementedException();
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReorg.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibReorg.java
@@ -32,6 +32,7 @@ import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
 import org.apache.sysds.runtime.data.SparseBlockMCSR;
+import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.functionobjects.SwapIndex;
 import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -65,12 +66,19 @@ public class CLALibReorg {
             // the compressed matrix. https://issues.apache.org/jira/browse/SYSTEMDS-3025
 			return transpose(cmb, ret, op.getNumThreads());
 		}
-		else {
-			String message = !warned ? op.getClass().getSimpleName() + " -- " + op.fn.getClass().getSimpleName() : null;
-			MatrixBlock tmp = cmb.getUncompressed(message, op.getNumThreads());
-			warned = true;
-			return tmp.reorgOperations(op, ret, startRow, startColumn, length);
+		else if(op.fn instanceof SortIndex) {
+			// order: keep the result compressed when a single column / single group is sorted ascending.
+			MatrixBlock res = CLALibSort.sort(cmb, (SortIndex) op.fn);
+			if(res != null)
+				return res;
+			// otherwise fall through to the decompression fallback below.
 		}
+
+		// Decompression fallback for reorg operations not supported directly on the compressed representation.
+		String message = !warned ? op.getClass().getSimpleName() + " -- " + op.fn.getClass().getSimpleName() : null;
+		MatrixBlock tmp = cmb.getUncompressed(message, op.getNumThreads());
+		warned = true;
+		return tmp.reorgOperations(op, ret, startRow, startColumn, length);
 	}
 
 	private static MatrixBlock transpose(CompressedMatrixBlock cmb, MatrixBlock ret, int k) {

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
@@ -27,6 +27,7 @@ import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
 
 public final class CLALibSort {
 
@@ -51,16 +52,102 @@ public final class CLALibSort {
 		if(!singleColumn || fn.getDecreasing() || fn.getIndexReturn())
 			return null;
 
+		final AColGroup sorted = sortSingleColumn(mb);
+		if(sorted == null)
+			return null;
+
+		final List<AColGroup> rg = new ArrayList<>(1);
+		rg.add(sorted);
+		return new CompressedMatrixBlock(mb.getNumRows(), mb.getNumColumns(), mb.getNonZeros(), false, rg);
+	}
+
+	/**
+	 * Compute the sorted value/weight table used by the quantile/median/IQM operations (the {@code sort} / qsort lop),
+	 * exploiting compression to sort the few distinct values instead of all rows.
+	 *
+	 * The compressed fast-path applies to an unweighted sort of a single column held in a single column group. The
+	 * produced table is bit-for-bit identical to {@link MatrixBlock#sortOperations(MatrixValue, MatrixBlock, int)}: a
+	 * {@code (1 + nnz) x 2} matrix holding one row per non-zero value (weight 1) plus a single collapsed row for the
+	 * zeros (weight = number of zeros), sorted ascending by value. For every other case (weights present, multiple
+	 * columns or groups, or an encoding without a sort implementation) it falls back to a decompressed sort.
+	 *
+	 * @param mb      the compressed matrix to sort
+	 * @param weights optional per-row weights, or {@code null}
+	 * @param result  the result matrix (reused by the fallback)
+	 * @param k       the parallelization degree
+	 * @return the sorted value/weight table
+	 */
+	public static MatrixBlock sort(CompressedMatrixBlock mb, MatrixValue weights, MatrixBlock result, int k) {
+		final MatrixBlock w = CompressedMatrixBlock.getUncompressed(weights);
+		if(w == null && mb.getNumColumns() == 1 && mb.getColGroups().size() == 1) {
+			final MatrixBlock fast = sortTableSingleColumn(mb, k);
+			if(fast != null)
+				return fast;
+		}
+
+		// fallback to uncompressed sort.
+		return CompressedMatrixBlock.getUncompressed(mb, "sortOperations", k).sortOperations(w, result, k);
+	}
+
+	private static AColGroup sortSingleColumn(CompressedMatrixBlock mb) {
 		try {
-			final AColGroup g = mb.getColGroups().get(0);
-			final AColGroup sorted = g.sort();
-			final List<AColGroup> rg = new ArrayList<>(1);
-			rg.add(sorted);
-			return new CompressedMatrixBlock(mb.getNumRows(), mb.getNumColumns(), mb.getNonZeros(), false, rg);
+			return mb.getColGroups().get(0).sort();
 		}
 		catch(NotImplementedException e) {
 			// the column-group encoding does not implement sort -> let the caller decompress.
 			return null;
 		}
+	}
+
+	private static MatrixBlock sortTableSingleColumn(CompressedMatrixBlock mb, int k) {
+		final long lnnz = mb.getNonZeros();
+		if(lnnz < 0) // unknown number of non-zeros, cannot size the table.
+			return null;
+
+		final AColGroup sorted = sortSingleColumn(mb);
+		if(sorted == null)
+			return null;
+
+		final int nRows = mb.getNumRows();
+		final int nnz = (int) lnnz;
+		final int zeroCount = nRows - nnz;
+
+		// decompress the already-sorted single column once (ascending, zeros contiguous).
+		final List<AColGroup> rg = new ArrayList<>(1);
+		rg.add(sorted);
+		final MatrixBlock sortedCol = new CompressedMatrixBlock(nRows, 1, lnnz, false, rg).decompress(k);
+
+		// build the value/weight table: one row per non-zero value, plus a single collapsed zero row.
+		final MatrixBlock tdw = new MatrixBlock(1 + nnz, 2, false);
+		tdw.allocateDenseBlock();
+		int w = 0;
+		boolean zeroWritten = false;
+		for(int i = 0; i < nRows; i++) {
+			final double v = sortedCol.get(i, 0);
+			if(v < 0) {
+				tdw.set(w, 0, v);
+				tdw.set(w, 1, 1);
+				w++;
+			}
+			else {
+				if(!zeroWritten) {
+					tdw.set(w, 0, 0);
+					tdw.set(w, 1, zeroCount);
+					w++;
+					zeroWritten = true;
+				}
+				if(v != 0) {
+					tdw.set(w, 0, v);
+					tdw.set(w, 1, 1);
+					w++;
+				}
+			}
+		}
+		if(!zeroWritten) { // all values negative: the zero row sorts to the end.
+			tdw.set(w, 0, 0);
+			tdw.set(w, 1, zeroCount);
+		}
+		tdw.recomputeNonZeros();
+		return tdw;
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.runtime.compress.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
+
+public class CLALibSort {
+
+	public static MatrixBlock sort(CompressedMatrixBlock mb, MatrixValue weights, MatrixBlock result, int k) {
+		// force uncompressed weights
+		weights = CompressedMatrixBlock.getUncompressed(weights);
+
+		if(mb.getNumColumns() == 1 && mb.getColGroups().size() == 1 && weights == null) {
+			return sortSingleCol(mb, k);
+		}
+
+		// fallback to uncompressed.
+		return CompressedMatrixBlock//
+			.getUncompressed(mb, "sortOperations")//
+			.sortOperations(weights, result);
+	}
+
+	private static MatrixBlock sortSingleCol(CompressedMatrixBlock mb, int k) {
+
+		AColGroup g = mb.getColGroups().get(0);
+
+		AColGroup r = g.sort();
+
+		List<AColGroup> rg = new ArrayList<>();
+		rg.add(r);
+		return new CompressedMatrixBlock(mb.getNumRows(), mb.getNumColumns(), mb.getNonZeros(), false, rg);
+	}
+}

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
@@ -22,35 +22,45 @@ package org.apache.sysds.runtime.compress.lib;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-import org.apache.sysds.runtime.matrix.data.MatrixValue;
 
-public class CLALibSort {
+public final class CLALibSort {
 
-	public static MatrixBlock sort(CompressedMatrixBlock mb, MatrixValue weights, MatrixBlock result, int k) {
-		// force uncompressed weights
-		weights = CompressedMatrixBlock.getUncompressed(weights);
-
-		if(mb.getNumColumns() == 1 && mb.getColGroups().size() == 1 && weights == null) {
-			return sortSingleCol(mb, k);
-		}
-
-		// fallback to uncompressed.
-		return CompressedMatrixBlock//
-			.getUncompressed(mb, "sortOperations")//
-			.sortOperations(weights, result);
+	private CLALibSort() {
+		// private constructor for utility class.
 	}
 
-	private static MatrixBlock sortSingleCol(CompressedMatrixBlock mb, int k) {
+	/**
+	 * Sort (order) a compressed matrix in place of the {@code order} built-in, while keeping the result compressed.
+	 *
+	 * The compressed fast-path only supports the case the user can benefit from: a single column held in a single column
+	 * group, sorted ascending and returning the sorted values (not the index permutation). For everything else (multiple
+	 * columns, multiple column groups, descending order, index return, or a column-group encoding without a sort
+	 * implementation) this returns {@code null} so the caller can fall back to a decompressed reorg.
+	 *
+	 * @param mb the compressed matrix to sort
+	 * @param fn the sort specification carried by the reorg operator
+	 * @return the sorted compressed matrix, or {@code null} if the compressed fast-path does not apply
+	 */
+	public static MatrixBlock sort(CompressedMatrixBlock mb, SortIndex fn) {
+		final boolean singleColumn = mb.getNumColumns() == 1 && mb.getColGroups().size() == 1;
+		if(!singleColumn || fn.getDecreasing() || fn.getIndexReturn())
+			return null;
 
-		AColGroup g = mb.getColGroups().get(0);
-
-		AColGroup r = g.sort();
-
-		List<AColGroup> rg = new ArrayList<>();
-		rg.add(r);
-		return new CompressedMatrixBlock(mb.getNumRows(), mb.getNumColumns(), mb.getNonZeros(), false, rg);
+		try {
+			final AColGroup g = mb.getColGroups().get(0);
+			final AColGroup sorted = g.sort();
+			final List<AColGroup> rg = new ArrayList<>(1);
+			rg.add(sorted);
+			return new CompressedMatrixBlock(mb.getNumRows(), mb.getNumColumns(), mb.getNonZeros(), false, rg);
+		}
+		catch(NotImplementedException e) {
+			// the column-group encoding does not implement sort -> let the caller decompress.
+			return null;
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
@@ -119,36 +119,22 @@ public final class CLALibSort {
 		rg.add(sorted);
 		final MatrixBlock sortedCol = new CompressedMatrixBlock(nRows, 1, lnnz, false, rg).decompress(k);
 
-		// build the value/weight table: one row per non-zero value, plus a single collapsed zero row.
+		// build the value/weight table: one row per non-zero value (weight 1) plus a single
+		// collapsed zero row (weight = number of zeros). The row order is irrelevant because the
+		// table is sorted by the reorg below, exactly as MatrixBlock.sortOperations does.
 		final MatrixBlock tdw = new MatrixBlock(1 + nnz, 2, false);
 		tdw.allocateDenseBlock();
 		int w = 0;
-		boolean zeroWritten = false;
 		for(int i = 0; i < nRows; i++) {
 			final double v = sortedCol.get(i, 0);
-			if(v < 0) {
+			if(v != 0) {
 				tdw.set(w, 0, v);
 				tdw.set(w, 1, 1);
 				w++;
 			}
-			else {
-				if(!zeroWritten) {
-					tdw.set(w, 0, 0);
-					tdw.set(w, 1, zeroCount);
-					w++;
-					zeroWritten = true;
-				}
-				if(v != 0) {
-					tdw.set(w, 0, v);
-					tdw.set(w, 1, 1);
-					w++;
-				}
-			}
 		}
-		if(!zeroWritten) { // all values negative: the zero row sorts to the end.
-			tdw.set(w, 0, 0);
-			tdw.set(w, 1, zeroCount);
-		}
+		tdw.set(w, 0, 0); // collapsed zero row (weight 0 when the column is dense)
+		tdw.set(w, 1, zeroCount);
 
 		// Emit through the same reorg used by MatrixBlock.sortOperations so the produced table is
 		// bit-for-bit identical to the uncompressed path, including its (intentionally unmaintained)

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibSort.java
@@ -26,8 +26,10 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.functionobjects.SortIndex;
+import org.apache.sysds.runtime.matrix.data.LibMatrixReorg;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixValue;
+import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 
 public final class CLALibSort {
 
@@ -80,7 +82,7 @@ public final class CLALibSort {
 	public static MatrixBlock sort(CompressedMatrixBlock mb, MatrixValue weights, MatrixBlock result, int k) {
 		final MatrixBlock w = CompressedMatrixBlock.getUncompressed(weights);
 		if(w == null && mb.getNumColumns() == 1 && mb.getColGroups().size() == 1) {
-			final MatrixBlock fast = sortTableSingleColumn(mb, k);
+			final MatrixBlock fast = sortTableSingleColumn(mb, result, k);
 			if(fast != null)
 				return fast;
 		}
@@ -99,7 +101,7 @@ public final class CLALibSort {
 		}
 	}
 
-	private static MatrixBlock sortTableSingleColumn(CompressedMatrixBlock mb, int k) {
+	private static MatrixBlock sortTableSingleColumn(CompressedMatrixBlock mb, MatrixBlock result, int k) {
 		final long lnnz = mb.getNonZeros();
 		if(lnnz < 0) // unknown number of non-zeros, cannot size the table.
 			return null;
@@ -147,7 +149,17 @@ public final class CLALibSort {
 			tdw.set(w, 0, 0);
 			tdw.set(w, 1, zeroCount);
 		}
-		tdw.recomputeNonZeros();
-		return tdw;
+
+		// Emit through the same reorg used by MatrixBlock.sortOperations so the produced table is
+		// bit-for-bit identical to the uncompressed path, including its (intentionally unmaintained)
+		// non-zero metadata. This keeps downstream quantile/median consumers and result comparisons
+		// consistent regardless of whether the input was compressed.
+		if(result == null)
+			result = new MatrixBlock(1 + nnz, 2, false);
+		else
+			result.reset(1 + nnz, 2, false);
+		final ReorgOperator rop = new ReorgOperator(new SortIndex(1, false, false), k);
+		LibMatrixReorg.reorg(tdw, result, rop);
+		return result;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
@@ -51,6 +51,7 @@ public class CompressedSortTest {
 
 	private static final ReorgOperator ASC = new ReorgOperator(new SortIndex(1, false, false), 1);
 	private static final ReorgOperator DESC = new ReorgOperator(new SortIndex(1, true, false), 1);
+	private static final ReorgOperator INDEX = new ReorgOperator(new SortIndex(1, false, true), 1);
 
 	@Test
 	public void sortDDC() {
@@ -127,6 +128,18 @@ public class CompressedSortTest {
 	}
 
 	@Test
+	public void sortIndexReturnFallback() {
+		// returning the sort permutation (index.return=TRUE) is not supported by the fast-path -> decompress fallback
+		runFallback(generate(ROWS, 1, 8, 1.0, 1, 50, 7), CompressionType.DDC, INDEX);
+	}
+
+	@Test
+	public void sortUnsupportedEncodingFallback() {
+		// OLE does not implement colgroup sort -> the fast-path declines and the order falls back to decompression
+		runFallback(generate(ROWS, 1, 8, 0.3, 1, 40, 23), CompressionType.OLE, ASC);
+	}
+
+	@Test
 	public void quantileTableDDC() {
 		runQuantile(generate(ROWS, 1, 8, 1.0, 1, 50, 7), CompressionType.DDC);
 	}
@@ -152,12 +165,24 @@ public class CompressedSortTest {
 	}
 
 	@Test
+	public void quantileTableAllNegativeDense() {
+		// dense column with no zeros -> the collapsed zero row carries weight 0
+		runQuantile(generate(ROWS, 1, 8, 1.0, -50, -1, 57), CompressionType.DDC);
+	}
+
+	@Test
 	public void quantileTableConst() {
 		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
 		for(int i = 0; i < ROWS; i++)
 			mb.set(i, 0, 3);
 		mb.recomputeNonZeros();
 		runQuantile(mb, CompressionType.CONST);
+	}
+
+	@Test
+	public void quantileTableUnsupportedEncodingFallback() {
+		// OLE does not implement colgroup sort -> the quantile table is built via the decompressed fallback
+		runQuantile(generate(ROWS, 1, 8, 0.3, 1, 40, 23), CompressionType.OLE);
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Random;
+
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
+import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
+import org.apache.sysds.runtime.compress.lib.CLALibSort;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Test;
+
+/**
+ * Tests the single-column sort of compressed column groups via {@link CLALibSort}. The compressed result is expected to
+ * match an ascending sort of the original column values for every implemented column-group encoding.
+ */
+public class CompressedSortTest {
+
+	private static final int ROWS = 1000;
+
+	@Test
+	public void sortDDC() {
+		// dense, few unique, positive -> DDC
+		run(generate(ROWS, 8, 1.0, -1, 50, 1, 7), CompressionType.DDC);
+	}
+
+	@Test
+	public void sortDDCWithNegatives() {
+		// dense, few unique, spanning negative/positive -> DDC
+		run(generate(ROWS, 10, 1.0, -25, 25, 0, 13), CompressionType.DDC);
+	}
+
+	@Test
+	public void sortSDCZeros() {
+		// sparse, few unique, positive -> SDC variant with zero default
+		run(generate(ROWS, 6, 0.2, 1, 40, 0, 23), CompressionType.SDC);
+	}
+
+	@Test
+	public void sortSDCWithNegatives() {
+		// sparse, few unique, spanning negative/zero/positive -> SDC variant
+		run(generate(ROWS, 8, 0.3, -20, 20, 0, 41), CompressionType.SDC);
+	}
+
+	@Test
+	public void sortSDCSingleValue() {
+		// sparse with a single distinct non-zero value -> SDCSingleZeros
+		run(generate(ROWS, 1, 0.25, 5, 5, 0, 99), CompressionType.SDC);
+	}
+
+	@Test
+	public void sortSDCSingleNonZeroDefault() {
+		// two distinct non-zero values, one dominant default -> SDCSingle
+		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
+		for(int i = 0; i < ROWS; i++)
+			mb.set(i, 0, i % 10 < 3 ? 3 : 7);
+		mb.recomputeNonZeros();
+		run(mb, CompressionType.SDC);
+	}
+
+	@Test
+	public void sortSDCSingleNonZeroDefaultNegative() {
+		// dominant non-zero default with a single smaller (negative) value -> SDCSingle
+		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
+		for(int i = 0; i < ROWS; i++)
+			mb.set(i, 0, i % 10 < 3 ? -4 : 7);
+		mb.recomputeNonZeros();
+		run(mb, CompressionType.SDC);
+	}
+
+	@Test
+	public void sortConst() {
+		// constant column -> CONST, sort is a no-op
+		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
+		for(int i = 0; i < ROWS; i++)
+			mb.set(i, 0, 3);
+		mb.recomputeNonZeros();
+		run(mb, CompressionType.CONST);
+	}
+
+	private void run(MatrixBlock mb, CompressionType ct) {
+		CompressionSettingsBuilder csb = new CompressionSettingsBuilder().setMinimumCompressionRatio(0.0)
+			.setValidCompressions(EnumSet.of(ct));
+		MatrixBlock compressed = CompressedMatrixBlockFactory.compress(mb, 1, csb).getLeft();
+		assertTrue("Expected the input to compress into a " + ct + " backed block",
+			compressed instanceof CompressedMatrixBlock);
+		CompressedMatrixBlock cmb = (CompressedMatrixBlock) compressed;
+		assertEquals("Expected a single column group", 1, cmb.getColGroups().size());
+
+		MatrixBlock actual = CompressedMatrixBlock.getUncompressed(CLALibSort.sort(cmb, null, null, 1), "sort");
+		MatrixBlock expected = referenceSort(mb);
+
+		TestUtils.compareMatrices(expected, actual, 0.0, "sort " + ct);
+	}
+
+	private static MatrixBlock referenceSort(MatrixBlock mb) {
+		final int n = mb.getNumRows();
+		double[] v = new double[n];
+		for(int i = 0; i < n; i++)
+			v[i] = mb.get(i, 0);
+		Arrays.sort(v);
+		MatrixBlock e = new MatrixBlock(n, 1, false);
+		for(int i = 0; i < n; i++)
+			e.set(i, 0, v[i]);
+		e.recomputeNonZeros();
+		return e;
+	}
+
+	private static MatrixBlock generate(int rows, int unique, double sparsity, int min, int max, int seed,
+		int valueSeed) {
+		final MatrixBlock mb = new MatrixBlock(rows, 1, false);
+		final Random pos = new Random(seed);
+		final Random val = new Random(valueSeed);
+		final double[] values = new double[Math.max(unique, 1)];
+		for(int i = 0; i < values.length; i++)
+			values[i] = min + (max > min ? val.nextInt(max - min + 1) : 0);
+		for(int i = 0; i < rows; i++)
+			if(pos.nextDouble() < sparsity)
+				mb.set(i, 0, values[pos.nextInt(values.length)]);
+		mb.recomputeNonZeros();
+		return mb;
+	}
+}

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
@@ -126,6 +126,79 @@ public class CompressedSortTest {
 		runFallback(generate(ROWS, 3, 6, 1.0, 1, 30, 31), CompressionType.DDC, ASC);
 	}
 
+	@Test
+	public void quantileTableDDC() {
+		runQuantile(generate(ROWS, 1, 8, 1.0, 1, 50, 7), CompressionType.DDC);
+	}
+
+	@Test
+	public void quantileTableDDCWithNegatives() {
+		runQuantile(generate(ROWS, 1, 10, 1.0, -25, 25, 13), CompressionType.DDC);
+	}
+
+	@Test
+	public void quantileTableSDCZeros() {
+		runQuantile(generate(ROWS, 1, 6, 0.2, 1, 40, 23), CompressionType.SDC);
+	}
+
+	@Test
+	public void quantileTableSDCWithNegatives() {
+		runQuantile(generate(ROWS, 1, 8, 0.3, -20, 20, 41), CompressionType.SDC);
+	}
+
+	@Test
+	public void quantileTableAllNegative() {
+		runQuantile(generate(ROWS, 1, 8, 0.4, -50, -1, 57), CompressionType.SDC);
+	}
+
+	@Test
+	public void quantileTableConst() {
+		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
+		for(int i = 0; i < ROWS; i++)
+			mb.set(i, 0, 3);
+		mb.recomputeNonZeros();
+		runQuantile(mb, CompressionType.CONST);
+	}
+
+	@Test
+	public void quantileWeightedFallback() {
+		MatrixBlock mb = generate(ROWS, 1, 8, 1.0, 1, 50, 7);
+		MatrixBlock weights = new MatrixBlock(ROWS, 1, false);
+		Random r = new Random(123);
+		for(int i = 0; i < ROWS; i++)
+			weights.set(i, 0, r.nextInt(4) + 1);
+		weights.recomputeNonZeros();
+		MatrixBlock expected = new MatrixBlock(mb).sortOperations(weights, new MatrixBlock(), 1);
+
+		CompressedMatrixBlock cmb = compress(mb, CompressionType.DDC);
+		MatrixBlock actual = cmb.sortOperations(weights, new MatrixBlock(), 1);
+
+		expected.recomputeNonZeros();
+		actual.recomputeNonZeros();
+		TestUtils.compareMatrices(expected, actual, 0.0, "weighted sortOperations fallback");
+	}
+
+	private void runQuantile(MatrixBlock mb, CompressionType ct) {
+		// reference is computed on a copy because compression may consume the input.
+		MatrixBlock expected = new MatrixBlock(mb).sortOperations(null, new MatrixBlock(), 1);
+
+		CompressedMatrixBlock cmb = compress(mb, ct);
+		assertEquals("Expected a single column group", 1, cmb.getColGroups().size());
+
+		MatrixBlock actual = cmb.sortOperations(null, new MatrixBlock(), 1);
+
+		// sortOperations leaves the non-zero count unmaintained; recompute so the value comparison reads the data.
+		expected.recomputeNonZeros();
+		actual.recomputeNonZeros();
+
+		// the value/weight table must match the uncompressed reference bit-for-bit ...
+		TestUtils.compareMatrices(expected, actual, 0.0, "sortOperations table " + ct);
+		// ... so the downstream median/quantile picks are identical.
+		assertEquals("median " + ct, expected.median(), actual.median(), 0.0);
+		assertEquals("q25 " + ct, expected.pickValue(0.25), actual.pickValue(0.25), 0.0);
+		assertEquals("q90 " + ct, expected.pickValue(0.90), actual.pickValue(0.90), 0.0);
+	}
+
 	private void runCompressed(MatrixBlock mb, CompressionType ct) {
 		CompressedMatrixBlock cmb = compress(mb, ct);
 		assertEquals("Expected a single column group", 1, cmb.getColGroups().size());

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedSortTest.java
@@ -22,126 +22,159 @@ package org.apache.sysds.test.component.compress;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Random;
 
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
 import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
-import org.apache.sysds.runtime.compress.lib.CLALibSort;
+import org.apache.sysds.runtime.compress.colgroup.ColGroupUncompressed;
+import org.apache.sysds.runtime.compress.colgroup.indexes.ColIndexFactory;
+import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Test;
 
 /**
- * Tests the single-column sort of compressed column groups via {@link CLALibSort}. The compressed result is expected to
- * match an ascending sort of the original column values for every implemented column-group encoding.
+ * Tests the {@code order} (sort) reorg operation on compressed matrices. A single column held in a single column group
+ * is sorted ascending while staying compressed (via {@link org.apache.sysds.runtime.compress.lib.CLALibSort}); every
+ * other configuration falls back to a decompressed reorg. In all cases the result must match the uncompressed reference.
  */
 public class CompressedSortTest {
 
 	private static final int ROWS = 1000;
 
+	private static final ReorgOperator ASC = new ReorgOperator(new SortIndex(1, false, false), 1);
+	private static final ReorgOperator DESC = new ReorgOperator(new SortIndex(1, true, false), 1);
+
 	@Test
 	public void sortDDC() {
-		// dense, few unique, positive -> DDC
-		run(generate(ROWS, 8, 1.0, -1, 50, 1, 7), CompressionType.DDC);
+		runCompressed(generate(ROWS, 1, 8, 1.0, 1, 50, 7), CompressionType.DDC);
 	}
 
 	@Test
 	public void sortDDCWithNegatives() {
-		// dense, few unique, spanning negative/positive -> DDC
-		run(generate(ROWS, 10, 1.0, -25, 25, 0, 13), CompressionType.DDC);
+		runCompressed(generate(ROWS, 1, 10, 1.0, -25, 25, 13), CompressionType.DDC);
 	}
 
 	@Test
 	public void sortSDCZeros() {
-		// sparse, few unique, positive -> SDC variant with zero default
-		run(generate(ROWS, 6, 0.2, 1, 40, 0, 23), CompressionType.SDC);
+		runCompressed(generate(ROWS, 1, 6, 0.2, 1, 40, 23), CompressionType.SDC);
 	}
 
 	@Test
 	public void sortSDCWithNegatives() {
-		// sparse, few unique, spanning negative/zero/positive -> SDC variant
-		run(generate(ROWS, 8, 0.3, -20, 20, 0, 41), CompressionType.SDC);
+		runCompressed(generate(ROWS, 1, 8, 0.3, -20, 20, 41), CompressionType.SDC);
 	}
 
 	@Test
-	public void sortSDCSingleValue() {
+	public void sortSDCSingleValueZeros() {
 		// sparse with a single distinct non-zero value -> SDCSingleZeros
-		run(generate(ROWS, 1, 0.25, 5, 5, 0, 99), CompressionType.SDC);
+		runCompressed(generate(ROWS, 1, 1, 0.25, 5, 5, 99), CompressionType.SDC);
 	}
 
 	@Test
 	public void sortSDCSingleNonZeroDefault() {
 		// two distinct non-zero values, one dominant default -> SDCSingle
-		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
-		for(int i = 0; i < ROWS; i++)
-			mb.set(i, 0, i % 10 < 3 ? 3 : 7);
-		mb.recomputeNonZeros();
-		run(mb, CompressionType.SDC);
+		runCompressed(twoValueColumn(3, 7), CompressionType.SDC);
 	}
 
 	@Test
 	public void sortSDCSingleNonZeroDefaultNegative() {
 		// dominant non-zero default with a single smaller (negative) value -> SDCSingle
-		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
-		for(int i = 0; i < ROWS; i++)
-			mb.set(i, 0, i % 10 < 3 ? -4 : 7);
-		mb.recomputeNonZeros();
-		run(mb, CompressionType.SDC);
+		runCompressed(twoValueColumn(-4, 7), CompressionType.SDC);
 	}
 
 	@Test
 	public void sortConst() {
-		// constant column -> CONST, sort is a no-op
 		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
 		for(int i = 0; i < ROWS; i++)
 			mb.set(i, 0, 3);
 		mb.recomputeNonZeros();
-		run(mb, CompressionType.CONST);
+		runCompressed(mb, CompressionType.CONST);
 	}
 
-	private void run(MatrixBlock mb, CompressionType ct) {
+	@Test
+	public void sortUncompressedColGroup() {
+		// a CompressedMatrixBlock holding a single uncompressed column group must also sort correctly
+		MatrixBlock raw = generate(ROWS, 1, ROWS, 1.0, -100000, 100000, 5);
+		List<AColGroup> groups = new ArrayList<>(1);
+		groups.add(ColGroupUncompressed.create(raw, ColIndexFactory.create(1)));
+		CompressedMatrixBlock cmb = new CompressedMatrixBlock(ROWS, 1, raw.getNonZeros(), false, groups);
+
+		MatrixBlock actual = cmb.reorgOperations(ASC, new MatrixBlock(), 0, 0, 0);
+		assertTrue("Expected the sorted result to stay compressed", actual instanceof CompressedMatrixBlock);
+		MatrixBlock expected = raw.reorgOperations(ASC, new MatrixBlock(), 0, 0, 0);
+		TestUtils.compareMatrices(expected, CompressedMatrixBlock.getUncompressed(actual, "sort"), 0.0,
+			"sort UNCOMPRESSED colgroup");
+	}
+
+	@Test
+	public void sortDescendingFallback() {
+		// descending order is not supported by the compressed fast-path -> decompress fallback
+		runFallback(generate(ROWS, 1, 8, 1.0, 1, 50, 7), CompressionType.DDC, DESC);
+	}
+
+	@Test
+	public void sortMultiColumnFallback() {
+		// order on a multi-column matrix sorts rows by the first column -> decompress fallback
+		runFallback(generate(ROWS, 3, 6, 1.0, 1, 30, 31), CompressionType.DDC, ASC);
+	}
+
+	private void runCompressed(MatrixBlock mb, CompressionType ct) {
+		CompressedMatrixBlock cmb = compress(mb, ct);
+		assertEquals("Expected a single column group", 1, cmb.getColGroups().size());
+
+		MatrixBlock actual = cmb.reorgOperations(ASC, new MatrixBlock(), 0, 0, 0);
+		assertTrue("Expected the sorted result to stay compressed for " + ct,
+			actual instanceof CompressedMatrixBlock);
+
+		MatrixBlock expected = mb.reorgOperations(ASC, new MatrixBlock(), 0, 0, 0);
+		TestUtils.compareMatrices(expected, CompressedMatrixBlock.getUncompressed(actual, "sort"), 0.0, "sort " + ct);
+	}
+
+	private void runFallback(MatrixBlock mb, CompressionType ct, ReorgOperator op) {
+		CompressedMatrixBlock cmb = compress(mb, ct);
+
+		MatrixBlock actual = cmb.reorgOperations(op, new MatrixBlock(), 0, 0, 0);
+		MatrixBlock expected = mb.reorgOperations(op, new MatrixBlock(), 0, 0, 0);
+		TestUtils.compareMatrices(expected, CompressedMatrixBlock.getUncompressed(actual, "sort"), 0.0,
+			"sort fallback " + ct);
+	}
+
+	private static CompressedMatrixBlock compress(MatrixBlock mb, CompressionType ct) {
 		CompressionSettingsBuilder csb = new CompressionSettingsBuilder().setMinimumCompressionRatio(0.0)
 			.setValidCompressions(EnumSet.of(ct));
 		MatrixBlock compressed = CompressedMatrixBlockFactory.compress(mb, 1, csb).getLeft();
 		assertTrue("Expected the input to compress into a " + ct + " backed block",
 			compressed instanceof CompressedMatrixBlock);
-		CompressedMatrixBlock cmb = (CompressedMatrixBlock) compressed;
-		assertEquals("Expected a single column group", 1, cmb.getColGroups().size());
-
-		MatrixBlock actual = CompressedMatrixBlock.getUncompressed(CLALibSort.sort(cmb, null, null, 1), "sort");
-		MatrixBlock expected = referenceSort(mb);
-
-		TestUtils.compareMatrices(expected, actual, 0.0, "sort " + ct);
+		return (CompressedMatrixBlock) compressed;
 	}
 
-	private static MatrixBlock referenceSort(MatrixBlock mb) {
-		final int n = mb.getNumRows();
-		double[] v = new double[n];
-		for(int i = 0; i < n; i++)
-			v[i] = mb.get(i, 0);
-		Arrays.sort(v);
-		MatrixBlock e = new MatrixBlock(n, 1, false);
-		for(int i = 0; i < n; i++)
-			e.set(i, 0, v[i]);
-		e.recomputeNonZeros();
-		return e;
+	private static MatrixBlock twoValueColumn(int rare, int dominant) {
+		MatrixBlock mb = new MatrixBlock(ROWS, 1, false);
+		for(int i = 0; i < ROWS; i++)
+			mb.set(i, 0, i % 10 < 3 ? rare : dominant);
+		mb.recomputeNonZeros();
+		return mb;
 	}
 
-	private static MatrixBlock generate(int rows, int unique, double sparsity, int min, int max, int seed,
-		int valueSeed) {
-		final MatrixBlock mb = new MatrixBlock(rows, 1, false);
+	private static MatrixBlock generate(int rows, int cols, int unique, double sparsity, int min, int max, int seed) {
+		final MatrixBlock mb = new MatrixBlock(rows, cols, false);
 		final Random pos = new Random(seed);
-		final Random val = new Random(valueSeed);
+		final Random val = new Random(seed * 31 + 1);
 		final double[] values = new double[Math.max(unique, 1)];
 		for(int i = 0; i < values.length; i++)
 			values[i] = min + (max > min ? val.nextInt(max - min + 1) : 0);
 		for(int i = 0; i < rows; i++)
-			if(pos.nextDouble() < sparsity)
-				mb.set(i, 0, values[pos.nextInt(values.length)]);
+			for(int j = 0; j < cols; j++)
+				if(pos.nextDouble() < sparsity)
+					mb.set(i, j, values[pos.nextInt(values.length)]);
 		mb.recomputeNonZeros();
 		return mb;
 	}

--- a/src/test/java/org/apache/sysds/test/component/compress/CompressedVectorTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/CompressedVectorTest.java
@@ -29,9 +29,11 @@ import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressionSettingsBuilder;
 import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
 import org.apache.sysds.runtime.functionobjects.CM;
+import org.apache.sysds.runtime.functionobjects.SortIndex;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.CMOperator;
 import org.apache.sysds.runtime.matrix.operators.CMOperator.AggregateOperationTypes;
+import org.apache.sysds.runtime.matrix.operators.ReorgOperator;
 import org.apache.sysds.test.TestUtils;
 import org.apache.sysds.test.component.compress.TestConstants.MatrixTypology;
 import org.apache.sysds.test.component.compress.TestConstants.OverLapping;
@@ -137,6 +139,26 @@ public class CompressedVectorTest extends CompressedTestBase {
 
 			MatrixBlock ret1 = mb.sortOperations();
 			MatrixBlock ret2 = cmb.sortOperations();
+
+			compareResultMatrices(ret1, ret2, 1);
+
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException(bufferedToString + "\n" + e.getMessage(), e);
+		}
+	}
+
+	@Test
+	public void testSort() {
+		try {
+			if(!(cmb instanceof CompressedMatrixBlock) || cols != 1)
+				return; // Input was not compressed then just pass test
+
+			// order() builtin: sort the single column ascending (compressed fast-path or decompress fallback).
+			ReorgOperator op = new ReorgOperator(new SortIndex(1, false, false), _k);
+			MatrixBlock ret1 = mb.reorgOperations(op, new MatrixBlock(), 0, 0, 0);
+			MatrixBlock ret2 = cmb.reorgOperations(op, new MatrixBlock(), 0, 0, 0);
 
 			compareResultMatrices(ret1, ret2, 1);
 

--- a/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/colgroup/ColGroupNegativeTests.java
@@ -481,6 +481,12 @@ public class ColGroupNegativeTests {
 			// TODO Auto-generated method stub
 			throw new UnsupportedOperationException("Unimplemented method 'removeEmptyColsSubset'");
 		}
+
+		@Override
+		public AColGroup sort() {
+			// TODO Auto-generated method stub
+			throw new UnsupportedOperationException("Unimplemented method 'sort'");
+		}
 	}
 
 	private class FakeDictBasedColGroup extends ADictBasedColGroup {
@@ -801,6 +807,12 @@ public class ColGroupNegativeTests {
 		protected AColGroup removeEmptyColsSubset(IColIndex newColumnIDs, IntArrayList selectedColumns) {
 			// TODO Auto-generated method stub
 			throw new UnsupportedOperationException("Unimplemented method 'removeEmptyColsSubset'");
+		}
+
+		@Override
+		public AColGroup sort() {
+			// TODO Auto-generated method stub
+			throw new UnsupportedOperationException("Unimplemented method 'sort'");
 		}
 	}
 }

--- a/src/test/java/org/apache/sysds/test/component/compress/dictionary/DictionaryTests.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/dictionary/DictionaryTests.java
@@ -366,6 +366,41 @@ public class DictionaryTests {
 	}
 
 	@Test
+	public void sort() {
+		if(nCol != 1)
+			return; // sort is only defined for single-column dictionaries.
+
+		final double[] sa = sortedValues(a);
+		final double[] sb = sortedValues(b);
+		if(sa == null && sb == null)
+			return; // neither encoding implements sort -> nothing to compare.
+
+		if(sa != null && sb != null)
+			TestUtils.compareMatricesBitAvgDistance(sa, sb, 10, 10, "Sorted values differ between dictionaries");
+	}
+
+	/**
+	 * Reorders the dictionary values by {@link IDictionary#sort()} and asserts the permutation yields a non-decreasing
+	 * sequence. Returns {@code null} when the encoding does not implement sort.
+	 */
+	private double[] sortedValues(IDictionary d) {
+		final int[] perm;
+		try {
+			perm = d.sort();
+		}
+		catch(NotImplementedException e) {
+			return null; // encoding does not support sort.
+		}
+		assertEquals("sort must return one index per value", nRow, perm.length);
+		final double[] sorted = new double[perm.length];
+		for(int i = 0; i < perm.length; i++)
+			sorted[i] = d.getValue(perm[i], 0, 1);
+		for(int i = 1; i < sorted.length; i++)
+			assertTrue("sort did not produce a non-decreasing sequence", sorted[i - 1] <= sorted[i]);
+		return sorted;
+	}
+
+	@Test
 	public void getValues() {
 		try {
 			double[] av = a.getValues();


### PR DESCRIPTION
Implement single-column sort for compressed matrices via a new AColGroup.sort that reorders the dictionary and remaps indexes. Add CLALibSort driver, IDictionary/Dictionary sort with shared index permutation, and per-column-group sort implementations.