### PR TITLE
[MINOR] Bump jackson to 2.15.4 (core/databind/annotations)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 		<antlr.version>4.8</antlr.version>
 		<protobuf.version>3.23.4</protobuf.version>
 		<spark.version>3.5.7</spark.version>
+		<jackson.version>2.15.4</jackson.version>
 		<scala.version>2.12.18</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
@@ -1433,26 +1434,22 @@
 			<version>1.4</version>
 		</dependency>
 
-		<!-- Keep the jackson trio aligned on the same patch. The version is
-		     capped at 2.15.x because Spark 3.5.x ships jackson-module-scala
-		     2.15.x, which rejects any jackson-databind outside [2.15.0, 2.16.0)
-		     at runtime. 2.15.4 is the latest patch in that line. -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.15.4</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.4</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.15.4</version>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1433,10 +1433,26 @@
 			<version>1.4</version>
 		</dependency>
 
+		<!-- Keep the jackson trio aligned on the same patch. The version is
+		     capped at 2.15.x because Spark 3.5.x ships jackson-module-scala
+		     2.15.x, which rejects any jackson-databind outside [2.15.0, 2.16.0)
+		     at runtime. 2.15.4 is the latest patch in that line. -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.15.4</version>
+		</dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.15.4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Align the jackson trio on 2.15.4, the latest 2.15.x patch. Stays within 2.15.x because Spark 3.5.7 ships jackson-module-scala 2.15.2, which rejects jackson-databind outside [2.15.0, 2.16.0) at runtime. Supersedes #2510