### PR TITLE
[MINOR][CI] Serialize federated monitoring/multitenant tests

### DIFF
--- a/.github/workflows/javaTests.yml
+++ b/.github/workflows/javaTests.yml
@@ -75,7 +75,7 @@ jobs:
           "**.functions.federated.primitives.part3.** -Dtest-threadCount=1 -Dtest-forkCount=1",
           "**.functions.federated.primitives.part4.** -Dtest-threadCount=1 -Dtest-forkCount=1",
           "**.functions.federated.primitives.part5.** -Dtest-threadCount=1 -Dtest-forkCount=1",
-          "**.functions.federated.monitoring.**,**.functions.federated.multitenant.**",
+          "**.functions.federated.monitoring.**,**.functions.federated.multitenant.** -Dtest-threadCount=1 -Dtest-forkCount=1",
           "**.functions.federated.codegen.**,**.functions.federated.FederatedTestObjectConstructor",
           "**.functions.codegenalg.partone.**",
           "**.functions.builtin.part1.**",


### PR DESCRIPTION

`**.functions.federated.monitoring.**,**.functions.federated.multitenant.**` was the only federated test group running at the default surefire parallelism (`parallel=classes`, `threadCount=2`). These tests spawn worker JVMs on fixed ports, run Spark, and share the static `/tmp/systemds` working directory, so two classes per fork race on those resources.

## Symptoms

- `Failed to create non-existing local working directory: /tmp/systemds`
- `Federated worker processes on port N died before becoming ready`
- All tests finish, then a leaked worker/Spark thread keeps the fork JVM alive until the 30m job cap cancels it.

## Change

- Run the group with `-Dtest-threadCount=1 -Dtest-forkCount=1`, matching every other federated group (the `federated.primitives.part1-5` groups already use this), so the classes execute serially and no longer contend for ports and the shared working directory.
