### PR TITLE
[MINOR][CI] Run component.c tests in parallel again

### DIFF
--- a/.github/workflows/javaTests.yml
+++ b/.github/workflows/javaTests.yml
@@ -59,7 +59,7 @@ jobs:
         tests: [
           "org.apache.sysds.test.applications.**",
           "**.test.usertest.**",
-          "**.component.c**.** -Dtest-threadCount=1 -Dtest-forkCount=1",
+          "**.component.c**.**",
           "**.component.e**.**,**.component.f**.**,**.component.m**.**,**.component.o**.**",
           "**.component.p**.**,**.component.r**.**,**.component.s**.**,**.component.t**.**,**.component.u**.**",
           "**.functions.a**.**,**.functions.binary.matrix.**,**.functions.binary.scalar.**,**.functions.binary.tensor.**",


### PR DESCRIPTION
Removes `-Dtest-threadCount=1 -Dtest-forkCount=1` from the `**.component.c**.**` entry in the javaTests matrix, so these tests run with the default parallel fork/thread configuration again instead of serially.