### PR TITLE
[BWARE] Restructure CLALibBinaryCellOp and decompression fallbacks

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -619,8 +619,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public MatrixBlock transposeSelfMatrixMultOperations(MatrixBlock out, MMTSJType tstype, int k) {
 		// check for transpose type
 		if(tstype == MMTSJType.LEFT) {
-			CLALibTSMM.leftMultByTransposeSelf(this, out, k);
-			return out;
+			return CLALibTSMM.leftMultByTransposeSelf(this, out, k);
 		}
 		else {
 			throw new DMLRuntimeException("Invalid MMTSJ type '" + tstype.toString() + "'.");

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlock.java
@@ -59,8 +59,8 @@ import org.apache.sysds.runtime.compress.lib.CLALibMMChain;
 import org.apache.sysds.runtime.compress.lib.CLALibMatrixMult;
 import org.apache.sysds.runtime.compress.lib.CLALibMerge;
 import org.apache.sysds.runtime.compress.lib.CLALibRemoveEmpty;
-import org.apache.sysds.runtime.compress.lib.CLALibReplace;
 import org.apache.sysds.runtime.compress.lib.CLALibReorg;
+import org.apache.sysds.runtime.compress.lib.CLALibReplace;
 import org.apache.sysds.runtime.compress.lib.CLALibReshape;
 import org.apache.sysds.runtime.compress.lib.CLALibRexpand;
 import org.apache.sysds.runtime.compress.lib.CLALibScalar;
@@ -103,6 +103,7 @@ import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.IndexRange;
 import org.apache.sysds.utils.DMLCompressionStatistics;
 import org.apache.sysds.utils.stats.InfrastructureAnalyzer;
+import org.apache.sysds.utils.stats.Timing;
 
 public class CompressedMatrixBlock extends MatrixBlock {
 	private static final Log LOG = LogFactory.getLog(CompressedMatrixBlock.class.getName());
@@ -477,16 +478,20 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	}
 
 	public static CompressedMatrixBlock read(DataInput in) throws IOException {
+		Timing t = new Timing();
 		int rlen = in.readInt();
 		int clen = in.readInt();
 		long nonZeros = in.readLong();
 		boolean overlappingColGroups = in.readBoolean();
 		List<AColGroup> groups = ColGroupIO.readGroups(in, rlen);
-		return new CompressedMatrixBlock(rlen, clen, nonZeros, overlappingColGroups, groups);
+		CompressedMatrixBlock ret =  new CompressedMatrixBlock(rlen, clen, nonZeros, overlappingColGroups, groups);
+		LOG.debug("Compressed read serialization time: " + t.stop());
+		return ret;
 	}
 
 	@Override
 	public void write(DataOutput out) throws IOException {
+		Timing t = new Timing();
 		final long estimateUncompressed = nonZeros > 0 ? MatrixBlock.estimateSizeOnDisk(rlen, clen,
 			nonZeros) : Long.MAX_VALUE;
 		final long estDisk = nonZeros > 0 ? getExactSizeOnDisk() : Long.MAX_VALUE;
@@ -514,6 +519,7 @@ public class CompressedMatrixBlock extends MatrixBlock {
 		out.writeLong(nonZeros);
 		out.writeBoolean(overlappingColGroups);
 		ColGroupIO.writeGroups(out, _colGroups);
+		LOG.debug("Compressed write serialization time: " + t.stop());
 	}
 
 	/**
@@ -613,14 +619,6 @@ public class CompressedMatrixBlock extends MatrixBlock {
 	public MatrixBlock transposeSelfMatrixMultOperations(MatrixBlock out, MMTSJType tstype, int k) {
 		// check for transpose type
 		if(tstype == MMTSJType.LEFT) {
-			if(isEmpty())
-				return new MatrixBlock(clen, clen, true);
-			// create output matrix block
-			if(out == null)
-				out = new MatrixBlock(clen, clen, false);
-			else
-				out.reset(clen, clen, false);
-			out.allocateDenseBlock();
 			CLALibTSMM.leftMultByTransposeSelf(this, out, k);
 			return out;
 		}

--- a/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/CompressedMatrixBlockFactory.java
@@ -64,7 +64,8 @@ public class CompressedMatrixBlockFactory {
 
 	private static final Log LOG = LogFactory.getLog(CompressedMatrixBlockFactory.class.getName());
 
-	private static final Object asyncCompressLock = new Object(); 
+	/** Global lock serializing all async compressions to bound concurrent compression memory/CPU. */
+	private static final Object asyncCompressLock = new Object();
 
 	/** Timing object to measure the time of each phase in the compression */
 	private final Timing time = new Timing(true);
@@ -188,7 +189,7 @@ public class CompressedMatrixBlockFactory {
 			// method call or code to be async
 			try {
 				CacheableData<?> data = ec.getCacheableData(varName);
-				synchronized(asyncCompressLock){ // synchronize on the data object to not allow multiple compressions of the same matrix.
+				synchronized(asyncCompressLock) { // global lock: serialize all async compressions (not per-matrix)
 					if(data instanceof MatrixObject) {
 						LOG.debug("Compressing Async");
 						MatrixObject mo = (MatrixObject) data;

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibBinaryCellOp.java
@@ -77,7 +77,7 @@ import org.apache.sysds.utils.stats.Timing;
 
 public final class CLALibBinaryCellOp {
 	private static final Log LOG = LogFactory.getLog(CLALibBinaryCellOp.class.getName());
-	public static final int DECOMPRESSION_BLEN = 16384 / 2;
+	public static final int DECOMPRESSION_BLEN = 8192;
 
 	private CLALibBinaryCellOp() {
 		// empty private constructor.
@@ -427,7 +427,12 @@ public final class CLALibBinaryCellOp {
 		MatrixBlock ret = new MatrixBlock(nRows, nCols, shouldBeSparseOut, -1).allocateBlock();
 
 		if(shouldBeSparseOut) {
-			if(!m1.isOverlapping() && MatrixBlock.evalSparseFormatInMemory(nRows, nCols, m1.getNonZeros())) {
+			// The sparse-sparse path only visits the stored non-zeros of m1, so it is correct only when the operation
+			// maps a zero in m1 to a zero output for every value of the vector m2 (i.e. it does not introduce non-zeros
+			// from m1's zeros). Otherwise fall back to the dense-scan sparse path that evaluates every cell.
+			final boolean sparseSafeOnM1Zeros = left ? op.isRowSafeLeft(m2) : op.isRowSafeRight(m2);
+			if(sparseSafeOnM1Zeros && !m1.isOverlapping() &&
+				MatrixBlock.evalSparseFormatInMemory(nRows, nCols, m1.getNonZeros())) {
 				if(k <= 1)
 					nnz = binaryMVColSingleThreadSparseSparse(m1, m2, op, left, ret);
 				else
@@ -1059,31 +1064,35 @@ public final class CLALibBinaryCellOp {
 
 		private final void processBlock(final int rl, final int ru, final List<AColGroup> groups, final AIterator[] its) {
 			decompressToTmpBlock(rl, ru, tmp.getSparseBlock(), groups, its);
-			processDense(rl, ru);
+			// decompressing multiple column groups can leave the temp rows with unsorted column indices, so sort
+			// before reading them in stored order into the (column-sorted) output sparse block.
+			tmp.sortSparseRows(0, ru - rl);
+			processSparse(rl, ru);
 			tmp.reset();
 		}
 
 		private final void processBlockLeft(final int rl, final int ru, final List<AColGroup> groups,
 			final AIterator[] its) {
 			decompressToTmpBlock(rl, ru, tmp.getSparseBlock(), groups, its);
-			processDenseLeft(rl, ru);
+			tmp.sortSparseRows(0, ru - rl);
+			processSparseLeft(rl, ru);
 			tmp.reset();
 		}
 
-		private final void processDense(final int rl, final int ru) {
+		private final void processSparse(final int rl, final int ru) {
 			final SparseBlock sb = _ret.getSparseBlock();
 			final SparseBlock _tmpSparse = tmp.getSparseBlock();
 			final double[] _m2Dense = _m2.getDenseBlockValues();
 			for(int row = rl; row < ru; row++) {
 				final double vr = _m2Dense[row];
 				final int tmpOff = (row - rl);
-				if(!_tmpSparse.isEmpty(tmpOff)){
+				if(!_tmpSparse.isEmpty(tmpOff)) {
 					int[] aoff = _tmpSparse.indexes(tmpOff);
 					double[] aval = _tmpSparse.values(tmpOff);
 					int apos = _tmpSparse.pos(tmpOff);
 					int alen = apos + _tmpSparse.size(tmpOff);
 
-					for(int j = apos; j < alen; j++){
+					for(int j = apos; j < alen; j++) {
 						sb.append(row, aoff[j], _op.fn.execute(aval[j], vr));
 					}
 				}
@@ -1091,21 +1100,20 @@ public final class CLALibBinaryCellOp {
 			}
 		}
 
-		private final void processDenseLeft(final int rl, final int ru) {
-			final int nCol = _m1.getNumColumns();
+		private final void processSparseLeft(final int rl, final int ru) {
 			final SparseBlock sb = _ret.getSparseBlock();
 			final SparseBlock _tmpSparse = tmp.getSparseBlock();
 			final double[] _m2Dense = _m2.getDenseBlockValues();
 			for(int row = rl; row < ru; row++) {
 				final double vr = _m2Dense[row];
-				final int tmpOff = (row - rl) * nCol;
-				if(!_tmpSparse.isEmpty(tmpOff)){
+				final int tmpOff = (row - rl);
+				if(!_tmpSparse.isEmpty(tmpOff)) {
 					int[] aoff = _tmpSparse.indexes(tmpOff);
 					double[] aval = _tmpSparse.values(tmpOff);
 					int apos = _tmpSparse.pos(tmpOff);
 					int alen = apos + _tmpSparse.size(tmpOff);
-					for(int j = apos; j < alen; j++){
-						sb.append(row, aoff[j], _op.fn.execute(vr,aval[j]));
+					for(int j = apos; j < alen; j++) {
+						sb.append(row, aoff[j], _op.fn.execute(vr, aval[j]));
 					}
 				}
 			}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryMatrixMatrixCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/BinaryMatrixMatrixCPInstruction.java
@@ -80,8 +80,15 @@ public class BinaryMatrixMatrixCPInstruction extends BinaryCPInstruction {
 			retBlock = inBlock1;
 		}
 		else {
-			if(LibCommonsMath.isSupportedMatrixMatrixOperation(getOpcode()) && !compressedLeft && !compressedRight)
+			if(LibCommonsMath.isSupportedMatrixMatrixOperation(getOpcode()) ){
+				if(compressedLeft)
+					inBlock1 = CompressedMatrixBlock.getUncompressed(inBlock1, getOpcode());
+				
+				if(compressedRight)
+					inBlock2 = CompressedMatrixBlock.getUncompressed(inBlock2, getOpcode());
+
 				retBlock = LibCommonsMath.matrixMatrixOperations(inBlock1, inBlock2, getOpcode());
+			}
 			else {
 				// Perform computation using input matrices, and produce the result matrix
 				BinaryOperator bop = (BinaryOperator) _optr;

--- a/src/test/java/org/apache/sysds/test/component/compress/lib/CLALibBinaryCellOpCustomTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/lib/CLALibBinaryCellOpCustomTest.java
@@ -22,14 +22,20 @@ package org.apache.sysds.test.component.compress.lib;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
 import org.apache.sysds.runtime.compress.CompressionStatistics;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup;
+import org.apache.sysds.runtime.compress.colgroup.AColGroup.CompressionType;
 import org.apache.sysds.runtime.compress.lib.CLALibBinaryCellOp;
 import org.apache.sysds.runtime.functionobjects.GreaterThanEquals;
 import org.apache.sysds.runtime.functionobjects.LessThanEquals;
 import org.apache.sysds.runtime.functionobjects.Minus;
+import org.apache.sysds.runtime.functionobjects.Multiply;
+import org.apache.sysds.runtime.matrix.data.LibMatrixBincell;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.BinaryOperator;
 import org.apache.sysds.test.TestUtils;
@@ -130,6 +136,41 @@ public class CLALibBinaryCellOpCustomTest {
 		MatrixBlock cRet = CLALibBinaryCellOp.binaryOperationsRight(op, spy, c2);
 
 		TestUtils.compareMatricesBitAvgDistance(new MatrixBlock(10, 10, 2.5 - 324.0), cRet, 0, 0, op.toString());
+	}
+
+	@Test
+	public void sparseSparseColVectorNonSDCGroup() {
+		// Drive the sparse-sparse column-vector path of CLALibBinaryCellOp through a compressed input whose
+		// column groups are not all SDC. The constant non-zero first column compresses to a non-SDC (Const/DDC)
+		// group, while the remaining columns stay sparse so the overall matrix is sparse enough to pick the
+		// sparse-sparse path. This exercises the non-SDC branch of decompressToTmpBlock(SparseBlock), which the
+		// all-SDC sparse inputs of CLALibBinaryCellOpTest never reach.
+		final int nRow = 300;
+		final int nCol = 12;
+		MatrixBlock mb = new MatrixBlock(nRow, nCol, false);
+		mb.allocateDenseBlock();
+		for(int i = 0; i < nRow; i++)
+			mb.set(i, 0, 3.0); // constant non-zero column -> non-SDC group
+		for(int i = 0; i < nRow; i += 7)
+			mb.set(i, 3, 1.0 + (i % 4)); // a few sparse non-zeros
+		for(int i = 0; i < nRow; i += 11)
+			mb.set(i, 8, 4.0);
+		mb.recomputeNonZeros();
+
+		CompressedMatrixBlock cmb = (CompressedMatrixBlock) CompressedMatrixBlockFactory.compress(mb, 1).getLeft();
+		assertTrue("input must compress to exercise the compressed path", cmb instanceof CompressedMatrixBlock);
+		boolean hasNonSDC = false;
+		for(AColGroup g : cmb.getColGroups())
+			hasNonSDC |= g.getCompType() != CompressionType.SDC;
+		assertTrue("need a non-SDC column group to cover the non-SDC decompress branch", hasNonSDC);
+
+		// Multiply is sparse-safe (f(0,v)==0), so the sparse-safe gate routes it through the sparse-sparse path.
+		BinaryOperator op = new BinaryOperator(Multiply.getMultiplyFnObject(), 1);
+		MatrixBlock cv = TestUtils.round(TestUtils.generateTestMatrixBlock(nRow, 1, -5, 5, 1.0, 7));
+
+		MatrixBlock cRet = CLALibBinaryCellOp.binaryOperationsRight(op, cmb, cv);
+		MatrixBlock uRet = LibMatrixBincell.bincellOp(mb, cv, null, op);
+		TestUtils.compareMatricesBitAvgDistance(uRet, cRet, 0, 0, op.toString());
 	}
 
 	@Test

--- a/src/test/java/org/apache/sysds/test/component/compress/lib/CompressedBinaryMatrixMatrixSolveTest.java
+++ b/src/test/java/org/apache/sysds/test/component/compress/lib/CompressedBinaryMatrixMatrixSolveTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.component.compress.lib;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.sysds.common.Types.DataType;
+import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.compress.CompressedMatrixBlockFactory;
+import org.apache.sysds.runtime.controlprogram.LocalVariableMap;
+import org.apache.sysds.runtime.controlprogram.caching.CacheableData;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.BinaryCPInstruction;
+import org.apache.sysds.runtime.instructions.cp.BinaryMatrixMatrixCPInstruction;
+import org.apache.sysds.runtime.matrix.data.LibCommonsMath;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.runtime.meta.MetaDataFormat;
+import org.apache.sysds.test.TestUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Drive the solve opcode through {@link BinaryMatrixMatrixCPInstruction} with compressed inputs to cover the
+ * commons-math matrix-matrix branch that decompresses compressed left/right operands before solving. The
+ * script-level solve tests only ever see uncompressed inputs, so this branch is otherwise unreached.
+ */
+public class CompressedBinaryMatrixMatrixSolveTest {
+
+	private static final String SOLVE = "solve";
+
+	@BeforeClass
+	public static void init() throws java.io.IOException {
+		CacheableData.initCaching("compressed_solve_instruction_test");
+	}
+
+	@Test
+	public void solveCompressedLeftCompressedRight() {
+		// A is a compressible, invertible matrix (constant off-diagonal with a larger diagonal), b is a
+		// compressed constant right-hand side: both inputs are CompressedMatrixBlock so the instruction must
+		// decompress both before delegating to commons-math solve.
+		final int n = 200;
+		MatrixBlock aUC = new MatrixBlock(n, n, false);
+		aUC.allocateDenseBlock();
+		for(int i = 0; i < n; i++)
+			for(int j = 0; j < n; j++)
+				aUC.set(i, j, i == j ? 5.0 : 1.0);
+		aUC.recomputeNonZeros();
+
+		CompressedMatrixBlock aC = (CompressedMatrixBlock) CompressedMatrixBlockFactory.compress(aUC, 1).getLeft();
+		assertTrue("A must compress to exercise the compressed-left path", aC instanceof CompressedMatrixBlock);
+		CompressedMatrixBlock bC = CompressedMatrixBlockFactory.createConstant(n, 2, 1.0);
+
+		MatrixBlock expected = LibCommonsMath.matrixMatrixOperations(
+			CompressedMatrixBlock.getUncompressed(aC), CompressedMatrixBlock.getUncompressed(bC), SOLVE);
+
+		MatrixBlock actual = runSolve(aC, bC);
+		TestUtils.compareMatricesBitAvgDistance(expected, actual, 0, 0, SOLVE);
+	}
+
+	@Test
+	public void solveCompressedLeftDenseRight() {
+		// Only the left operand is compressed; the right-hand side stays dense (a single column).
+		final int n = 200;
+		MatrixBlock aUC = new MatrixBlock(n, n, false);
+		aUC.allocateDenseBlock();
+		for(int i = 0; i < n; i++)
+			for(int j = 0; j < n; j++)
+				aUC.set(i, j, i == j ? 5.0 : 1.0);
+		aUC.recomputeNonZeros();
+
+		CompressedMatrixBlock aC = (CompressedMatrixBlock) CompressedMatrixBlockFactory.compress(aUC, 1).getLeft();
+		assertTrue("A must compress to exercise the compressed-left path", aC instanceof CompressedMatrixBlock);
+		MatrixBlock b = TestUtils.round(TestUtils.generateTestMatrixBlock(n, 1, -5, 5, 1.0, 7));
+
+		MatrixBlock expected = LibCommonsMath.matrixMatrixOperations(
+			CompressedMatrixBlock.getUncompressed(aC), b, SOLVE);
+
+		MatrixBlock actual = runSolve(aC, b);
+		TestUtils.compareMatricesBitAvgDistance(expected, actual, 0, 0, SOLVE);
+	}
+
+	private static MatrixBlock runSolve(MatrixBlock a, MatrixBlock b) {
+		ExecutionContext ec = new ExecutionContext(new LocalVariableMap());
+		ec.setAutoCreateVars(true);
+		ec.setVariable("A", matrixObject("A", a));
+		ec.setVariable("b", matrixObject("b", b));
+		solveInstruction().processInstruction(ec);
+		return ec.getMatrixObject("out").acquireReadAndRelease();
+	}
+
+	private static BinaryMatrixMatrixCPInstruction solveInstruction() {
+		String in1 = InstructionUtils.concatOperandParts("A", DataType.MATRIX.name(), ValueType.FP64.name(), "false");
+		String in2 = InstructionUtils.concatOperandParts("b", DataType.MATRIX.name(), ValueType.FP64.name(), "false");
+		String out = InstructionUtils.concatOperandParts("out", DataType.MATRIX.name(), ValueType.FP64.name(), "false");
+		String str = InstructionUtils.concatOperands("CP", SOLVE, in1, in2, out);
+		return (BinaryMatrixMatrixCPInstruction) BinaryCPInstruction.parseInstruction(str);
+	}
+
+	private static MatrixObject matrixObject(String name, MatrixBlock mb) {
+		MatrixCharacteristics mc = new MatrixCharacteristics(mb.getNumRows(), mb.getNumColumns(), 1000, mb.getNonZeros());
+		MatrixObject mo = new MatrixObject(ValueType.FP64, "/dev/null/" + name,
+			new MetaDataFormat(mc, FileFormat.BINARY), mb);
+		return mo;
+	}
+}


### PR DESCRIPTION

Reworks how the compressed library handles binary cell-wise operations, broadening the set of inputs it can keep compressed and tightening the "give up and decompress" path so it is consistent across operation shapes.