### PR TITLE
[SYSTEMDS-3951] MM Chain Optimization w/ Basic Average Estimator

### DIFF
--- a/src/main/java/org/apache/sysds/hops/estim/MMNode.java
+++ b/src/main/java/org/apache/sysds/hops/estim/MMNode.java
@@ -47,6 +47,15 @@ public class MMNode
 		_op = null;
 		_misc = null;
 	}
+
+	public MMNode(DataCharacteristics mc) {
+		_m1 = null;
+		_m2 = null;
+		_data = null;
+		_mc = mc;
+		_op = null;
+		_misc = null;
+	}
 	
 	public MMNode(MMNode left, MMNode right, OpCode op, long[] misc) {
 		_m1 = left;
@@ -112,7 +121,7 @@ public class MMNode
 	}
 	
 	public boolean isLeaf() {
-		return _data != null;
+		return _op == null;
 	}
 	
 	public MatrixBlock getData() {

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriteStatus.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriteStatus.java
@@ -19,8 +19,6 @@
 
 package org.apache.sysds.hops.rewrite;
 
-import org.apache.sysds.runtime.controlprogram.LocalVariableMap;
-
 public class ProgramRewriteStatus 
 {
 	//status of applied rewrites
@@ -30,17 +28,11 @@ public class ProgramRewriteStatus
 	
 	//current context
 	private boolean _inParforCtx = false;
-	private LocalVariableMap _vars = null;
 	
 	public ProgramRewriteStatus() {
 		_rmBranches = false;
 		_inParforCtx = false;
 		_injectCheckpoints = false;
-	}
-	
-	public ProgramRewriteStatus(LocalVariableMap vars) {
-		this();
-		_vars = vars;
 	}
 	
 	public void setRemovedBranches(){
@@ -73,9 +65,5 @@ public class ProgramRewriteStatus
 	
 	public boolean getInjectedCheckpoints(){
 		return _injectCheckpoints;
-	}
-	
-	public LocalVariableMap getVariables() {
-		return _vars;
 	}
 }

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -22,18 +22,12 @@ package org.apache.sysds.hops.rewrite;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.sysds.hops.Hop;
-import org.apache.sysds.hops.HopsException;
+import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.estim.MMNode;
-import org.apache.sysds.hops.estim.EstimatorMatrixHistogram;
-import org.apache.sysds.hops.estim.EstimatorMatrixHistogram.MatrixHistogram;
+import org.apache.sysds.hops.estim.EstimatorBasicAvg;
 import org.apache.sysds.hops.estim.SparsityEstimator.OpCode;
-import org.apache.sysds.runtime.controlprogram.LocalVariableMap;
-import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
-import org.apache.sysds.runtime.instructions.cp.Data;
-import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 /**
  * Rule: Determine the optimal order of execution for a chain of
@@ -53,9 +47,8 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 		double[] dimsArray = new double[mmChain.size() + 1];
 		boolean dimsKnown = getDimsArray( hop, mmChain, dimsArray );
 		MMNode[] sketchArray = new MMNode[mmChain.size() + 1];
-		boolean inputsAvail = getInputMatrices(hop, mmChain, sketchArray, state);
-		
-		if( dimsKnown && inputsAvail ) {
+		boolean inputMetaAvail = getInputMatrixCharacteristics(hop, mmChain, sketchArray, state);
+		if(dimsKnown && inputMetaAvail) {
 			// Step 3: clear the links among Hops within the identified chain
 			clearLinksWithinChain ( hop, mmOperators );
 			
@@ -92,7 +85,7 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 		}
 
 		//compute cost-optimal chains for increasing chain sizes 
-		EstimatorMatrixHistogram estim = new EstimatorMatrixHistogram(true);
+		EstimatorBasicAvg estim = new EstimatorBasicAvg();
 		for( int l = 2; l <= size; l++ ) { // chain length
 			for( int i = 0; i < size - l + 1; i++ ) {
 				int j = i + l - 1;
@@ -102,14 +95,14 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 				{
 					//construct estimation nodes (w/ lazy propagation and memoization)
 					MMNode tmp = new MMNode(dpMatrixS[i][k], dpMatrixS[k+1][j], OpCode.MM);
-					estim.estim(tmp, false);
-					MatrixHistogram lhs = (MatrixHistogram) dpMatrixS[i][k].getSynopsis();
-					MatrixHistogram rhs = (MatrixHistogram) dpMatrixS[k+1][j].getSynopsis();
-					
+					estim.estim(tmp);
+
 					//recursive cost computation
-					double cost = dpMatrix[i][k] + dpMatrix[k + 1][j] 
-						+ dotProduct(lhs.getColCounts(), rhs.getRowCounts());
-					
+					double cost = dpMatrix[i][k] + dpMatrix[k+1][j] +
+						OptimizerUtils.getSparsity(tmp.getLeft().getDataCharacteristics()) *
+							OptimizerUtils.getSparsity(tmp.getRight().getDataCharacteristics()) *
+							tmp.getLeft().getRows() * tmp.getLeft().getCols() * tmp.getRight().getCols();
+
 					//prune suboptimal
 					if( cost < dpMatrix[i][j] ) {
 						dpMatrix[i][j] = cost;
@@ -119,29 +112,30 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 				}
 
 				if( LOG.isTraceEnabled() ){
-					LOG.trace("mmchainopt [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
+					LOG.trace("mmchainoptsparse [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
+					System.out.println("mmchainoptsparse [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
 				}
 			}
 		}
 
 		return split;
 	}
-	
-	private static boolean getInputMatrices(Hop hop, List<Hop> chain, MMNode[] sketchArray, ProgramRewriteStatus state) {
-		throw new NotImplementedException("Not implemeneted yet. Prior implementation did not work.");
-	}
-	
-	private static MatrixBlock getMatrix(String name, LocalVariableMap vars) {
-		Data dat = vars.get(name);
-		if( !(dat instanceof MatrixObject) )
-			throw new HopsException("Input '"+name+"' not a matrix: "+dat.getDataType());
-		return ((MatrixObject)dat).acquireReadAndRelease();
-	}
-	
-	private static double dotProduct(int[] h1cNnz, int[] h2rNnz) {
-		long fp = 0;
-		for( int j=0; j<h1cNnz.length; j++ )
-			fp += (long)h1cNnz[j] * h2rNnz[j];
-		return fp;
+
+	private static boolean getInputMatrixCharacteristics(Hop hop, List<Hop> chain, MMNode[] sketchArray, ProgramRewriteStatus state) {
+		boolean inputMetaAvail = true;
+
+		for(int counter = 0; counter < chain.size(); counter++ ) {
+			Hop currentHop = chain.get(counter);
+			inputMetaAvail &= currentHop.isMatrix();
+			inputMetaAvail &= !currentHop.isFederated();
+			inputMetaAvail &= (currentHop.getDataCharacteristics().getNonZeros() != -1);
+			if(inputMetaAvail) {
+				sketchArray[counter] = new MMNode(currentHop.getDataCharacteristics());
+			}
+			else
+				break;
+		}
+
+		return inputMetaAvail;
 	}
 }

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -111,10 +111,8 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 					}
 				}
 
-				if( LOG.isTraceEnabled() ){
+				if(LOG.isTraceEnabled())
 					LOG.trace("mmchainoptsparse [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
-					System.out.println("mmchainoptsparse [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
-				}
 			}
 		}
 

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -59,7 +59,7 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 			int[][] split = mmChainDPSparse(dimsArray, sketchArray, mmChain.size());
 			
 			 // Step 5: Relink the hops using the optimal ordering (split[][]) found from DP.
-			LOG.trace("Optimal MM Chain: ");
+			LOG.trace("Optimal Sparse MM Chain:");
 			mmChainRelinkHops(mmOperators.get(0), 0, size - 1, mmChain, mmOperators, new MutableInt(1), split, 1);
 		}
 	}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -22,8 +22,8 @@ package org.apache.sysds.hops.rewrite;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.sysds.common.Types.OpOpData;
 import org.apache.sysds.hops.Hop;
 import org.apache.sysds.hops.HopsException;
 import org.apache.sysds.hops.estim.MMNode;
@@ -128,18 +128,7 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 	}
 	
 	private static boolean getInputMatrices(Hop hop, List<Hop> chain, MMNode[] sketchArray, ProgramRewriteStatus state) {
-		boolean inputsAvail = true;
-		LocalVariableMap vars = state.getVariables();
-		
-		for( int i=0; i<chain.size(); i++ ) {
-			inputsAvail &= HopRewriteUtils.isData(chain.get(0), OpOpData.TRANSIENTREAD);
-			if( inputsAvail )
-				sketchArray[i] = new MMNode(getMatrix(chain.get(i).getName(), vars));
-			else 
-				break;
-		}
-		
-		return inputsAvail;
+		throw new NotImplementedException("Not implemeneted yet. Prior implementation did not work.");
 	}
 	
 	private static MatrixBlock getMatrix(String name, LocalVariableMap vars) {

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -97,8 +97,8 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 					MMNode tmp = new MMNode(dpMatrixS[i][k], dpMatrixS[k+1][j], OpCode.MM);
 					estim.estim(tmp);
 
-					//recursive cost computation
-					double cost = dpMatrix[i][k] + dpMatrix[k+1][j] +
+					// recursive cost computation
+					double cost = dpMatrix[i][k] + dpMatrix[k + 1][j] +
 						OptimizerUtils.getSparsity(tmp.getLeft().getDataCharacteristics()) *
 							OptimizerUtils.getSparsity(tmp.getRight().getDataCharacteristics()) *
 							tmp.getLeft().getRows() * tmp.getLeft().getCols() * tmp.getRight().getCols();
@@ -112,17 +112,19 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 				}
 
 				if(LOG.isTraceEnabled())
-					LOG.trace("mmchainoptsparse [i="+(i+1)+",j="+(j+1)+"]: costs = "+dpMatrix[i][j]+", split = "+(split[i][j]+1));
+					LOG.trace("mmchainoptsparse [i=" + (i + 1) + ",j=" + (j + 1) + "]: costs = " + dpMatrix[i][j]
+						+ ", split = " + (split[i][j] + 1));
 			}
 		}
 
 		return split;
 	}
 
-	private static boolean getInputMatrixCharacteristics(Hop hop, List<Hop> chain, MMNode[] sketchArray, ProgramRewriteStatus state) {
+	private static boolean getInputMatrixCharacteristics(Hop hop, List<Hop> chain, MMNode[] sketchArray,
+		ProgramRewriteStatus state) {
 		boolean inputMetaAvail = true;
 
-		for(int counter = 0; counter < chain.size(); counter++ ) {
+		for(int counter = 0; counter < chain.size(); counter++) {
 			Hop currentHop = chain.get(counter);
 			inputMetaAvail &= currentHop.isMatrix();
 			inputMetaAvail &= !currentHop.isFederated();

--- a/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
+++ b/src/test/java/org/apache/sysds/test/AutomatedTestBase.java
@@ -2261,6 +2261,8 @@ public abstract class AutomatedTestBase {
 	}
 
 	public boolean bufferContainsString(ByteArrayOutputStream buffer, String str) {
+		if(buffer == null)
+			return false;
 		return Arrays.stream(buffer.toString().split("\n")).anyMatch(x -> x.contains(str));
 	}
 

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
@@ -67,12 +67,15 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 	@Parameterized.Parameter(3)
 	public double eps;
 
+	@Parameterized.Parameter(4)
+	public boolean tsmm;
+
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {
 		return Arrays.asList(new Object[][] {
-			// {rows, cols, sparsities, eps},
-			{1000, 300, new double[]{0.10d, 0.10d}, Math.pow(10, -10)},
-			// {2, 300, new double[]{0.005, 1}, Math.pow(10, -10)},
+			// {rows, cols, sparsities, eps, tsmm},
+			{1000, 300, new double[]{0.10d, 0.10d}, Math.pow(10, -10), false},
+			{5, 3, new double[]{0.1, 1}, Math.pow(10, -10), true},
 		});
 	}
 
@@ -137,10 +140,20 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
 
 			if(rewrites) {
-				Assert.assertTrue(log_out.stream().anyMatch(
-					l -> l.getMessage().toString().contains("mmchainoptsparse")));
-				Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
-					heavyHittersContainsSubString("sp_mapmmchain"));
+				String delimiter = ";";
+				String log_out_string = String.join(delimiter, log_out.stream().map(l -> l.getMessage().toString()).toArray(String[]::new));
+				Assert.assertTrue(log_out_string.contains("mmchainoptsparse"));
+				if(tsmm) {
+					Assert.assertTrue(log_out_string.contains("Optimal Sparse MM Chain:" + delimiter +
+						"--(" + delimiter + "----(" + delimiter + "------Hop parsertemp"));
+					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.TSMM.toString()) ||
+						heavyHittersContainsSubString("sp_tsmm"));
+				} else {
+					Assert.assertTrue(log_out_string.contains("Optimal Sparse MM Chain:" + delimiter +
+						"--(" + delimiter + "----Hop parsertemp"));
+					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
+						heavyHittersContainsSubString("sp_mapmmchain"));
+				}
 			}
 			else {
 				Assert.assertFalse(log_out.stream().anyMatch(

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
@@ -74,9 +74,8 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 	public static Collection<Object[]> data() {
 		return Arrays.asList(new Object[][] {
 			// {rows, cols, sparsities, eps, tsmm},
-			{1000, 300, new double[]{0.10d, 0.10d}, Math.pow(10, -10), false},
-			{5, 3, new double[]{0.1, 1}, Math.pow(10, -10), true},
-		});
+			{1000, 300, new double[] {0.10d, 0.10d}, Math.pow(10, -10), false},
+			{5, 3, new double[] {0.1, 1}, Math.pow(10, -10), true},});
 	}
 
 	@Override
@@ -149,13 +148,15 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 						+ "----(" + delimiter + "------Hop parsertemp"));
 					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.TSMM.toString()) ||
 						heavyHittersContainsSubString("sp_tsmm"));
-				} else {
+				}
+				else {
 					Assert.assertTrue(log_out_string
 						.contains("Optimal Sparse MM Chain:" + delimiter + "--(" + delimiter + "----Hop parsertemp"));
 					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 						heavyHittersContainsSubString("sp_mapmmchain"));
 				}
-			} else {
+			}
+			else {
 				Assert.assertFalse(
 					log_out.stream().anyMatch(l -> l.getMessage().toString().contains("mmchainoptsparse")));
 				Assert.assertFalse(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
@@ -21,6 +21,7 @@ package org.apache.sysds.test.functions.rewrite;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.sysds.common.Opcodes;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.recompile.Recompiler;
@@ -28,17 +29,18 @@ import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.test.LoggingUtils;
+import org.apache.sysds.test.LoggingUtils.TestAppender;
 
 import org.junit.Assert;
 import org.junit.runners.Parameterized;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
@@ -123,7 +125,10 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 
 
 			//execute tests
-			ByteArrayOutputStream stdout = this.runTestCatchStdout();
+			TestAppender appender = LoggingUtils.overwrite(); // capture log output
+			runTest(true, false, null, -1);
+			List<LoggingEvent> log_out = LoggingUtils.reinsert(appender); // revert the logger to print to stdout
+
 			runRScript(true);
 
 			//compare matrices
@@ -132,12 +137,14 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
 
 			if(rewrites) {
-				Assert.assertTrue(bufferContainsString(stdout, "mmchainoptsparse"));
+				Assert.assertTrue(log_out.stream().anyMatch(
+					l -> l.getMessage().toString().contains("mmchainoptsparse")));
 				Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 					heavyHittersContainsSubString("sp_mapmmchain"));
 			}
 			else {
-				Assert.assertFalse(bufferContainsString(stdout, "mmchainopt"));
+				Assert.assertFalse(log_out.stream().anyMatch(
+					l -> l.getMessage().toString().contains("mmchainoptsparse")));
 				Assert.assertFalse(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 					heavyHittersContainsSubString("sp_mapmmchain"));
 			}
@@ -147,16 +154,5 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = oldFlag2;
 			Recompiler.reinitRecompiler();
 		}
-	}
-
-	private ByteArrayOutputStream runTestCatchStdout() {
-		ByteArrayOutputStream buff = new ByteArrayOutputStream();
-		PrintStream ps = new PrintStream(buff);
-		PrintStream old = System.out;
-		System.setOut(ps);
-		runTest(true, false, null, -1);
-		System.out.flush();
-		System.setOut(old);
-		return buff;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
@@ -141,23 +141,23 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 
 			if(rewrites) {
 				String delimiter = ";";
-				String log_out_string = String.join(delimiter, log_out.stream().map(l -> l.getMessage().toString()).toArray(String[]::new));
+				String log_out_string = String.join(delimiter,
+					log_out.stream().map(l -> l.getMessage().toString()).toArray(String[]::new));
 				Assert.assertTrue(log_out_string.contains("mmchainoptsparse"));
 				if(tsmm) {
-					Assert.assertTrue(log_out_string.contains("Optimal Sparse MM Chain:" + delimiter +
-						"--(" + delimiter + "----(" + delimiter + "------Hop parsertemp"));
+					Assert.assertTrue(log_out_string.contains("Optimal Sparse MM Chain:" + delimiter + "--(" + delimiter
+						+ "----(" + delimiter + "------Hop parsertemp"));
 					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.TSMM.toString()) ||
 						heavyHittersContainsSubString("sp_tsmm"));
 				} else {
-					Assert.assertTrue(log_out_string.contains("Optimal Sparse MM Chain:" + delimiter +
-						"--(" + delimiter + "----Hop parsertemp"));
+					Assert.assertTrue(log_out_string
+						.contains("Optimal Sparse MM Chain:" + delimiter + "--(" + delimiter + "----Hop parsertemp"));
 					Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 						heavyHittersContainsSubString("sp_mapmmchain"));
 				}
-			}
-			else {
-				Assert.assertFalse(log_out.stream().anyMatch(
-					l -> l.getMessage().toString().contains("mmchainoptsparse")));
+			} else {
+				Assert.assertFalse(
+					log_out.stream().anyMatch(l -> l.getMessage().toString().contains("mmchainoptsparse")));
 				Assert.assertFalse(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 					heavyHittersContainsSubString("sp_mapmmchain"));
 			}

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteMatrixMultChainOptSparseTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.sysds.test.functions.rewrite;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.sysds.common.Opcodes;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.hops.recompile.Recompiler;
@@ -26,26 +28,64 @@ import org.apache.sysds.runtime.matrix.data.MatrixValue;
 import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
+
 import org.junit.Assert;
+import org.junit.runners.Parameterized;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 
+@RunWith(value = Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
 public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 
 	private static final String TEST_NAME = "RewriteMatrixMultChainOpSparse";
 	private static final String TEST_DIR = "functions/rewrite/";
 	private static final String TEST_CLASS_DIR =
 		TEST_DIR + RewriteMatrixMultChainOptSparseTest.class.getSimpleName() + "/";
+	private static final String PACKAGE = "org.apache.sysds.hops.rewrite.HopRewriteRule";
+	private static Level _oldLevel;
 
-	private static final int rows = 1000;
-	private static final int cols = 300;
-	private static final double eps = Math.pow(10, -10);
+	@Parameterized.Parameter(0)
+	public int rows;
+
+	@Parameterized.Parameter(1)
+	public int cols;
+
+	@Parameterized.Parameter(2)
+	public double[] sparsities;
+
+	@Parameterized.Parameter(3)
+	public double eps;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			// {rows, cols, sparsities, eps},
+			{1000, 300, new double[]{0.10d, 0.10d}, Math.pow(10, -10)},
+			// {2, 300, new double[]{0.005, 1}, Math.pow(10, -10)},
+		});
+	}
 
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+		_oldLevel = Logger.getLogger(PACKAGE).getLevel();
+		Logger.getLogger(PACKAGE).setLevel(Level.TRACE);
+	}
+
+	@Override
+	public void tearDown() {
+		super.tearDown();
+		Logger.getLogger(PACKAGE).setLevel(_oldLevel);
 	}
 
 	@Test
@@ -74,13 +114,16 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 
 			OptimizerUtils.ALLOW_ADVANCED_MMCHAIN_REWRITES = rewrites;
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = rewrites;
-			double[][] X = getRandomMatrix(rows, cols, -1, 1, 0.10d, 7);
-			double[][] Y = getRandomMatrix(cols, 1, -1, 1, 0.10d, 3);
-			writeInputMatrixWithMTD("X", X, true);
-			writeInputMatrixWithMTD("Y", Y, true);
+			double[][] X = getRandomMatrix(rows, cols, -1, 1, sparsities[0], 7);
+			double[][] Y = getRandomMatrix(cols, 1, -1, 1, sparsities[1], 3);
+			long X_nnz = Stream.of(X).mapToLong(row -> DoubleStream.of(row).filter(val -> val != 0).count()).sum();
+			long Y_nnz = Stream.of(Y).mapToLong(row -> DoubleStream.of(row).filter(val -> val != 0).count()).sum();
+			writeInputMatrixWithMTD("X", X, X_nnz, true);
+			writeInputMatrixWithMTD("Y", Y, Y_nnz, true);
+
 
 			//execute tests
-			runTest(true, false, null, -1);
+			ByteArrayOutputStream stdout = this.runTestCatchStdout();
 			runRScript(true);
 
 			//compare matrices
@@ -89,12 +132,14 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
 
 			if(rewrites) {
+				Assert.assertTrue(bufferContainsString(stdout, "mmchainoptsparse"));
 				Assert.assertTrue(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
 					heavyHittersContainsSubString("sp_mapmmchain"));
 			}
 			else {
+				Assert.assertFalse(bufferContainsString(stdout, "mmchainopt"));
 				Assert.assertFalse(heavyHittersContainsSubString(Opcodes.MMCHAIN.toString()) ||
-						heavyHittersContainsSubString("sp_mapmmchain"));
+					heavyHittersContainsSubString("sp_mapmmchain"));
 			}
 		}
 		finally {
@@ -102,5 +147,16 @@ public class RewriteMatrixMultChainOptSparseTest extends AutomatedTestBase {
 			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = oldFlag2;
 			Recompiler.reinitRecompiler();
 		}
+	}
+
+	private ByteArrayOutputStream runTestCatchStdout() {
+		ByteArrayOutputStream buff = new ByteArrayOutputStream();
+		PrintStream ps = new PrintStream(buff);
+		PrintStream old = System.out;
+		System.setOut(ps);
+		runTest(true, false, null, -1);
+		System.out.flush();
+		System.setOut(old);
+		return buff;
 	}
 }


### PR DESCRIPTION
Hi,
this PR changes the estimator for sparse mm chain rewrites from MNC to the metadata average estimator. Integration of MNC for these rewrites is missing the information about the underlying matrix histograms.
This PR also fixes the corresponding test, which previously only validated if there was any mm chain optimization.
Thank you and all the best,
David