### PR TITLE
[SYSTEMDS-3855] Vector API: Sparse-Sparse Matrix Multiplication Kernels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1588,5 +1588,19 @@
 			<artifactId>fastdoubleparser</artifactId>
 			<version>0.9.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.37</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixMult.java
@@ -2051,7 +2051,7 @@ public class LibMatrixMult
 				int blen = b.size(aix[k]);
 				int[] bix = b.indexes(aix[k]);
 				double[] bvals = b.values(aix[k]);
-				vectMultiplyAdd(avals[k], bvals, cvals, bix, bpos, 0, blen);
+				vectMultiplyAddScatter(avals[k], bvals, cvals, bix, bpos, 0, blen);
 			}
 	}
 	
@@ -2069,7 +2069,7 @@ public class LibMatrixMult
 			for(int k = apos; k < apos+alen; k++) {
 				int aixk = aix[k];
 				if( b.isEmpty(aixk) ) continue;
-				vectMultiplyAdd(avals[k], b.values(aixk), tmp,
+				vectMultiplyAddScatter(avals[k], b.values(aixk), tmp,
 					b.indexes(aixk), b.pos(aixk), 0, b.size(aixk));
 				hitNonEmpty = true;
 			}
@@ -2100,7 +2100,7 @@ public class LibMatrixMult
 			for(int k = apos; k < apos+alen; k++) {
 				int aixk = aix[k];
 				if( b.isEmpty(aixk) ) continue;
-				vectMultiplyAdd(avals[k], b.values(aixk), cvals,
+				vectMultiplyAddScatter(avals[k], b.values(aixk), cvals,
 					b.indexes(aixk), b.pos(aixk), cix, b.size(aixk));
 			}
 		}
@@ -2132,7 +2132,7 @@ public class LibMatrixMult
 					int k = curk[i-bi] + apos;
 					for(; k < apos+alen && aix[k]<bkmin; k++) {
 						if( b.isEmpty(aix[k]) ) continue;
-						vectMultiplyAdd(avals[k], b.values(aix[k]), cvals,
+						vectMultiplyAddScatter(avals[k], b.values(aix[k]), cvals,
 							b.indexes(aix[k]), b.pos(aix[k]), cix, b.size(aix[k]));
 					}
 					curk[i-bi] = k - apos;

--- a/src/test/java/org/apache/sysds/test/component/matrix/BenchmarkMatMult.java
+++ b/src/test/java/org/apache/sysds/test/component/matrix/BenchmarkMatMult.java
@@ -1,0 +1,83 @@
+package org.apache.sysds.test.component.matrix;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.sysds.runtime.matrix.data.LibMatrixMult;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.test.TestUtils;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class BenchmarkMatMult {
+
+	private MatrixBlock left;
+	private MatrixBlock right;
+	private MatrixBlock result;
+
+	@Param({"1024", "2048", "4096", "8192"})
+	public int m;
+
+	@Param({"1"})
+	public int cd;
+
+	@Param({"0.5", "0.75", "1.0"})
+	public double sparsityLeft;
+
+	@Param({"0.001", "0.01", "0.1", "0.2"})
+	public double sparsityRight;
+
+	@Param({"1024", "2048", "4096", "8192"})
+	public int n;
+
+	@Setup(Level.Trial)
+	public void setup() {
+		left = TestUtils.ceil(TestUtils.generateTestMatrixBlock(m, cd, -10, 10, sparsityLeft, 13));
+		if (!left.isInSparseFormat()) {
+			left.sparseToDense();
+			left.denseToSparse(true);
+		}
+
+		MatrixBlock rightOriginal = TestUtils.ceil(TestUtils.generateTestMatrixBlock(cd, n, -10, 10, sparsityRight, 14));
+		right = new MatrixBlock();
+		right.copy(rightOriginal, false);
+		if (!right.isInSparseFormat()) {
+			right.sparseToDense();
+			right.denseToSparse(true);
+		}
+
+		result = new MatrixBlock(m, n, true);
+		result.allocateBlock();
+	}
+
+	@Setup(Level.Iteration)
+	public void clearResult() {
+		result.reset(m, n, true);
+	}
+
+	@Benchmark
+	public void benchmarkSparseSparse(Blackhole bh) {
+		LibMatrixMult.matrixMult(left, right, result);
+		bh.consume(result);
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		String tag = "vector-api-mult-sparse-sparse-" + System.currentTimeMillis();
+		Options opt = new OptionsBuilder()
+			.include(BenchmarkMatMult.class.getName())
+			.jvmArgs("--add-modules=jdk.incubator.vector")
+			.result(tag + ".csv")
+			.resultFormat(ResultFormatType.CSV)
+			.build();
+		new Runner(opt).run();
+	}
+}


### PR DESCRIPTION
This PR completes the missing Vector API (SIMD) implementations for sparse matrix combinations, extending the work done in previous dense/sparse vectorization PR https://github.com/apache/systemds/pull/2423. 

## Modifications
Replaced the scalar inner loops with the vectorized "vectMultiplyAddScatter" using the JDK 17 Vector API in the following three Sparse-Sparse matrix multiplication kernels within "LibMatrixMult.java":
1. matrixMultSparseSparseMM 
2. matrixMultSparseSparseMMSmallRHS 
3. matrixMultSparseSparseSparseMM 

## Testing & Validation
* Component tests (MatrixMultiplyTest) executed successfully (5000 tests passed, 0 failures).

# BENCHMARK

### Hardware Environment (Linux)
* **OS:** Ubuntu Linux
* **CPU Model:** AMD Ryzen 5 PRO 7530U (x86_64)
* **Cores/Threads:** 6 Cores / 12 Threads (Turbo: 4.54 GHz)
* **Vector Capability:** 256-bit (AVX2)
* **Cache:** L1: 384 KiB / L2: 3 MiB / L3: 16 MiB
* **Memory:** 16 GB 


The benchmark uses like the PR Request before the Java Microbenchmark Harness (JMH) framework to measure the performance of the rewritten kernels. The result is the average execution time in microseconds. Each benchmark run consists of 5 warmup iterations followed by 10 measurement iterations (1 second each), executed in a single forked JVM.

### Sparse-Sparse Benchmark Result Summary
* The vectorized implementations yield solid performance gains (up to **1.35x**) on larger matrices (e.g., 8192x8192).
* Minor performance regressions (dropping to **~0.87x**) occur when the right hand sparsity is precisely around `0.01`, likely where the overhead of vector preparation and scatter operations slightly outweighs the raw SIMD throughput.

### Benchmark Parameters
* **m:** 1024, 2048, 4096, 8192
* **cd:** 1
* **n:** 1024, 2048, 4096, 8192
* **Sparsity Left:** 0.5, 0.75, 1.0
* **Sparsity Right:** 0.001, 0.01, 0.1, 0.2
* **Total Configs:** 192

### Top Performance Gains (Speedup > 1.0)
| m | n | sparsityLeft | sparsityRight | Speedup |
|---|---|--------------|---------------|---------|
| 8192 | 4096 | 1.0 | 0.001 | **1.35x** |
| 8192 | 8192 | 0.5 | 0.001 | **1.35x** |
| 8192 | 8192 | 0.75 | 0.001 | **1.33x** |
| 8192 | 8192 | 1.0 | 0.001 | **1.32x** |
| 8192 | 4096 | 1.0 | 0.010 | **1.22x** |

### Top Performance Losses (Speedup < 1.0)
| m | n | sparsityLeft | sparsityRight | Speedup |
|---|---|--------------|---------------|---------|
| 8192 | 2048 | 1.0 | 0.010 | **0.87x** |
| 1024 | 2048 | 0.75 | 0.010 | **0.88x** |
| 4096 | 8192 | 0.75 | 0.010 | **0.90x** |
| 8192 | 2048 | 0.5 | 0.010 | **0.91x** |
| 2048 | 4096 | 1.0 | 0.010 | **0.92x** |

### Baseline vs Vectorized Performance plots
<img width="1600" height="1200" alt="performanceComparisonsSYSTEMDS" src="https://github.com/user-attachments/assets/239f5fe1-4d64-41d4-8c7f-ae6337727b4c" />


### Raw Data
[runtimeComparisonSYSTEMDSProject.csv](https://github.com/user-attachments/files/30123047/runtimeComparisonSYSTEMDSProject.csv)
