### PR TITLE
[SYSTEMDS-3332] Support for matrix-vector operations in ternary ifelse(X,B,v)

### DIFF
--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -2186,9 +2186,12 @@ public class BuiltinFunctionExpression extends DataIdentifier {
 		final long n = Math.max(Math.max(c1, c2), c3);
 
 		boolean unknownDim = (r1 == -1 || r2 == -1 || r3 == -1 || c1 == -1 || c2 == -1 || c3 == -1);
-		if (!unknownDim && ((r1 != 1 && r1 != m) || (r2 != 1 && r2 != m)
-			|| (r3 != 1 && r3 != m) || (c1 != 1 && c1 != n)
-			|| (c2 != 1 && c2 != n) || (c3 != 1 && c3 != n))) {
+		if (!unknownDim && ((dt1 == DataType.MATRIX && r1 != 1 && r1 != m)
+			|| (dt2 == DataType.MATRIX && r2 != 1 && r2 != m)
+			|| (dt3 == DataType.MATRIX && r3 != 1 && r3 != m)
+			|| (dt1 == DataType.MATRIX && c1 != 1 && c1 != n)
+			|| (dt2 == DataType.MATRIX && c2 != 1 && c2 != n)
+			|| (dt3 == DataType.MATRIX && c3 != 1 && c3 != n))) {
 			raiseValidateError("Mismatch in matrix dimensions of parameters for function "
 					+ this.getOpCode(), conditional, LanguageErrorCodes.INVALID_PARAMETERS);
 		}

--- a/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
+++ b/src/main/java/org/apache/sysds/parser/BuiltinFunctionExpression.java
@@ -2170,19 +2170,33 @@ public class BuiltinFunctionExpression extends DataIdentifier {
 	}
 	
 	private void setTernaryOutputProperties(DataIdentifier output, boolean conditional) {
-		DataType dt1 = getFirstExpr().getOutput().getDataType();
-		DataType dt2 = getSecondExpr().getOutput().getDataType();
-		DataType dt3 = getThirdExpr().getOutput().getDataType();
-		DataType dtOut = (dt1.isMatrix() || dt2.isMatrix() || dt3.isMatrix()) ?
-			DataType.MATRIX : DataType.SCALAR;
-		if( dt1==DataType.MATRIX && dt2==DataType.MATRIX )
-			checkMatchingDimensions(getFirstExpr(), getSecondExpr(), false, conditional);
-		if( dt1==DataType.MATRIX && dt3==DataType.MATRIX )
-			checkMatchingDimensions(getFirstExpr(), getThirdExpr(), false, conditional);
-		if( dt2==DataType.MATRIX && dt3==DataType.MATRIX )
-			checkMatchingDimensions(getSecondExpr(), getThirdExpr(), false, conditional);
+		Expression expr1 = getFirstExpr();
+		Expression expr2 = getSecondExpr();
+		Expression expr3 = getThirdExpr();
+		DataType dt1 = expr1.getOutput().getDataType();
+		DataType dt2 = expr2.getOutput().getDataType();
+		DataType dt3 = expr3.getOutput().getDataType();
+		final long r1 = expr1.getOutput().getDim1();
+		final long r2 = expr2.getOutput().getDim1();
+		final long r3 = expr3.getOutput().getDim1();
+		final long c1 = expr1.getOutput().getDim2();
+		final long c2 = expr2.getOutput().getDim2();
+		final long c3 = expr3.getOutput().getDim2();
+		final long m = Math.max(Math.max(r1, r2), r3);
+		final long n = Math.max(Math.max(c1, c2), c3);
+
+		boolean unknownDim = (r1 == -1 || r2 == -1 || r3 == -1 || c1 == -1 || c2 == -1 || c3 == -1);
+		if (!unknownDim && ((r1 != 1 && r1 != m) || (r2 != 1 && r2 != m)
+			|| (r3 != 1 && r3 != m) || (c1 != 1 && c1 != n)
+			|| (c2 != 1 && c2 != n) || (c3 != 1 && c3 != n))) {
+			raiseValidateError("Mismatch in matrix dimensions of parameters for function "
+					+ this.getOpCode(), conditional, LanguageErrorCodes.INVALID_PARAMETERS);
+		}
+
 		MatrixCharacteristics dims1 = getBinaryMatrixCharacteristics(getFirstExpr(), getSecondExpr());
 		MatrixCharacteristics dims2 = getBinaryMatrixCharacteristics(getSecondExpr(), getThirdExpr());
+		DataType dtOut = (dt1.isMatrix() || dt2.isMatrix() || dt3.isMatrix()) ?
+			DataType.MATRIX : DataType.SCALAR;
 		output.setDataType(dtOut);
 		output.setValueType(dtOut==DataType.MATRIX ? ValueType.FP64 :
 			computeValueType(getSecondExpr(), getThirdExpr(), true));

--- a/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibTernaryOp.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/lib/CLALibTernaryOp.java
@@ -59,7 +59,7 @@ public final class CLALibTernaryOp {
 		final int n = Math.max(Math.max(c1, c2), c3);
 
 		// double check that the dimensions are valid.
-		MatrixBlock.ternaryOperationCheck(s1, s2, s3, m, r1, r2, r3, n, c1, c2, c3);
+		MatrixBlock.ternaryOperationCheck(op, s1, s2, s3, m, r1, r2, r3, n, c1, c2, c3);
 
 		MatrixBlock ret;
 

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixTercell.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixTercell.java
@@ -92,11 +92,18 @@ public class LibMatrixTercell
 		//basic ternary operations (all combinations sparse/dense)
 		int n = ret.clen;
 		long lnnz = 0;
+		final int r1 = m1.getNumRows();
+		final int r2 = m2.getNumRows();
+		final int r3 = m3.getNumRows();
+		final int c1 = m1.getNumColumns();
+		final int c2 = m2.getNumColumns();
+		final int c3 = m3.getNumColumns();
+
 		for( int i=rl; i<ru; i++ )
 			for( int j=0; j<n; j++ ) {
-				double in1 = s1 ? d1 : m1.get(i, j);
-				double in2 = s2 ? d2 : m2.get(i, j);
-				double in3 = s3 ? d3 : m3.get(i, j);
+				double in1 = s1 ? d1 : m1.get(Math.min(i, r1-1), Math.min(j, c1-1));
+				double in2 = s2 ? d2 : m2.get(Math.min(i, r2-1), Math.min(j, c2-1));
+				double in3 = s3 ? d3 : m3.get(Math.min(i, r3-1), Math.min(j, c3-1));
 				double val = op.fn.execute(in1, in2, in3);
 				lnnz += (val != 0) ? 1 : 0;
 				ret.appendValuePlain(i, j, val);

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixTercell.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/LibMatrixTercell.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.functionobjects.IfElse;
 import org.apache.sysds.runtime.matrix.operators.TernaryOperator;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 import org.apache.sysds.runtime.util.UtilFunctions;
@@ -89,6 +90,63 @@ public class LibMatrixTercell
 	private static long unsafeTernary(MatrixBlock m1, MatrixBlock m2, MatrixBlock m3, MatrixBlock ret,
 		TernaryOperator op, boolean s1, boolean s2, boolean s3, double d1, double d2, double d3, int rl, int ru)
 	{
+		if(op.fn instanceof IfElse) {
+			return unsafeTernaryIfElse(m1, m2, m3, ret, op, s1, s2,
+			s3, d1, d2, d3, rl, ru);
+		}
+		else {
+			return unsafeTernaryDefault(m1, m2, m3, ret, op, s1, s2,
+				s3, d1, d2, d3, rl, ru);
+		}
+	}
+
+	private static long unsafeTernaryIfElse(MatrixBlock m1, MatrixBlock m2, MatrixBlock m3, MatrixBlock ret,
+		TernaryOperator op, boolean s1, boolean s2, boolean s3, double d1, double d2, double d3, int rl, int ru)
+	{
+		// IfElse specific optimizations are applied here
+		int n = ret.clen;
+		long lnnz = 0;
+		final int r1 = m1.getNumRows();
+		final int c1 = m1.getNumColumns();
+		if (c1 == 1) {
+			for( int i=rl; i<ru; i++ ) {
+				double in1 = s1 ? d1 : m1.get(Math.min(i, r1-1), 0);
+				MatrixBlock tmp = (in1 != 0) ? m2 : m3;
+				final int tmpCol = tmp.getNumColumns();
+				final int tmpRow = tmp.getNumRows();
+				final int tmpi = Math.min(i, tmpRow-1);
+				for( int j=0; j<n; j++ ) {
+					double val = tmp.get(tmpi, Math.min(j, tmpCol-1));
+					lnnz += (val != 0) ? 1 : 0;
+					ret.appendValuePlain(i, j, val);
+				}
+			}
+			return lnnz;
+		}
+		else if (r1 == 1) {
+			for( int j=0; j<n; j++ ) {
+				double in1 = s1 ? d1 : m1.get(0, Math.min(j, c1-1));
+				MatrixBlock tmp = (in1 != 0) ? m2 : m3;
+				final int tmpCol = tmp.getNumColumns();
+				final int tmpRow = tmp.getNumRows();
+				final int tmpj = Math.min(j, tmpCol-1);
+				for( int i=rl; i<ru; i++ ) {
+					double val = tmp.get(Math.min(i, tmpRow-1), tmpj);
+					lnnz += (val != 0) ? 1 : 0;
+					ret.appendValuePlain(i, j, val);
+				}
+			}
+			return lnnz;
+		}
+		else {
+			return unsafeTernaryDefault(m1, m2, m3, ret, op, s1, s2,
+				s3, d1, d2, d3, rl, ru);
+		}
+	}
+
+	private static long unsafeTernaryDefault(MatrixBlock m1, MatrixBlock m2, MatrixBlock m3, MatrixBlock ret,
+		TernaryOperator op, boolean s1, boolean s2, boolean s3, double d1, double d2, double d3, int rl, int ru)
+	{
 		//basic ternary operations (all combinations sparse/dense)
 		int n = ret.clen;
 		long lnnz = 0;
@@ -99,15 +157,19 @@ public class LibMatrixTercell
 		final int c2 = m2.getNumColumns();
 		final int c3 = m3.getNumColumns();
 
-		for( int i=rl; i<ru; i++ )
+		for( int i=rl; i<ru; i++ ) {
+			final int i1 = Math.min(i, r1-1);
+			final int i2 = Math.min(i, r2-1);
+			final int i3 = Math.min(i, r3-1);
 			for( int j=0; j<n; j++ ) {
-				double in1 = s1 ? d1 : m1.get(Math.min(i, r1-1), Math.min(j, c1-1));
-				double in2 = s2 ? d2 : m2.get(Math.min(i, r2-1), Math.min(j, c2-1));
-				double in3 = s3 ? d3 : m3.get(Math.min(i, r3-1), Math.min(j, c3-1));
+				double in1 = s1 ? d1 : m1.get(i1, Math.min(j, c1-1));
+				double in2 = s2 ? d2 : m2.get(i2, Math.min(j, c2-1));
+				double in3 = s3 ? d3 : m3.get(i3, Math.min(j, c3-1));
 				double val = op.fn.execute(in1, in2, in3);
 				lnnz += (val != 0) ? 1 : 0;
 				ret.appendValuePlain(i, j, val);
 			}
+		}
 		
 		//set global output nnz once
 		return lnnz;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -3080,7 +3080,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 		final int n = Math.max(Math.max(c1, c2), c3);
 		final long nnz = nonZeros;
 		
-		ternaryOperationCheck(s1, s2, s3, m, r1, r2, r3, n, c1, c2, c3);
+		ternaryOperationCheck(op, s1, s2, s3, m, r1, r2, r3, n, c1, c2, c3);
 		
 		//prepare result
 		if( op.fn instanceof IfElse && (s1 || nnz==0 || nnz==(long)m*n) ) {
@@ -3141,11 +3141,24 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 		return ret;
 	}
 
-	public static void ternaryOperationCheck(boolean s1, boolean s2, boolean s3, int m, int r1, int r2, int r3, int n, int c1, int c2, int c3){
+	public static void ternaryOperationCheck(TernaryOperator op, boolean s1, boolean s2, boolean s3, int m, int r1, int r2, int r3, int n, int c1, int c2, int c3){
 		//error handling 
-		if( (!s1 && (r1 != m || c1 != n))
-		|| (!s2 && (r2 != m || c2 != n))
-		|| (!s3 && (r3 != m || c3 != n)) ) {
+		boolean error = false;
+		if (op.fn instanceof IfElse) {
+			error = ((r1 != 1 && r1 != m)
+				|| (r2 != 1 && r2 != m)
+				|| (r3 != 1 && r3 != m)
+				|| (c1 != 1 && c1 != n)
+				|| (c2 != 1 && c2 != n)
+				|| (c3 != 1 && c3 != n));
+		}
+		else {
+			error = ((!s1 && (r1 != m || c1 != n))
+				|| (!s2 && (r2 != m || c2 != n))
+				|| (!s3 && (r3 != m || c3 != n)));
+		}
+
+		if (error) {
 			throw new DMLRuntimeException("Block sizes are not matched for ternary cell operations: "
 			+ r1 + "x" + c1 + " vs " + r2 + "x" + c2 + " vs " + r3 + "x" + c3);
 		}

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -3084,25 +3084,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 		
 		//prepare result
 		if( op.fn instanceof IfElse && (s1 || nnz==0 || nnz==(long)m*n) ) {
-			
-			ret.reset(m, n, false);
-			
-			//SPECIAL CASE for shallow-copy if-else
-			boolean expr = s1 ? (d1 != 0) : (nnz==(long)m*n);
-			MatrixBlock tmp = expr ? m2 : m3;
-			if( tmp.rlen==m && tmp.clen==n ) {
-				//shallow copy incl meta data
-				ret.copyShallow(tmp);
-			}
-			else {
-				//fill output with given scalar value
-				double tmpVal = tmp.get(0, 0);
-				if( tmpVal != 0 ) {
-					ret.allocateDenseBlock();
-					ret.denseBlock.set(tmpVal);
-					ret.nonZeros = (long)m * n;
-				}
-			}
+			ternaryIfElseCopy(s1, m, n, d1, nnz, m2, m3, ret);
 		}
 		else{
 			final boolean PM_Or_MM = (op.fn instanceof PlusMultiply || op.fn instanceof MinusMultiply);
@@ -3139,6 +3121,69 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 		}
 		
 		return ret;
+	}
+
+	/**
+	 * Copies and applies broadcasting to either second or third input to IfElse operation.
+	 *
+	 * If the first value of the IfElse-operation meets certain conditions, then
+	 * either the m2 or m3 matrix inputs of IfElse is the result of the operation.
+	 * This methods handles the copying if the conditions are met.
+	 *
+	 * @param s1  Flag, whether the first matrix is a scalar.
+	 * @param m   Rows of the resulting matrix.
+	 * @param n   Columns of the resulting matrix
+	 * @param d1  Value of the entry 0,0 of the first matrix input.
+	 * @param nnz Non-zero entries of the first matrix
+	 * @param m2  Second matrix input of the IfElse operation
+	 * @param m3  Third matrix input of the IfElse operation
+	 * @param ret Result of the operation, where either m2 or m3 is copied into
+	 */
+	private void ternaryIfElseCopy(boolean s1, int m, int n, double d1, long nnz, MatrixBlock m2, MatrixBlock m3, MatrixBlock ret) {
+		ret.reset(m, n, false);
+
+		boolean expr = s1 ? (d1 != 0) : (nnz==(long)m*n);
+		MatrixBlock tmp = expr ? m2 : m3;
+		if (tmp.rlen==m && tmp.clen==n) {
+			//shallow copy incl meta data
+			ret.copyShallow(tmp);
+		}
+		else if (tmp.rlen==m && tmp.clen==1) {
+			ret.allocateDenseBlock();
+			ret.nonZeros = 0;
+			for (int i = 0; i < m; i++) {
+				double tmpVal = tmp.get(i, 0);
+				if (tmpVal != 0) {
+					ret.denseBlock.fillRow(i, tmp.get(i, 0));
+					ret.nonZeros += n;
+				}
+			}
+			ret.examSparsity();
+		}
+		else if (tmp.rlen==1 && tmp.clen==n) {
+			if (tmp.nonZeros != 0) {
+				ret.allocateDenseBlock();
+				ret.nonZeros = 0;
+				double[] tmpArr = new double[n];
+				for (int i = 0; i < n; i++) {
+					tmpArr[i] = tmp.get(0, i);
+				}
+				for (int i = 0; i < m; i++) {
+					ret.denseBlock.set(i, tmpArr);
+					ret.nonZeros += tmp.nonZeros;
+				}
+				ret.examSparsity();
+			}
+		}
+		else {
+			//fill output with given scalar value
+			double tmpVal = tmp.get(0, 0);
+			if (tmpVal != 0) {
+				ret.allocateDenseBlock();
+				ret.denseBlock.set(tmpVal);
+				ret.nonZeros = (long)m * n;
+			}
+		}
 	}
 
 	public static void ternaryOperationCheck(TernaryOperator op, boolean s1, boolean s2, boolean s3, int m, int r1, int r2, int r3, int n, int c1, int c2, int c3){

--- a/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
@@ -808,7 +808,7 @@ public class FullIfElseTest extends AutomatedTestBase
 			writeInputMatrixWithMTD("A", A, true);
 			double[][] B = getMatrixOfType(mtype2, sparse, 2);
 			writeInputMatrixWithMTD("B", B, true);
-			double[][] C = getMatrixOfType(mtype2, sparse, 3);
+			double[][] C = getMatrixOfType(mtype3, sparse, 3);
 			writeInputMatrixWithMTD("C", C, true);
 			
 			//run test cases
@@ -838,10 +838,10 @@ public class FullIfElseTest extends AutomatedTestBase
 				ret = getRandomMatrix(rows, cols, 0, 1, sparsity, seed);
 				break;
 			case COL:
-				ret = getRandomMatrix(1, cols, 0, 1, sparsity, seed);
+				ret = getRandomMatrix(rows, 1, 0, 1, sparsity, seed);
 				break;
 			case ROW:
-				ret = getRandomMatrix(rows, 1, 0, 1, sparsity, seed);
+				ret = getRandomMatrix(1, cols, 0, 1, sparsity, seed);
 				break;
 			default:
 		}

--- a/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
@@ -55,84 +55,645 @@ public class FullIfElseTest extends AutomatedTestBase
 	}
 
 	@Test
+	public void testScalarScalarScalarSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarScalarColSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarScalarRowSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarScalarMatrixSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColScalarSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColColSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColRowSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColMatrixSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowScalarSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowColSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowRowSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowMatrixSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixScalarSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixColSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixRowSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixMatrixSparseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarScalarSparseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarColSparseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarRowSparseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarMatrixSparseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColColScalarSparseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColColColSparseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColColRowSparseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColColMatrixSparseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowScalarSparseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowColSparseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowRowSparseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowMatrixSparseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixScalarSparseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixColSparseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixRowSparseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixMatrixSparseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarScalarSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarColSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarRowSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarMatrixSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColScalarSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColColSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColRowSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColMatrixSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowScalarSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowColSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowRowSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowMatrixSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixScalarSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixColSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixRowSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixMatrixSparseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarScalarSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarColSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarRowSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarMatrixSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColScalarSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColColSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColRowSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColMatrixSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowScalarSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowColSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowRowSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowMatrixSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixScalarSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixColSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.COL, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixRowSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.ROW, true, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixMatrixSparseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
+	}
+
+	@Test
 	public void testScalarScalarScalarDenseCP() {
 		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
 	}
-	
+
 	@Test
-	public void testMatrixScalarScalarDenseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
+	public void testScalarScalarColDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.COL, false, ExecType.CP);
 	}
-	
+
 	@Test
-	public void testScalarMatrixScalarDenseCP() {
-		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
+	public void testScalarScalarRowDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.ROW, false, ExecType.CP);
 	}
-	
-	@Test
-	public void testMatrixMatrixScalarDenseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
-	}
-	
+
 	@Test
 	public void testScalarScalarMatrixDenseCP() {
 		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
 	}
-	
+
 	@Test
-	public void testMatrixScalarMatrixDenseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
+	public void testScalarColScalarDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.SCALAR, false, ExecType.CP);
 	}
-	
+
+	@Test
+	public void testScalarColColDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColRowDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarColMatrixDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.COL, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowScalarDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowColDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowRowDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarRowMatrixDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.ROW, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixScalarDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixColDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testScalarMatrixRowDenseCP() {
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.ROW, false, ExecType.CP);
+	}
+
 	@Test
 	public void testScalarMatrixMatrixDenseCP() {
 		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
 	}
-	
+
+	@Test
+	public void testColScalarScalarDenseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarColDenseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarRowDenseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColScalarMatrixDenseCP() {
+		runIfElseTest(MatType.COL, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColColScalarDenseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColColColDenseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColColRowDenseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColColMatrixDenseCP() {
+		runIfElseTest(MatType.COL, MatType.COL, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowScalarDenseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowColDenseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowRowDenseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColRowMatrixDenseCP() {
+		runIfElseTest(MatType.COL, MatType.ROW, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixScalarDenseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixColDenseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixRowDenseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testColMatrixMatrixDenseCP() {
+		runIfElseTest(MatType.COL, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarScalarDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarColDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarRowDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowScalarMatrixDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColScalarDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColColDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColRowDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowColMatrixDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.COL, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowScalarDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowColDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowRowDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowRowMatrixDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.ROW, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixScalarDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixColDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixRowDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testRowMatrixMatrixDenseCP() {
+		runIfElseTest(MatType.ROW, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarScalarDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarColDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarRowDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixScalarMatrixDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColScalarDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColColDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColRowDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixColMatrixDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.COL, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowScalarDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowColDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowRowDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.ROW, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixRowMatrixDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.ROW, MatType.MATRIX, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixScalarDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixColDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.COL, false, ExecType.CP);
+	}
+
+	@Test
+	public void testMatrixMatrixRowDenseCP() {
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.ROW, false, ExecType.CP);
+	}
+
 	@Test
 	public void testMatrixMatrixMatrixDenseCP() {
 		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
 	}
 
-	@Test
-	public void testScalarScalarScalarSparseCP() {
-		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testMatrixScalarScalarSparseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testScalarMatrixScalarSparseCP() {
-		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testMatrixMatrixScalarSparseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testScalarScalarMatrixSparseCP() {
-		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testMatrixScalarMatrixSparseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testScalarMatrixMatrixSparseCP() {
-		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
-	}
-	
-	@Test
-	public void testMatrixMatrixMatrixSparseCP() {
-		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
-	}
 
 	//SPARK
 	

--- a/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
@@ -44,6 +44,10 @@ public class FullIfElseTest extends AutomatedTestBase
 	private final static double sparsity1 = 0.6;
 	private final static double sparsity2 = 0.1;
 	
+	private enum MatType {
+		MATRIX, COL, ROW, SCALAR
+	}
+
 	@Override
 	public void setUp() {
 		TestUtils.clearAssertionInformation();
@@ -52,167 +56,167 @@ public class FullIfElseTest extends AutomatedTestBase
 
 	@Test
 	public void testScalarScalarScalarDenseCP() {
-		runIfElseTest(false, false, false, false, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixScalarScalarDenseCP() {
-		runIfElseTest(true, false, false, false, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarMatrixScalarDenseCP() {
-		runIfElseTest(false, true, false, false, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixMatrixScalarDenseCP() {
-		runIfElseTest(true, true, false, false, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarScalarMatrixDenseCP() {
-		runIfElseTest(false, false, true, false, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixScalarMatrixDenseCP() {
-		runIfElseTest(true, false, true, false, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarMatrixMatrixDenseCP() {
-		runIfElseTest(false, true, true, false, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixMatrixMatrixDenseCP() {
-		runIfElseTest(true, true, true, false, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, false, ExecType.CP);
 	}
 
 	@Test
 	public void testScalarScalarScalarSparseCP() {
-		runIfElseTest(false, false, false, true, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixScalarScalarSparseCP() {
-		runIfElseTest(true, false, false, true, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarMatrixScalarSparseCP() {
-		runIfElseTest(false, true, false, true, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixMatrixScalarSparseCP() {
-		runIfElseTest(true, true, false, true, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarScalarMatrixSparseCP() {
-		runIfElseTest(false, false, true, true, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixScalarMatrixSparseCP() {
-		runIfElseTest(true, false, true, true, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testScalarMatrixMatrixSparseCP() {
-		runIfElseTest(false, true, true, true, ExecType.CP);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
 	}
 	
 	@Test
 	public void testMatrixMatrixMatrixSparseCP() {
-		runIfElseTest(true, true, true, true, ExecType.CP);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, true, ExecType.CP);
 	}
 
 	//SPARK
 	
 	@Test
 	public void testScalarScalarScalarDenseSP() {
-		runIfElseTest(false, false, false, false, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixScalarScalarDenseSP() {
-		runIfElseTest(true, false, false, false, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarMatrixScalarDenseSP() {
-		runIfElseTest(false, true, false, false, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixMatrixScalarDenseSP() {
-		runIfElseTest(true, true, false, false, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarScalarMatrixDenseSP() {
-		runIfElseTest(false, false, true, false, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixScalarMatrixDenseSP() {
-		runIfElseTest(true, false, true, false, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarMatrixMatrixDenseSP() {
-		runIfElseTest(false, true, true, false, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, false, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixMatrixMatrixDenseSP() {
-		runIfElseTest(true, true, true, false, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, false, ExecType.SPARK);
 	}
 
 	@Test
 	public void testScalarScalarScalarSparseSP() {
-		runIfElseTest(false, false, false, true, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.SCALAR, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixScalarScalarSparseSP() {
-		runIfElseTest(true, false, false, true, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.SCALAR, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarMatrixScalarSparseSP() {
-		runIfElseTest(false, true, false, true, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.SCALAR, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixMatrixScalarSparseSP() {
-		runIfElseTest(true, true, false, true, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.SCALAR, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarScalarMatrixSparseSP() {
-		runIfElseTest(false, false, true, true, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.SCALAR, MatType.MATRIX, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixScalarMatrixSparseSP() {
-		runIfElseTest(true, false, true, true, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.SCALAR, MatType.MATRIX, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testScalarMatrixMatrixSparseSP() {
-		runIfElseTest(false, true, true, true, ExecType.SPARK);
+		runIfElseTest(MatType.SCALAR, MatType.MATRIX, MatType.MATRIX, true, ExecType.SPARK);
 	}
 	
 	@Test
 	public void testMatrixMatrixMatrixSparseSP() {
-		runIfElseTest(true, true, true, true, ExecType.SPARK);
+		runIfElseTest(MatType.MATRIX, MatType.MATRIX, MatType.MATRIX, true, ExecType.SPARK);
 	}
 
-	private void runIfElseTest(boolean matrix1, boolean matrix2, boolean matrix3, boolean sparse, ExecType et){
+	private void runIfElseTest(MatType mtype1, MatType mtype2, MatType mtype3, boolean sparse, ExecType et){
 		setOutputBuffering(true);
 		//rtplatform for MR
 		ExecMode platformOld = rtplatform;
@@ -239,12 +243,11 @@ public class FullIfElseTest extends AutomatedTestBase
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
 			//generate actual datasets (matrices and scalars)
-			double sparsity = sparse ? sparsity2 : sparsity1;
-			double[][] A = matrix1 ? getRandomMatrix(rows, cols, 0, 1, sparsity, 1) : getScalar(1);
+			double[][] A = getMatrixOfType(mtype1, sparse, 1);
 			writeInputMatrixWithMTD("A", A, true);
-			double[][] B = matrix2 ? getRandomMatrix(rows, cols, 0, 1, sparsity, 2) : getScalar(2);
+			double[][] B = getMatrixOfType(mtype2, sparse, 2);
 			writeInputMatrixWithMTD("B", B, true);
-			double[][] C = matrix3 ? getRandomMatrix(rows, cols, 0, 1, sparsity, 3) : getScalar(3);
+			double[][] C = getMatrixOfType(mtype2, sparse, 3);
 			writeInputMatrixWithMTD("C", C, true);
 			
 			//run test cases
@@ -263,7 +266,24 @@ public class FullIfElseTest extends AutomatedTestBase
 		}
 	}
 	
-	private static double[][] getScalar(int input) {
-		return new double[][]{{7d*input}};
+	private double[][] getMatrixOfType(MatType mtype, boolean sparse, long seed) {
+		double[][] ret = null;
+		double sparsity = sparse ? sparsity2 : sparsity1;
+		switch(mtype) {
+			case SCALAR:
+				ret = getRandomMatrix(1, 1, 0, 1, sparsity, seed);
+				break;
+			case MATRIX:
+				ret = getRandomMatrix(rows, cols, 0, 1, sparsity, seed);
+				break;
+			case COL:
+				ret = getRandomMatrix(1, cols, 0, 1, sparsity, seed);
+				break;
+			case ROW:
+				ret = getRandomMatrix(rows, 1, 0, 1, sparsity, seed);
+				break;
+			default:
+		}
+		return ret;
 	}
 }

--- a/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ternary/FullIfElseTest.java
@@ -37,9 +37,10 @@ public class FullIfElseTest extends AutomatedTestBase
 	
 	private final static String TEST_DIR = "functions/ternary/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + FullIfElseTest.class.getSimpleName() + "/";
+	private final static double eps = 1e-10;
 	
 	private final static int rows = 2111;
-	private final static int cols = 30;
+	private final static int cols = 300;
 	
 	private final static double sparsity1 = 0.6;
 	private final static double sparsity2 = 0.1;
@@ -799,7 +800,7 @@ public class FullIfElseTest extends AutomatedTestBase
 			
 			String HOME = SCRIPT_DIR + TEST_DIR;
 			fullDMLScriptName = HOME + TEST_NAME1 + ".dml";
-			programArgs = new String[]{"-explain","-args", input("A"), input("B"), input("C"), output("R")};
+			programArgs = new String[]{"-explain", "-stats", "-args", input("A"), input("B"), input("C"), output("R")};
 			fullRScriptName = HOME + TEST_NAME1 + ".R";
 			rCmd = "Rscript" + " " + fullRScriptName + " " + inputDir() + " " + expectedDir();
 	
@@ -818,7 +819,7 @@ public class FullIfElseTest extends AutomatedTestBase
 			//compare output matrices 
 			HashMap<CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir("R");
 			HashMap<CellIndex, Double> rfile  = readRMatrixFromExpectedDir("R");
-			TestUtils.compareMatrices(dmlfile, rfile, 0, "Stat-DML", "Stat-R");
+			TestUtils.compareMatrices(dmlfile, rfile, eps, "Stat-DML", "Stat-R");
 		}
 		finally {
 			rtplatform = platformOld;

--- a/src/test/scripts/functions/ternary/TernaryIfElse.R
+++ b/src/test/scripts/functions/ternary/TernaryIfElse.R
@@ -31,14 +31,20 @@ m = max(max(nrow(A), nrow(B)), nrow(C))
 n = max(max(ncol(A), ncol(B)), ncol(C))
 
 if( nrow(A)==1 ) {
+  A = matrix(A, m, n, byrow=TRUE);
+} else if ( ncol(A) == 1 ) {
   A = matrix(A, m, n);
 }
 if( nrow(B)==1 ) {
+  B = matrix(B, m, n, byrow=TRUE);
+} else if ( ncol(B)==1 ) {
   B = matrix(B, m, n);
 }
 if( nrow(C)==1 ) {
+  C = matrix(C, m, n, byrow=TRUE);
+} else if( ncol(C)==1 ) {
   C = matrix(C, m, n);
-}  
+}
 
 R = matrix(ifelse(as.vector(A), as.vector(B), as.vector(C)), m, n);
 

--- a/src/test/scripts/functions/ternary/TernaryIfElse.dml
+++ b/src/test/scripts/functions/ternary/TernaryIfElse.dml
@@ -23,21 +23,25 @@ A = read($1);
 B = read($2);
 C = read($3);
 
-if( nrow(A)==1 & nrow(B)==1 & nrow(C)==1 )
+isscalar = function(matrix[double] A) return (boolean C) {
+    C = nrow(A)==1 & ncol(A)==1
+}
+
+if( isscalar(A) & isscalar(B) & isscalar(C) )
   R = as.matrix(ifelse(as.scalar(A), as.scalar(B), as.scalar(C)));
-else if( nrow(A)>1 & nrow(B)==1 & nrow(C)==1 )  
+else if( !isscalar(A) & isscalar(B) & isscalar(C))
   R = ifelse(A, as.scalar(B), as.scalar(C));
-else if( nrow(A)==1 & nrow(B)>1 & nrow(C)==1 )
+else if( isscalar(A) & !isscalar(B) & isscalar(C) )
   R = ifelse(as.scalar(A), B, as.scalar(C));
-else if( nrow(A)>1 & nrow(B)>1 & nrow(C)==1 )  
+else if( !isscalar(A) & !isscalar(B) & isscalar(C) )
   R = ifelse(A, B, as.scalar(C));
-else if( nrow(A)==1 & nrow(B)==1 & nrow(C)>1 )
+else if( isscalar(A)==1 & isscalar(B) & !isscalar(C) )
   R = ifelse(as.scalar(A), as.scalar(B), C);
-else if( nrow(A)>1 & nrow(B)==1 & nrow(C)>1 )  
+else if( !isscalar(A) & isscalar(B) & !isscalar(C) )
   R = ifelse(A, as.scalar(B), C);
-else if( nrow(A)==1 & nrow(B)>1 & nrow(C)>1 )
+else if( isscalar(A)==1 & !isscalar(B) & !isscalar(C) )
   R = ifelse(as.scalar(A), B, C);
-else if( nrow(A)>1 & nrow(B)>1 & nrow(C)>1 )  
+else if( !isscalar(A) & !isscalar(B) & !isscalar(C) )
   R = ifelse(A, B, C);
 
 write(R, $4);


### PR DESCRIPTION
This PR introduces broadcasting ifelse as well as optimizations for certain cases. The broadcasting is done such that the resulting values are the maximum rows and columns of the inputs.

The following optimizations have been implemented
- the previous optimization for scalar values and certain non zero entries have been extended to contain broadcasting behavior
- if the first input matrix block is a column vector, then the entire row of either second or third input matrix block can be copied to the result matrix.
- if the first input matrix block is a row vector, then the entire column of either second or third input matrix block can be copied to the resulting matrix. The benchmarks also for larger matrices have shown, that this optimization is effective although we are iterating column first. Note that this seems to be effective although it is not good for caching.

**Measurements.** In the following benchmarks a row size of 2111 and column size of 300 have been used. Note that multiple tests are run for each optimization (around 30 for each); the median value is displayed to be more robust to outliers.
- Scalar optimization. In this case we are testing all test cases involving a scalar as first input and comparing them. Meaning we only test components `**.functions.ternary.FullIfElseTest#testScalar*`
    - Without optimization: 0.024s
    - With optimization: 0.000s (mean was 0.003s)
- Row optimization. In this case we test the row vector optimization, meaning we only run the tests `**.functions.ternary.FullIfElseTest#testRow*`
    - Without optimization: 0.074s
    - With optimization: 0.035s
- Column optimization. In this case we test the column vector optimization, meaning we only run the tests `**.functions.ternary.FullIfElseTest#testCol*`
    - Without optimization: 0.068s
    - With optimization: 0.038s
- Overall. This executes all tests in `**.functions.ternary.FullIfElseTest` with and without optimizations
    - Without optimization: 0.069s
    - With optimization: 0.027s

**Column optimization case.** Running larger matrices for all tests took extremely long. This is why I only did this for the column case, which deserved to be scrutinized more. The `testColMatrixMatrixDenseCP` test with a row size of 4111 and column size of 3000 was executed out with and without optimization the optimized version ran in 0.838s and the one without optimization required 1.547s. Other seeds for the matrix yielded similar results.

Additional comments
- The eps value in the tests were set to `1e-10` otherwise there are errors with the matrix comparisons. This issue seems to be present in other tests such as the `FullTransposeTest` as well. Maybe some exact values get lost while matrices are stored in files due to compression.
- Tests have been implemented for every matrix, row vector, column vector and scalar value combination. Those tests were of cause not generated by hand by instead by a python script to avoid human error. Same for the aggregation of the measurements above.