### PR TITLE
[SYSTEMDS-3953] Support value averaging for quantile operations on even-length arrays

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -4784,7 +4784,8 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 			output.reset(qs.rlen, qs.clen, false);
 
 		for(int i = 0; i < qs.rlen; i++) {
-			output.set(i, 0, this.pickValue(qs.get(i, 0), average));
+			// FIXME: include the average parameter here to fix SYSTEMDS-3953
+			output.set(i, 0, this.pickValue(qs.get(i, 0)));
 		}
 		
 		return output;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -4782,9 +4782,9 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 			output=new MatrixBlock(qs.rlen, qs.clen, false); // resulting matrix is mostly likely be dense
 		else
 			output.reset(qs.rlen, qs.clen, false);
-		
-		for ( int i=0; i < qs.rlen; i++ ) {
-			output.set(i, 0, this.pickValue(qs.get(i,0), average));
+
+		for(int i = 0; i < qs.rlen; i++) {
+			output.set(i, 0, this.pickValue(qs.get(i, 0), average));
 		}
 		
 		return output;

--- a/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/matrix/data/MatrixBlock.java
@@ -4784,8 +4784,7 @@ public class MatrixBlock extends MatrixValue implements CacheBlock<MatrixBlock>,
 			output.reset(qs.rlen, qs.clen, false);
 		
 		for ( int i=0; i < qs.rlen; i++ ) {
-			// FIXME: [SYSTEMDS-3953] consider the average parameter here
-			output.set(i, 0, this.pickValue(qs.get(i,0)) );
+			output.set(i, 0, this.pickValue(qs.get(i,0), average));
 		}
 		
 		return output;

--- a/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
@@ -21,6 +21,7 @@ package org.apache.sysds.test.functions.binary.matrix;
 
 import java.util.HashMap;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.apache.sysds.common.Types.ExecMode;
 import org.apache.sysds.common.Types.ExecType;
@@ -186,11 +187,13 @@ public class QuantileTest extends AutomatedTestBase
 	}
 
 	@Test
+	@Ignore // FIXME: fix SYSTEMDS-3953 Issue 2
 	public void testQuartileArrayCP() {
 		runQuantileTest(TEST_NAME6, 0, false, ExecType.CP);
 	}
 
 	@Test
+	@Ignore // FIXME: fix SYSTEMDS-3953 Issue 2
 	public void testQuartileArraySP() {
 		runQuantileTest(TEST_NAME6, 0, false, ExecType.SPARK);
 	}

--- a/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
@@ -187,13 +187,13 @@ public class QuantileTest extends AutomatedTestBase
 	}
 
 	@Test
-	@Ignore // FIXME: fix SYSTEMDS-3953 Issue 2
+	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void testQuartileArrayCP() {
 		runQuantileTest(TEST_NAME6, 0, false, ExecType.CP);
 	}
 
 	@Test
-	@Ignore // FIXME: fix SYSTEMDS-3953 Issue 2
+	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void testQuartileArraySP() {
 		runQuantileTest(TEST_NAME6, 0, false, ExecType.SPARK);
 	}

--- a/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
@@ -53,17 +53,17 @@ public class QuantileTest extends AutomatedTestBase
 	{
 		TestUtils.clearAssertionInformation();
 		addTestConfiguration(TEST_NAME1,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] { "R" }) ); 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME1, new String[] {"R"}));
 		addTestConfiguration(TEST_NAME2,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] { "R" }) ); 
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME2, new String[] {"R"}));
 		addTestConfiguration(TEST_NAME3,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] { "R" }) );
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME3, new String[] {"R"}));
 		addTestConfiguration(TEST_NAME4,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] { "R" }) );
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] {"R"}));
 		addTestConfiguration(TEST_NAME5,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] { "R" }) );
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] {"R"}));
 		addTestConfiguration(TEST_NAME6,
-			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[] { "R" }) );
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[] {"R"}));
 	}
 	
 	@Test

--- a/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/binary/matrix/QuantileTest.java
@@ -36,6 +36,7 @@ public class QuantileTest extends AutomatedTestBase
 	private final static String TEST_NAME3 = "IQM";
 	private final static String TEST_NAME4 = "QuantileBug";
 	private final static String TEST_NAME5 = "MedianBug";
+	private final static String TEST_NAME6 = "QuartileArray";
 	
 	private final static String TEST_DIR = "functions/binary/matrix/";
 	private final static String TEST_CLASS_DIR = TEST_DIR + QuantileTest.class.getSimpleName() + "/";
@@ -60,6 +61,8 @@ public class QuantileTest extends AutomatedTestBase
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME4, new String[] { "R" }) );
 		addTestConfiguration(TEST_NAME5,
 			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME5, new String[] { "R" }) );
+		addTestConfiguration(TEST_NAME6,
+			new TestConfiguration(TEST_CLASS_DIR, TEST_NAME6, new String[] { "R" }) );
 	}
 	
 	@Test
@@ -180,6 +183,16 @@ public class QuantileTest extends AutomatedTestBase
 	@Test
 	public void testMedianBugSP() {
 		runQuantileTest(TEST_NAME5, -1, false, ExecType.SPARK);
+	}
+
+	@Test
+	public void testQuartileArrayCP() {
+		runQuantileTest(TEST_NAME6, 0, false, ExecType.CP);
+	}
+
+	@Test
+	public void testQuartileArraySP() {
+		runQuantileTest(TEST_NAME6, 0, false, ExecType.SPARK);
 	}
 
 	private void runQuantileTest( String TEST_NAME, double p, boolean sparse, ExecType et)

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
@@ -30,6 +30,7 @@ import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -93,6 +94,7 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
+	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void federatedQuantilesCP() {
 		federatedQuartile(Types.ExecMode.SINGLE_NODE, TEST_NAME4, -1);
 	}
@@ -123,6 +125,7 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
+	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void federatedQuantilesSP() {
 		federatedQuartile(Types.ExecMode.SPARK, TEST_NAME4, -1);
 	}

--- a/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/federated/primitives/part2/FederatedQuantileTest.java
@@ -30,7 +30,6 @@ import org.apache.sysds.test.AutomatedTestBase;
 import org.apache.sysds.test.TestConfiguration;
 import org.apache.sysds.test.TestUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -94,7 +93,6 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void federatedQuantilesCP() {
 		federatedQuartile(Types.ExecMode.SINGLE_NODE, TEST_NAME4, -1);
 	}
@@ -125,7 +123,6 @@ public class FederatedQuantileTest extends AutomatedTestBase {
 	}
 
 	@Test
-	@Ignore // FIXME: fix SYSTEMDS-3953
 	public void federatedQuantilesSP() {
 		federatedQuartile(Types.ExecMode.SPARK, TEST_NAME4, -1);
 	}

--- a/src/test/scripts/functions/binary/matrix/QuartileArray.R
+++ b/src/test/scripts/functions/binary/matrix/QuartileArray.R
@@ -1,0 +1,33 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+args <- commandArgs(TRUE)
+options(digits=22)
+
+library("Matrix")
+
+A = as.matrix(c(1,5,7,10))
+
+m = quantile(A, c(0.25, 0.5, 0.75));
+
+writeMM(as(m, "CsparseMatrix"), paste(args[3], "R", sep=""));
+
+

--- a/src/test/scripts/functions/binary/matrix/QuartileArray.dml
+++ b/src/test/scripts/functions/binary/matrix/QuartileArray.dml
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+A = as.matrix(list(1,5,7,10));
+m = quantile(A, as.matrix(list(0.25, 0.5, 0.75)));
+write(m, $3, format="text");


### PR DESCRIPTION
This PR fixes the second issue reported in [SYSTEMDS-3953](https://issues.apache.org/jira/projects/SYSTEMDS/issues/SYSTEMDS-3953) by passing the boolean argument to the underlying method. This is only a minor change to the main code.
The PR also adds respective test cases, which are ignored for now since they are failing due to the second issue in [SYSTEMDS-3953](https://issues.apache.org/jira/projects/SYSTEMDS/issues/SYSTEMDS-3953).