### PR TITLE
[MINOR] Fix literal parsing issue in svn promote script

### DIFF
--- a/dev/release/svn-staging-to-release.sh
+++ b/dev/release/svn-staging-to-release.sh
@@ -74,7 +74,7 @@ cd svn-release-systemds
 
 if [[ $dry_run_flag != 1 ]]; then
   # This step prompts for the Apache Credentials
-  svn ci --username $ASF_USERNAME -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache \n
+  svn ci --username "$ASF_USERNAME" -m"Apache SystemDS $RELEASE_VERSION Released" --no-auth-cache
   [[ $? == 0 ]] && printf '\n Publishing to $RELEASE_LOCATION is complete!\n'
 else
   printf "\n==========\n"
@@ -82,7 +82,7 @@ else
   printf "At $RELEASE_LOCATION \n"
   printf "\n==========\n"
   printf "You might want to manually check the files and run the following:\n"
-  printf "svn ci --username $ASF_USERNAME -m'Apache SystemDS $RELEASE_VERSION Released' --no-auth-cache \n"
+  printf "svn ci --username $ASF_USERNAME -m\"Apache SystemDS $RELEASE_VERSION Released\" --no-auth-cache\n"
   printf "\n==========\n"
 fi
 


### PR DESCRIPTION
The failure is localized to the release commit line: the script is passing a literal \n as an extra SVN argument, which turns into the bogus path /svn-release-systemds/n.