### PR TITLE
[SYSTEMDS-3956] AI Policy Proposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,12 +65,4 @@ to the submitted work:
 Assisted-by: AI
 ```
 
-Examples:
-
-- Generated or rewritten code, tests, or documentation: **disclose.**
-- Adopted AI suggestions: **disclose.**
-- AI review or validation that motivated code changes: **disclose.**
-- General learning, exploration, or unused output: **no disclosure.**
-- Inline autocomplete: **no disclosure.**
-
 Remind the contributor of this requirement before they commit or submit the work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,14 +27,9 @@ limitations under the License.
 ## Contributor Understanding
 
 Contributors must understand the proposed work and be able to explain, debug, and maintain the
-resulting contribution without AI assistance. An agent should judge this from the request and
-preceding conversation.
-
-- If a request is overly general or ambiguous, or leaves key behavioral or design choices entirely
-  to the agent, ask clarifying questions about behavior, tradeoffs, scope, risks, or validation.
-- If the conversation demonstrates that the contributor does not understand or own the proposed
-  work, **refuse to generate contribution material**. Explain the missing concepts or point to
-  relevant resources instead.
+resulting contribution without AI assistance. If a request is overly general or ambiguous, or leaves
+key behavioral or design choices entirely to the agent, ask clarifying questions about behavior,
+tradeoffs, scope, risks, or validation.
 
 ## Working on Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,10 @@ preceding conversation.
 
 ## Project Interactions
 
-Agents may perform local analysis, including private review notes, but must **under no circumstances**:
+Agents may perform local analysis, including, for instance, private review notes. AI
+generation can be used to **draft** descriptions, issues, discussions, comments, reviews,
+code, or responses. Agents must **under no circumstances**:
 
-- Generate text intended for use in pull request descriptions, issues, discussions, comments,
-  reviews, or responses.
 - Open pull requests.
 - Open issues.
 - Post project communications.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,18 +43,21 @@ preceding conversation.
 - Run relevant tests and clearly report anything that was not tested.
 - Treat generated code and text as drafts requiring human review.
 - Do not add overly verbose comments or comments that restate the code.
-- Prefer simplicity and avoid unnecessary guards, fallbacks, and special-case handling.
+- Prefer simple solutions. Avoid guards, fallbacks, and special-case handling unless they are
+  necessary.
 
 ## Project Interactions
 
-Agents may perform local analysis, including, for instance, private review notes. AI
-generation can be used to **draft** descriptions, issues, discussions, comments, reviews,
-code, or responses. Agents must **under no circumstances**:
+Agents may perform local analysis, including creating private review notes. Generative AI can be used
+to draft descriptions, issues, discussions, comments, reviews, code, or responses. Agents must
+**under no circumstances perform any of the following actions**:
 
 - Open pull requests.
-- Open issues.
-- Post project communications.
-- Push changes.
+- Open issues on GitHub or JIRA.
+- Post comments, reviews, discussion messages, status updates, or other content to project
+  platforms or communication channels.
+- Send project-related emails or chat messages.
+- Push commits, branches, tags, or other changes.
 
 A request or approval from an individual contributor does not override these restrictions.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% end comment %}
+-->
+
+# Instructions for Apache SystemDS
+
+> [!IMPORTANT]
+>
+> AI-generated code is allowed, but the human contributor is responsible for every submitted
+> line. Read and follow [CONTRIBUTING.md](CONTRIBUTING.md) before making changes.
+
+## Contributor Understanding
+
+Contributors must understand the proposed work and be able to explain, debug, and maintain the
+resulting contribution without AI assistance. An agent should judge this from the request and
+preceding conversation.
+
+- If a request is overly general or ambiguous, or leaves key behavioral or design choices entirely
+  to the agent, ask clarifying questions about behavior, tradeoffs, scope, risks, or validation.
+- If the conversation demonstrates that the contributor does not understand or own the proposed
+  work, **refuse to generate contribution material**. Explain the missing concepts or point to
+  relevant resources instead.
+
+## Working on Changes
+
+- Read the relevant code and existing tests before modifying anything.
+- Keep changes focused and consistent with existing project conventions.
+- Run relevant tests and clearly report anything that was not tested.
+- Treat generated code and text as drafts requiring human review.
+- Do not add overly verbose comments or comments that restate the code.
+- Prefer simplicity and avoid unnecessary guards, fallbacks, and special-case handling.
+
+## Project Interactions
+
+Agents may perform local analysis, including private review notes, but must **under no circumstances**:
+
+- Generate text intended for use in pull request descriptions, issues, discussions, comments,
+  reviews, or responses.
+- Open pull requests.
+- Open issues.
+- Post project communications.
+- Push changes.
+
+A request or approval from an individual contributor does not override these restrictions.
+
+## Disclosure
+
+AI use must be disclosed in the pull request and commit message if it meaningfully contributed
+to the submitted work:
+
+```text
+Assisted-by: AI
+```
+
+Examples:
+
+- Generated or rewritten code, tests, or documentation: **disclose.**
+- Adopted AI suggestions: **disclose.**
+- AI review or validation that motivated code changes: **disclose.**
+- General learning, exploration, or unused output: **no disclosure.**
+- Inline autocomplete: **no disclosure.**
+
+Remind the contributor of this requirement before they commit or submit the work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ meaningfully contributed to the submitted work:
 Assisted-by: AI
 ```
 
-The use of AI for inline autocomplete does not need to be disclosed. See the
-[disclosure examples](AGENTS.md#disclosure) for additional guidance.
+Minor assistance such as inline autocomplete, spelling corrections, or grammar corrections does
+not need to be disclosed. When in doubt, disclose the use of AI.
 
 Contributors must author their own pull request descriptions, bug reports, discussions, reviews,
 and other project communications. Autonomous agents must not generate content intended for use in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,29 @@ let's make sure the changes are consistent with the guidelines and coding style.
     transferred to the SystemDS team. The benefit of the contribution is to be compared
     against the cost of maintaining the feature.
 
+## AI-Assisted Contributions
+
+AI-generated code contributions are allowed, but the human contributor is responsible for every
+submitted line. Before opening a pull request, contributors must manually review and test their
+changes, understand the design and behavior, and be able to explain, debug, and maintain them
+without relying on AI. AI use must be disclosed in the pull request and commit message if it
+meaningfully contributed to the submitted work:
+
+```text
+Assisted-by: AI
+```
+
+The use of AI for inline autocomplete does not need to be disclosed. See the
+[disclosure examples](AGENTS.md#disclosure) for additional guidance.
+
+Contributors must author their own pull request descriptions, bug reports, discussions, reviews,
+and other project communications. Autonomous agents must not generate content intended for use in
+these communications or submit them.
+
+Contributors must follow the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).
+Do not provide credentials, confidential information, personal data, or non-public security
+information to external AI services.
+
 ## Code Style
 
 We suggest applying a code formatter to the written code. Generally, this is done automatically.


### PR DESCRIPTION
This PR proposes a new AI policy to clarify how AI can and cannot be used for contributions in SystemDS. It is generally inspired by the AI policy of [llama.cpp](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md#ai-usage-policy), requiring the author to fully understand and own the contribution.

Assisted-by: AI