### PR TITLE
[SYSTEMDS-3970] Obtain Nnz Information of Reads before Rewriting Main Program Block

### DIFF
--- a/src/main/java/org/apache/sysds/conf/DMLConfig.java
+++ b/src/main/java/org/apache/sysds/conf/DMLConfig.java
@@ -98,8 +98,9 @@ public class DMLConfig
 	public static final String NATIVE_BLAS          = "sysds.native.blas";
 	public static final String NATIVE_BLAS_DIR      = "sysds.native.blas.directory";
 	public static final String DAG_LINEARIZATION    = "sysds.compile.linearization";
-	public static final String SPARSITY_REWRITES    = "sysds.rewrites.sparsity.enabled"; // boolean
-	public static final String SPARSITY_ESTIMATOR   = "sysds.rewrites.sparsity.estimator"; // see EstiamtionUtils.EstimatorType
+	public static final String SPARSITY_REWRITES    = "sysds.sparsity.rewrites.enabled"; // boolean
+	public static final String SPARSITY_RECOMPILE   = "sysds.sparsity.recompile.enabled"; // boolean
+	public static final String SPARSITY_ESTIMATOR   = "sysds.sparsity.estimator"; // see EstiamtionUtils.EstimatorType
 	public static final String CODEGEN              = "sysds.codegen.enabled"; //boolean
 	public static final String CODEGEN_API          = "sysds.codegen.api"; // see SpoofCompiler.API
 	public static final String CODEGEN_COMPILER     = "sysds.codegen.compiler"; //see SpoofCompiler.CompilerType
@@ -192,6 +193,7 @@ public class DMLConfig
 		_defaultVals.put(COMPRESSED_TRANSFORMENCODE, "false");
 		_defaultVals.put(DAG_LINEARIZATION,      DagLinearizer.DEPTH_FIRST.name());
 		_defaultVals.put(SPARSITY_REWRITES,      "false");
+		_defaultVals.put(SPARSITY_RECOMPILE,     "false");
 		_defaultVals.put(SPARSITY_ESTIMATOR,     EstimatorType.BASIC_AVG.name());
 		_defaultVals.put(CODEGEN,                "false" );
 		_defaultVals.put(CODEGEN_API,            GeneratorAPI.JAVA.name() );
@@ -481,7 +483,7 @@ public class DMLConfig
 			COMPRESSED_LINALG, COMPRESSED_LOSSY, COMPRESSED_VALID_COMPRESSIONS, COMPRESSED_OVERLAPPING,
 			COMPRESSED_SAMPLING_RATIO, COMPRESSED_SOFT_REFERENCE_COUNT,
 			COMPRESSED_COCODE, COMPRESSED_TRANSPOSE, COMPRESSED_TRANSFORMENCODE, DAG_LINEARIZATION,
-			SPARSITY_REWRITES, SPARSITY_ESTIMATOR,
+			SPARSITY_REWRITES, SPARSITY_RECOMPILE, SPARSITY_ESTIMATOR,
 			CODEGEN, CODEGEN_API, CODEGEN_COMPILER, CODEGEN_OPTIMIZER, CODEGEN_PLANCACHE, CODEGEN_LITERALS,
 			STATS_MAX_WRAP_LEN, LINEAGECACHESPILL, COMPILERASSISTED_RW, BUFFERPOOL_LIMIT, MEMORY_MANAGER,
 			PRINT_GPU_MEMORY_INFO, AVAILABLE_GPUS, SYNCHRONIZE_GPU, EAGER_CUDA_FREE, GPU_RULE_BASED_PLACEMENT,

--- a/src/main/java/org/apache/sysds/hops/Hop.java
+++ b/src/main/java/org/apache/sysds/hops/Hop.java
@@ -1081,7 +1081,11 @@ public abstract class Hop implements ParseInfo {
 	public boolean colsKnown() {
 		return _dataType.isScalar() || _dc.colsKnown();
 	}
-	
+
+	public boolean nnzKnown() {
+		return (getDataCharacteristics() != null) && getDataCharacteristics().nnzKnown();
+	}
+
 	public static void resetVisitStatus( List<Hop> hops ) {
 		if( hops != null )
 			for( Hop hopRoot : hops )

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
@@ -106,7 +106,7 @@ public class ProgramRewriter{
 				_sbRuleSet.add(      new RewriteCompressedReblock()              ); // Compression Rewrite
 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS )
 				_sbRuleSet.add(  new RewriteSplitDagUnknownCSVRead()             ); //dependency: reblock, merge blocks
-			if(ConfigurationManager.getDMLConfig().getBooleanValue(DMLConfig.SPARSITY_REWRITES))
+			if(ConfigurationManager.getDMLConfig().getBooleanValue(DMLConfig.SPARSITY_RECOMPILE))
 				_sbRuleSet.add(new RewriteSplitDagUnknownNnzRead());
 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS && 
 				ConfigurationManager.getCompilerConfigFlag(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS) )

--- a/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/ProgramRewriter.java
@@ -106,6 +106,8 @@ public class ProgramRewriter{
 				_sbRuleSet.add(      new RewriteCompressedReblock()              ); // Compression Rewrite
 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS )
 				_sbRuleSet.add(  new RewriteSplitDagUnknownCSVRead()             ); //dependency: reblock, merge blocks
+			if(ConfigurationManager.getDMLConfig().getBooleanValue(DMLConfig.SPARSITY_REWRITES))
+				_sbRuleSet.add(new RewriteSplitDagUnknownNnzRead());
 			if( OptimizerUtils.ALLOW_SPLIT_HOP_DAGS && 
 				ConfigurationManager.getCompilerConfigFlag(ConfigType.ALLOW_INDIVIDUAL_SB_SPECIFIC_OPS) )
 				_sbRuleSet.add(  new RewriteSplitDagDataDependentOperators()     ); //dependency: merge blocks

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
@@ -73,20 +73,18 @@ public class RewriteMatrixMultChainOptimization extends HopRewriteRule
 	 * 
 	 * @param hop high-level operator
 	 */
-	private void ruleOptimizeMMChains(Hop hop, ProgramRewriteStatus state) 
-	{
-		if( hop.isVisited() )
+	private void ruleOptimizeMMChains(Hop hop, ProgramRewriteStatus state) {
+		if(hop.isVisited())
 			return;
 		
-		if( HopRewriteUtils.isMatrixMultiply(hop)
-			&& !((AggBinaryOp)hop).hasLeftPMInput() && !hop.isVisited() ) 
+		if(HopRewriteUtils.isMatrixMultiply(hop) && !((AggBinaryOp)hop).hasLeftPMInput())
 		{
 			// Try to find and optimize the chain in which current Hop is the
 			// last operator
 			prepAndOptimizeMMChain(hop, state);
 		}
 		
-		for( Hop hi : hop.getInput() )
+		for(Hop hi : hop.getInput())
 			ruleOptimizeMMChains(hi, state);
 
 		hop.setVisited();

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
@@ -76,9 +76,8 @@ public class RewriteMatrixMultChainOptimization extends HopRewriteRule
 	private void ruleOptimizeMMChains(Hop hop, ProgramRewriteStatus state) {
 		if(hop.isVisited())
 			return;
-		
-		if(HopRewriteUtils.isMatrixMultiply(hop) && !((AggBinaryOp)hop).hasLeftPMInput())
-		{
+
+		if(HopRewriteUtils.isMatrixMultiply(hop) && !((AggBinaryOp) hop).hasLeftPMInput()) {
 			// Try to find and optimize the chain in which current Hop is the
 			// last operator
 			prepAndOptimizeMMChain(hop, state);

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimization.java
@@ -384,10 +384,10 @@ public class RewriteMatrixMultChainOptimization extends HopRewriteRule
 		return CollectionUtils.cardinality(h, p.getInput());
 	}
 	
-	private static void logTraceHop( Hop hop, int level ) {
-		if( LOG.isTraceEnabled() ) {
+	protected void logTraceHop(Hop hop, int level) {
+		if(LOG.isTraceEnabled()) {
 			String offset = Explain.getIdentation(level);
-			LOG.trace(offset+ "Hop " + hop.getName() + "(" + hop.getClass().getSimpleName() 
+			LOG.trace(offset+ "Hop " + hop.getName() + "(" + hop.getClass().getSimpleName()
 				+ ", " + hop.getHopID() + ")" + " " + hop.getDim1() + "x" + hop.getDim2());
 		}
 	}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -132,7 +132,7 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 			Hop currentHop = chain.get(counter);
 			inputMetaAvail &= currentHop.isMatrix();
 			inputMetaAvail &= !currentHop.isFederated();
-			inputMetaAvail &= (currentHop.getDataCharacteristics().getNonZeros() != -1);
+			inputMetaAvail &= (currentHop.getNnz() != -1);
 			if(inputMetaAvail) {
 				sketchArray[counter] = new MMNode(currentHop.getDataCharacteristics());
 			}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteMatrixMultChainOptimizationSparse.java
@@ -31,6 +31,7 @@ import org.apache.sysds.hops.estim.MMNode;
 import org.apache.sysds.hops.estim.SparsityEstimator;
 import org.apache.sysds.hops.estim.EstimationUtils.EstimatorType;
 import org.apache.sysds.hops.estim.SparsityEstimator.OpCode;
+import org.apache.sysds.utils.Explain;
 
 /**
  * Rule: Determine the optimal order of execution for a chain of
@@ -141,5 +142,15 @@ public class RewriteMatrixMultChainOptimizationSparse extends RewriteMatrixMultC
 		}
 
 		return inputMetaAvail;
+	}
+
+	@Override
+	protected void logTraceHop(Hop hop, int level) {
+		if(LOG.isTraceEnabled()) {
+			String offset = Explain.getIdentation(level);
+			LOG.trace(offset+ "Hop " + hop.getName() + "(" + hop.getClass().getSimpleName()
+				+ ", " + hop.getHopID() + ")" + " " + hop.getDim1() + "x" + hop.getDim2()
+				+ " sparsity " + hop.getSparsity());
+		}
 	}
 }

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,7 @@ public class RewriteSplitDagUnknownNnzRead extends StatementBlockRewriteRule {
 	public List<StatementBlock> rewriteStatementBlock(StatementBlock sb, ProgramRewriteStatus state) {
 		ArrayList<StatementBlock> ret = new ArrayList<>();
 
-		// collect all reads hops w/ unknown nnz
+		// collect all read hops w/ unknown nnz
 		ArrayList<Hop> cand = new ArrayList<>();
 		collectReadHopsUnknownNnz(sb.getHops(), cand);
 

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.hops.rewrite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sysds.common.Types.OpOpData;
+import org.apache.sysds.hops.DataOp;
+import org.apache.sysds.hops.Hop;
+import org.apache.sysds.hops.LiteralOp;
+import org.apache.sysds.parser.DataIdentifier;
+import org.apache.sysds.parser.StatementBlock;
+import org.apache.sysds.parser.VariableSet;
+
+/**
+ * Rule: Split Hop DAG after reads with unknown nnz. This is important to create recompile
+ * hooks if mtd has unspecified nnz.
+ */
+public class RewriteSplitDagUnknownNnzRead extends StatementBlockRewriteRule {
+	@Override
+	public boolean createsSplitDag() {
+		return true;
+	}
+
+	@Override
+	public List<StatementBlock> rewriteStatementBlock(StatementBlock sb, ProgramRewriteStatus state) {
+		ArrayList<StatementBlock> ret = new ArrayList<>();
+
+		// collect all reads hops w/ unknown nnz
+		ArrayList<Hop> cand = new ArrayList<>();
+		collectReadHopsUnknownNnz(sb.getHops(), cand);
+
+		// split hop dag on demand
+		if(!cand.isEmpty()) {
+			// duplicate sb incl live variable sets
+			StatementBlock sb1 = new StatementBlock();
+			sb1.setDMLProg(sb.getDMLProg());
+			sb1.setParseInfo(sb);
+			sb1.setLiveIn(new VariableSet());
+			sb1.setLiveOut(new VariableSet());
+
+			// move reads incl reblock to new statement block
+			// (and replace original persistent read with transient read)
+			ArrayList<Hop> sb1hops = new ArrayList<>();
+			for(Hop reblock : cand) {
+				// replace reblock inputs to avoid dangling references across dags
+				// (otherwise, for instance, literal ops are shared across dags)
+				for(int i = 0; i < reblock.getInput().size(); i++) {
+					if(reblock.getInput().get(i) instanceof LiteralOp) {
+						HopRewriteUtils.replaceChildReference(reblock, reblock.getInput().get(i),
+							new LiteralOp((LiteralOp) reblock.getInput().get(i)));
+					}
+				}
+
+				// create new transient read
+				DataOp tRead = HopRewriteUtils.createTransientRead(reblock.getName(), reblock);
+				tRead.setRequiresRecompile();
+
+				// replace reblock with transient read
+				ArrayList<Hop> parents = new ArrayList<>(reblock.getParent());
+				for(int i = 0; i < parents.size(); i++) {
+					Hop parent = parents.get(i);
+					HopRewriteUtils.replaceChildReference(parent, reblock, tRead);
+				}
+
+				// add reblock sub dag to first statement block
+				DataOp tWrite = HopRewriteUtils.createTransientWrite(reblock.getName(), reblock);
+				sb1hops.add(tWrite);
+
+				// update live in and out of new statement block (for piggybacking)
+				DataIdentifier diVar = sb.variablesRead().getVariable(reblock.getName());
+				if(diVar != null) { // var read should always exist because persistent read
+					sb1.liveOut().addVariable(reblock.getName(), new DataIdentifier(diVar));
+					sb.liveIn().addVariable(reblock.getName(), new DataIdentifier(diVar));
+				}
+			}
+
+			sb1.setHops(sb1hops);
+			sb1.updateRecompilationFlag();
+			ret.add(sb1); // statement block with permanent read and transient write
+			ret.add(sb); // statement block with transient read
+			sb.setSplitDag(true); // avoid later merge by other rewrites
+			LOG.debug("Applied splitDagUnknownNnzRead.");
+		}
+		// keep original hop dag
+		else {
+			ret.add(sb);
+		}
+
+		return ret;
+	}
+
+	@Override
+	public List<StatementBlock> rewriteStatementBlocks(List<StatementBlock> sbs, ProgramRewriteStatus state) {
+		return sbs;
+	}
+
+	private void collectReadHopsUnknownNnz(ArrayList<Hop> roots, ArrayList<Hop> cand) {
+		if(roots == null)
+			return;
+		Hop.resetVisitStatus(roots);
+		for(Hop root : roots)
+			collectReadHopsUnknownNnz(root, cand);
+	}
+
+	private void collectReadHopsUnknownNnz(Hop hop, ArrayList<Hop> cand) {
+		if(hop.isVisited())
+			return;
+
+		// collect persistent reads with unknown nnz
+		if(hop instanceof DataOp) {
+			DataOp dop = (DataOp) hop;
+			if(dop.getOp() == OpOpData.PERSISTENTREAD && !dop.nnzKnown()) {
+				cand.add(dop);
+			}
+		}
+
+		// process children
+		if(hop.getInput() != null) {
+			for(Hop c : hop.getInput()) {
+				collectReadHopsUnknownNnz(c, cand);
+			}
+		}
+
+		hop.setVisited();
+	}
+}

--- a/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
+++ b/src/main/java/org/apache/sysds/hops/rewrite/RewriteSplitDagUnknownNnzRead.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.sysds.common.Types.OpOpData;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.hops.DataOp;
 import org.apache.sysds.hops.Hop;
 import org.apache.sysds.hops.LiteralOp;
@@ -48,8 +50,8 @@ public class RewriteSplitDagUnknownNnzRead extends StatementBlockRewriteRule {
 		ArrayList<Hop> cand = new ArrayList<>();
 		collectReadHopsUnknownNnz(sb.getHops(), cand);
 
-		// split hop dag on demand
-		if(!cand.isEmpty()) {
+		// split hop dag on demand and if sparsity rewrites are enabled (splitting is pointless w/o rewrite)
+		if(!cand.isEmpty() && ConfigurationManager.getDMLConfig().getBooleanValue(DMLConfig.SPARSITY_REWRITES)) {
 			// duplicate sb incl live variable sets
 			StatementBlock sb1 = new StatementBlock();
 			sb1.setDMLProg(sb.getDMLProg());

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteSplitDagUnknownNnzReadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteSplitDagUnknownNnzReadTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.rewrite;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.sysds.common.Opcodes;
+import org.apache.sysds.conf.ConfigurationManager;
+import org.apache.sysds.conf.DMLConfig;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.hops.recompile.Recompiler;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.apache.sysds.test.LoggingUtils;
+import org.apache.sysds.test.LoggingUtils.TestAppender;
+
+import org.junit.Assert;
+import org.junit.runners.Parameterized;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
+
+@RunWith(value = Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
+public class RewriteSplitDagUnknownNnzReadTest extends AutomatedTestBase {
+
+	private static final String TEST_NAME = "RewriteSplitDagUnknownNnz";
+	private static final String TEST_DIR = "functions/rewrite/";
+	private static final String TEST_CLASS_DIR =
+		TEST_DIR + RewriteSplitDagUnknownNnzReadTest.class.getSimpleName() + "/";
+	private static final String PACKAGE_REWRITE = "org.apache.sysds.hops.rewrite.HopRewriteRule";
+	private static final String PACKAGE_RECOMPILE = "org.apache.sysds.hops.rewrite.StatementBlockRewriteRule";
+	private static Level _oldLevelRewrite;
+	private static Level _oldLevelRecompile;
+
+	@Parameterized.Parameter(0)
+	public int rows;
+
+	@Parameterized.Parameter(1)
+	public int cols;
+
+	@Parameterized.Parameter(2)
+	public double[] sparsities;
+
+	@Parameterized.Parameter(3)
+	public double eps;
+
+	@Parameterized.Parameter(4)
+	public boolean tsmm;
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			// {rows, cols, sparsities, eps},
+			{1000, 300, new double[] {0.10d, 0.10d}, Math.pow(10, -10), false},
+			{5, 3, new double[] {0.1, 1}, Math.pow(10, -10), true},});
+	}
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		addTestConfiguration(TEST_NAME, new TestConfiguration(TEST_CLASS_DIR, TEST_NAME, new String[] {"R"}));
+		_oldLevelRewrite = Logger.getLogger(PACKAGE_REWRITE).getLevel();
+		Logger.getLogger(PACKAGE_REWRITE).setLevel(Level.TRACE);
+		_oldLevelRecompile = Logger.getLogger(PACKAGE_RECOMPILE).getLevel();
+		Logger.getLogger(PACKAGE_RECOMPILE).setLevel(Level.TRACE);
+	}
+
+	@Override
+	public void tearDown() {
+		super.tearDown();
+		Logger.getLogger(PACKAGE_REWRITE).setLevel(_oldLevelRewrite);
+		Logger.getLogger(PACKAGE_RECOMPILE).setLevel(_oldLevelRecompile);
+	}
+
+	@Test
+	public void testSplitDagUnknownNnzRead() {
+		boolean oldFlag1 = OptimizerUtils.ALLOW_TRANSPOSE_MMCHAIN_REWRITES;
+		boolean oldFlag2 = OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES;
+		DMLConfig oldDMLConfig = ConfigurationManager.getDMLConfig();
+
+		try {
+			TestConfiguration config = getTestConfiguration(TEST_NAME);
+			loadTestConfiguration(config);
+
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-explain", "hops", "-stats",
+				"-args", input("X"), input("Y"), output("R")};
+
+			OptimizerUtils.ALLOW_TRANSPOSE_MMCHAIN_REWRITES = true;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = true;
+
+			double[][] X = getRandomMatrix(rows, cols, -1, 1, sparsities[0], 7);
+			double[][] Y = getRandomMatrix(cols, 1, -1, 1, sparsities[1], 3);
+			long Y_nnz = Stream.of(Y).mapToLong(row -> DoubleStream.of(row).filter(val -> val != 0).count()).sum();
+			writeInputMatrixWithMTD("X", X, true); // write matrix characteristics w/ missing nnz
+			writeInputMatrixWithMTD("Y", Y, Y_nnz, true);
+
+			// run reference test
+			TestAppender appender = LoggingUtils.overwrite(); // capture log output
+			runTest(true, false, null, -1);
+			List<LoggingEvent> log_reference = LoggingUtils.reinsert(appender); // revert the logger to print to stdout
+
+			// get reference result matrix
+			HashMap<MatrixValue.CellIndex, Double> referenceResult = readDMLMatrixFromOutputDir("R");
+
+			try {
+				DMLConfig dmlConfig = new DMLConfig(getCurConfigFile().getPath());
+				dmlConfig.setTextValue(DMLConfig.SPARSITY_REWRITES, "true");
+				dmlConfig.setTextValue(DMLConfig.SPARSITY_RECOMPILE, "true");
+				overwriteCurrentConfig(dmlConfig);
+			}
+			catch(FileNotFoundException fnfe) {
+				Assert.fail("Could not find DML config file: " +
+					getCurConfigFile().getPath() + " . " + fnfe.getMessage());
+			}
+			catch(IOException ioe) {
+				Assert.fail("Could not overwrite the DML configuration file. " + ioe.getMessage());
+			}
+
+			// run original test
+			appender = LoggingUtils.overwrite(); // capture log output
+			runTest(true, false, null, -1);
+			List<LoggingEvent> log_original = LoggingUtils.reinsert(appender); // revert the logger to print to stdout
+
+			// get resulting matrix
+			HashMap<MatrixValue.CellIndex, Double> originalResult = readDMLMatrixFromOutputDir("R");
+
+			// compare matrices
+			TestUtils.compareMatrices(originalResult, referenceResult, eps, "Stat-Original", "Stat-Reference");
+
+			final String DELIMITER = "\n";
+			// check original log output
+			String log_original_string = String.join(DELIMITER,
+				log_original.stream().map(l -> l.getMessage().toString()).toArray(String[]::new));
+			Assert.assertTrue(log_original_string.contains("Applied splitDagUnknownNnzRead."));
+			Assert.assertTrue(log_original_string.contains("mmchainoptsparse"));
+			Assert.assertTrue(log_original_string.contains("Optimal Sparse MM Chain:"));
+			// check reference log output
+			String log_reference_string = String.join(DELIMITER,
+				log_reference.stream().map(l -> l.getMessage().toString()).toArray(String[]::new));
+			Assert.assertFalse(log_reference_string.contains("splitDagUnknownNnzRead"));
+			Assert.assertFalse(log_reference_string.contains("mmchainoptsparse"));
+		}
+		finally {
+			OptimizerUtils.ALLOW_TRANSPOSE_MMCHAIN_REWRITES = oldFlag1;
+			OptimizerUtils.ALLOW_SUM_PRODUCT_REWRITES = oldFlag2;
+			try {
+				overwriteCurrentConfig(oldDMLConfig);
+			}
+			catch(IOException ioe) {
+				Assert.fail("Unable to restore the previous DML configuration. " + ioe.getMessage());
+			}
+			Recompiler.reinitRecompiler();
+		}
+	}
+
+	private void overwriteCurrentConfig(DMLConfig config) throws IOException {
+		Files.write(getCurConfigFile().toPath(), config.serializeDMLConfig().getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteSplitDagUnknownNnzReadTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/rewrite/RewriteSplitDagUnknownNnzReadTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,6 @@ package org.apache.sysds.test.functions.rewrite;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.apache.sysds.common.Opcodes;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.conf.DMLConfig;
 import org.apache.sysds.hops.OptimizerUtils;
@@ -142,8 +141,8 @@ public class RewriteSplitDagUnknownNnzReadTest extends AutomatedTestBase {
 				overwriteCurrentConfig(dmlConfig);
 			}
 			catch(FileNotFoundException fnfe) {
-				Assert.fail("Could not find DML config file: " +
-					getCurConfigFile().getPath() + " . " + fnfe.getMessage());
+				Assert.fail(
+					"Could not find DML config file: " + getCurConfigFile().getPath() + " . " + fnfe.getMessage());
 			}
 			catch(IOException ioe) {
 				Assert.fail("Could not overwrite the DML configuration file. " + ioe.getMessage());

--- a/src/test/scripts/functions/rewrite/RewriteSplitDagUnknownNnz.dml
+++ b/src/test/scripts/functions/rewrite/RewriteSplitDagUnknownNnz.dml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+
+X = read($1);
+Y = read($2);
+
+R = t(X) %*% X %*% Y;
+
+write(R, $3);


### PR DESCRIPTION
Hi,
This PR adds the rewriting functionality to split a permanent read operation into a separate, preceding statement block if the meta data of the read object does not provide information about its number of non-zeros beforehand. By performing the read separately, the sparsity information can already be leveraged when recompiling the main program block.

The PR also adds a flag to disable and enable this new feature (disabled by default) as well as unit tests to cover the functionality.

All the best,
David