### PR TITLE
[SYSTEMDS-3963] Deactivate the Java Code Formatter in the GitHub Workflows

### DIFF
--- a/.github/workflows/javaCodestyle.yml
+++ b/.github/workflows/javaCodestyle.yml
@@ -74,46 +74,46 @@ jobs:
     - name: Run Checkstyle
       run: mvn -ntp -B -Dcheckstyle.skip=false checkstyle:check
 
-  java_format:
-    name: Java Format Check
-    # line-scoped to the PR diff -> needs the pull_request base commit
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
+  # java_format:
+  #   name: Java Format Check
+  #   # line-scoped to the PR diff -> needs the pull_request base commit
+  #   if: github.event_name == 'pull_request'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Checkout Repository
+  #     uses: actions/checkout@v7
+  #     with:
+  #       fetch-depth: 0
 
-    - name: Setup Java 17 adopt
-      uses: actions/setup-java@v5
-      with:
-        distribution: adopt
-        java-version: '17'
-        cache: 'maven'
+  #   - name: Setup Java 17 adopt
+  #     uses: actions/setup-java@v5
+  #     with:
+  #       distribution: adopt
+  #       java-version: '17'
+  #       cache: 'maven'
 
-    - name: Setup Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.11'
+  #   - name: Setup Python
+  #     uses: actions/setup-python@v7
+  #     with:
+  #       python-version: '3.11'
 
-    - name: Unit-test the format checker
-      run: |
-        python -m pip install --quiet pytest
-        python -m pytest dev/tests -q
+  #   - name: Unit-test the format checker
+  #     run: |
+  #       python -m pip install --quiet pytest
+  #       python -m pytest dev/tests -q
 
-    - name: Check formatting of PR-edited lines
-      env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      run: |
-        # Fails only if the Eclipse formatter would change a line this PR edited.
-        # See dev/format_changed.py for the line-scoping logic.
-        if ! python3 dev/format_changed.py --check "$BASE_SHA"; then
-          echo "::error::Some lines edited by this PR are not formatted per dev/CodeStyle_eclipse.xml."
-          echo "Fix only your edited lines locally and commit the result:"
-          echo ""
-          echo "  dev/format-changed.sh"
-          echo ""
-          echo "(Do NOT run a bare 'mvn formatter:format' -- it reformats the whole tree.)"
-          exit 1
-        fi
+  #   - name: Check formatting of PR-edited lines
+  #     env:
+  #       BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  #     run: |
+  #       # Fails only if the Eclipse formatter would change a line this PR edited.
+  #       # See dev/format_changed.py for the line-scoping logic.
+  #       if ! python3 dev/format_changed.py --check "$BASE_SHA"; then
+  #         echo "::error::Some lines edited by this PR are not formatted per dev/CodeStyle_eclipse.xml."
+  #         echo "Fix only your edited lines locally and commit the result:"
+  #         echo ""
+  #         echo "  dev/format-changed.sh"
+  #         echo ""
+  #         echo "(Do NOT run a bare 'mvn formatter:format' -- it reformats the whole tree.)"
+  #         exit 1
+  #       fi

--- a/dev/format-changed.sh
+++ b/dev/format-changed.sh
@@ -43,6 +43,14 @@
 #
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+if [ $# -ne 0 ]; then
+if [[ "$1" == "--force" ]]; then
+    shift;
+    echo "Please check the resulting changes very carefully, as they might contain undesired modifications to the code.";
+    cd "$(git rev-parse --show-toplevel)";
+    exec python3 dev/format_changed.py --fix "$@";
+fi
+fi
 
-exec python3 dev/format_changed.py --fix "$@"
+echo "The formatting script is currently not supported, as it performs undesired modifications of code. You can still run this script with the '--force' flag. However, please double check the results very carefully." >&2;
+exit 1;


### PR DESCRIPTION
Hi,
this PR deactivates the java formatter in the GitHub workflows, since applying the code style formatting sometimes results in actual code changes. Deactivating the formatter is just a temporary answer to this problem. The code style demands an actual rework.
@janniklinde do you agree to deactivating the formatting workflow temporarily?

All the best,
David